### PR TITLE
fix: resolve stale execution status from terminal event precedence

### DIFF
--- a/noetl/server/api/v2.py
+++ b/noetl/server/api/v2.py
@@ -2340,6 +2340,22 @@ async def get_execution_status(execution_id: str, full: bool = False):
                 """, (int(execution_id),))
                 latest_event = await cur.fetchone()
 
+                await cur.execute("""
+                    SELECT event_type, node_name, status, created_at
+                    FROM noetl.event
+                    WHERE execution_id = %s
+                      AND event_type IN (
+                        'playbook.completed',
+                        'workflow.completed',
+                        'playbook.failed',
+                        'workflow.failed',
+                        'execution.cancelled'
+                      )
+                    ORDER BY event_id DESC
+                    LIMIT 1
+                """, (int(execution_id),))
+                terminal_event = await cur.fetchone()
+
         # Fallback completion inference:
         # Some runs reach terminal step completion in events but may miss
         # playbook/workflow terminal flags in engine state.
@@ -2347,28 +2363,31 @@ async def get_execution_status(execution_id: str, full: bool = False):
             if state.current_step == "end" and "end" in state.completed_steps and not failed:
                 completed = True
                 completion_inferred = True
-            elif latest_event:
+            else:
                 terminal_complete_events = {"playbook.completed", "workflow.completed"}
                 terminal_failed_events = {"playbook.failed", "workflow.failed", "execution.cancelled"}
+                terminal_type = terminal_event["event_type"] if terminal_event else None
 
-                if latest_event["event_type"] in terminal_complete_events:
+                if terminal_type in terminal_complete_events:
                     completed = True
                     completion_inferred = True
-                elif latest_event["event_type"] in terminal_failed_events:
+                elif terminal_type in terminal_failed_events:
                     completed = True
-                    failed = latest_event["event_type"] != "execution.cancelled"
+                    failed = terminal_type != "execution.cancelled"
                     completion_inferred = True
-                elif (
+                elif latest_event and (
                     latest_event["node_name"] == "end"
                     and latest_event["status"] == "COMPLETED"
-                        and latest_event["event_type"] in {"command.completed", "call.done", "step.exit"}
+                    and latest_event["event_type"] in {"command.completed", "call.done", "step.exit"}
                 ):
                     completed = True
                     completion_inferred = True
 
+        duration_anchor = terminal_event or latest_event
+
         duration = _duration_fields(
             first_event.get("created_at") if first_event else None,
-            latest_event.get("created_at") if latest_event else None,
+            duration_anchor.get("created_at") if duration_anchor else None,
             completed,
         )
 

--- a/tests/api/test_v2_execution_status_terminal.py
+++ b/tests/api/test_v2_execution_status_terminal.py
@@ -1,0 +1,93 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import noetl.server.api.v2 as v2_api
+
+
+class _CursorCtx:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    async def __aenter__(self):
+        return self._cursor
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeCursor:
+    def __init__(self, start_time: datetime, latest_time: datetime, terminal_time: datetime):
+        self._query = ""
+        self._start_time = start_time
+        self._latest_time = latest_time
+        self._terminal_time = terminal_time
+
+    async def execute(self, query, _params):
+        self._query = query
+
+    async def fetchone(self):
+        if "ORDER BY event_id ASC" in self._query:
+            return {"created_at": self._start_time}
+        if "AND event_type IN (" in self._query:
+            return {
+                "event_type": "playbook.completed",
+                "node_name": "bhs/state_report_generation_prod_v10",
+                "status": "COMPLETED",
+                "created_at": self._terminal_time,
+            }
+        if "ORDER BY event_id DESC" in self._query:
+            return {
+                "event_type": "batch.processing",
+                "node_name": "events.batch",
+                "status": "RUNNING",
+                "created_at": self._latest_time,
+            }
+        raise AssertionError(f"Unexpected query in test cursor: {self._query}")
+
+
+class _FakeConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self, row_factory=None):  # noqa: ARG002
+        return _CursorCtx(self._cursor)
+
+
+class _ConnCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_status_prefers_terminal_event_when_latest_event_is_batch_processing(monkeypatch):
+    start_time = datetime(2026, 3, 18, 3, 31, 10, tzinfo=timezone.utc)
+    terminal_time = datetime(2026, 3, 18, 3, 33, 40, tzinfo=timezone.utc)
+    latest_batch_time = datetime(2026, 3, 18, 3, 33, 42, tzinfo=timezone.utc)
+
+    fake_state = SimpleNamespace(
+        completed=False,
+        failed=False,
+        current_step="load_patients_for_adt",
+        completed_steps={"start", "load_next_facility"},
+        variables={},
+    )
+    fake_engine = SimpleNamespace(state_store=SimpleNamespace(get_state=lambda _execution_id: fake_state))
+    fake_cursor = _FakeCursor(start_time, latest_batch_time, terminal_time)
+
+    monkeypatch.setattr(v2_api, "get_engine", lambda: fake_engine)
+    monkeypatch.setattr(v2_api, "get_pool_connection", lambda: _ConnCtx(_FakeConn(fake_cursor)))
+
+    result = await v2_api.get_execution_status("585000300126142930")
+
+    assert result["completed"] is True
+    assert result["failed"] is False
+    assert result["completion_inferred"] is True
+    assert result["end_time"] == terminal_time.isoformat()


### PR DESCRIPTION
## Root Cause
`GET /api/executions/{execution_id}/status` had two code paths:
- fallback path (no in-memory state): checks terminal lifecycle events across event log
- state-present path: only checked the *latest* event

In production, latest events can be non-terminal batch events (e.g. `batch.processing`) even when terminal lifecycle events already exist. That made `/status` return stale `completed=false` while `/api/executions` showed `COMPLETED`.

## Fix
- In the state-present `/status` path, query terminal lifecycle events from `noetl.event` and give them precedence for completion/failure derivation.
- Keep legacy end-step fallback for runs without lifecycle markers.
- Anchor `end_time`/duration to terminal-event timestamp when present.

## Tests
- Added API regression test for this exact scenario:
  - `tests/api/test_v2_execution_status_terminal.py`

## Validation
- `.venv/bin/python -m pytest -q tests/api/test_v2_execution_status_terminal.py tests/unit/dsl/v2/test_task_sequence_loop_completion.py`
