### PR TITLE
fix(dsl): stabilize set_ctx with reference-only step results

### DIFF
--- a/noetl/core/dsl/render.py
+++ b/noetl/core/dsl/render.py
@@ -51,11 +51,15 @@ class TaskResultProxy:
     def __getitem__(self, key):
         try:
             data = object.__getattribute__(self, "_data")
+            def _wrap(val: Any):
+                if isinstance(val, dict):
+                    return TaskResultProxy(val, name=str(key))
+                return val
             if key in data:
-                return data[key]
+                return _wrap(data[key])
             context = data.get("context") if isinstance(data, dict) else None
             if isinstance(context, dict) and key in context:
-                return context[key]
+                return _wrap(context[key])
             return data[key]
         except Exception as e:
             raise KeyError(key) from e

--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -429,11 +429,19 @@ class ExecutionState:
                 # Reference-only compatibility:
                 # worker/server store compact step output under result.context, while
                 # many existing templates still read step.command_0.*.
-                # Promote context keys to the top-level in-memory render object.
+                # Promote only known command keys to avoid flattening arbitrary
+                # user payloads that may legitimately use a nested "context".
                 context_obj = result.get("context")
                 if isinstance(context_obj, dict):
-                    for key, value in context_obj.items():
-                        result.setdefault(key, value)
+                    has_reference_shape = "reference" in result or "_ref" in result
+                    has_command_context = any(
+                        str(key).startswith("command_") for key in context_obj.keys()
+                    )
+                    if has_reference_shape or has_command_context:
+                        for key, value in context_obj.items():
+                            key_str = str(key)
+                            if key_str.startswith("command_") or key_str == "command_id":
+                                result.setdefault(key, value)
                 else:
                     # Also support templates that expect step.context.* when the
                     # payload is already a plain dict of compact fields.

--- a/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
+++ b/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
@@ -4,6 +4,7 @@ import pytest
 import yaml
 
 import noetl.core.dsl.v2.engine as engine_module
+from noetl.core.dsl.render import TaskResultProxy
 from noetl.core.dsl.v2.engine import ControlFlowEngine, ExecutionState, PlaybookRepo, StateStore
 from noetl.core.dsl.v2.models import Command, Event, Playbook, ToolCall
 
@@ -817,6 +818,54 @@ workflow:
     assert "context" in step_result
     assert step_result["context"]["report_start_date"] == "2026-03-01"
     assert step_result["context"]["report_end_date"] == "2026-03-31"
+
+
+def test_mark_step_completed_does_not_flatten_non_reference_context_payload():
+    playbook = Playbook(**yaml.safe_load(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: context_flatten_guard_test
+  path: tests/context_flatten_guard_test
+workflow:
+  - step: end
+    tool:
+      kind: python
+      code: |
+        def main():
+          return {}
+        """
+    ))
+    state = ExecutionState("9024", playbook, payload={})
+    state.mark_step_completed(
+        "end",
+        {
+            "status": "COMPLETED",
+            "context": {"ctx_vars": {"foo": "bar"}},
+        },
+    )
+
+    step_result = state.step_results["end"]
+    assert "ctx_vars" not in step_result
+    assert step_result["context"]["ctx_vars"]["foo"] == "bar"
+
+
+def test_task_result_proxy_getitem_wraps_context_dict_values():
+    proxy = TaskResultProxy(
+        {
+            "status": "COMPLETED",
+            "context": {
+                "command_0": {
+                    "rows": [{"facility_mapping_id": 42}],
+                    "row_count": 1,
+                }
+            },
+        }
+    )
+    command_result = proxy["command_0"]
+    assert isinstance(command_result, TaskResultProxy)
+    assert command_result.rows[0]["facility_mapping_id"] == 42
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- restore compatibility for templates that read `step.command_0.*` when step results are now persisted as `{status, context, reference}`
- promote `result.context` keys into in-memory step result object during `mark_step_completed` so runtime `set_ctx` and replay both resolve command fields
- add a `context` alias for plain dict step results to support templates reading `step.context.*`
- harden `TaskResultProxy` fallback for `context`-backed fields and add replay/unit coverage

## Why
Current prod runs show heavy churn from repeated `set_ctx` render failures (`dict object has no attribute command_0`) and state-replay misses. This patch preserves reference-only transport while keeping existing playbook expressions functional.

## Validation
- `python3 -m py_compile noetl/core/dsl/render.py noetl/core/dsl/v2/engine.py tests/unit/dsl/v2/test_task_sequence_loop_completion.py`
- attempted targeted pytest, but local env is missing `psycopg` dependency during collection

Refs: AHM-4124