### PR TITLE
fix: recover stalled loops and retry transient postgres connection drops

### DIFF
--- a/noetl/core/cache/nats_kv.py
+++ b/noetl/core/cache/nats_kv.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 import nats
 from nats.js import JetStreamContext
 from nats.js.kv import KeyValue
+from nats.js.errors import KeyNotFoundError
 from noetl.core.logger import setup_logger
 from noetl.core.config import get_settings
 
@@ -119,6 +120,8 @@ class NATSKVCache:
             if entry and entry.value:
                 return json.loads(entry.value.decode('utf-8'))
             return None
+        except KeyNotFoundError:
+            return None
         except Exception as e:
             logger.warning(f"Failed to get loop state from NATS K/V: {e}")
             return None
@@ -165,9 +168,14 @@ class NATSKVCache:
         # caller may temporarily render an empty local collection.
         incoming_collection_size = int(state.get("collection_size", 0) or 0)
         existing_collection_size = 0
-        existing_state = await self.get_loop_state(execution_id, step_name, event_id=event_id)
-        if isinstance(existing_state, dict):
-            existing_collection_size = int(existing_state.get("collection_size", 0) or 0)
+        if incoming_collection_size <= 0:
+            existing_state = await self.get_loop_state(
+                execution_id,
+                step_name,
+                event_id=event_id,
+            )
+            if isinstance(existing_state, dict):
+                existing_collection_size = int(existing_state.get("collection_size", 0) or 0)
         if incoming_collection_size <= 0 and existing_collection_size > 0:
             state["collection_size"] = existing_collection_size
         else:

--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -1425,6 +1425,89 @@ class ControlFlowEngine:
             )
             return []
 
+    async def _find_orphaned_loop_iteration_indices(
+        self,
+        execution_id: str,
+        node_name: str,
+        loop_event_id: Optional[str] = None,
+        limit: int = 10,
+    ) -> list[int]:
+        """Find issued loop indexes that never started and have no terminal event."""
+        if limit <= 0:
+            return []
+
+        try:
+            loop_filter = ""
+            issued_params: list[Any] = [int(execution_id), node_name]
+            if loop_event_id:
+                loop_filter = "AND meta->>'loop_event_id' = %s"
+                issued_params.append(str(loop_event_id))
+
+            params: list[Any] = [
+                *issued_params,
+                int(execution_id),
+                node_name,
+                int(execution_id),
+                node_name,
+                int(limit),
+            ]
+
+            async with get_pool_connection() as conn:
+                async with conn.cursor(row_factory=dict_row) as cur:
+                    await cur.execute(
+                        f"""
+                        WITH issued AS (
+                            SELECT
+                                meta->>'command_id' AS command_id,
+                                NULLIF(meta->>'loop_iteration_index', '')::int AS loop_iteration_index
+                            FROM noetl.event
+                            WHERE execution_id = %s
+                              AND node_name = %s
+                              AND event_type = 'command.issued'
+                              {loop_filter}
+                        ),
+                        started AS (
+                            SELECT DISTINCT result->'data'->>'command_id' AS command_id
+                            FROM noetl.event
+                            WHERE execution_id = %s
+                              AND node_name = %s
+                              AND event_type = 'command.started'
+                        ),
+                        terminal AS (
+                            SELECT DISTINCT result->'data'->>'command_id' AS command_id
+                            FROM noetl.event
+                            WHERE execution_id = %s
+                              AND node_name = %s
+                              AND event_type IN ('command.completed', 'command.failed')
+                        )
+                        SELECT i.loop_iteration_index
+                        FROM issued i
+                        LEFT JOIN started s ON s.command_id = i.command_id
+                        LEFT JOIN terminal t ON t.command_id = i.command_id
+                        WHERE i.loop_iteration_index IS NOT NULL
+                          AND s.command_id IS NULL
+                          AND t.command_id IS NULL
+                        ORDER BY i.loop_iteration_index
+                        LIMIT %s
+                        """,
+                        tuple(params),
+                    )
+                    rows = await cur.fetchall()
+
+            return [
+                int(row.get("loop_iteration_index"))
+                for row in rows or []
+                if row.get("loop_iteration_index") is not None
+            ]
+        except Exception as exc:
+            logger.warning(
+                "[TASK_SEQ-LOOP] Failed to detect orphaned loop iterations for %s/%s: %s",
+                execution_id,
+                node_name,
+                exc,
+            )
+            return []
+
     def _get_loop_max_in_flight(self, step: Step) -> int:
         """Resolve max in-flight limit for loop scheduling."""
         if not step.loop:
