### PR TITLE
chore: Bump version to 2.5.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.5.3"
+version = "2.5.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/noetl"

--- a/docker/release/Dockerfile.deb
+++ b/docker/release/Dockerfile.deb
@@ -18,7 +18,7 @@ WORKDIR /build
 COPY . .
 
 # Build Debian package
-RUN ./scripts/build_deb.sh ${VERSION:-2.5.3}
+RUN ./scripts/build_deb.sh ${VERSION:-2.5.4}
 
 # Packages will be in build/deb/
 CMD ["bash"]

--- a/docker/release/build-deb-docker.sh
+++ b/docker/release/build-deb-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION=${1:-2.5.3}
+VERSION=${1:-2.5.4}
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 

--- a/docker/release/publish-apt-docker.sh
+++ b/docker/release/publish-apt-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION=${1:-2.5.3}
+VERSION=${1:-2.5.4}
 ARCH=${2:-arm64}
 DEB_FILE="build/deb/noetl_${VERSION}-1_${ARCH}.deb"
 

--- a/homebrew/noetl.rb
+++ b/homebrew/noetl.rb
@@ -1,7 +1,7 @@
 class Noetl < Formula
   desc "NoETL workflow automation CLI - Execute playbooks locally or orchestrate distributed pipelines"
   homepage "https://noetl.io"
-  url "https://github.com/noetl/noetl/archive/refs/tags/v2.5.3.tar.gz"
+  url "https://github.com/noetl/noetl/archive/refs/tags/v2.5.4.tar.gz"
   sha256 "ca37a41ed35ef0dd1af7f062dade0440f95029738e472c28d389c3b4f9ccbb74" # Will be filled during release
   license "MIT"
   head "https://github.com/noetl/noetl.git", branch: "master"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "noetl"
-version = "2.5.3"
+version = "2.5.4"
 description = "A framework to build and run data pipelines and workflows."
 authors = [
     { name = "Kadyapam", email = "182583029+kadyapam@users.noreply.github.com" },


### PR DESCRIPTION
Update version across all distribution channels:
- Rust crate (Cargo.toml workspace)
- Homebrew formula (homebrew/noetl.rb)
- Python package (pyproject.toml)
- Debian package build scripts
- APT repository publish scripts