### PR TITLE
fix: stabilize reference-chain stress harness and page reduction flow

### DIFF
--- a/tests/fixtures/playbooks/load_test/reference_chain_loop_stress/reference_chain_loop_stress.yaml
+++ b/tests/fixtures/playbooks/load_test/reference_chain_loop_stress/reference_chain_loop_stress.yaml
@@ -45,82 +45,85 @@ workflow:
   - step: fetch_page
     desc: Fetch one page with bounded linked references
     tool:
-      kind: http
-      method: GET
-      url: "{{ api_url }}/api/v1/reference-chain/items"
-      params:
-        page: "{{ ctx.current_page }}"
-        pageSize: "{{ page_size }}"
-        total: "{{ total_records }}"
-        payload_kb: "{{ page_payload_kb }}"
-        ref_mode: linked
-      spec:
-        policy:
-          rules:
-            - when: "{{ outcome.status == 'error' and (outcome.error.retryable or (outcome.error.message is defined and ('Connection reset' in outcome.error.message or 'timed out' in outcome.error.message))) }}"
-              then:
-                do: retry
-                attempts: 6
-                backoff: exponential
-                delay: 0.8
-            - when: "{{ outcome.status == 'error' }}"
-              then:
-                do: fail
-            - else:
+      - name: fetch
+        kind: http
+        method: GET
+        url: "{{ api_url }}/api/v1/reference-chain/items"
+        params:
+          page: "{{ ctx.current_page }}"
+          pageSize: "{{ page_size }}"
+          total: "{{ total_records }}"
+          payload_kb: "{{ page_payload_kb }}"
+          ref_mode: linked
+        spec:
+          policy:
+            rules:
+              - when: "{{ outcome.status == 'error' and (outcome.error.retryable or (outcome.error.message is defined and ('Connection reset' in outcome.error.message or 'timed out' in outcome.error.message))) }}"
                 then:
-                  do: continue
-    next:
-      spec:
-        mode: exclusive
-      arcs:
-        - step: merge_page
+                  do: retry
+                  attempts: 6
+                  backoff: exponential
+                  delay: 0.8
+              - when: "{{ outcome.status == 'error' }}"
+                then:
+                  do: fail
+              - else:
+                  then:
+                    do: continue
+      - name: reduce_page
+        kind: python
+        args:
+          response: "{{ _prev.data }}"
+          current_chain_ok: "{{ ctx.chain_contract_ok }}"
+          pages_fetched: "{{ ctx.pages_fetched }}"
+        code: |
+          payload = response if isinstance(response, dict) else {}
+          records = payload.get("data", []) if isinstance(payload, dict) else []
+          paging = payload.get("paging", {}) if isinstance(payload, dict) else {}
+          refs = payload.get("refs", {}) if isinstance(payload, dict) else {}
 
-  - step: merge_page
-    desc: Derive page-local workset and validate linked-chain behavior
-    tool:
-      kind: python
-      args:
-        response: "{{ fetch_page }}"
-        current_chain_ok: "{{ ctx.chain_contract_ok }}"
-        pages_fetched: "{{ ctx.pages_fetched }}"
-      code: |
-        payload = response.get("data", response if isinstance(response, dict) else {})
-        records = payload.get("data", []) if isinstance(payload, dict) else []
-        paging = payload.get("paging", {}) if isinstance(payload, dict) else {}
-        refs = payload.get("refs", {}) if isinstance(payload, dict) else {}
+          stubs = [
+            {
+              "record_id": item.get("record_id"),
+              "record_ref": item.get("record_ref"),
+            }
+            for item in records
+            if item.get("record_id") is not None and item.get("record_ref")
+          ]
 
