### PR TITLE
fix: keep call.done from closing pending commands

### DIFF
--- a/noetl/server/api/event_queries.py
+++ b/noetl/server/api/event_queries.py
@@ -16,13 +16,13 @@ PENDING_COMMAND_COUNT_SQL = """
         SELECT meta->>'command_id' AS command_id
         FROM noetl.event
         WHERE execution_id = %(execution_id)s
-          AND event_type IN ('command.completed', 'command.failed')
+          AND event_type IN ('command.completed', 'command.failed', 'command.cancelled')
           AND meta ? 'command_id'
         UNION ALL
         SELECT result->'data'->>'command_id' AS command_id
         FROM noetl.event
         WHERE execution_id = %(execution_id)s
-          AND event_type IN ('command.completed', 'command.failed')
+          AND event_type IN ('command.completed', 'command.failed', 'command.cancelled')
           AND (result->'data') ? 'command_id'
     )
     SELECT COUNT(*) AS pending_count

--- a/tests/api/execution/test_executions_status_consistency.py
+++ b/tests/api/execution/test_executions_status_consistency.py
@@ -113,6 +113,9 @@ def test_pending_command_count_sql_tracks_command_ids():
     assert "UNION ALL" in sql
     assert "SELECT node_name" not in sql
     assert "'call.done'" not in sql
+    assert "'command.completed'" in sql
+    assert "'command.failed'" in sql
+    assert "'command.cancelled'" in sql
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_v2_execution_status_terminal.py
+++ b/tests/api/test_v2_execution_status_terminal.py
@@ -88,6 +88,9 @@ def test_v2_pending_command_count_sql_tracks_command_ids():
     assert "UNION ALL" in sql
     assert "SELECT node_name" not in sql
     assert "'call.done'" not in sql
+    assert "'command.completed'" in sql
+    assert "'command.failed'" in sql
+    assert "'command.cancelled'" in sql
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- stop treating `call.done` as a terminal command event in shared pending-command inference
- keep `/status` and execution detail from inferring `COMPLETED` while task-sequence work is still active
- lock the SQL shape with regressions

## Validation
- `uv run pytest -q tests/api/test_v2_execution_status_terminal.py tests/api/execution/test_executions_status_consistency.py`
- `15 passed`

## Related
- fixes #305
