### PR TITLE
fix: add command reaper to recover commands orphaned by OOMKill/SIGKILL

### DIFF
--- a/noetl/server/app.py
+++ b/noetl/server/app.py
@@ -27,6 +27,7 @@ from noetl.server.auto_resume import (
     resume_interrupted_executions,
     get_auto_resume_metrics_snapshot,
 )
+from noetl.server.command_reaper import run_command_reaper
 
 logger = setup_logger(__name__, include_location=True)
 
@@ -252,6 +253,20 @@ def _create_app(settings: Settings, enable_ui: Optional[bool] = None) -> FastAPI
             except Exception as e:
                 logger.exception(f"Failed to start runtime sweeper: {e}")
 
+            # --------------------------------------------------
+            # Command reaper: recovers commands orphaned by OOMKill/SIGKILL
+            # --------------------------------------------------
+            reaper_task: Optional[asyncio.Task] = None
+            try:
+                logger.info("Starting command reaper background task...")
+                reaper_task = asyncio.create_task(
+                    run_command_reaper(stop_event, server_url),
+                    name="command-reaper",
+                )
+                logger.info("Command reaper background task started successfully")
+            except Exception as e:
+                logger.exception(f"Failed to start command reaper: {e}")
+
             yield
             # Shutdown
             stop_event.set()
@@ -262,6 +277,13 @@ def _create_app(settings: Settings, enable_ui: Optional[bool] = None) -> FastAPI
                         await sweeper_task
                 except Exception as e:
                     logger.exception(f"Critical error during sweeper task shutdown: {e}")
+            if reaper_task:
+                try:
+                    reaper_task.cancel()
+                    with contextlib.suppress(Exception):
+                        await reaper_task
+                except Exception as e:
+                    logger.exception(f"Critical error during command reaper shutdown: {e}")
             if auto_resume_task:
                 try:
                     auto_resume_task.cancel()

