### PR TITLE
fix: keep repeated batch executions running until all commands finish

### DIFF
--- a/noetl/server/api/event_queries.py
+++ b/noetl/server/api/event_queries.py
@@ -1,0 +1,38 @@
+PENDING_COMMAND_COUNT_SQL = """
+    WITH issued_commands AS (
+        SELECT meta->>'command_id' AS command_id
+        FROM noetl.event
+        WHERE execution_id = %(execution_id)s
+          AND event_type = 'command.issued'
+          AND meta ? 'command_id'
+        UNION ALL
+        SELECT result->'data'->>'command_id' AS command_id
+        FROM noetl.event
+        WHERE execution_id = %(execution_id)s
+          AND event_type = 'command.issued'
+          AND (result->'data') ? 'command_id'
+    ),
+    finished_commands AS (
+        SELECT meta->>'command_id' AS command_id
+        FROM noetl.event
+        WHERE execution_id = %(execution_id)s
+          AND event_type IN ('call.done', 'command.completed', 'command.failed')
+          AND meta ? 'command_id'
+        UNION ALL
+        SELECT result->'data'->>'command_id' AS command_id
+        FROM noetl.event
+        WHERE execution_id = %(execution_id)s
+          AND event_type IN ('call.done', 'command.completed', 'command.failed')
+          AND (result->'data') ? 'command_id'
+    )
+    SELECT COUNT(*) AS pending_count
+    FROM (
+        SELECT command_id
+        FROM issued_commands
+        WHERE command_id IS NOT NULL
+        EXCEPT
+        SELECT command_id
+        FROM finished_commands
+        WHERE command_id IS NOT NULL
+    ) AS pending
+"""

--- a/noetl/server/api/execution/endpoint.py
+++ b/noetl/server/api/execution/endpoint.py
@@ -13,6 +13,7 @@ from psycopg.types.json import Json
 from noetl.core.db.pool import get_pool_connection, get_snowflake_id
 from noetl.core.logger import setup_logger
 from noetl.core.common import convert_snowflake_ids_for_api
