### PR TITLE
fix(postgres): enforce auth contract and pgbouncer routing

### DIFF
--- a/noetl/server/api/v2.py
+++ b/noetl/server/api/v2.py
@@ -903,7 +903,7 @@ def _validate_postgres_command_context(*, step: str, tool_kind: str, context: di
     """
     Enforce postgres command contract before command.issued is persisted.
 
-    Postgres execution must use auth references, not inline db_* fields.
+    Postgres execution must include auth and must not pass direct db_* fields.
     """
     if str(tool_kind).lower() != "postgres":
         return
@@ -915,8 +915,48 @@ def _validate_postgres_command_context(*, step: str, tool_kind: str, context: di
     if auth_cfg in (None, "", {}):
         raise ValueError(
             f"Postgres command for step '{step}' is missing auth in command context. "
-            "Use tool.auth and avoid direct db_* connection variables."
+            "Use tool.auth."
         )
+
+    forbidden_fields = {
+        "db_host",
+        "db_port",
+        "db_user",
+        "db_password",
+        "db_name",
+        "db_conn_string",
+    }
+    direct_fields: set[str] = set()
+    if isinstance(tool_config, dict):
+        direct_fields.update(
+            key for key in forbidden_fields if tool_config.get(key) not in (None, "")
+        )
+    if isinstance(args, dict):
+        direct_fields.update(
+            key for key in forbidden_fields if args.get(key) not in (None, "")
+        )
+    if direct_fields:
+        raise ValueError(
+            f"Postgres command for step '{step}' includes forbidden direct connection fields: "
+            f"{', '.join(sorted(direct_fields))}. Use auth references only."
+        )
+
+
+def _validate_postgres_command_context_or_422(
+    *,
+    step: str,
+    tool_kind: str,
+    context: dict[str, Any],
+) -> None:
+    try:
+        _validate_postgres_command_context(step=step, tool_kind=tool_kind, context=context)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Invalid command context for step '{step}' and tool '{tool_kind}': {exc}"
+            ),
+        ) from exc
 
 
 async def _store_command_context_if_needed(
@@ -1280,7 +1320,7 @@ async def execute(req: ExecuteRequest) -> ExecuteResponse:
                         "pipeline": cmd.pipeline,  # Canonical v2: task pipeline
                         "spec": cmd.spec.model_dump() if cmd.spec else None,  # Step behavior (next_mode)
                     }
