### PR TITLE
chore: update master branch references to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: "Semantic Release ⚙️"
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - '**/*.py'
       - '**/Dockerfile'

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["master"],
+  "branches": ["main"],
   "ci": false,
   "plugins": [
     [

--- a/ci/bootstrap/QUICKSTART.md
+++ b/ci/bootstrap/QUICKSTART.md
@@ -375,8 +375,8 @@ git log -1 --oneline
 # Update to latest
 cd noetl
 git fetch origin
-git checkout master
-git pull origin master
+git checkout main
+git pull origin main
 cd ..
 
 # Or update to specific version

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -114,4 +114,4 @@ cp target/release/noetl /usr/local/bin/
 
 ## License
 
-MIT License - see [LICENSE](https://github.com/noetl/noetl/blob/master/LICENSE)
+MIT License - see [LICENSE](https://github.com/noetl/noetl/blob/main/LICENSE)

--- a/tests/playwright/REAMDE.MD
+++ b/tests/playwright/REAMDE.MD
@@ -13,10 +13,10 @@ source .venv/bin/activate
 pip install -e .      
 noetl register ./examples/weather/weather_example.yaml --host localhost --port 8082
 
-git checkout master
+git checkout main
 git pull
 git checkout e2e
-git merge master
+git merge main
 git push
 noetl k8s reset
 


### PR DESCRIPTION
## Summary
- Updated `.releaserc.json` — semantic-release now targets `main` branch
- Updated `.github/workflows/release.yml` — CI push trigger now watches `main`
- Updated 3 documentation files (`QUICKSTART.md`, `REAMDE.MD`, `homebrew/README.md`) — git commands and links now reference `main`

**Note:** `master_regression_test` references in test fixtures were intentionally left unchanged — those are test artifact names, not branch references.

## Context
The default branch was renamed from `master` to `main` via the GitHub API. GitHub automatically:
- Retargeted all open PRs
- Migrated branch protection rules
- Set up `master` → `main` redirects

This PR updates the remaining in-code references so CI and docs are consistent.

## Test plan
- [ ] Verify semantic-release workflow triggers on push to `main`
- [ ] Confirm no remaining `master` branch references in CI configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)