### PR TITLE
chore: install noetl with [cli] extra in bootstrap

### DIFF
--- a/ci/bootstrap/bootstrap.sh
+++ b/ci/bootstrap/bootstrap.sh
@@ -501,10 +501,10 @@ setup_venv() {
     log_info "Installing uv..."
     pip install uv
     
-    # Install noetl in development mode
-    log_info "Installing NoETL..."
+    # Install noetl in development mode with CLI
+    log_info "Installing NoETL with CLI..."
     cd "$NOETL_ROOT"
-    uv pip install -e .
+    uv pip install -e ".[cli]"
     
     # Install project dependencies if pyproject.toml exists
     if [[ -f "$PROJECT_ROOT/pyproject.toml" ]]; then


### PR DESCRIPTION
Update bootstrap script to install \`noetl[cli]\` to ensure the Rust CLI binary from noetl-cli package is properly installed on PATH.

This fixes the integration test workflow after restructuring the CLI as a separate maturin package (published as noetl-cli on PyPI).

**Changes:**
- Update \`ci/bootstrap/bootstrap.sh\` to install with \`[cli]\` extra
- \`noetl\` binary from PyPI is available on PATH

**Testing:**
- Verified with fresh venv installation after \`make destroy\` + \`make bootstrap\`
- Binary installs to \`.venv/bin/noetl\` (Mach-O 64-bit ARM64 executable)
- Version check: \`noetl 2.5.2\