### PR TITLE
fix: restore replayed set_ctx state from persisted events

### DIFF
--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -866,6 +866,8 @@ class StateStore:
                 loop_iteration_state: dict[str, dict[str, Any]] = {}
                 loop_iteration_counts: dict[str, int] = {}
                 loop_event_ids = {}  # {step_name: loop_event_id}
+                replay_render_env = Environment(undefined=StrictUndefined)
+                from noetl.core.dsl.render import render_template as recursive_render
                 
                 for row in rows:
                     if isinstance(row, dict):
@@ -905,6 +907,18 @@ class StateStore:
                     event_payload = result_data
                     if isinstance(result_data, dict) and "kind" in result_data and "data" in result_data:
                         event_payload = result_data.get("data")
+
+                    # Task-sequence policy rules can mutate ctx on the worker. Replay must
+                    # restore those execution-scoped variables from persisted call.done events
+                    # so a cache miss on another server does not lose them.
+                    if event_type == 'call.done' and isinstance(event_payload, dict) and isinstance(node_name, str) and node_name.endswith(":task_sequence"):
+                        response_data = event_payload.get("response", event_payload)
+                        if isinstance(response_data, dict):
+                            task_ctx = response_data.get("ctx", {})
+                            if isinstance(task_ctx, dict):
+                                for key, value in task_ctx.items():
+                                    state.variables[key] = value
+                                    logger.debug("[STATE-LOAD] Replayed task-sequence ctx: %s", key)
 
                     # For loop steps, collect iteration results from step.exit events
                     if event_type == 'step.exit' and event_payload and node_name in loop_steps:
@@ -959,6 +973,36 @@ class StateStore:
                             else event_payload
                         )
                         state.mark_step_completed(node_name, step_result)
+
+                        step_def = state.get_step(node_name)
+                        if step_def and step_def.set_ctx:
+                            replay_event = Event(
+                                execution_id=execution_id,
+                                step=node_name,
+                                name="step.exit",
+                                payload=event_payload if isinstance(event_payload, dict) else {"result": event_payload},
+                            )
+                            context = state.get_render_context(replay_event)
+                            for key, value_template in step_def.set_ctx.items():
+                                try:
+                                    if isinstance(value_template, str) and "{{" in value_template:
+                                        rendered_value = recursive_render(
+                                            replay_render_env,
+                                            value_template,
+                                            context,
+                                            strict_keys=True,
+                                        )
+                                    else:
+                                        rendered_value = value_template
+                                    state.variables[key] = rendered_value
+                                    logger.debug("[STATE-LOAD] Replayed set_ctx %s from %s", key, node_name)
+                                except Exception as exc:
+                                    logger.warning(
+                                        "[STATE-LOAD] Failed to replay set_ctx %s for %s: %s",
+                                        key,
+                                        node_name,
+                                        exc,
+                                    )
                 
                 # Initialize loop_state for loop steps with collected iteration results
                 for step_name in loop_steps:

--- a/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
+++ b/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
@@ -362,6 +362,138 @@ async def test_state_replay_unwraps_step_exit_result_and_skips_task_sequence_com
 
 
 @pytest.mark.asyncio
+async def test_state_replay_restores_set_ctx_variables_for_later_steps(monkeypatch):
+    playbook = Playbook(**yaml.safe_load(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: replay_set_ctx
+  path: tests/replay_set_ctx
+workload:
+  pg_auth: pg_k8s
+workflow:
+  - step: load_next_facility
+    tool:
+      kind: postgres
+      auth: pg_k8s
+      query: SELECT 1;
+    set_ctx:
+      facility_mapping_id: "{{ load_next_facility.command_0.rows[0].facility_mapping_id }}"
+      facility_id: "{{ load_next_facility.command_0.rows[0].facility_id }}"
+  - step: load_patient_ids_context
+    tool:
+      kind: postgres
+      auth: pg_k8s
+      query: SELECT 1;
+    set_ctx:
+      patient_count: "{{ load_patient_ids_context.command_0.rows[0].patient_count | int }}"
+      facility_mapping_id: "{{ load_next_facility.command_0.rows[0].facility_mapping_id }}"
+  - step: load_patients_for_assessments
+    tool:
+      kind: postgres
+      auth: pg_k8s
+      query: |
+        SELECT w.patient_id
+        FROM public.patient_ids_work w
+        WHERE w.facility_mapping_id = {{ facility_mapping_id }}
+          AND {{ patient_count }} > 0;
+        """
+    ))
+    playbook_repo = PlaybookRepo()
+    state_store = StateStore(playbook_repo)
+
+    async def fake_load_playbook_by_id(_catalog_id):
+        return playbook
+
+    monkeypatch.setattr(playbook_repo, "load_playbook_by_id", fake_load_playbook_by_id)
+
+    class FakeCursor:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, query, _params):
+            self.last_query = query
+
+        async def fetchone(self):
+            return {
+                "catalog_id": "cat-ctx",
+                "result": {"workload": {"pg_auth": "pg_k8s"}},
+            }
+
+        async def fetchall(self):
+            return [
+                {
+                    "node_name": "load_next_facility",
+                    "event_type": "step.exit",
+                    "result": {
+                        "kind": "data",
+                        "data": {
+                            "result": {
+                                "command_0": {
+                                    "rows": [
+                                        {
+                                            "facility_mapping_id": 53,
+                                            "facility_id": 777,
+                                        }
+                                    ],
+                                    "row_count": 1,
+                                }
+                            },
+                            "status": "completed",
+                        },
+                    },
+                    "meta": None,
+                },
+                {
+                    "node_name": "load_patient_ids_context",
+                    "event_type": "step.exit",
+                    "result": {
+                        "kind": "data",
+                        "data": {
+                            "result": {
+                                "command_0": {
+                                    "rows": [{"patient_count": 3}],
+                                    "row_count": 1,
+                                }
+                            },
+                            "status": "completed",
+                        },
+                    },
+                    "meta": None,
+                },
+            ]
+
+    class FakeConnection:
+        def cursor(self, row_factory=None):  # noqa: ARG002
+            return FakeCursor()
+
+    class FakeConnectionContext:
+        async def __aenter__(self):
+            return FakeConnection()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(engine_module, "get_pool_connection", lambda: FakeConnectionContext())
+
+    state = await state_store.load_state("9021")
+
+    assert state is not None
+    assert state.variables["facility_mapping_id"] == 53
+    assert state.variables["facility_id"] == 777
+    assert state.variables["patient_count"] == 3
+
+    context = state.get_render_context(Event(execution_id="9021", step="load_patients_for_assessments", name="call.done", payload={}))
+    assert context["facility_mapping_id"] == 53
+    assert context["ctx"]["facility_mapping_id"] == 53
+    assert context["patient_count"] == 3
+
+
+@pytest.mark.asyncio
 async def test_terminal_events_emit_when_pending_key_is_task_sequence_suffix(monkeypatch):
     fixture = Path(
         "tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step/"


### PR DESCRIPTION
## Summary
- replay execution-scoped set_ctx values from persisted step.exit events during StateStore cache misses
- replay task-sequence ctx mutations from persisted call.done events
- add regression coverage proving later steps still see facility and patient context after state reload

## Why
With two server instances, correctness cannot depend on pod memory. This makes persisted events authoritative for rebuilding execution state after server handoff or cache loss.

## Validation
- uv run pytest -q tests/render/test_result_addressing.py tests/unit/dsl/v2/test_task_sequence_loop_completion.py