### PR TITLE
fix: invalidate stale execution cache when command issuance fails

### DIFF
--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -944,6 +944,24 @@ class StateStore:
         if deleted:
             logger.info(f"Evicted completed execution {execution_id} from cache")
 
+    async def invalidate_state(self, execution_id: str, reason: str = "manual") -> bool:
+        """Invalidate cached execution state so next load reconstructs from events."""
+        execution_key = str(execution_id)
+        deleted = await self._memory_cache.delete(execution_key)
+        if deleted:
+            logger.warning(
+                "[STATE-CACHE-INVALIDATE] execution_id=%s reason=%s",
+                execution_key,
+                reason,
+            )
+        else:
+            logger.debug(
+                "[STATE-CACHE-INVALIDATE] execution_id=%s reason=%s cache_miss=true",
+                execution_key,
+                reason,
+            )
+        return deleted
+
 
 class TemplateCache:
     """

--- a/noetl/server/api/v2.py
+++ b/noetl/server/api/v2.py
@@ -278,6 +278,24 @@ def get_engine():
     return _engine
 
 
+async def _invalidate_execution_state_cache(
+    execution_id: str,
+    reason: str,
+    engine: Optional[ControlFlowEngine] = None,
+) -> None:
+    """Best-effort cache invalidation to recover from partial command issuance failures."""
+    try:
+        active_engine = engine or get_engine()
+        await active_engine.state_store.invalidate_state(str(execution_id), reason=reason)
+    except Exception as cache_error:
+        logger.warning(
+            "[STATE-CACHE-INVALIDATE] failed execution_id=%s reason=%s error=%s",
+            execution_id,
+            reason,
+            cache_error,
+        )
+
+
 async def get_nats_publisher():
     """Get or initialize NATS publisher."""
     global _nats_publisher
@@ -1062,6 +1080,8 @@ async def handle_event(req: EventRequest) -> EventResponse:
     - command.completed: Already processed by worker
     - step.enter: Just marks step started
     """
+    engine: Optional[ControlFlowEngine] = None
+    commands_generated = False
     try:
         engine = get_engine()
         
@@ -1221,6 +1241,7 @@ async def handle_event(req: EventRequest) -> EventResponse:
         if req.name not in skip_engine_events:
             # Pass already_persisted=True because we already persisted the event above
             commands = await engine.handle_event(event, already_persisted=True)
+            commands_generated = bool(commands)
             logger.debug(f"[ENGINE] Processed {req.name} for step {req.step}, generated {len(commands)} commands")
         else:
             logger.debug(f"[ENGINE] Skipped engine for administrative event {req.name}")
@@ -1336,6 +1357,12 @@ async def handle_event(req: EventRequest) -> EventResponse:
         return EventResponse(status="ok", event_id=evt_id, commands_generated=len(commands))
     
     except PoolTimeout:
+        if engine is not None and commands_generated:
+            await _invalidate_execution_state_cache(
+                req.execution_id,
+                reason="command_issue_pool_timeout",
+                engine=engine,
+            )
         retry_after = _compute_retry_after()
         logger.warning("[EVENTS] DB pool saturated while persisting %s for step %s retry_after=%ss", req.name, req.step, retry_after)
         raise HTTPException(
@@ -1344,6 +1371,12 @@ async def handle_event(req: EventRequest) -> EventResponse:
             headers={"Retry-After": retry_after},
         )
     except Exception as e:
+        if engine is not None and commands_generated:
+            await _invalidate_execution_state_cache(
+                req.execution_id,
+                reason=f"command_issue_failed:{type(e).__name__}",
+                engine=engine,
+            )
         logger.error(f"handle_event failed: {e}", exc_info=True)
         raise HTTPException(500, str(e))
 
@@ -1695,10 +1728,20 @@ async def _issue_commands_for_batch(job: _BatchAcceptJob, commands: list) -> Non
 
 async def _process_accepted_batch(job: _BatchAcceptJob) -> int:
     commands: list = []
+    engine: Optional[ControlFlowEngine] = None
     if job.last_actionable_event:
         engine = get_engine()
         commands = await engine.handle_event(job.last_actionable_event, already_persisted=True)
-    await _issue_commands_for_batch(job, commands)
+    try:
+        await _issue_commands_for_batch(job, commands)
+    except Exception as e:
+        if engine is not None and commands:
+            await _invalidate_execution_state_cache(
+                str(job.execution_id),
+                reason=f"batch_command_issue_failed:{type(e).__name__}",
+                engine=engine,
+            )
+        raise
     return len(commands)
 
 

