### PR TITLE
fix(server): recover bounded context from response envelopes

### DIFF
--- a/noetl/server/api/v2.py
+++ b/noetl/server/api/v2.py
@@ -2148,16 +2148,9 @@ def _extract_reference_from_payload(
 
 
 def _extract_context_from_payload(payload: dict[str, Any]) -> Optional[dict[str, Any]]:
-    size_cache: dict[int, int] = {}
-
-    def _json_size_cached(obj: dict[str, Any]) -> int:
-        cache_key = id(obj)
-        cached = size_cache.get(cache_key)
-        if cached is not None:
-            return cached
-        size = _estimate_json_size(obj)
-        size_cache[cache_key] = size
-        return size
+    def _json_size(obj: dict[str, Any]) -> int:
+        # Context dicts are mutated while being bounded; avoid stale cache-by-id sizing.
+        return _estimate_json_size(obj)
 
     def _filter_context_obj(context_obj: dict[str, Any]) -> Optional[dict[str, Any]]:
         filtered = {
@@ -2239,11 +2232,11 @@ def _extract_context_from_payload(payload: dict[str, Any]) -> Optional[dict[str,
             merged = dict(candidate)
             for key, value in compact_fields.items():
                 merged.setdefault(key, value)
-            if _json_size_cached(merged) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
+            if _json_size(merged) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
                 return merged
 
             if not compact_fields:
-                if _json_size_cached(candidate) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
+                if _json_size(candidate) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
                     return candidate
                 return None
 
@@ -2253,17 +2246,19 @@ def _extract_context_from_payload(payload: dict[str, Any]) -> Optional[dict[str,
                 if key in bounded:
                     continue
                 bounded[key] = value
-                if _json_size_cached(bounded) > _EVENT_RESULT_CONTEXT_MAX_BYTES:
+                if _json_size(bounded) > _EVENT_RESULT_CONTEXT_MAX_BYTES:
                     del bounded[key]
                     break
             if bounded:
                 return bounded
 
-            if _json_size_cached(compact_fields) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
+            if _json_size(compact_fields) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
                 return compact_fields
-            if _json_size_cached(candidate) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
+            if not compact_fields and _json_size(candidate) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
                 return candidate
-        return compact_fields or None
+        if compact_fields and _json_size(compact_fields) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
+            return compact_fields
+        return None
 
     compact: dict[str, Any] = {}
     for key in (

--- a/noetl/worker/task_sequence_executor.py
+++ b/noetl/worker/task_sequence_executor.py
@@ -48,6 +48,7 @@ Canonical v10 usage in playbooks:
 
 import asyncio
 import time
+import re
 from typing import Any, Optional, Callable, Awaitable
 from dataclasses import dataclass, field
 
@@ -693,7 +694,14 @@ class TaskSequenceExecutor:
         if not text:
             return False
 
-        ref_markers = ("result_ref", "_ref", "reference", "artifact", "noetl://", "ref")
+        ref_markers = (
+            r"\bresult_ref\b",
+            r"\b_ref\b",
+            r"\breference\b",
+            r"\bdata_reference\b",
+            r"noetl://",
+            r"\bartifact\b",
+        )
         not_found_markers = (
             "not found",
             "missing",
@@ -703,7 +711,7 @@ class TaskSequenceExecutor:
             "does not exist",
         )
 
-        return any(marker in text for marker in ref_markers) and any(
+        return any(re.search(marker, text) for marker in ref_markers) and any(
             marker in text for marker in not_found_markers
         )
 

--- a/tests/api/test_v2_reference_only_result_helpers.py
+++ b/tests/api/test_v2_reference_only_result_helpers.py
@@ -86,7 +86,8 @@ def test_extract_context_filters_transport_wrappers_and_honors_size_limit(monkey
     assert context == {"safe": "ok", "command_id": "cmd-1"}
 
 
-def test_extract_context_derives_from_response_payload():
+def test_extract_context_derives_from_response_payload(monkeypatch):
+    monkeypatch.setattr(v2_api, "_EVENT_RESULT_CONTEXT_MAX_ROWS_PER_COMMAND", 1)
     context = v2_api._extract_context_from_payload(
         {
             "command_id": "cmd-42",
@@ -111,7 +112,8 @@ def test_extract_context_derives_from_response_payload():
     assert context["command_0"]["rows"][0]["facility_mapping_id"] == 123
 
 
-def test_extract_context_derives_from_result_payload():
+def test_extract_context_derives_from_result_payload(monkeypatch):
+    monkeypatch.setattr(v2_api, "_EVENT_RESULT_CONTEXT_MAX_ROWS_PER_COMMAND", 1)
     context = v2_api._extract_context_from_payload(
         {
             "command_id": "cmd-result-1",

--- a/tests/worker/test_task_sequence_executor.py
+++ b/tests/worker/test_task_sequence_executor.py
@@ -367,3 +367,9 @@ async def test_task_sequence_missing_reference_error_reports_reference_code():
     assert result["status"] == "failed"
     assert result["error"]["code"] == "REFERENCE_NOT_AVAILABLE"
     assert result["error"]["retryable"] is True
+
+
+def test_task_sequence_missing_reference_detection_avoids_refresh_false_positive():
+    assert TaskSequenceExecutor._is_missing_reference_error(
+        "refresh token missing for upstream auth provider"
+    ) is False


### PR DESCRIPTION
## Summary
- derive event.result.context from payload.response / payload.result when explicit payload.context is missing
- keep derived context strictly bounded (size + per-command row caps) and preserve compact routing keys under merge pressure
- harden task-sequence replay behavior for missing references (REFERENCE_NOT_AVAILABLE) including jump: previous recovery semantics
- tighten missing-reference detection to avoid false positives (for example refresh-token errors)
- make context-row-cap tests deterministic regardless env

## Why
Reference-only worker events can omit explicit context; this caused template/runtime lookups (for example command_0.rows[0].facility_mapping_id) to fail even when worker response contained the needed values. Copilot review also surfaced edge cases around mutable size caching and overly broad missing-reference matching.

## Validation
- python3 -m pytest tests/api/test_v2_reference_only_result_helpers.py tests/worker/test_task_sequence_executor.py -q
- result: 17 passed
