### PR TITLE
chore: bump noetl-cli to v2.5.3 and fix compiler warnings

### DIFF
--- a/crates/noetlcli/Cargo.lock
+++ b/crates/noetlcli/Cargo.lock
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-cli"
-version = "2.5.2"
+version = "2.5.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/crates/noetlcli/Cargo.toml
+++ b/crates/noetlcli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noetl-cli"
-version = "2.5.2"
+version = "2.5.3"
 edition = "2021"
 
 [[bin]]

--- a/crates/noetlcli/pyproject.toml
+++ b/crates/noetlcli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "noetl-cli"
-version = "2.5.2"
+version = "2.5.3"
 description = "NoETL CLI (Rust) - Command-line interface for NoETL workflow automation"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/crates/noetlcli/src/playbook_runner.rs
+++ b/crates/noetlcli/src/playbook_runner.rs
@@ -1,16 +1,16 @@
 use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
-use serde_json;
+use serde::Deserialize;
 use serde_yaml;
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::path::PathBuf;
+use std::process::Command;
 
 #[derive(Debug, Deserialize)]
 pub struct Playbook {
     #[serde(rename = "apiVersion")]
     api_version: String,
+    #[allow(dead_code)]
     kind: String,
     metadata: Metadata,
     workload: Option<HashMap<String, serde_yaml::Value>>,
@@ -20,6 +20,7 @@ pub struct Playbook {
 #[derive(Debug, Deserialize)]
 struct Metadata {
     name: String,
+    #[allow(dead_code)]
     path: Option<String>,
 }
 
@@ -32,6 +33,7 @@ struct Step {
     #[serde(rename = "case")]
     case: Option<Vec<CaseCondition>>,
     #[serde(rename = "loop")]
+    #[allow(dead_code)]
     loop_config: Option<LoopConfig>,
     vars: Option<HashMap<String, String>>,
 }
@@ -98,6 +100,7 @@ enum NextStep {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct LoopConfig {
     #[serde(rename = "in")]
     in_collection: String,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ notebook = [
     "matplotlib>=3.10.3",
 ]
 # Rust CLI (optional for users who need command-line interface)
-cli = ["noetl-cli==2.5.2"]
+cli = ["noetl-cli==2.5.3"]
 
 # CLI moved to optional dependency [cli] - install with: uv pip install "noetl[cli]"
 # This avoids conflicts with the Rust noetl binary from noetl-cli package


### PR DESCRIPTION
- Update version to 2.5.3 in Cargo.toml, pyproject.toml
- Remove unused imports (Serialize, serde_json, Path, Stdio)
- Add #[allow(dead_code)] for fields used only for YAML deserialization
- Published to PyPI: https://pypi.org/project/noetl-cli/2.5.3/