### PR TITLE
chore: Add Cargo.lock for reproducible builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-gateway"
-version = "2.5.11"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "async-graphql",


### PR DESCRIPTION
Binary crates should commit Cargo.lock to ensure deterministic builds across environments.