### PR TITLE
docs: Format 'tools' in README as inline code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **NoETL** is an automation framework for orchestrating **APIs, databases, and scripts** using a declarative **Playbook DSL**.
 
-Execution is standardized around an **MCP-style tool model**: consistent tool contracts, structured input/output, and a predictable lifecycle. From an MCP perspective, “tools” include API endpoints, database operations, and scripts/utilities **NoETL** orchestrates and optimizes them via playbooks.
+Execution is standardized around an **MCP-style tool model**: consistent tool contracts, structured input/output, and a predictable lifecycle. From an MCP perspective, `tools` include API endpoints, database operations, and scripts/utilities **NoETL** orchestrates and optimizes them via playbooks.
 
 With **NoETL Gateway**, playbooks can be deployed as a **distributed backend**: developers ship business logic as playbooks, and UIs/clients call stable endpoints without deploying dedicated microservices for each workflow.
 


### PR DESCRIPTION
Updated README to format 'tools' as inline code.