### PR TITLE
fix: preserve ctx and iter dict lookup in render templates

### DIFF
--- a/noetl/core/dsl/render.py
+++ b/noetl/core/dsl/render.py
@@ -233,7 +233,23 @@ def render_template(env: Environment, template: Any, context: Dict, rules: Dict 
             try:
                 custom_context = render_ctx.copy()
 
-                reserved = {'work', 'workload', 'context', 'env', 'job', 'input', 'data', 'results'}
+                reserved = {
+                    'work',
+                    'workload',
+                    'context',
+                    'env',
+                    'job',
+                    'input',
+                    'data',
+                    'results',
+                    # Keep execution/iteration namespaces as plain dicts so
+                    # Jinja can perform normal item lookup (e.g. ctx.foo)
+                    # without TaskResultProxy interfering with runtime vars.
+                    'ctx',
+                    'iter',
+                    'loop',
+                    'event',
+                }
                 for key, value in render_ctx.items():
                     if key in reserved:
                         continue

--- a/tests/render/test_result_addressing.py
+++ b/tests/render/test_result_addressing.py
@@ -26,3 +26,33 @@ def test_step_result_addressing_default_elapsed():
         strict_keys=True,
     )
     assert out == 0
+
+
+def test_ctx_namespace_uses_plain_dict_lookup():
+    env = Environment(loader=BaseLoader(), undefined=StrictUndefined)
+    ctx = {
+        'ctx': {
+            'facility_mapping_id': 53,
+            'facility_org_uuid': 'org-1',
+        },
+        'facility_mapping_id': 53,
+        'workload': {},
+    }
+
+    out = render_template(env, "{{ ctx.facility_mapping_id }}", ctx, strict_keys=True)
+    assert out == 53
+
+
+def test_iter_namespace_uses_plain_dict_lookup():
+    env = Environment(loader=BaseLoader(), undefined=StrictUndefined)
+    ctx = {
+        'iter': {
+            'patient': {
+                'patient_id': 101,
+            }
+        },
+        'workload': {},
+    }
+
+    out = render_template(env, "{{ iter.patient.patient_id }}", ctx, strict_keys=True)
+    assert out == 101


### PR DESCRIPTION
## Summary\n- keep execution namespaces like ctx and iter as plain dicts during Jinja rendering\n- prevent TaskResultProxy from breaking runtime variable lookups like ctx.facility_mapping_id\n- add focused render regressions for ctx and iter lookups\n\n## Validation\n- uv run pytest -q tests/render/test_result_addressing.py\n\n## Context\nThis fixes the prod failure seen in execution 588775268844568971 where rendering  failed and malformed SQL reached Postgres.