### PR TITLE
chore: bump version to 2.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "noetl"
-version = "2.8.3"
+version = "2.8.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-control-plane"
-version = "2.8.3"
+version = "2.8.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-gateway"
-version = "2.8.3"
+version = "2.8.4"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-tools"
-version = "2.8.3"
+version = "2.8.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6032,7 +6032,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "worker-pool"
-version = "2.8.3"
+version = "2.8.4"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.3"
+version = "2.8.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/noetl"

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noetl-gateway"
-version = "2.8.3"
+version = "2.8.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/noetl"

--- a/crates/noetl/Cargo.toml
+++ b/crates/noetl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noetl"
-version = "2.8.3"
+version = "2.8.4"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/homebrew/noetl.rb
+++ b/homebrew/noetl.rb
@@ -1,15 +1,15 @@
 class Noetl < Formula
   desc "NoETL workflow automation CLI - Execute playbooks locally or orchestrate distributed pipelines"
   homepage "https://noetl.io"
-  url "https://github.com/noetl/noetl/archive/refs/tags/v2.8.3.tar.gz"
-  sha256 "82ad6b367c2d42402b559e2eea42c4434ec139683b5d45eb522c43030f16a0b3"
+  url "https://github.com/noetl/noetl/archive/refs/tags/v2.8.4.tar.gz"
+  sha256 "PLACEHOLDER_SHA256"
   license "MIT"
   head "https://github.com/noetl/noetl.git", branch: "master"
 
   depends_on "rust" => :build
 
   def install
-    cd "crates/noetlctl" do
+    cd "crates/noetl" do
       system "cargo", "install", *std_cargo_args
     end
   end


### PR DESCRIPTION
This pull request updates the NoETL project to version 2.8.4, ensuring consistency across all package manifests and updating the Homebrew formula accordingly. The main changes are version bumps and a fix to the install path in the Homebrew formula.

Version updates:

* Bumped the version from 2.8.3 to 2.8.4 in `Cargo.toml`, `crates/noetl/Cargo.toml`, and `crates/gateway/Cargo.toml` to keep all Rust package manifests in sync. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L12-R12) [[2]](diffhunk://#diff-f54ca928ff74267f534d441c6410038851a984e8745c843d8fe886a7f5773f36L3-R3) [[3]](diffhunk://#diff-5e0a91b58021cfa95a20eaf5b0dd940e3486c856da48bb54755cc94eda78b265L3-R3)

Homebrew formula adjustments:

* Updated the Homebrew formula `homebrew/noetl.rb` to use the new 2.8.4 tarball URL and a placeholder SHA256, and changed the install path from `crates/noetlctl` to `crates/noetl` to reflect the correct crate location.