### PR TITLE
fix: invalidate stale cross-pod execution state cache

### DIFF
--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -757,6 +757,48 @@ class StateStore:
         # No need to persist to workload table - it's redundant with event log
         # Just keep in memory cache for performance
         logger.debug(f"State cached in memory for execution {state.execution_id}")
+
+    async def should_refresh_cached_state(
+        self,
+        execution_id: str,
+        last_event_id: Optional[int],
+        *,
+        allowed_missing_events: int = 1,
+    ) -> bool:
+        """Return True when cached state is older than the persisted event stream.
+
+        When API/event ingestion persists the current event before calling the engine,
+        a healthy local cache should lag by at most that single event. If more than one
+        newer event exists in Postgres, another server advanced the execution and the
+        local in-memory snapshot is stale.
+        """
+        if last_event_id is None:
+            return True
+
+        async with get_pool_connection() as conn:
+            async with conn.cursor(row_factory=dict_row) as cur:
+                await cur.execute(
+                    """
+                    SELECT COUNT(*)::int AS newer_count, MAX(event_id) AS latest_event_id
+                    FROM noetl.event
+                    WHERE execution_id = %s AND event_id > %s
+                    """,
+                    (int(execution_id), int(last_event_id)),
+                )
+                row = await cur.fetchone()
+
+        newer_count = int((row or {}).get("newer_count", 0) or 0)
+        latest_event_id = (row or {}).get("latest_event_id")
+        refresh = newer_count > max(0, allowed_missing_events)
+        if refresh:
+            logger.warning(
+                "[STATE-CACHE-STALE] execution_id=%s last_event_id=%s latest_event_id=%s newer_count=%s",
+                execution_id,
+                last_event_id,
+                latest_event_id,
+                newer_count,
+            )
+        return refresh
     
     async def load_state(self, execution_id: str) -> Optional[ExecutionState]:
         """Load execution state from memory or reconstruct from events."""