-                    _validate_postgres_command_context(
+                    _validate_postgres_command_context_or_422(
                         step=cmd.step,
                         tool_kind=cmd.tool.kind,
                         context=context,
@@ -1984,7 +2024,7 @@ async def handle_event(req: EventRequest) -> EventResponse:
                         "pipeline": cmd.pipeline,  # Canonical v2: task pipeline
                         "spec": cmd.spec.model_dump() if cmd.spec else None,  # Step behavior (next_mode)
                     }
-                    _validate_postgres_command_context(
+                    _validate_postgres_command_context_or_422(
                         step=cmd.step,
                         tool_kind=cmd.tool.kind,
                         context=context,
@@ -2659,7 +2699,7 @@ async def _issue_commands_for_batch(job: _BatchAcceptJob, commands: list) -> Non
                     "pipeline": cmd.pipeline,
                     "spec": cmd.spec.model_dump() if cmd.spec else None,
                 }
-                _validate_postgres_command_context(
+                _validate_postgres_command_context_or_422(
                     step=cmd.step,
                     tool_kind=cmd.tool.kind,
                     context=context,

--- a/noetl/tools/postgres/auth.py
+++ b/noetl/tools/postgres/auth.py
@@ -16,15 +16,9 @@ from noetl.core.dsl.render import render_template
 from noetl.worker.secrets import fetch_credential_by_key
 from noetl.worker.auth_resolver import resolve_auth
 from noetl.worker.auth_compatibility import transform_credentials_to_auth, validate_auth_transition
+from .env import env_bool
 
 logger = setup_logger(__name__, include_location=True)
-
-
-def _env_bool(name: str, default: bool) -> bool:
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _has_non_empty_auth(task_config: Dict, task_with: Dict) -> bool:
@@ -50,7 +44,7 @@ def resolve_postgres_auth(task_config: Dict, task_with: Dict, jinja_env: Environ
     # Apply backwards compatibility transformation for deprecated 'credentials' field
     validate_auth_transition(task_config, task_with)
     task_config, task_with = transform_credentials_to_auth(task_config, task_with)
-    auth_required = _env_bool("NOETL_POSTGRES_AUTH_REQUIRED", True)
+    auth_required = env_bool("NOETL_POSTGRES_AUTH_REQUIRED", True)
     has_auth_config = _has_non_empty_auth(task_config, task_with)
 
     if auth_required and not has_auth_config:
@@ -216,7 +210,10 @@ def validate_and_render_connection_params(task_with: Dict, jinja_env: Environmen
     if _missing:
         raise ValueError(
             "Postgres connection is not configured. Missing: " + ", ".join(_missing) +
-            ". Use `auth: <credential_key>` or `auth: {type: postgres, host: ..., user: ..., password: ..., database: ...}` on the step."
+            ". Use `auth: <credential_key>`, `auth: {type: postgres, credential: <key>}`, "
+            "or inline fields via "
+            "`auth: {type: postgres, source: inline, fields: {host: ..., user: ..., password: ..., database: ...}}` "
+            "on the step."
         )
 
     # Build a rendering context that includes a 'workload' alias for compatibility
@@ -255,7 +252,7 @@ def validate_and_render_connection_params(task_with: Dict, jinja_env: Environmen
     if not pg_db or str(pg_db).strip() == '':
         raise ValueError("Database name is empty after rendering")
 
-    enforce_pgbouncer = _env_bool("NOETL_POSTGRES_ENFORCE_PGBOUNCER", False)
+    enforce_pgbouncer = env_bool("NOETL_POSTGRES_ENFORCE_PGBOUNCER", False)
     if enforce_pgbouncer:
         pgbouncer_host = (os.getenv("NOETL_POSTGRES_PGBOUNCER_HOST") or "").strip()
         pgbouncer_port = (os.getenv("NOETL_POSTGRES_PGBOUNCER_PORT") or "").strip()
@@ -267,7 +264,7 @@ def validate_and_render_connection_params(task_with: Dict, jinja_env: Environmen
         pg_host = pgbouncer_host
         if pgbouncer_port:
             pg_port = pgbouncer_port
-        logger.info(
+        logger.debug(
             "POSTGRES: Enforcing pgbouncer route host=%s port=%s (auth host=%s port=%s)",
             pg_host,
             pg_port,

--- a/noetl/tools/postgres/env.py
+++ b/noetl/tools/postgres/env.py
@@ -1,0 +1,10 @@
+"""Environment parsing helpers for postgres tool modules."""
+
+import os
+
+
+def env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}

--- a/noetl/tools/postgres/executor.py
+++ b/noetl/tools/postgres/executor.py
@@ -21,18 +21,12 @@ from noetl.worker.keychain_resolver import populate_keychain_context
 
 from .auth import resolve_postgres_auth, validate_and_render_connection_params
 from .command import escape_task_with_params, decode_base64_commands, render_and_split_commands
+from .env import env_bool
 from .execution import execute_sql_with_connection
 from .response import process_results, format_success_response, format_error_response, format_exception_response
 from .models import validate_pool_config
 
 logger = setup_logger(__name__, include_location=True)
-
-
-def _env_bool(name: str, default: bool) -> bool:
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _env_int(name: str, default: int) -> int:
@@ -247,14 +241,14 @@ async def _execute_postgres_task_async(
         # Step 6: Resolve connection mode and pool configuration.
         # Default mode is pooled for stable DB pressure in distributed runs.
         pool_config = task_config.get('pool')
-        use_pool = _env_bool("NOETL_POSTGRES_USE_POOL_DEFAULT", True)
+        use_pool = env_bool("NOETL_POSTGRES_USE_POOL_DEFAULT", True)
         pool_params = {}
         pool_name = None
 
         if isinstance(pool_config, bool):
             use_pool = pool_config
         elif pool_config is None:
-            use_pool = _env_bool("NOETL_POSTGRES_USE_POOL_DEFAULT", True)
+            use_pool = env_bool("NOETL_POSTGRES_USE_POOL_DEFAULT", True)
         elif isinstance(pool_config, dict):
             use_pool = True
             try:

--- a/noetl/worker/v2_worker_nats.py
+++ b/noetl/worker/v2_worker_nats.py
@@ -1566,7 +1566,29 @@ class V2Worker:
                 if postgres_auth in (None, "", {}):
                     raise ValueError(
                         f"Postgres step '{step}' is missing auth in command context. "
-                        "Use tool.auth and do not rely on direct db_* variables."
+                        "Use tool.auth."
+                    )
+                forbidden_fields = {
+                    "db_host",
+                    "db_port",
+                    "db_user",
+                    "db_password",
+                    "db_name",
+                    "db_conn_string",
+                }
+                direct_fields = set()
+                if isinstance(tool_config, dict):
+                    direct_fields.update(
+                        key for key in forbidden_fields if tool_config.get(key) not in (None, "")
+                    )
+                if isinstance(args, dict):
+                    direct_fields.update(
+                        key for key in forbidden_fields if args.get(key) not in (None, "")
+                    )
+                if direct_fields:
+                    raise ValueError(
+                        f"Postgres step '{step}' includes forbidden direct connection fields: "
+                        f"{', '.join(sorted(direct_fields))}. Use auth references only."
                     )
 
             # Execute tool

--- a/tests/api/test_v2_command_context_transport.py
+++ b/tests/api/test_v2_command_context_transport.py
@@ -82,3 +82,15 @@ def test_validate_postgres_command_context_accepts_tool_or_args_auth():
             "args": {"auth": "pg_main"},
         },
     )
+
+
+def test_validate_postgres_command_context_rejects_direct_connection_fields():
+    with pytest.raises(ValueError, match="forbidden direct connection fields"):
+        v2_api._validate_postgres_command_context(
+            step="load_rows",
+            tool_kind="postgres",
+            context={
+                "tool_config": {"auth": "pg_main", "db_host": "localhost"},
+                "args": {},
+            },
+        )

--- a/tests/plugin/test_postgres_auth_resolution.py
+++ b/tests/plugin/test_postgres_auth_resolution.py
@@ -8,12 +8,15 @@ class DummyJinja:
 
 def test_missing_fields_error():
     task_config = {"type": "postgres", "command_b64": "U0VMRUNUIDE7"}  # SELECT 1;
-    try:
-        pgmod.execute_postgres_task(task_config, context={}, jinja_env=DummyJinja(), task_with={}, log_event_callback=lambda *a, **k: None)
-        assert False, "should raise"
-    except ValueError as e:
-        msg = str(e)
-        assert "requires `auth`" in msg
+    result = pgmod.execute_postgres_task(
+        task_config,
+        context={},
+        jinja_env=DummyJinja(),
+        task_with={},
+        log_event_callback=lambda *a, **k: None,
+    )
+    assert result["status"] == "error"
+    assert "requires `auth`" in result.get("error", "")
 
 
 def test_validate_connection_enforces_pgbouncer_route(monkeypatch):

--- a/tests/worker/test_v2_worker_playbook_tool.py
+++ b/tests/worker/test_v2_worker_playbook_tool.py
@@ -449,6 +449,41 @@ async def test_execute_command_postgres_requires_auth_in_context(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_execute_command_postgres_rejects_direct_connection_fields(monkeypatch):
+    worker = V2Worker(worker_id="test-worker")
+    emitted = []
+
+    async def fake_emit_event(_server_url, _execution_id, _step, event_name, payload, **_kwargs):
+        emitted.append((event_name, payload))
+
+    async def fake_emit_batch_events(*_args, **_kwargs):
+        return True
+
+    async def fail_execute_tool(*_args, **_kwargs):
+        raise AssertionError("_execute_tool should not run when direct db_* fields are present")
+
+    monkeypatch.setattr(worker, "_emit_event", fake_emit_event)
+    monkeypatch.setattr(worker, "_emit_batch_events", fake_emit_batch_events)
+    monkeypatch.setattr(worker, "_execute_tool", fail_execute_tool)
+
+    command = {
+        "execution_id": "exec-4",
+        "step": "load_rows",
+        "tool_kind": "postgres",
+        "context": {
+            "tool_config": {"auth": "pg_main", "db_host": "localhost"},
+            "args": {},
+            "render_context": {},
+        },
+    }
+
+    await worker._execute_command(command, server_url="http://noetl.test", command_id="cmd-4")
+
+    failed_payload = next(payload for name, payload in emitted if name == "command.failed")
+    assert "forbidden direct connection fields" in failed_payload["error"]
+
+
+@pytest.mark.asyncio
 async def test_wait_for_postgres_capacity_retries_until_headroom(monkeypatch):
     worker = V2Worker(worker_id="test-worker")
     worker._running = True


### PR DESCRIPTION
## Summary
- require postgres commands to carry `auth` in command context before `command.issued` is persisted
- enforce worker-side guard for postgres commands so missing auth fails fast with `command.failed`
- make postgres auth resolution strict (`NOETL_POSTGRES_AUTH_REQUIRED=true` by default)
- add optional hard pgbouncer routing (`NOETL_POSTGRES_ENFORCE_PGBOUNCER`, `NOETL_POSTGRES_PGBOUNCER_HOST`, `NOETL_POSTGRES_PGBOUNCER_PORT`)
- ignore inline `db_conn_string` when pgbouncer enforcement is enabled to guarantee pool routing

## Tests
- `python3 -m py_compile` on changed runtime/test files
- `pytest` collection in this shell is currently blocked by local environment/dependency issues (`psycopg`, `httpx`, and local package path resolution)
