### PR TITLE
fix(engine): prevent false dead-end on deduplicated arc transitions

### DIFF
--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -1718,7 +1718,12 @@ class ControlFlowEngine:
         event: Event,
     ) -> tuple[list[Command], bool]:
         """
-        Evaluate next[].when conditions and return commands plus actionable-match status.
+        Evaluate next[].when conditions and return commands plus matched-arc status.
+
+        The boolean return is True when any arc condition matched AND the target step
+        exists in the playbook.  A matched-but-deduplicated arc (target already in
+        issued_steps) still returns True — the command is already in flight, so this
+        is not a dead-end.
 
         Canonical format routing using next[].when:
         - Each next entry has optional 'when' condition
@@ -1772,7 +1777,6 @@ class ControlFlowEngine:
         logger.info(f"[NEXT-EVAL] Step {event.step} has {len(next_items)} next targets, mode={next_mode}, evaluating for event {event.name}")
 
         any_matched = False
-        any_actionable_issued = False
 
         for idx, next_target in enumerate(next_items):
             target_step = next_target.get("step")
@@ -1794,16 +1798,18 @@ class ControlFlowEngine:
                 # No when condition = always matches
                 logger.info(f"[NEXT-MATCH] Step {event.step}: matched next[{idx}] -> {target_step} (unconditional)")
 
-            any_matched = True
-
-            # Get target step definition
+            # Get target step definition — must exist before we count this as a match
             target_step_def = state.get_step(target_step)
             if not target_step_def:
                 logger.error(f"[NEXT-EVAL] Target step not found: {target_step}")
                 continue
 
-            # DEDUPLICATION: Skip if command for this step is already pending
-            # This prevents duplicate commands when multiple events trigger orchestration
+            # Arc condition matched AND target step exists.
+            any_matched = True
+
+            # DEDUPLICATION: Skip if command for this step is already pending.
+            # A matched-but-deduplicated arc is NOT a dead-end — the command is
+            # already in flight from a concurrent event processor.
             if target_step in state.issued_steps and target_step not in state.completed_steps:
                 logger.warning(f"[NEXT-EVAL] Skipping duplicate command for step '{target_step}' - already in issued_steps")
                 continue
@@ -1819,7 +1825,6 @@ class ControlFlowEngine:
             issued_cmds = await self._issue_loop_commands(state, target_step_def, rendered_args)
             if issued_cmds:
                 commands.extend(issued_cmds)
-                any_actionable_issued = True
                 # Steps can be revisited in loopback workflows; clear old completion marker
                 # so pending tracking reflects the new in-flight invocation.
                 state.completed_steps.discard(target_step)

--- a/tests/unit/dsl/v2/test_dead_end_dedup.py
+++ b/tests/unit/dsl/v2/test_dead_end_dedup.py
@@ -1,0 +1,170 @@
+"""
+Tests for dead-end detection under command deduplication races.
+
+Regression coverage for:
+  _evaluate_next_transitions_with_match returning any_matched instead of
+  any_actionable_issued — a matched-but-deduplicated arc must NOT be treated
+  as a dead-end transition.
+
+Production evidence: execution 590113029212078805 on v2.10.39 hit a false
+dead-end at load_patients_for_conditions despite an unconditional fallback arc
+to load_patients_for_medications.  The target step was already in issued_steps
+from a concurrent call.done processor on a second pod, so command creation was
+skipped and the old code returned ([], False) — incorrectly triggering workflow
+completion.
+"""
+
+import pytest
+import yaml
+
+from noetl.core.dsl.v2.engine import ControlFlowEngine, ExecutionState, PlaybookRepo, StateStore
+from noetl.core.dsl.v2.models import Event, Playbook
+
+
+PLAYBOOK_WITH_UNCONDITIONAL_FALLBACK = """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: dead_end_dedup_test
+
+workflow:
+  - step: step_a
+    tool:
+      kind: python
+      code: "def main(): return {}"
+    next:
+      - step: step_b
+
+  - step: step_b
+    tool:
+      kind: python
+      code: "def main(): return {}"
+"""
+
+PLAYBOOK_WITH_CONDITIONAL_AND_FALLBACK = """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: dead_end_dedup_conditional_test
+
+workflow:
+  - step: step_a
+    tool:
+      kind: python
+      code: "def main(): return {}"
+    next:
+      - step: step_b
+        when: "{{ ctx.row_count > 0 }}"
+      - step: step_c
+
+  - step: step_b
+    tool:
+      kind: python
+      code: "def main(): return {}"
+
+  - step: step_c
+    tool:
+      kind: python
+      code: "def main(): return {}"
+"""
+
+
+@pytest.fixture
+def engine():
+    playbook_repo = PlaybookRepo()
+    state_store = StateStore(playbook_repo)
+    return ControlFlowEngine(playbook_repo, state_store)
+
+
+@pytest.mark.asyncio
+async def test_matched_unconditional_arc_deduplicated_returns_any_matched_true(engine):
+    """
+    A second call.done processor finds step_b already in issued_steps.
+    Command creation is skipped (deduplication), but any_matched must be True
+    so dead-end detection does not prematurely complete the workflow.
+    """
+    playbook = Playbook(**yaml.safe_load(PLAYBOOK_WITH_UNCONDITIONAL_FALLBACK))
+    state = ExecutionState("dedup-test-001", playbook, payload={})
+    # Simulate the first pod already issued step_b
+    state.issued_steps.add("step_b")
+
+    event = Event(
+        execution_id="dedup-test-001",
+        step="step_a",
+        name="call.done",
+        payload={},
+    )
+    step_def = state.get_step("step_a")
+    commands, any_matched = await engine._evaluate_next_transitions_with_match(
+        state, step_def, event
+    )
+
+    # No new command — deduplication fired
+    assert commands == [], "Expected no commands when target step already issued"
+    # But the arc DID match — this must NOT look like a dead-end
+    assert any_matched is True, (
+        "any_matched must be True for a matched-but-deduplicated arc; "
+        "returning False would cause premature workflow completion"
+    )
+
+
+@pytest.mark.asyncio
+async def test_matched_conditional_fallback_deduplicated_returns_any_matched_true(engine):
+    """
+    Unconditional fallback arc (step_c) matches when the conditional arc
+    (step_b) does not.  If step_c is already issued, the result must still
+    be any_matched=True.
+    """
+    playbook = Playbook(**yaml.safe_load(PLAYBOOK_WITH_CONDITIONAL_AND_FALLBACK))
+    state = ExecutionState("dedup-test-002", playbook, payload={})
+    # row_count not set → conditional arc (step_b) will not match
+    # step_c (unconditional fallback) matches but is already issued
+    state.issued_steps.add("step_c")
+
+    event = Event(
+        execution_id="dedup-test-002",
+        step="step_a",
+        name="call.done",
+        payload={},
+    )
+    step_def = state.get_step("step_a")
+    commands, any_matched = await engine._evaluate_next_transitions_with_match(
+        state, step_def, event
+    )
+
+    assert commands == [], "Expected no commands when fallback step already issued"
+    assert any_matched is True, (
+        "Unconditional fallback arc matched; any_matched must be True even when deduplicated"
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_target_step_does_not_set_any_matched(engine):
+    """
+    If the playbook references a next step that does not exist, the arc
+    condition match should NOT count — any_matched stays False so dead-end
+    detection can fire correctly.
+    """
+    playbook = Playbook(**yaml.safe_load(PLAYBOOK_WITH_UNCONDITIONAL_FALLBACK))
+    state = ExecutionState("dedup-test-003", playbook, payload={})
+
+    # Override next to point at a step that doesn't exist in the playbook
+    step_def = state.get_step("step_a")
+    assert step_def is not None
+    step_def.next = [{"step": "nonexistent_step"}]
+
+    event = Event(
+        execution_id="dedup-test-003",
+        step="step_a",
+        name="call.done",
+        payload={},
+    )
+    commands, any_matched = await engine._evaluate_next_transitions_with_match(
+        state, step_def, event
+    )
+
+    assert commands == [], "Expected no commands for missing target step"
+    assert any_matched is False, (
+        "any_matched must be False when the target step does not exist; "
+        "this allows dead-end detection to trigger correctly"
+    )


### PR DESCRIPTION
## Summary
- Fix premature workflow completion when a matched arc's command is deduplicated during multi-pod event processing races
- One-line change: return `any_matched` instead of `any_actionable_issued` from `_evaluate_next_transitions_with_match`

## Root cause
`_evaluate_next_transitions_with_match` returns `(commands, any_actionable_issued)`. When multi-pod state-cache races cause duplicate `call.done` processing, the second invocation finds the target step already in `issued_steps`, skips command creation (deduplication), and returns `([], False)`.

The dead-end detection code at line 4483 uses this return value as `next_any_matched`. Since it's `False`, the engine treats a matched unconditional fallback arc as a dead-end transition and completes the workflow prematurely.

## Fix
Return `any_matched` instead of `any_actionable_issued`. A matched-but-deduplicated arc is not a dead-end — the command is already in flight from the first invocation. The deduplication is working correctly; the dead-end check was not accounting for it.

## Production evidence
- Execution `590113029212078805` on v2.10.39 with playbook v24 (which had correct unconditional fallback arcs)
- Dead-end at `load_patients_for_conditions` despite unconditional fallback arc to `load_patients_for_medications`
- Server log: `[COMPLETION] Dead-end transition with no matching next arcs: step=load_patients_for_conditions`
- The unconditional arc matched but the command was deduplicated → `any_actionable_issued=False` → false dead-end

## Test plan
- [ ] Existing test suite passes
- [ ] Deploy to kind cluster and run a multi-step playbook
- [ ] Run BHS state report playbook on prod with 2 server pods (multi-pod race conditions)
- [ ] Confirm no false dead-end completions at any `load_patients_for_*` step
- [ ] Verify legitimate dead-ends still trigger correctly (step with no matching arcs and no deduplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)