@@ -853,7 +895,7 @@ class StateStore:
                 
                 # Replay events to rebuild state (event sourcing)
                 await cur.execute("""
-                    SELECT node_name, event_type, result, meta
+                    SELECT event_id, node_name, event_type, result, meta
                     FROM noetl.event
                     WHERE execution_id = %s
                     ORDER BY event_id
@@ -871,15 +913,22 @@ class StateStore:
                 
                 for row in rows:
                     if isinstance(row, dict):
+                        event_id = row.get("event_id")
                         node_name = row.get("node_name")
                         event_type = row.get("event_type")
                         result_data = row.get("result")
                         meta_data = row.get("meta")
                     else:
-                        node_name = row[0]
-                        event_type = row[1]
-                        result_data = row[2]
-                        meta_data = row[3] if len(row) > 3 else None
+                        event_id = row[0]
+                        node_name = row[1]
+                        event_type = row[2]
+                        result_data = row[3]
+                        meta_data = row[4] if len(row) > 4 else None
+
+                    if event_id is not None:
+                        state.last_event_id = int(event_id)
+                        if isinstance(node_name, str) and node_name:
+                            state.step_event_ids[node_name] = int(event_id)
 
                     # Track issued commands for pending detection (race condition fix)
                     if event_type == 'command.issued':
@@ -3203,7 +3252,24 @@ class ControlFlowEngine:
         commands: list[Command] = []
         normalized_payload = _unwrap_event_payload(event.payload)
         
-        # Load execution state (from memory cache or reconstruct from events)
+        # Load execution state. For already-persisted events we must guard against
+        # stale per-pod memory snapshots when another server advanced this execution.
+        if already_persisted:
+            cached_state = self.state_store.get_state(event.execution_id)
+            if (
+                cached_state
+                and cached_state.last_event_id is not None
+                and await self.state_store.should_refresh_cached_state(
+                    event.execution_id,
+                    cached_state.last_event_id,
+                    allowed_missing_events=1,
+                )
+            ):
+                await self.state_store.invalidate_state(
+                    event.execution_id,
+                    reason="stale_cache_newer_persisted_events",
+                )
+
         state = await self.state_store.load_state(event.execution_id)
         if not state:
             logger.error(f"Execution state not found: {event.execution_id}")

--- a/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
+++ b/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
@@ -779,3 +779,195 @@ async def test_completed_execution_short_circuits_late_events(monkeypatch):
     commands = await engine.handle_event(event, already_persisted=True)
 
     assert commands == []
+
+
+@pytest.mark.asyncio
+async def test_state_replay_restores_event_watermark(monkeypatch):
+    playbook = Playbook(**yaml.safe_load(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: replay_event_ids
+  path: tests/replay_event_ids
+workload:
+  pg_auth: pg_k8s
+workflow:
+  - step: load_next_facility
+    tool:
+      kind: postgres
+      auth: pg_k8s
+      query: SELECT 1;
+  - step: load_patient_ids_context
+    tool:
+      kind: postgres
+      auth: pg_k8s
+      query: SELECT 1;
+        """
+    ))
+    playbook_repo = PlaybookRepo()
+    state_store = StateStore(playbook_repo)
+
+    async def fake_load_playbook_by_id(_catalog_id):
+        return playbook
+
+    monkeypatch.setattr(playbook_repo, "load_playbook_by_id", fake_load_playbook_by_id)
+
+    class FakeCursor:
+        def __init__(self):
+            self.last_query = ""
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, query, _params):
+            self.last_query = query
+
+        async def fetchone(self):
+            return {
+                "catalog_id": "cat-event-ids",
+                "result": {"workload": {"pg_auth": "pg_k8s"}},
+            }
+
+        async def fetchall(self):
+            return [
+                {
+                    "event_id": 101,
+                    "node_name": "load_next_facility",
+                    "event_type": "step.exit",
+                    "result": {
+                        "kind": "data",
+                        "data": {"result": {"command_0": {"rows": [{"facility_mapping_id": 53}]}}},
+                    },
+                    "meta": None,
+                },
+                {
+                    "event_id": 102,
+                    "node_name": "load_patient_ids_context",
+                    "event_type": "step.exit",
+                    "result": {
+                        "kind": "data",
+                        "data": {"result": {"command_0": {"rows": [{"patient_count": 3}]}}},
+                    },
+                    "meta": None,
+                },
+            ]
+
+    class FakeConnection:
+        def cursor(self, row_factory=None):  # noqa: ARG002
+            return FakeCursor()
+
+    class FakeConnectionContext:
+        async def __aenter__(self):
+            return FakeConnection()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(engine_module, "get_pool_connection", lambda: FakeConnectionContext())
+
+    state = await state_store.load_state("9030")
+
+    assert state is not None
+    assert state.last_event_id == 102
+    assert state.step_event_ids["load_next_facility"] == 101
+    assert state.step_event_ids["load_patient_ids_context"] == 102
+
+
+@pytest.mark.asyncio
+async def test_handle_event_invalidates_stale_cached_state(monkeypatch):
+    playbook = Playbook(**yaml.safe_load(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: stale_cache_refresh
+  path: tests/stale_cache_refresh
+workflow:
+  - step: start
+    tool:
+      kind: python
+      code: |
+        result = {"ok": True}
+        """
+    ))
+    playbook_repo = PlaybookRepo()
+    state_store = StateStore(playbook_repo)
+    engine = ControlFlowEngine(playbook_repo, state_store)
+
+    execution_id = "9031"
+    stale_state = ExecutionState(execution_id, playbook, payload={})
+    stale_state.last_event_id = 10
+    await state_store.save_state(stale_state)
+
+    refreshed_state = ExecutionState(execution_id, playbook, payload={})
+    refreshed_state.last_event_id = 12
+
+    invalidate_calls = []
+
+    async def fake_should_refresh(_execution_id, _last_event_id, *, allowed_missing_events=1):
+        assert _execution_id == execution_id
+        assert _last_event_id == 10
+        assert allowed_missing_events == 1
+        return True
+
+    async def fake_invalidate(execution_id_arg, reason="manual"):
+        invalidate_calls.append((execution_id_arg, reason))
+        return True
+
+    async def fake_load_state(_execution_id):
+        assert _execution_id == execution_id
+        return refreshed_state
+
+    async def fake_persist_event(_event, state_obj):
+        state_obj.last_event_id = (state_obj.last_event_id or 0) + 1
+
+    async def fake_save_state(_state):
+        return None
+
+    class FakeCursor:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, query, _params=None):
+            self.last_query = query
+
+        async def fetchone(self):
+            return {"pending_count": 0}
+
+    class FakeConnection:
+        def cursor(self, row_factory=None):  # noqa: ARG002
+            return FakeCursor()
+
+    class FakeConnectionContext:
+        async def __aenter__(self):
+            return FakeConnection()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(engine_module, "get_pool_connection", lambda: FakeConnectionContext())
+    monkeypatch.setattr(state_store, "should_refresh_cached_state", fake_should_refresh)
+    monkeypatch.setattr(state_store, "invalidate_state", fake_invalidate)
+    monkeypatch.setattr(state_store, "load_state", fake_load_state)
+    monkeypatch.setattr(engine, "_persist_event", fake_persist_event)
+    monkeypatch.setattr(state_store, "save_state", fake_save_state)
+
+    event = Event(
+        execution_id=execution_id,
+        step="start",
+        name="call.done",
+        payload={"response": {"status": "completed", "result": {"ok": True}}},
+    )
+
+    await engine.handle_event(event, already_persisted=True)
+
+    assert invalidate_calls == [
+        (execution_id, "stale_cache_newer_persisted_events")
+    ]


### PR DESCRIPTION
## Summary
- invalidate cached execution state when persisted events show another server advanced the execution
- restore replayed event watermarks so freshness checks have a durable baseline
- add regression coverage for stale cache invalidation and replayed event ids

## Why
With multiple server pods, a local in-memory snapshot may be older than the persisted event stream. This change keeps memory as a cache while making Postgres event history authoritative when another pod has already processed newer events.

## Validation
- uv run pytest -q tests/render/test_result_addressing.py tests/unit/dsl/v2/test_task_sequence_loop_completion.py