### PR TITLE
fix: persist task sequence continuation state

### DIFF
--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -3734,6 +3734,8 @@ class ControlFlowEngine:
             # returns. Persist that state before returning so later status/completion checks
             # do not see a stale pre-continuation snapshot.
             await self.state_store.save_state(state)
+            if not already_persisted:
+                await self._persist_event(event, state)
             return commands
 
         # Task-sequence lifecycle is driven by call.done/call.error. The corresponding

--- a/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
+++ b/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
@@ -304,6 +304,91 @@ async def test_task_sequence_loop_persists_issued_steps_before_return(monkeypatc
     assert parent_step in saved_issued_steps[-1]
 
 
+@pytest.mark.asyncio
+async def test_task_sequence_loop_persists_event_before_early_return_when_needed(monkeypatch):
+    fixture = Path(
+        "tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step/"
+        "traveler_batch_enrichment_in_step.yaml"
+    )
+    playbook = Playbook(**yaml.safe_load(fixture.read_text(encoding="utf-8")))
+
+    playbook_repo = PlaybookRepo()
+    state_store = StateStore(playbook_repo)
+    engine = ControlFlowEngine(playbook_repo, state_store)
+
+    execution_id = "9011b"
+    parent_step = "run_batch_workers"
+    state = ExecutionState(execution_id, playbook, payload={})
+    state.loop_state[parent_step] = {
+        "collection": [],
+        "iterator": "batch",
+        "index": 0,
+        "mode": "sequential",
+        "completed": False,
+        "results": [],
+        "failed_count": 0,
+        "aggregation_finalized": False,
+        "event_id": None,
+    }
+    await state_store.save_state(state)
+
+    fake_cache = FakeNATSCache()
+
+    async def fake_get_nats_cache():
+        return fake_cache
+
+    call_order: list[str] = []
+    real_save_state = state_store.save_state
+
+    async def tracking_save_state(state_obj):
+        call_order.append("save_state")
+        await real_save_state(state_obj)
+
+    async def fake_persist_event(event_obj, state_obj):  # noqa: ARG001
+        call_order.append(f"persist:{event_obj.name}")
+        state_obj.last_event_id = "persisted-call-done"
+
+    async def fake_create_command_for_step(_state, step_def, _args):
+        return Command(
+            execution_id=execution_id,
+            step=step_def.step,
+            tool=ToolCall(kind="playbook", config={}),
+            args={},
+            render_context={},
+        )
+
+    async def fake_evaluate_next_transitions(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr(engine_module, "get_nats_cache", fake_get_nats_cache)
+    monkeypatch.setattr(engine, "_persist_event", fake_persist_event)
+    monkeypatch.setattr(engine, "_create_command_for_step", fake_create_command_for_step)
+    monkeypatch.setattr(engine, "_evaluate_next_transitions", fake_evaluate_next_transitions)
+    monkeypatch.setattr(state_store, "save_state", tracking_save_state)
+
+    event = Event(
+        execution_id=execution_id,
+        step=f"{parent_step}:task_sequence",
+        name="call.done",
+        payload={
+            "response": {
+                "status": "completed",
+                "results": {
+                    "worker_result": {
+                        "status": "completed",
+                    }
+                },
+            }
+        },
+    )
+
+    commands = await engine.handle_event(event, already_persisted=False)
+
+    assert len(commands) == 1
+    assert commands[0].step == parent_step
+    assert call_order[-2:] == ["save_state", "persist:call.done"]
+
+
 def test_normalize_loop_collection_does_not_split_unresolved_template():
     playbook_repo = PlaybookRepo()
     state_store = StateStore(playbook_repo)


### PR DESCRIPTION
## Summary
- persist task-sequence loop state before returning from `call.done`
- track loop-generated commands in `state.issued_steps` before the early return
- add regression coverage for task-sequence continuation bookkeeping

## Prod evidence
- execution `589327893881160142` kept advancing through `fetch_medications:task_sequence`
- old churn-heavy execution `589251756484198578` showed the sharper inconsistency:
  - status endpoint reported `completed=true` / `completion_inferred=true`
  - while server and worker logs still showed fresh `fetch_medications:task_sequence` `call.done`, `command.issued`, `command.claimed`, and loop-count increments
- the task-sequence `call.done` branch in `engine.handle_event()` was returning before the normal tail that:
  - adds emitted commands into `state.issued_steps`
  - saves updated execution state

## Validation
- `uv run pytest -q tests/unit/dsl/v2/test_task_sequence_loop_completion.py tests/api/test_v2_execution_status_terminal.py tests/api/execution/test_executions_status_consistency.py`
- `30 passed`
