### PR TITLE
fix: align execution detail status with terminal inference

### DIFF
--- a/noetl/server/api/execution/endpoint.py
+++ b/noetl/server/api/execution/endpoint.py
@@ -1055,28 +1055,36 @@ async def get_execution(
             """, {"execution_id": execution_id})
             latest_event = await cursor.fetchone()
 
-            await cursor.execute(
-                """
-                SELECT COUNT(*) AS pending_count
-                FROM (
-                    SELECT node_name
-                    FROM noetl.event
-                    WHERE execution_id = %(execution_id)s
-                      AND event_type = 'command.issued'
-                    EXCEPT
-                    SELECT node_name
-                    FROM noetl.event
-                    WHERE execution_id = %(execution_id)s
-                      AND event_type IN (
-                          'call.done',
-                          'command.completed',
-                          'command.failed'
-                      )
-                ) AS pending
-                """,
-                {"execution_id": execution_id},
+            pending_row = {"pending_count": 0}
+            should_check_pending_commands = (
+                terminal_event is None
+                and latest_event is not None
+                and latest_event.get("event_type") == "batch.completed"
+                and latest_event.get("status") == "COMPLETED"
             )
-            pending_row = await cursor.fetchone()
+            if should_check_pending_commands:
+                await cursor.execute(
+                    """
+                    SELECT COUNT(*) AS pending_count
+                    FROM (
+                        SELECT node_name
+                        FROM noetl.event
+                        WHERE execution_id = %(execution_id)s
+                          AND event_type = 'command.issued'
+                        EXCEPT
+                        SELECT node_name
+                        FROM noetl.event
+                        WHERE execution_id = %(execution_id)s
+                          AND event_type IN (
+                              'call.done',
+                              'command.completed',
+                              'command.failed'
+                          )
+                    ) AS pending
+                    """,
+                    {"execution_id": execution_id},
+                )
+                pending_row = await cursor.fetchone()
 
     if first_event is None:
         # No events found - check v2 engine fallback

--- a/tests/api/execution/test_executions_status_consistency.py
+++ b/tests/api/execution/test_executions_status_consistency.py
@@ -233,3 +233,75 @@ async def test_get_execution_infers_completed_from_batch_done_without_pending_co
     assert result["status"] == "COMPLETED"
     assert result["end_time"] == latest.isoformat()
     assert result["duration_human"] == "1h 51m 2s"
+
+
+@pytest.mark.asyncio
+async def test_get_execution_prefers_terminal_failure_over_batch_completion_inference(monkeypatch):
+    start = datetime(2026, 3, 21, 8, 12, 52, tzinfo=timezone.utc)
+    latest = datetime(2026, 3, 21, 10, 3, 54, tzinfo=timezone.utc)
+    terminal = datetime(2026, 3, 21, 10, 3, 40, tzinfo=timezone.utc)
+    event_rows = [
+        {
+            "event_id": 587372302669448146,
+            "event_type": "batch.completed",
+            "node_id": "events.batch",
+            "node_name": "events.batch",
+            "status": "COMPLETED",
+            "created_at": latest,
+            "context": None,
+            "result": None,
+            "error": None,
+            "catalog_id": 7,
+            "parent_execution_id": None,
+            "parent_event_id": None,
+            "duration": None,
+        }
+    ]
+    first_event = {
+        "event_id": 1,
+        "event_type": "playbook.initialized",
+        "catalog_id": 7,
+        "parent_execution_id": None,
+        "created_at": start,
+        "status": "INITIALIZED",
+    }
+    latest_event = {
+        "event_type": "batch.completed",
+        "node_name": "events.batch",
+        "created_at": latest,
+        "status": "COMPLETED",
+    }
+    terminal_event = {
+        "event_type": "playbook.failed",
+        "status": "FAILED",
+        "created_at": terminal,
+    }
+    catalog_row = {"path": "bhs/state_report_generation_prod_v10", "version": 7}
+
+    monkeypatch.setattr(
+        execution_api,
+        "get_pool_connection",
+        _ConnectionFactory(
+            _FakeConn(
+                _GetExecutionCursor(
+                    events=event_rows,
+                    first_event=first_event,
+                    terminal_event=terminal_event,
+                    latest_event=latest_event,
+                    pending_row={"pending_count": 0},
+                )
+            ),
+            _FakeConn(_CatalogCursor(catalog_row)),
+        ),
+    )
+
+    result = await execution_api.get_execution(
+        "587316413618979403",
+        page=1,
+        page_size=100,
+        since_event_id=None,
+        event_type=None,
+    )
+
+    assert result["status"] == "FAILED"
+    assert result["end_time"] == terminal.isoformat()


### PR DESCRIPTION
## Summary
- align `/api/executions/{id}` status derivation with the terminal inference already used by `/api/executions/{id}/status`
- mark detail responses as `COMPLETED` when the latest event is `batch.completed` and there are no pending commands
- preserve explicit terminal lifecycle events as the first source of truth
- add a regression test covering the production mismatch seen on execution `587316413618979403`

## Validation
- `uv run pytest -q tests/api/execution/test_executions_status_consistency.py tests/api/test_v2_execution_status_terminal.py`