-        stubs = [
-          {
-            "record_id": item.get("record_id"),
-            "record_ref": item.get("record_ref"),
+          mode = refs.get("mode", "unknown")
+          chain = refs.get("chain", []) if isinstance(refs.get("chain", []), list) else []
+          linked_ok = (mode != "linked") or (len(chain) <= 2)
+          chain_ok = bool(current_chain_ok) and linked_ok
+
+          current_page = int(paging.get("page", 1) or 1)
+          has_more = bool(paging.get("hasMore", False))
+
+          result = {
+            "page_records": stubs,
+            "page_record_count": len(stubs),
+            "has_more": has_more,
+            "next_page": current_page + 1,
+            "chain_contract_ok": chain_ok,
+            "linked_chain_length": len(chain),
+            "mode": mode,
+            "pages_fetched": int(pages_fetched or 0) + 1,
           }
-          for item in records
-          if item.get("record_id") is not None and item.get("record_ref")
-        ]
-
-        mode = refs.get("mode", "unknown")
-        chain = refs.get("chain", []) if isinstance(refs.get("chain", []), list) else []
-        linked_ok = (mode != "linked") or (len(chain) <= 2)
-        chain_ok = bool(current_chain_ok) and linked_ok
-
-        current_page = int(paging.get("page", 1) or 1)
-        has_more = bool(paging.get("hasMore", False))
-
-        result = {
-          "page_records": stubs,
-          "page_record_count": len(stubs),
-          "has_more": has_more,
-          "next_page": current_page + 1,
-          "chain_contract_ok": chain_ok,
-          "linked_chain_length": len(chain),
-          "mode": mode,
-          "pages_fetched": int(pages_fetched or 0) + 1,
-        }
+    result:
+      output_select:
+        - page_records
+        - page_record_count
+        - has_more
+        - next_page
+        - chain_contract_ok
+        - linked_chain_length
+        - mode
+        - pages_fetched
     set_ctx:
-      has_more: "{{ merge_page.has_more }}"
-      current_page: "{{ merge_page.next_page }}"
-      chain_contract_ok: "{{ merge_page.chain_contract_ok }}"
-      pages_fetched: "{{ merge_page.pages_fetched }}"
+      has_more: "{{ fetch_page.has_more }}"
+      current_page: "{{ fetch_page.next_page }}"
+      chain_contract_ok: "{{ fetch_page.chain_contract_ok }}"
+      pages_fetched: "{{ fetch_page.pages_fetched }}"
     next:
       spec:
         mode: exclusive
@@ -133,7 +136,7 @@ workflow:
       spec:
         mode: parallel
         max_in_flight: 200
-      in: "{{ merge_page.page_records }}"
+      in: "{{ fetch_page.page_records }}"
       iterator: record
     tool:
       kind: python
@@ -161,7 +164,7 @@ workflow:
       kind: python
       args:
         loop_summary: "{{ process_records }}"
-        merge_result: "{{ merge_page }}"
+        merge_result: "{{ fetch_page }}"
         processed_total: "{{ ctx.processed_total }}"
         chain_contract_ok: "{{ ctx.chain_contract_ok }}"
       code: |

--- a/tests/scripts/test_reference_chain_loop_stress.py
+++ b/tests/scripts/test_reference_chain_loop_stress.py
@@ -17,10 +17,31 @@ PLAYBOOK_FILE = Path(
 )
 
 
-def post_json(base_url: str, path: str, payload: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:
-    resp = requests.post(f"{base_url}{path}", json=payload, timeout=timeout)
-    resp.raise_for_status()
-    return resp.json()
+def post_json(
+    base_url: str,
+    path: str,
+    payload: dict[str, Any],
+    timeout: float = 30.0,
+    attempts: int = 1,
+    retry_delay_seconds: float = 1.0,
+) -> dict[str, Any]:
+    last_error: Exception | None = None
+    for attempt in range(1, max(1, attempts) + 1):
+        try:
+            resp = requests.post(f"{base_url}{path}", json=payload, timeout=timeout)
+            resp.raise_for_status()
+            return resp.json()
+        except requests.HTTPError as exc:
+            status_code = exc.response.status_code if exc.response is not None else None
+            if attempt >= attempts or status_code is None or status_code < 500:
+                raise
+            last_error = exc
+        except requests.RequestException as exc:
+            if attempt >= attempts:
+                raise
+            last_error = exc
+        time.sleep(retry_delay_seconds * attempt)
+    raise RuntimeError(f"request failed after retries: {last_error}")
 
 
 def parse_first_value(rows: Any) -> Any:
@@ -36,7 +57,40 @@ def parse_first_value(rows: Any) -> Any:
 
 def query_postgres(base_url: str, query: str) -> Any:
     payload = {"query": query, "schema": "noetl"}
-    data = post_json(base_url, "/api/postgres/execute", payload, timeout=60.0)
+    data = post_json(
+        base_url,
+        "/api/postgres/execute",
+        payload,
+        timeout=60.0,
+        attempts=6,
+        retry_delay_seconds=1.0,
+    )
+    if str(data.get("status", "")).lower() == "error":
+        error_text = str(data.get("error") or "")
+        retryable_markers = (
+            "connection refused",
+            "connection is lost",
+            "server closed the connection unexpectedly",
+            "database system is in recovery mode",
+            "couldn't get a connection",
+        )
+        if any(marker in error_text.lower() for marker in retryable_markers):
+            for attempt in range(1, 6):
+                time.sleep(float(attempt))
+                data = post_json(
+                    base_url,
+                    "/api/postgres/execute",
+                    payload,
+                    timeout=60.0,
+                    attempts=3,
+                    retry_delay_seconds=1.0,
+                )
+                if str(data.get("status", "")).lower() != "error":
+                    return data.get("result", [])
+                error_text = str(data.get("error") or "")
+                if not any(marker in error_text.lower() for marker in retryable_markers):
+                    break
+        raise RuntimeError(f"postgres query failed: {data.get('error')}")
     return data.get("result", [])
 
 
@@ -44,7 +98,14 @@ def register_playbook(base_url: str) -> dict[str, Any]:
     with PLAYBOOK_FILE.open("r", encoding="utf-8") as fh:
         playbook = yaml.safe_load(fh)
     payload = {"content": json.dumps(playbook)}
-    result = post_json(base_url, "/api/catalog/register", payload, timeout=60.0)
+    result = post_json(
+        base_url,
+        "/api/catalog/register",
+        payload,
+        timeout=60.0,
+        attempts=6,
+        retry_delay_seconds=1.0,
+    )
     return {"playbook": playbook, "result": result}
 
 
@@ -102,41 +163,76 @@ def _parse_metrics_row(row: Any) -> dict[str, Any]:
 
 
 def fetch_poll_metrics(base_url: str, execution_id: int) -> tuple[Optional[str], int, int]:
-    rows = query_postgres(
-        base_url,
-        f"""
-        WITH ev AS (
-          SELECT event_id, event_type, loop_name
-          FROM noetl.event
-          WHERE execution_id = {execution_id}
-        ),
-        status_event AS (
-          SELECT lower(event_type) AS event_type
-          FROM ev
-          WHERE event_type IN (
-            'playbook.completed',
-            'playbook_completed',
-            'playbook.failed',
-            'playbook_failed',
-            'workflow.completed',
-            'workflow_completed',
-            'workflow.failed',
-            'workflow_failed'
-          )
-          ORDER BY event_id DESC
-          LIMIT 1
-        )
-        SELECT
-          COALESCE((SELECT event_type FROM status_event), '') AS last_status_event,
-          COALESCE(SUM(CASE
-            WHEN loop_name = 'process_records' AND event_type = 'step.exit'
-            THEN 1
-            ELSE 0
-          END), 0) AS iteration_count,
-          COUNT(*) AS event_count
-        FROM ev
-        """,
+    metrics_query_node_name = f"""
+    WITH ev AS (
+      SELECT event_id, event_type, node_name
+      FROM noetl.event
+      WHERE execution_id = {execution_id}
+    ),
+    status_event AS (
+      SELECT lower(event_type) AS event_type
+      FROM ev
+      WHERE event_type IN (
+        'playbook.completed',
+        'playbook_completed',
+        'playbook.failed',
+        'playbook_failed',
+        'workflow.completed',
+        'workflow_completed',
+        'workflow.failed',
+        'workflow_failed'
+      )
+      ORDER BY event_id DESC
+      LIMIT 1
     )
+    SELECT
+      COALESCE((SELECT event_type FROM status_event), '') AS last_status_event,
+      COALESCE(SUM(CASE
+        WHEN node_name = 'process_records' AND event_type = 'step.exit'
+        THEN 1
+        ELSE 0
+      END), 0) AS iteration_count,
+      COUNT(*) AS event_count
+    FROM ev
+    """
+    metrics_query_loop_name = f"""
+    WITH ev AS (
+      SELECT event_id, event_type, loop_name
+      FROM noetl.event
+      WHERE execution_id = {execution_id}
+    ),
+    status_event AS (
+      SELECT lower(event_type) AS event_type
+      FROM ev
+      WHERE event_type IN (
+        'playbook.completed',
+        'playbook_completed',
+        'playbook.failed',
+        'playbook_failed',
+        'workflow.completed',
+        'workflow_completed',
+        'workflow.failed',
+        'workflow_failed'
+      )
+      ORDER BY event_id DESC
+      LIMIT 1
+    )
+    SELECT
+      COALESCE((SELECT event_type FROM status_event), '') AS last_status_event,
+      COALESCE(SUM(CASE
+        WHEN loop_name = 'process_records' AND event_type = 'step.exit'
+        THEN 1
+        ELSE 0
+      END), 0) AS iteration_count,
+      COUNT(*) AS event_count
+    FROM ev
+    """
+    try:
+        rows = query_postgres(base_url, metrics_query_node_name)
+    except RuntimeError as exc:
+        if "column \"node_name\" does not exist" not in str(exc).lower():
+            raise
+        rows = query_postgres(base_url, metrics_query_loop_name)
     row = _parse_metrics_row(rows[0] if rows else {})
     status = _normalize_execution_status(str(row.get("last_status_event") or ""))
     return status, int(row.get("iteration_count") or 0), int(row.get("event_count") or 0)


### PR DESCRIPTION
## Summary
- harden `test_reference_chain_loop_stress.py` against transient API/DB outages with bounded retries
- make polling SQL schema-compatible across environments (`node_name` first, `loop_name` fallback)
- refactor stress playbook page shaping into `fetch_page` task sequence and wire downstream steps to reduced page output

## Why
The stress gate was failing for non-functional reasons (transient DB recovery / API hiccups), and page result wrapping behavior was causing brittle field access in the stress playbook path.

## Validation
- ✅ `382` records passed end-to-end
  - execution_id: `585774931485393066`
  - finalize: `processed_total=382`, `pages_fetched=16`, `chain_contract_ok=true`
- ✅ `10000` records completed in local kind with stable progress and finalization
  - execution_id: `585776475081540440`
  - finalize: `processed_total=10000`, `pages_fetched=100`, `chain_contract_ok=true`

## Notes
- During validation, local Postgres had transient recovery windows; runner retries now tolerate those short interruptions.