+from noetl.server.api.event_queries import PENDING_COMMAND_COUNT_SQL
 from .schema import (
     ExecutionEntryResponse,
     CancelExecutionRequest,
@@ -313,44 +314,7 @@ def _derive_execution_terminal_status(row: Optional[dict[str, Any]]) -> str:
     return "RUNNING"
 
 
-_PENDING_COMMAND_COUNT_SQL = """
-    WITH issued_commands AS (
-        SELECT meta->>'command_id' AS command_id
-        FROM noetl.event
-        WHERE execution_id = %(execution_id)s
-          AND event_type = 'command.issued'
-          AND meta ? 'command_id'
-        UNION
-        SELECT result->'data'->>'command_id' AS command_id
-        FROM noetl.event
-        WHERE execution_id = %(execution_id)s
-          AND event_type = 'command.issued'
-          AND (result->'data') ? 'command_id'
-    ),
-    finished_commands AS (
-        SELECT meta->>'command_id' AS command_id
-        FROM noetl.event
-        WHERE execution_id = %(execution_id)s
-          AND event_type IN ('call.done', 'command.completed', 'command.failed')
-          AND meta ? 'command_id'
-        UNION
-        SELECT result->'data'->>'command_id' AS command_id
-        FROM noetl.event
-        WHERE execution_id = %(execution_id)s
-          AND event_type IN ('call.done', 'command.completed', 'command.failed')
-          AND (result->'data') ? 'command_id'
-    )
-    SELECT COUNT(*) AS pending_count
-    FROM (
-        SELECT command_id
-        FROM issued_commands
-        WHERE command_id IS NOT NULL
-        EXCEPT
-        SELECT command_id
-        FROM finished_commands
-        WHERE command_id IS NOT NULL
-    ) AS pending
-"""
+_PENDING_COMMAND_COUNT_SQL = PENDING_COMMAND_COUNT_SQL
 
 
 def _infer_execution_completion_from_events(

--- a/noetl/server/api/v2.py
+++ b/noetl/server/api/v2.py
@@ -29,6 +29,7 @@ from noetl.core.dsl.v2.engine import ControlFlowEngine, PlaybookRepo, StateStore
 from noetl.core.db.pool import get_pool_connection, get_server_pool_stats
 from noetl.core.messaging import NATSCommandPublisher
 from noetl.claim_policy import decide_reclaim_for_existing_claim
+from noetl.server.api.event_queries import PENDING_COMMAND_COUNT_SQL
 
 from noetl.core.logger import setup_logger
 logger = setup_logger(__name__, include_location=True)
@@ -491,44 +492,7 @@ _HANDLE_EVENT_CLAIMED_LOOKUP_SQL = _build_command_id_latest_lookup_sql(
     event_type_predicate=_EVENT_TYPE_CLAIMED_PREDICATE,
     alias="claimed_event",
 )
-_PENDING_COMMAND_COUNT_SQL = """
-    WITH issued_commands AS (
-        SELECT meta->>'command_id' AS command_id
-        FROM noetl.event
-        WHERE execution_id = %(execution_id)s
-          AND event_type = 'command.issued'
-          AND meta ? 'command_id'
-        UNION
-        SELECT result->'data'->>'command_id' AS command_id
-        FROM noetl.event
-        WHERE execution_id = %(execution_id)s
-          AND event_type = 'command.issued'
-          AND (result->'data') ? 'command_id'
-    ),
-    finished_commands AS (
-        SELECT meta->>'command_id' AS command_id
-        FROM noetl.event
-        WHERE execution_id = %(execution_id)s
-          AND event_type IN ('call.done', 'command.completed', 'command.failed')
-          AND meta ? 'command_id'
-        UNION
-        SELECT result->'data'->>'command_id' AS command_id
-        FROM noetl.event
-        WHERE execution_id = %(execution_id)s
-          AND event_type IN ('call.done', 'command.completed', 'command.failed')
-          AND (result->'data') ? 'command_id'
-    )
-    SELECT COUNT(*) AS pending_count
-    FROM (
-        SELECT command_id
-        FROM issued_commands
-        WHERE command_id IS NOT NULL
-        EXCEPT
-        SELECT command_id
-        FROM finished_commands
-        WHERE command_id IS NOT NULL
-    ) AS pending
-"""
+_PENDING_COMMAND_COUNT_SQL = PENDING_COMMAND_COUNT_SQL
 
 
 @dataclass(slots=True)

--- a/tests/api/execution/test_executions_status_consistency.py
+++ b/tests/api/execution/test_executions_status_consistency.py
@@ -108,6 +108,7 @@ def test_pending_command_count_sql_tracks_command_ids():
     sql = " ".join(execution_api._PENDING_COMMAND_COUNT_SQL.split())
     assert "meta->>'command_id'" in sql
     assert "result->'data'->>'command_id'" in sql
+    assert "UNION ALL" in sql
     assert "SELECT node_name" not in sql
 
 

--- a/tests/api/test_v2_execution_status_terminal.py
+++ b/tests/api/test_v2_execution_status_terminal.py
@@ -85,6 +85,7 @@ def test_v2_pending_command_count_sql_tracks_command_ids():
     sql = " ".join(v2_api._PENDING_COMMAND_COUNT_SQL.split())
     assert "meta->>'command_id'" in sql
     assert "result->'data'->>'command_id'" in sql
+    assert "UNION ALL" in sql
     assert "SELECT node_name" not in sql
 
 


### PR DESCRIPTION
## Summary
- keep execution completion inference keyed on unique command ids instead of shared node names
- apply the same pending-command logic to both `/api/executions/{id}` and `/api/executions/{id}/status`
- add regressions for repeated batch loop work so active executions do not flip to COMPLETED early

## Validation
- uv run pytest -q tests/api/execution tests/api/test_v2_execution_status_terminal.py tests/api/test_v2_command_id_lookup_sql.py tests/api/test_active_claim_cache.py tests/api/test_v2_db_resilience.py

## Context
- Fixes #292
- Jira: AHM-4330
- Production reproduction: execution `588463546770392019` on `bhs/state_report_generation_prod_v10` reported COMPLETED while `events.batch` loop work was still active.