@@ -2734,6 +2817,8 @@ class ControlFlowEngine:
                         or _parse_iso_utc(nats_loop_state.get("updated_at"))
                     )
                     last_repair = _parse_iso_utc(nats_loop_state.get("last_watchdog_repair_at"))
+                    if last_repair is None:
+                        last_repair = _parse_iso_utc(loop_state.get("last_watchdog_repair_at"))
 
                     stalled_seconds = (
                         (now_utc - last_progress).total_seconds()
@@ -2749,41 +2834,39 @@ class ControlFlowEngine:
                         stalled_seconds >= _LOOP_STALL_WATCHDOG_SECONDS
                         and repair_cooldown_elapsed
                     ):
-                        nats_loop_state["scheduled_count"] = completed_count
-                        nats_loop_state["completed_count"] = completed_count
-                        nats_loop_state["last_watchdog_repair_at"] = now_utc.isoformat()
-                        nats_loop_state["watchdog_repair_count"] = int(
-                            nats_loop_state.get("watchdog_repair_count", 0) or 0
-                        ) + 1
-
-                        await nats_cache.set_loop_state(
+                        orphaned_indexes = await self._find_orphaned_loop_iteration_indices(
                             str(state.execution_id),
                             step.step,
-                            nats_loop_state,
-                            event_id=resolved_loop_event_id,
+                            loop_event_id=resolved_loop_event_id,
+                            limit=max(1, _TASKSEQ_LOOP_REPAIR_THRESHOLD),
                         )
-                        nats_loop_state = await nats_cache.get_loop_state(
-                            str(state.execution_id),
-                            step.step,
-                            event_id=resolved_loop_event_id,
-                        )
-
-                        claimed_index = await nats_cache.claim_next_loop_index(
-                            str(state.execution_id),
-                            step.step,
-                            collection_size=len(collection),
-                            max_in_flight=max_in_flight,
-                            event_id=resolved_loop_event_id,
-                        )
-                        if claimed_index is not None:
-                            scheduled_hint = int(
-                                (nats_loop_state or {}).get("scheduled_count", completed_count + 1)
-                                or (completed_count + 1)
-                            )
-                            in_flight = max(0, scheduled_hint - completed_count)
+                        issued_repairs_raw = loop_state.get("repair_issued_indexes", [])
+                        issued_repairs = {
+                            int(idx)
+                            for idx in issued_repairs_raw
+                            if isinstance(idx, int) or (isinstance(idx, str) and str(idx).isdigit())
+                        }
+                        recovered_index: Optional[int] = None
+                        for orphaned_idx in orphaned_indexes:
+                            if (
+                                orphaned_idx in issued_repairs
+                                or orphaned_idx < completed_count
+                                or orphaned_idx >= collection_size_hint
+                            ):
+                                continue
+                            recovered_index = orphaned_idx
+                            break
+                        if recovered_index is not None:
+                            claimed_index = recovered_index
+                            issued_repairs.add(recovered_index)
+                            loop_state["repair_issued_indexes"] = sorted(issued_repairs)
+                            loop_state["last_watchdog_repair_at"] = now_utc.isoformat()
+                            loop_state["watchdog_repair_count"] = int(
+                                loop_state.get("watchdog_repair_count", 0) or 0
+                            ) + 1
                             logger.warning(
-                                "[LOOP-WATCHDOG] Recovered stalled loop for %s via %s "
-                                "(completed=%s scheduled_before=%s size=%s claimed=%s stalled_for=%.1fs)",
+                                "[LOOP-WATCHDOG] Recovered stalled loop for %s via orphaned index replay "
+                                "(event_id=%s completed=%s scheduled=%s size=%s claimed=%s stalled_for=%.1fs)",
                                 step.step,
                                 resolved_loop_event_id,
                                 completed_count,

--- a/noetl/tools/postgres/execution.py
+++ b/noetl/tools/postgres/execution.py
@@ -11,6 +11,7 @@ This module keeps database pressure predictable in distributed runs by:
 import asyncio
 import os
 import random
+import re
 import time as time_module
 from decimal import Decimal
 from datetime import date, datetime, time
@@ -66,6 +67,59 @@ def _is_retryable_connection_error(exc: Exception) -> bool:
     return any(marker in msg for marker in retry_markers)
 
 
+def _is_midstream_connection_drop_error(exc: Exception) -> bool:
+    """Detect abrupt connection loss while reading command results."""
+    msg = str(exc).lower()
+    retry_markers = (
+        "server closed the connection unexpectedly",
+        "terminating connection due to administrator command",
+        "connection is closed",
+        "connection already closed",
+        "consuming input failed",
+        "connection reset by peer",
+        "broken pipe",
+        "ssl syscall error",
+        "eof detected",
+    )
+    return any(marker in msg for marker in retry_markers)
+
+
+def _strip_leading_sql_comments(command: str) -> str:
+    text = (command or "").lstrip()
+    while text:
+        if text.startswith("/*"):
+            end = text.find("*/")
+            if end < 0:
+                return text
+            text = text[end + 2 :].lstrip()
+            continue
+        if text.startswith("--"):
+            newline = text.find("\n")
+            if newline < 0:
+                return ""
+            text = text[newline + 1 :].lstrip()
+            continue
+        break
+    return text
+
+
+def _sql_verb(command: str) -> str:
+    stripped = _strip_leading_sql_comments(command)
+    if not stripped:
+        return ""
+    match = re.match(r"([A-Za-z]+)", stripped)
+    return match.group(1).upper() if match else ""
+
+
+def _is_retry_safe_read_statement(command: str) -> bool:
+    """Allow mid-stream reconnect retry only for read-only statements."""
+    verb = _sql_verb(command)
+    if verb not in {"SELECT", "SHOW", "EXPLAIN", "VALUES", "DESCRIBE", "DESC"}:
+        return False
+    # Conservative guard: avoid replaying locking reads.
+    return "FOR UPDATE" not in (command or "").upper()
+
+
 _DIRECT_CONN_LIMIT = max(1, _env_int("NOETL_POSTGRES_MAX_DIRECT_CONNECTIONS", 4))
 _CONNECT_ATTEMPTS = max(1, _env_int("NOETL_POSTGRES_CONNECT_ATTEMPTS", 3))
 _RETRY_BASE_DELAY_SECONDS = max(
@@ -88,6 +142,12 @@ class _TransientConnectionDrop(Exception):
         self.partial_results = dict(partial_results or {})
 
 
+def _get_plugin_connection_ctx(connection_string: str, pool_name: str, **pool_params):
+    from .pool import get_plugin_connection
+
+    return get_plugin_connection(connection_string, pool_name=pool_name, **pool_params)
+
+
 async def _execute_with_pooled_connection(
     connection_string: str,
     commands: List[str],
@@ -98,13 +158,11 @@ async def _execute_with_pooled_connection(
     pool_name: str,
     pool_params: dict,
 ) -> Dict[str, Dict]:
-    from .pool import get_plugin_connection
-
     next_command_index = 0
     aggregated_results: Dict[str, Dict] = {}
     for attempt in range(1, _CONNECT_ATTEMPTS + 1):
         try:
-            async with get_plugin_connection(
+            async with _get_plugin_connection_ctx(
                 connection_string, pool_name=pool_name, **pool_params
             ) as conn:
                 conn_pid = conn.info.backend_pid if conn and conn.info else "unknown"
@@ -405,8 +463,8 @@ async def execute_sql_statements_async(
                                 "message": f"Command executed. {cursor.rowcount} rows affected.",
                             }
         except Exception as cmd_error:
-            is_transient_drop = _is_retryable_connection_error(cmd_error)
-            retryable_command = not is_call and not is_autocommit_ddl
+            is_transient_drop = _is_midstream_connection_drop_error(cmd_error)
+            retryable_command = _is_retry_safe_read_statement(cmd)
             if is_transient_drop and retryable_command:
                 logger.warning(
                     "[PID-%s] SQL command_%s transient drop detected (%s); "

--- a/tests/unit/core/cache/test_nats_kv_loop_claim.py
+++ b/tests/unit/core/cache/test_nats_kv_loop_claim.py
@@ -25,6 +25,11 @@ class _FakeKV:
         self.revision += 1
         return self.revision
 
+    async def put(self, _key: str, value: bytes):
+        self.payload = json.loads(value.decode("utf-8"))
+        self.revision += 1
+        return self.revision
+
 
 @pytest.mark.asyncio
 async def test_claim_next_loop_index_preserves_existing_nonzero_collection_size():
@@ -74,3 +79,55 @@ async def test_claim_next_loop_index_keeps_zero_when_no_existing_size():
     assert claimed is None
     assert fake_kv.payload["collection_size"] == 0
     assert fake_kv.payload["scheduled_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_set_loop_state_skips_existing_lookup_for_positive_collection_size(monkeypatch):
+    cache = NATSKVCache()
+    fake_kv = _FakeKV({"collection_size": 1, "completed_count": 0, "scheduled_count": 0})
+    cache._kv = fake_kv
+    lookup_calls = 0
+
+    async def fake_get_loop_state(*_args, **_kwargs):
+        nonlocal lookup_calls
+        lookup_calls += 1
+        return {"collection_size": 99}
+
+    monkeypatch.setattr(cache, "get_loop_state", fake_get_loop_state)
+
+    ok = await cache.set_loop_state(
+        execution_id="e3",
+        step_name="loop_step",
+        state={"collection_size": 4, "completed_count": 0, "scheduled_count": 0},
+        event_id="loop_3",
+    )
+
+    assert ok is True
+    assert lookup_calls == 0
+    assert fake_kv.payload["collection_size"] == 4
+
+
+@pytest.mark.asyncio
+async def test_set_loop_state_preserves_existing_collection_size_when_incoming_zero(monkeypatch):
+    cache = NATSKVCache()
+    fake_kv = _FakeKV({"collection_size": 1, "completed_count": 0, "scheduled_count": 0})
+    cache._kv = fake_kv
+    lookup_calls = 0
+
+    async def fake_get_loop_state(*_args, **_kwargs):
+        nonlocal lookup_calls
+        lookup_calls += 1
+        return {"collection_size": 8}
+
+    monkeypatch.setattr(cache, "get_loop_state", fake_get_loop_state)
+
+    ok = await cache.set_loop_state(
+        execution_id="e4",
+        step_name="loop_step",
+        state={"collection_size": 0, "completed_count": 1, "scheduled_count": 1},
+        event_id="loop_4",
+    )
+
+    assert ok is True
+    assert lookup_calls == 1
+    assert fake_kv.payload["collection_size"] == 8

--- a/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
+++ b/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
@@ -327,7 +327,11 @@ async def test_loop_watchdog_recovers_stalled_scheduled_counts(monkeypatch):
     async def fake_get_nats_cache():
         return fake_cache
 
+    async def fake_find_orphaned(*_args, **_kwargs):
+        return [1]
+
     monkeypatch.setattr(engine_module, "get_nats_cache", fake_get_nats_cache)
+    monkeypatch.setattr(engine, "_find_orphaned_loop_iteration_indices", fake_find_orphaned)
     monkeypatch.setattr(engine_module, "_LOOP_STALL_WATCHDOG_SECONDS", 1.0)
     monkeypatch.setattr(engine_module, "_LOOP_STALL_RECOVERY_COOLDOWN_SECONDS", 0.0)
 
@@ -337,5 +341,5 @@ async def test_loop_watchdog_recovers_stalled_scheduled_counts(monkeypatch):
     assert command is not None
     assert command.args.get("claimed_batch") == 2
     assert command.args.get("claimed_index") == 1
-    assert int(fake_cache.state.get("scheduled_count", 0)) == 2
-    assert int(fake_cache.state.get("watchdog_repair_count", 0)) >= 1
+    assert int(fake_cache.state.get("scheduled_count", 0)) == 4
+    assert int(state.loop_state["run_batch_workers"].get("watchdog_repair_count", 0)) >= 1

--- a/tests/unit/tools/postgres/test_execution_transient_retry.py
+++ b/tests/unit/tools/postgres/test_execution_transient_retry.py
@@ -25,6 +25,28 @@ class _FakeConn:
         return None
 
 
+class _FakePoolConnCtx:
+    async def __aenter__(self):
+        return _FakeConn()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_midstream_retry_safety_predicates():
+    assert execution_module._is_retry_safe_read_statement("SELECT 1")
+    assert execution_module._is_retry_safe_read_statement("/*hint*/\nSHOW search_path")
+    assert not execution_module._is_retry_safe_read_statement("INSERT INTO t VALUES (1)")
+    assert not execution_module._is_retry_safe_read_statement("SELECT * FROM t FOR UPDATE")
+
+    assert execution_module._is_midstream_connection_drop_error(
+        Exception("server closed the connection unexpectedly")
+    )
+    assert not execution_module._is_midstream_connection_drop_error(
+        Exception("statement timeout expired")
+    )
+
+
 @pytest.mark.asyncio
 async def test_direct_connection_retries_transient_drop_from_failed_index(monkeypatch):
     connect_calls = []
@@ -66,3 +88,52 @@ async def test_direct_connection_retries_transient_drop_from_failed_index(monkey
     assert execute_calls[1][1] == 1
     assert result["command_0"]["status"] == "success"
     assert result["command_1"]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_pooled_connection_retries_transient_drop_from_failed_index(monkeypatch):
+    pool_open_calls = []
+    execute_calls = []
+
+    def fake_get_plugin_connection_ctx(*_args, **_kwargs):
+        pool_open_calls.append(True)
+        return _FakePoolConnCtx()
+
+    async def fake_execute_sql_statements_async(_conn, commands, start_index=0):
+        execute_calls.append((list(commands), start_index))
+        if len(execute_calls) == 1:
+            raise execution_module._TransientConnectionDrop(
+                "server closed the connection unexpectedly",
+                failed_command_index=2,
+                partial_results={
+                    "command_0": {"status": "success", "row_count": 1},
+                    "command_1": {"status": "success", "row_count": 1},
+                },
+            )
+        return {"command_2": {"status": "success", "row_count": 1}}
+
+    async def fake_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(execution_module, "_get_plugin_connection_ctx", fake_get_plugin_connection_ctx)
+    monkeypatch.setattr(execution_module, "execute_sql_statements_async", fake_execute_sql_statements_async)
+    monkeypatch.setattr(execution_module, "_CONNECT_ATTEMPTS", 2)
+    monkeypatch.setattr(execution_module.asyncio, "sleep", fake_sleep)
+
+    result = await execution_module._execute_with_pooled_connection(
+        connection_string="postgresql://user:pass@host/db",
+        commands=["SELECT 1", "SELECT 2", "SELECT 3"],
+        conn_id="conn-2",
+        host="host",
+        port="5432",
+        database="db",
+        pool_name="pg_db",
+        pool_params={},
+    )
+
+    assert len(pool_open_calls) == 2
+    assert execute_calls[0][1] == 0
+    assert execute_calls[1][1] == 2
+    assert result["command_0"]["status"] == "success"
+    assert result["command_1"]["status"] == "success"
+    assert result["command_2"]["status"] == "success"


### PR DESCRIPTION
## Summary\n- prevent NATS KV loop claim paths from regressing known non-zero collection size to 0\n- add runtime loop-stall watchdog recovery for saturated stale scheduled counters\n- add transient connection-drop retry continuation for postgres command execution\n- add targeted regression tests for loop claim safety, watchdog recovery, and postgres transient retry\n\n## Validation\n- uv run pytest -q tests/unit/core/cache/test_nats_kv_loop_claim.py tests/unit/dsl/v2/test_loop_parallel_dispatch.py tests/unit/tools/postgres/test_execution_transient_retry.py\n- kind-noetl deploy with local/noetl:ahm-4316-4318-4320-4322\n- uv run python tests/scripts/test_reference_chain_loop_stress.py --base-url http://localhost:18082 --total-records 382 --page-size 25 --stall-seconds 120 --timeout 1200\n\n## Tracking\n- Jira: AHM-4316, AHM-4318, AHM-4320, AHM-4322\n- GitHub: #281 #282 #283 #284