### PR TITLE
fix: stop inferring completion for active fallback status

### DIFF
--- a/noetl/server/api/v2.py
+++ b/noetl/server/api/v2.py
@@ -2780,15 +2780,17 @@ async def get_execution_status(execution_id: str, full: bool = False):
 
             completed = False
             failed = False
-            completion_inferred = True
+            completion_inferred = False
 
             terminal_type = terminal_event["event_type"] if terminal_event else None
             if terminal_type in terminal_complete_events:
                 completed = True
                 failed = False
+                completion_inferred = True
             elif terminal_type in terminal_failed_events:
                 completed = True
                 failed = terminal_type != "execution.cancelled"
+                completion_inferred = True
             elif (
                 latest_event["node_name"] == "end"
                 and latest_event["status"] == "COMPLETED"
@@ -2796,6 +2798,7 @@ async def get_execution_status(execution_id: str, full: bool = False):
             ):
                 completed = True
                 failed = False
+                completion_inferred = True
             elif (
                 latest_event["event_type"] == "batch.completed"
                 and latest_event["status"] == "COMPLETED"
@@ -2803,6 +2806,7 @@ async def get_execution_status(execution_id: str, full: bool = False):
             ):
                 completed = True
                 failed = False
+                completion_inferred = True
 
             completed_steps: list[str] = []
             seen_steps: set[str] = set()

--- a/tests/api/test_v2_execution_status_terminal.py
+++ b/tests/api/test_v2_execution_status_terminal.py
@@ -38,6 +38,11 @@ class _FakeCursor:
     async def execute(self, query, _params):
         self._query = query
 
+    async def fetchall(self):
+        if "event_type = 'step.exit'" in self._query:
+            return []
+        raise AssertionError(f"Unexpected fetchall query in test cursor: {self._query}")
+
     async def fetchone(self):
         if "ORDER BY event_id ASC" in self._query:
             return {"created_at": self._start_time}
@@ -184,3 +189,31 @@ async def test_status_keeps_running_when_batch_completed_still_has_pending_comma
     assert result["failed"] is False
     assert result["completion_inferred"] is False
     assert result["end_time"] is None
+
+
+@pytest.mark.asyncio
+async def test_status_event_log_fallback_keeps_completion_inferred_false_for_non_terminal_call_done(monkeypatch):
+    start_time = datetime(2026, 3, 24, 6, 20, 0, tzinfo=timezone.utc)
+    latest_time = datetime(2026, 3, 24, 6, 26, 29, tzinfo=timezone.utc)
+
+    fake_engine = SimpleNamespace(state_store=SimpleNamespace(get_state=lambda _execution_id: None))
+    fake_cursor = _FakeCursor(
+        start_time,
+        latest_time,
+        terminal_time=None,
+        pending_count=0,
+        latest_event_type="call.done",
+        latest_status="COMPLETED",
+    )
+
+    monkeypatch.setattr(v2_api, "get_engine", lambda: fake_engine)
+    monkeypatch.setattr(v2_api, "get_pool_connection", lambda: _ConnCtx(_FakeConn(fake_cursor)))
+
+    result = await v2_api.get_execution_status("589375687589363999")
+
+    assert result["current_step"] == "events.batch"
+    assert result["completed"] is False
+    assert result["failed"] is False
+    assert result["completion_inferred"] is False
+    assert result["end_time"] is None
+    assert result["source"] == "event_log_fallback"


### PR DESCRIPTION
## Summary
- stop marking completion_inferred true by default in the event-log fallback status path
- only set completion_inferred when the API actually infers a terminal outcome
- add a regression test for a non-terminal call.done fallback case like execution 589375687589363999

## Validation
- uv run pytest -q tests/api/test_v2_execution_status_terminal.py tests/api/execution/test_executions_status_consistency.py