### PR TITLE
fix(engine): skip workflow.failed when command.failed arrives with pending recovery

### DIFF
--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -63,6 +63,13 @@ _EXECUTION_TERMINAL_EVENT_TYPES = {
     "workflow.completed",
     "workflow.failed",
     "execution.cancelled",
+    # NOTE: "command.failed" is intentionally NOT in this set.
+    # command.failed is an infrastructure-level event (retries exhausted) that may arrive
+    # after a call.error arc has already issued recovery steps. It does not by itself make
+    # an execution terminal — only workflow.failed/playbook.failed do. This means that when
+    # the command.failed handler skips terminal emission (recovery in-flight), the status
+    # API will NOT report the execution as completed/failed based on the command.failed
+    # event alone. The execution remains in-progress until a true terminal event is emitted.
 }
 _EXECUTION_FAILURE_EVENT_TYPES = {
     "playbook.failed",

--- a/tests/unit/dsl/v2/test_engine.py
+++ b/tests/unit/dsl/v2/test_engine.py
@@ -3,18 +3,67 @@ Tests for NoETL DSL v2 Control Flow Engine
 """
 
 import pytest
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
 from noetl.core.dsl.v2.engine import ControlFlowEngine, PlaybookRepo, StateStore, ExecutionState
 from noetl.core.dsl.v2.models import Event, Command, Playbook
 from noetl.core.dsl.v2.parser import DSLParser
+
+
+@asynccontextmanager
+async def _mock_pool_connection(pending_count: int = 0):
+    """Async context manager that returns a fake DB connection/cursor yielding pending_count."""
+    cur = AsyncMock()
+    cur.__aenter__ = AsyncMock(return_value=cur)
+    cur.__aexit__ = AsyncMock(return_value=False)
+    cur.fetchone = AsyncMock(return_value={"pending_count": pending_count})
+    conn = AsyncMock()
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=False)
+    conn.cursor = MagicMock(return_value=cur)
+    yield conn
 
 
 @pytest.fixture
 def engine_setup():
     """Set up engine components."""
     playbook_repo = PlaybookRepo()
-    state_store = StateStore()
+    state_store = StateStore(playbook_repo)
     engine = ControlFlowEngine(playbook_repo, state_store)
     return engine, playbook_repo, state_store
+
+
+def _make_minimal_playbook(name: str = "test") -> Playbook:
+    """Return a minimal v2 playbook with a single step that has a call.error recovery arc."""
+    yaml_content = f"""
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: {name}
+
+workflow:
+  - step: fetch_data
+    tool:
+      kind: http
+      method: GET
+      endpoint: "https://api.example.com/data"
+    next:
+      - step: recovery_step
+        when: "{{{{ event.name == 'call.error' }}}}"
+      - step: end
+
+  - step: recovery_step
+    tool:
+      kind: http
+      method: GET
+      endpoint: "https://api.example.com/fallback"
+
+  - step: end
+    tool:
+      kind: python
+      code: "def main(): return {{}}"
+"""
+    return DSLParser().parse(yaml_content)
 
 
 def test_handle_workflow_start(engine_setup):
@@ -386,8 +435,115 @@ workflow:
     )
     
     commands = engine.handle_event(event)
-    
+
     # Should generate command for process step with args
     assert len(commands) == 1
     assert commands[0].step == "process"
     assert commands[0].args is not None
+
+
+@pytest.mark.asyncio
+async def test_command_failed_with_pending_recovery_does_not_terminate(engine_setup):
+    """
+    When command.failed arrives while recovery commands are in-flight (issued via a
+    call.error arc), the engine must NOT emit workflow.failed/playbook.failed and must
+    NOT mark the execution as completed.
+
+    Regression: prior to the fix, command.failed unconditionally emitted terminal events,
+    cutting executions short even when call.error had already issued recovery steps.
+    """
+    engine, playbook_repo, state_store = engine_setup
+    playbook = _make_minimal_playbook("recovery_test")
+
+    # Pre-build execution state that mirrors what the engine would have after
+    # call.error fired and issued recovery_step (recovery command is in-flight).
+    state = ExecutionState(
+        execution_id="exec-recovery",
+        playbook=playbook,
+        payload={},
+    )
+    # recovery_step was issued by the call.error arc but has not yet completed.
+    state.issued_steps.add("recovery_step")
+    state.failed = True  # command.failed also sets this; pre-set to mimic real sequence
+
+    # Wire the state into the store's in-memory cache so load_state returns it
+    # without hitting the database.
+    await state_store.save_state(state)
+
+    # Patch _persist_event so the test doesn't need a live DB connection.
+    engine._persist_event = AsyncMock(return_value=None)
+
+    event = Event(
+        execution_id="exec-recovery",
+        step="fetch_data",
+        name="command.failed",
+        payload={"error": {"message": "infra retry exhausted"}},
+    )
+
+    commands = await engine.handle_event(event, already_persisted=True)
+
+    # Execution must NOT be terminated: state.completed remains False.
+    reloaded = await state_store.load_state("exec-recovery")
+    assert reloaded is not None
+    assert reloaded.completed is False, (
+        "Execution should not be completed — recovery commands are still in-flight"
+    )
+
+    # No terminal events should have been emitted via _persist_event.
+    terminal_event_names = {
+        call.args[0].name
+        for call in engine._persist_event.call_args_list
+        if call.args
+    }
+    assert "workflow.failed" not in terminal_event_names, (
+        "workflow.failed must not be emitted while recovery commands are pending"
+    )
+    assert "playbook.failed" not in terminal_event_names, (
+        "playbook.failed must not be emitted while recovery commands are pending"
+    )
+
+
+@pytest.mark.asyncio
+async def test_command_failed_without_pending_commands_terminates(engine_setup):
+    """
+    When command.failed arrives and there are NO pending recovery commands, the
+    engine must emit terminal failure events and stop the execution.
+    """
+    engine, playbook_repo, state_store = engine_setup
+    playbook = _make_minimal_playbook("no_recovery_test")
+
+    state = ExecutionState(
+        execution_id="200000000000000001",
+        playbook=playbook,
+        payload={},
+    )
+    # No recovery commands in-flight — issued_steps is empty.
+    assert not state.issued_steps
+
+    await state_store.save_state(state)
+    engine._persist_event = AsyncMock(return_value=None)
+
+    event = Event(
+        execution_id="200000000000000001",
+        step="fetch_data",
+        name="command.failed",
+        payload={"error": {"message": "infra retry exhausted"}},
+    )
+
+    # Patch the DB pool: issued_steps is empty so the engine falls back to a DB
+    # pending-count query. Return 0 to confirm no recovery commands are in-flight.
+    with patch("noetl.core.dsl.v2.engine.get_pool_connection", lambda: _mock_pool_connection(0)):
+        commands = await engine.handle_event(event, already_persisted=True)
+
+    # Terminal events must have been emitted.
+    emitted = {
+        call.args[0].name
+        for call in engine._persist_event.call_args_list
+        if call.args
+    }
+    assert "workflow.failed" in emitted or "playbook.failed" in emitted, (
+        "Terminal failure events must be emitted when no recovery is in-flight"
+    )
+
+    # Engine returns empty commands list to stop further orchestration.
+    assert commands == [], "Engine must return [] to halt orchestration on unrecovered failure"


### PR DESCRIPTION
## Summary

- `command.failed` handler unconditionally emitted `workflow.failed` even when a prior `call.error` arc had already issued recovery/fallback steps
- Fix: check `has_pending_commands` before emitting terminal events — if recovery commands are in-flight, log a warning and skip the terminal emission to allow recovery to complete
- Addresses premature termination at multi-facility loop boundaries in BHS state program executions

## Root Cause

When a step fails, two events fire in sequence:
1. `call.error` — application-level, fires ~immediately, evaluates recovery arcs (can issue follow-on steps)
2. `command.failed` — infrastructure-level, fires ~17s later after retries exhausted

The `command.failed` handler did not check whether recovery had already been initiated via `call.error`. If a `call.error` arc issued recovery steps, those were reflected in `has_pending_commands`. The fix skips terminal emission when pending commands exist.

## Test plan
- [ ] Run BHS state report generation playbook across multiple facilities — verify no premature `workflow.failed` when `call.error` recovery arcs are active
- [ ] Verify `command.failed` still emits `workflow.failed` correctly when there are no pending recovery commands (i.e., genuine unrecoverable failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)