### PR TITLE
fix: guard loop continuation from mutable ctx

### DIFF
--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -376,7 +376,9 @@ class ExecutionState:
             event_id: Event ID that initiated this loop instance (for uniqueness)
         """
         self.loop_state[step_name] = {
-            "collection": collection,
+            # Keep a local snapshot so downstream in-place list mutations outside loop_state
+            # do not alter continuation/retry scheduling.
+            "collection": list(collection),
             "iterator": iterator,
             "index": 0,
             "mode": mode,
@@ -2296,7 +2298,7 @@ class ControlFlowEngine:
                     name="loop_continue",
                     payload={}
                 ))
-                collection = existing_loop_state.get("collection", [])
+                collection = list(existing_loop_state.get("collection", []))
                 logger.debug(
                     "[LOOP] Reusing cached collection for %s continuation/retry (size=%s)",
                     step.step,
@@ -2392,7 +2394,7 @@ class ControlFlowEngine:
                         loop_event_id,
                     )
                 else:
-                    existing_loop_state["collection"] = collection
+                    existing_loop_state["collection"] = list(collection)
             loop_state = existing_loop_state
             loop_event_id_for_metadata = (
                 str(loop_state.get("event_id"))
@@ -3045,7 +3047,7 @@ class ControlFlowEngine:
                             context = state.get_render_context(event)
                             rendered_collection = self._render_template(parent_step_def.loop.in_, context)
                             rendered_collection = self._normalize_loop_collection(rendered_collection, parent_step)
-                            loop_state["collection"] = rendered_collection
+                            loop_state["collection"] = list(rendered_collection)
                             collection_size = len(rendered_collection)
                             logger.info(f"[TASK_SEQ-LOOP] Re-rendered collection for {parent_step}: {collection_size} items")
 
@@ -3377,7 +3379,7 @@ class ControlFlowEngine:
                         loop_context = state.get_render_context(event)
                         rendered_collection = self._render_template(step_def.loop.in_, loop_context)
                         rendered_collection = self._normalize_loop_collection(rendered_collection, event.step)
-                        loop_state["collection"] = rendered_collection
+                        loop_state["collection"] = list(rendered_collection)
                         collection_size = len(rendered_collection)
                         logger.info(f"[LOOP-CALL.DONE] Re-rendered collection for {event.step}: {collection_size} items")
 
@@ -3640,7 +3642,7 @@ class ControlFlowEngine:
                         context = state.get_render_context(event)
                         collection = self._render_template(step_def.loop.in_, context)
                         collection = self._normalize_loop_collection(collection, event.step)
-                        loop_state["collection"] = collection
+                        loop_state["collection"] = list(collection)
                         logger.info(f"[LOOP-SETUP] Rendered collection for {event.step}: {len(collection)} items")
                         
                         # Store initial loop state in NATS K/V with event_id

--- a/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
+++ b/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
@@ -131,15 +131,16 @@ async def test_loop_continue_reuses_cached_collection_when_ctx_key_missing(monke
     engine = ControlFlowEngine(playbook_repo, state_store)
 
     execution_id = "9302"
+    source_patients = [
+        {"patient_id": 101},
+        {"patient_id": 102},
+    ]
     state = ExecutionState(
         execution_id,
         parsed_playbook,
         payload={
             "ctx": {
-                "patients_needing_demographics": [
-                    {"patient_id": 101},
-                    {"patient_id": 102},
-                ]
+                "patients_needing_demographics": source_patients
             }
         },
     )
@@ -159,7 +160,11 @@ async def test_loop_continue_reuses_cached_collection_when_ctx_key_missing(monke
     assert first.args.get("claimed_patient_id") == 101
     assert first.args.get("claimed_index") == 0
 
-    # Simulate context mutation after loop init; continuation must use cached snapshot.
+    # Simulate in-place mutation of original source list after loop init.
+    source_patients.clear()
+    source_patients.append({"patient_id": 999})
+
+    # Also remove ctx key; continuation must still use cached snapshot.
     state.variables.pop("patients_needing_demographics", None)
 
     second = await engine._create_command_for_step(


### PR DESCRIPTION
## Summary
- reuse cached `loop_state.collection` on `__loop_continue` / `__loop_retry` instead of re-rendering `loop.in` from mutable `ctx`
- keep fallback behavior: if cached collection is missing/invalid, warn and re-render
- switch loop event-id fallback to `time.time_ns()` to avoid coroutine/DB dependency in this path
- add regression test for continuation when the original `ctx` key is removed mid-loop

## Why
Large facility runs were failing mid-loop with template errors like missing `ctx.patients_needing_demographics`, then reaper/claim churn caused memory pressure and OOM restarts.

## Validation
- `uv run pytest -q tests/unit/dsl/v2/test_loop_parallel_dispatch.py tests/unit/dsl/v2/test_task_sequence_loop_completion.py`
- result: `12 passed`