--- a/tests/api/test_v2_batch_async.py
+++ b/tests/api/test_v2_batch_async.py
@@ -1,4 +1,5 @@
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
@@ -113,3 +114,132 @@ async def test_batch_worker_unavailable_error_code(monkeypatch):
 
     assert exc.value.status_code == 503
     assert exc.value.detail["code"] == v2_api._BATCH_FAILURE_WORKER_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_process_accepted_batch_invalidates_state_cache_when_command_issue_fails(monkeypatch):
+    invalidations = []
+
+    class FakeStateStore:
+        async def invalidate_state(self, execution_id, reason="manual"):
+            invalidations.append((execution_id, reason))
+            return True
+
+    class FakeEngine:
+        def __init__(self):
+            self.state_store = FakeStateStore()
+
+        async def handle_event(self, _event, already_persisted=False):
+            assert already_persisted is True
+            return [SimpleNamespace(step="next")]
+
+    async def _fail_issue(_job, _commands):
+        raise RuntimeError("command insert failed")
+
+    fake_engine = FakeEngine()
+    monkeypatch.setattr(v2_api, "get_engine", lambda: fake_engine)
+    monkeypatch.setattr(v2_api, "_issue_commands_for_batch", _fail_issue)
+
+    job = _build_acceptance_result().job
+    job.last_actionable_event = SimpleNamespace(name="call.done")
+
+    with pytest.raises(RuntimeError, match="command insert failed"):
+        await v2_api._process_accepted_batch(job)
+
+    assert invalidations
+    assert invalidations[0][0] == "1"
+    assert invalidations[0][1].startswith("batch_command_issue_failed:")
+
+
+@pytest.mark.asyncio
+async def test_handle_event_invalidates_state_cache_when_command_persist_fails(monkeypatch):
+    invalidations = []
+
+    class FakeStateStore:
+        async def invalidate_state(self, execution_id, reason="manual"):
+            invalidations.append((execution_id, reason))
+            return True
+
+    class FakeEngine:
+        def __init__(self):
+            self.state_store = FakeStateStore()
+
+        async def handle_event(self, _event, already_persisted=False):
+            assert already_persisted is True
+            return [SimpleNamespace(step="next")]
+
+    class _CursorCtx:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        async def __aenter__(self):
+            return self._cursor
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _PersistCursor:
+        async def execute(self, *_args, **_kwargs):
+            return None
+
+        async def fetchone(self):
+            return {"catalog_id": 10}
+
+    class _PersistConn:
+        def cursor(self, row_factory=None):
+            return _CursorCtx(_PersistCursor())
+
+        async def commit(self):
+            return None
+
+    class _ConnCtx:
+        def __init__(self, conn):
+            self._conn = conn
+
+        async def __aenter__(self):
+            return self._conn
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _FailConnCtx:
+        async def __aenter__(self):
+            raise RuntimeError("command persist failed")
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    calls = {"count": 0}
+
+    def _fake_get_pool_connection():
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return _ConnCtx(_PersistConn())
+        return _FailConnCtx()
+
+    async def _fake_get_nats_publisher():
+        return SimpleNamespace()
+
+    async def _fake_next_snowflake_id(_cur):
+        return 12345
+
+    fake_engine = FakeEngine()
+    monkeypatch.setattr(v2_api, "get_engine", lambda: fake_engine)
+    monkeypatch.setattr(v2_api, "get_pool_connection", _fake_get_pool_connection)
+    monkeypatch.setattr(v2_api, "_next_snowflake_id", _fake_next_snowflake_id)
+    monkeypatch.setattr(v2_api, "get_nats_publisher", _fake_get_nats_publisher)
+
+    req = v2_api.EventRequest(
+        execution_id="42",
+        step="step1",
+        name="call.done",
+        payload={"status": "completed"},
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await v2_api.handle_event(req)
+
+    assert exc.value.status_code == 500
+    assert invalidations
+    assert invalidations[0][0] == "42"
+    assert invalidations[0][1].startswith("command_issue_failed:")


### PR DESCRIPTION
## Summary
- add execution-state cache invalidation when command issuance fails after `engine.handle_event` updated in-memory `issued_steps`
- cover both single-event path (`POST /api/events`) and async batch path (`/api/events/batch` worker processing)
- add regression tests for both invalidation paths in `tests/api/test_v2_batch_async.py`

## Problem
`engine.handle_event(..., already_persisted=True)` updates cached `issued_steps` before `command.issued` rows are committed.
If the subsequent DB command issuance transaction fails, cache keeps stale `issued_steps` and later retries can be deduplicated incorrectly.

## Fix
- add `StateStore.invalidate_state(execution_id, reason)`
- add best-effort invalidation in `/api/events` error path when command issuance fails after commands were generated
- add best-effort invalidation in async batch worker path when `_issue_commands_for_batch` fails after commands were generated

## Validation
- `uv run pytest -q tests/api/test_v2_batch_async.py`
- Result: `5 passed`

Closes #255
