### PR TITLE
chore: bump noetlctl to 2.5.5

### DIFF
--- a/crates/noetlctl/pyproject.toml
+++ b/crates/noetlctl/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "noetlctl"
-version = "2.5.4"
+version = "2.5.5"
 description = "NoETL CLI (Rust) - Command-line interface for NoETL workflow automation"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Bumps noetlctl pyproject.toml version from 2.5.4 to 2.5.5 to complete version alignment across all distribution channels.