--- a/noetl/server/command_reaper.py
+++ b/noetl/server/command_reaper.py
@@ -1,0 +1,207 @@
+"""
+Periodic command reaper for orphaned commands.
+
+When a worker is OOMKilled or otherwise crashes ungracefully, it cannot emit
+command.completed / command.failed events. Its NATS messages were already ACKed
+at claim time, so no automatic redelivery occurs. Without intervention, those
+commands stay in RUNNING state indefinitely.
+
+This module provides a background task that:
+1. Periodically finds commands claimed by workers that are now offline or
+   have a stale heartbeat.
+2. Re-publishes a NATS notification for each such command.
+3. A healthy worker picks up the notification, calls claim_command, and the
+   existing decide_reclaim_for_existing_claim() logic detects the dead worker
+   and reclaims the command transparently.
+
+Environment variables:
+  NOETL_COMMAND_REAPER_ENABLED          - true/false (default: true)
+  NOETL_COMMAND_REAPER_INTERVAL_SECONDS - scan frequency (default: 60)
+  NOETL_COMMAND_REAPER_WORKER_STALE_SECONDS
+                                        - heartbeat age to treat worker as dead
+                                          (default: 60; should be >= sweep_interval
+                                           so sweeper marks worker offline first)
+  NOETL_COMMAND_REAPER_MAX_PER_RUN      - max commands re-published per cycle
+                                          (default: 100)
+  NOETL_COMMAND_REAPER_LOOKBACK_HOURS   - how far back to scan for issued commands
+                                          (default: 24)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from psycopg.rows import dict_row
+
+from noetl.core.db.pool import get_pool_connection
+from noetl.core.logger import setup_logger
+
+logger = setup_logger(__name__, include_location=True)
+
+_REAPER_ENABLED = os.getenv("NOETL_COMMAND_REAPER_ENABLED", "true").strip().lower() in {
+    "1", "true", "yes", "on"
+}
+_REAPER_INTERVAL_SECONDS = max(
+    10.0, float(os.getenv("NOETL_COMMAND_REAPER_INTERVAL_SECONDS", "60"))
+)
+_REAPER_WORKER_STALE_SECONDS = max(
+    30.0, float(os.getenv("NOETL_COMMAND_REAPER_WORKER_STALE_SECONDS", "60"))
+)
+_REAPER_MAX_PER_RUN = max(
+    1, int(os.getenv("NOETL_COMMAND_REAPER_MAX_PER_RUN", "100"))
+)
+_REAPER_LOOKBACK_HOURS = max(
+    1, int(os.getenv("NOETL_COMMAND_REAPER_LOOKBACK_HOURS", "24"))
+)
+
+
+async def _find_orphaned_commands(
+    stale_seconds: float,
+    lookback_hours: int,
+    max_commands: int,
+) -> list[dict]:
+    """
+    Return commands that are claimed but not terminal, where the claiming
+    worker is offline or has a stale heartbeat.
+
+    Each row: {event_id, execution_id, command_id, step}
+    """
+    async with get_pool_connection(timeout=5.0) as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                WITH latest_claims AS (
+                    -- Most recent command.claimed event per command_id
+                    SELECT DISTINCT ON (meta->>'command_id')
+                        meta->>'command_id'  AS command_id,
+                        worker_id,
+                        execution_id
+                    FROM noetl.event
+                    WHERE event_type = 'command.claimed'
+                      AND created_at > NOW() - (%s * INTERVAL '1 hour')
+                    ORDER BY meta->>'command_id', event_id DESC
+                )
+                SELECT
+                    issued.event_id,
+                    issued.execution_id,
+                    claims.command_id,
+                    issued.node_name AS step
+                FROM latest_claims claims
+                JOIN noetl.event issued
+                    ON  issued.event_type = 'command.issued'
+                    AND issued.execution_id = claims.execution_id
+                    AND issued.meta->>'command_id' = claims.command_id
+                LEFT JOIN noetl.runtime r
+                    ON  r.name = claims.worker_id
+                    AND r.kind = 'worker_pool'
+                WHERE
+                    -- Worker is gone or heartbeat is stale
+                    (   r.name IS NULL
+                        OR r.status != 'ready'
+                        OR r.heartbeat < NOW() - (%s * INTERVAL '1 second')
+                    )
+                    -- Command has not reached a terminal state
+                    AND NOT EXISTS (
+                        SELECT 1 FROM noetl.event t
+                        WHERE t.execution_id = issued.execution_id
+                          AND t.event_type IN ('command.completed', 'command.failed')
+                          AND t.meta->>'command_id' = claims.command_id
+                    )
+                    -- Execution is not cancelled
+                    AND NOT EXISTS (
+                        SELECT 1 FROM noetl.event x
+                        WHERE x.execution_id = issued.execution_id
+                          AND x.event_type = 'execution.cancelled'
+                    )
+                ORDER BY issued.event_id
+                LIMIT %s
+                """,
+                (lookback_hours, stale_seconds, max_commands),
+            )
+            rows = await cur.fetchall()
+    return list(rows or [])
+
+
+async def run_command_reaper(stop_event: asyncio.Event, server_url: str) -> None:
+    """
+    Background task: scan for orphaned commands and re-publish NATS notifications.
+
+    Designed to run for the lifetime of the server process. Exits cleanly when
+    stop_event is set or the task is cancelled.
+    """
+    if not _REAPER_ENABLED:
+        logger.info("[REAPER] Disabled via NOETL_COMMAND_REAPER_ENABLED=false")
+        return
+
+    logger.info(
+        "[REAPER] Started (interval=%.0fs, stale_threshold=%.0fs, lookback=%dh)",
+        _REAPER_INTERVAL_SECONDS,
+        _REAPER_WORKER_STALE_SECONDS,
+        _REAPER_LOOKBACK_HOURS,
+    )
+
+    while not stop_event.is_set():
+        try:
+            await asyncio.sleep(_REAPER_INTERVAL_SECONDS)
+        except asyncio.CancelledError:
+            logger.info("[REAPER] Cancelled during sleep; exiting")
+            break
+
+        if stop_event.is_set():
+            break
+
+        try:
+            orphaned = await _find_orphaned_commands(
+                stale_seconds=_REAPER_WORKER_STALE_SECONDS,
+                lookback_hours=_REAPER_LOOKBACK_HOURS,
+                max_commands=_REAPER_MAX_PER_RUN,
+            )
+
+            if not orphaned:
+                logger.debug("[REAPER] No orphaned commands found")
+                continue
+
+            logger.warning(
+                "[REAPER] Found %d orphaned command(s) from dead workers; re-publishing to NATS",
+                len(orphaned),
+            )
+
+            from noetl.server.api.v2 import get_nats_publisher
+            nats_pub = await get_nats_publisher()
+
+            republished = 0
+            for cmd in orphaned:
+                try:
+                    await nats_pub.publish_command(
+                        execution_id=int(cmd["execution_id"]),
+                        event_id=int(cmd["event_id"]),
+                        command_id=str(cmd["command_id"]),
+                        step=str(cmd["step"]),
+                        server_url=server_url,
+                    )
+                    republished += 1
+                    logger.info(
+                        "[REAPER] Re-published command: execution_id=%s command_id=%s step=%s",
+                        cmd["execution_id"],
+                        cmd["command_id"],
+                        cmd["step"],
+                    )
+                except Exception as pub_err:
+                    logger.error(
+                        "[REAPER] Failed to re-publish command %s: %s",
+                        cmd.get("command_id"),
+                        pub_err,
+                    )
+
+            logger.info(
+                "[REAPER] Re-published %d/%d orphaned commands",
+                republished,
+                len(orphaned),
+            )
+
+        except asyncio.CancelledError:
+            logger.info("[REAPER] Cancelled during scan; exiting")
+            break
+        except Exception as e:
+            logger.error("[REAPER] Scan failed: %s", e, exc_info=True)


### PR DESCRIPTION
When a worker is killed ungracefully (OOMKill, SIGKILL, node eviction), commands it was processing remain in RUNNING state indefinitely. The NATS message was already ACKed at claim time, so no automatic redelivery occurs. The runtime sweeper marks the worker offline but has no mechanism to recover the stuck commands.

Add noetl/server/command_reaper.py: a background task that periodically scans for commands claimed by workers with a stale or offline heartbeat and re-publishes a NATS notification for each orphaned command. This triggers the existing claim/reclaim flow — decide_reclaim_for_existing_claim() detects the dead worker (worker_inactive or worker_heartbeat_stale) and grants the claim to a healthy worker.

Wire the reaper into the server lifespan in app.py alongside the existing runtime sweeper. The reaper shares the same stop_event for clean shutdown.

Configurable via environment variables:
  NOETL_COMMAND_REAPER_ENABLED           (default: true)
  NOETL_COMMAND_REAPER_INTERVAL_SECONDS  (default: 60)
  NOETL_COMMAND_REAPER_WORKER_STALE_SECONDS (default: 60)
  NOETL_COMMAND_REAPER_MAX_PER_RUN       (default: 100)
  NOETL_COMMAND_REAPER_LOOKBACK_HOURS    (default: 24)