### PR TITLE
fix(engine): recover loop no-slot stalls via counter reconcile

### DIFF
--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -57,6 +57,10 @@ _LOOP_STALL_RECOVERY_COOLDOWN_SECONDS = max(
     0.0,
     float(os.getenv("NOETL_LOOP_STALL_RECOVERY_COOLDOWN_SECONDS", "15")),
 )
+_LOOP_COUNTER_RECONCILE_COOLDOWN_SECONDS = max(
+    0.0,
+    float(os.getenv("NOETL_LOOP_COUNTER_RECONCILE_COOLDOWN_SECONDS", "10")),
+)
 _STATE_CACHE_ALLOWED_MISSING_EVENTS = max(
     1,
     int(os.getenv("NOETL_STATE_CACHE_ALLOWED_MISSING_EVENTS", "3")),
@@ -223,6 +227,20 @@ def _pending_step_key(step_name: Optional[str]) -> str:
     if isinstance(step_name, str) and step_name.endswith(":task_sequence"):
         return step_name.rsplit(":", 1)[0]
     return str(step_name)
+
+
+def _node_name_candidates(node_name: str) -> tuple[str, ...]:
+    """Return canonical event node-name aliases for step and task-sequence rows."""
+    normalized = str(node_name)
+    candidates: list[str] = [normalized]
+    if normalized.endswith(":task_sequence"):
+        parent = normalized.rsplit(":", 1)[0]
+        if parent:
+            candidates.append(parent)
+    else:
+        candidates.append(f"{normalized}:task_sequence")
+    # Preserve order while removing duplicates.
+    return tuple(dict.fromkeys(candidates))
 
 
 # Type variable for generic BoundedCache
@@ -1705,6 +1723,7 @@ class ControlFlowEngine:
     ) -> int:
         """Count persisted events for a node/event pair (best-effort fallback path)."""
         try:
+            node_names = list(_node_name_candidates(node_name))
             async with get_pool_connection() as conn:
                 async with conn.cursor(row_factory=dict_row) as cur:
                     await cur.execute(
@@ -1712,10 +1731,10 @@ class ControlFlowEngine:
                         SELECT COUNT(*) AS cnt
                         FROM noetl.event
                         WHERE execution_id = %s
-                          AND node_name = %s
+                          AND node_name = ANY(%s)
                           AND event_type = %s
                         """,
-                        (int(execution_id), node_name, event_type),
+                        (int(execution_id), node_names, event_type),
                     )
                     row = await cur.fetchone()
                     return int((row or {}).get("cnt", 0) or 0)
@@ -1742,7 +1761,8 @@ class ControlFlowEngine:
 
         try:
             loop_filter = ""
-            issued_params: list[Any] = [int(execution_id), node_name]
+            node_names = list(_node_name_candidates(node_name))
+            issued_params: list[Any] = [int(execution_id), node_names]
             if loop_event_id:
                 loop_filter = "AND meta->>'loop_event_id' = %s"
                 issued_params.append(str(loop_event_id))
@@ -1750,7 +1770,7 @@ class ControlFlowEngine:
             params: list[Any] = [
                 *issued_params,
                 int(execution_id),
-                node_name,
+                node_names,
                 int(limit),
             ]
 
@@ -1764,7 +1784,7 @@ class ControlFlowEngine:
                                 NULLIF(meta->>'loop_iteration_index', '')::int AS loop_iteration_index
                             FROM noetl.event
                             WHERE execution_id = %s
-                              AND node_name = %s
+                              AND node_name = ANY(%s)
                               AND event_type = 'command.issued'
                               {loop_filter}
                         ),
@@ -1772,7 +1792,7 @@ class ControlFlowEngine:
                             SELECT DISTINCT meta->>'command_id' AS command_id
                             FROM noetl.event
                             WHERE execution_id = %s
-                              AND node_name = %s
+                              AND node_name = ANY(%s)
                               AND event_type IN ('command.completed', 'command.failed', 'command.cancelled')
                               AND meta ? 'command_id'
                         )
@@ -1815,7 +1835,8 @@ class ControlFlowEngine:
 
         try:
             loop_filter = ""
-            issued_params: list[Any] = [int(execution_id), node_name]
+            node_names = list(_node_name_candidates(node_name))
+            issued_params: list[Any] = [int(execution_id), node_names]
             if loop_event_id:
                 loop_filter = "AND meta->>'loop_event_id' = %s"
                 issued_params.append(str(loop_event_id))
@@ -1823,9 +1844,9 @@ class ControlFlowEngine:
             params: list[Any] = [
                 *issued_params,
                 int(execution_id),
-                node_name,
+                node_names,
                 int(execution_id),
-                node_name,
+                node_names,
                 int(limit),
             ]
 
@@ -1839,7 +1860,7 @@ class ControlFlowEngine:
                                 NULLIF(meta->>'loop_iteration_index', '')::int AS loop_iteration_index
                             FROM noetl.event
                             WHERE execution_id = %s
-                              AND node_name = %s
+                              AND node_name = ANY(%s)
                               AND event_type = 'command.issued'
                               {loop_filter}
                         ),
@@ -1847,7 +1868,7 @@ class ControlFlowEngine:
                             SELECT DISTINCT meta->>'command_id' AS command_id
                             FROM noetl.event
                             WHERE execution_id = %s
-                              AND node_name = %s
+                              AND node_name = ANY(%s)
                               AND event_type = 'command.started'
                               AND meta ? 'command_id'
                         ),
@@ -1855,7 +1876,7 @@ class ControlFlowEngine:
                             SELECT DISTINCT meta->>'command_id' AS command_id
                             FROM noetl.event
                             WHERE execution_id = %s
-                              AND node_name = %s
+                              AND node_name = ANY(%s)
                               AND event_type IN ('command.completed', 'command.failed', 'command.cancelled')
                               AND meta ? 'command_id'
                         )
@@ -3208,6 +3229,95 @@ class ControlFlowEngine:
                 )
                 in_flight = max(0, scheduled_hint - completed_count)
 
+                # Fast counter reconciliation:
+                # If distributed counters report no claimable slot but persisted state shows
+                # no in-flight command rows, advance completed_count from durable events and
+                # retry claim immediately. This avoids silent loop stalls waiting for another
+                # unrelated event to trigger watchdog recovery.
+                if (
+                    claimed_index is None
+                    and nats_loop_state
+                    and collection_size_hint > completed_count
+                    and (
+                        scheduled_hint >= collection_size_hint
+                        or in_flight >= max_in_flight
+                    )
+                ):
+                    now_utc = datetime.now(timezone.utc)
+                    last_counter_reconcile = _parse_iso_utc(
+                        nats_loop_state.get("last_counter_reconcile_at")
+                    ) or _parse_iso_utc(loop_state.get("last_counter_reconcile_at"))
+                    reconcile_cooldown_elapsed = (
+                        last_counter_reconcile is None
+                        or (now_utc - last_counter_reconcile).total_seconds()
+                        >= _LOOP_COUNTER_RECONCILE_COOLDOWN_SECONDS
+                    )
+                    if reconcile_cooldown_elapsed:
+                        missing_indexes = await self._find_missing_loop_iteration_indices(
+                            str(state.execution_id),
+                            step.step,
+                            loop_event_id=resolved_loop_event_id,
+                            limit=1,
+                        )
+                        if not missing_indexes:
+                            persisted_completed = await self._count_step_events(
+                                state.execution_id,
+                                step.step,
+                                "call.done",
+                            )
+                            if persisted_completed >= 0:
+                                persisted_completed = min(
+                                    persisted_completed,
+                                    collection_size_hint,
+                                )
+                                if persisted_completed > completed_count:
+                                    repaired_completed = persisted_completed
+                                    repaired_scheduled = max(
+                                        int(
+                                            (nats_loop_state or {}).get(
+                                                "scheduled_count",
+                                                scheduled_hint,
+                                            )
+                                            or scheduled_hint
+                                        ),
+                                        repaired_completed,
+                                    )
+                                    repaired_at = now_utc.isoformat()
+                                    nats_loop_state["completed_count"] = repaired_completed
+                                    nats_loop_state["scheduled_count"] = repaired_scheduled
+                                    nats_loop_state["last_counter_reconcile_at"] = repaired_at
+                                    nats_loop_state["last_progress_at"] = repaired_at
+                                    nats_loop_state["updated_at"] = repaired_at
+                                    loop_state["scheduled_count"] = repaired_scheduled
+                                    loop_state["last_counter_reconcile_at"] = repaired_at
+                                    await nats_cache.set_loop_state(
+                                        str(state.execution_id),
+                                        step.step,
+                                        nats_loop_state,
+                                        event_id=resolved_loop_event_id,
+                                    )
+                                    completed_count = repaired_completed
+                                    scheduled_hint = repaired_scheduled
+                                    in_flight = max(0, scheduled_hint - completed_count)
+                                    claimed_index = await nats_cache.claim_next_loop_index(
+                                        str(state.execution_id),
+                                        step.step,
+                                        collection_size=len(collection),
+                                        max_in_flight=max_in_flight,
+                                        event_id=resolved_loop_event_id,
+                                    )
+                                    if claimed_index is not None:
+                                        logger.warning(
+                                            "[LOOP-COUNTER-RECONCILE] Recovered claim slot for %s "
+                                            "(event_id=%s completed=%s scheduled=%s size=%s claimed=%s)",
+                                            step.step,
+                                            resolved_loop_event_id,
+                                            completed_count,
+                                            scheduled_hint,
+                                            collection_size_hint,
+                                            claimed_index,
+                                        )
+
                 # Runtime loop-stall watchdog:
                 # If there is pending work but no claimable slot is available, stale
                 # distributed loop metadata can leave the loop parked indefinitely.
@@ -3217,7 +3327,8 @@ class ControlFlowEngine:
                 # In both cases, look for orphaned iteration indexes and replay one when
                 # progress has been stale long enough.
                 if (
-                    nats_loop_state
+                    claimed_index is None
+                    and nats_loop_state
                     and collection_size_hint > completed_count
                     and (
                         scheduled_hint >= collection_size_hint

--- a/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
+++ b/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
@@ -557,6 +557,79 @@ async def test_loop_watchdog_recovers_stale_inflight_saturation(monkeypatch):
     assert int(state.loop_state["run_batch_workers"].get("watchdog_repair_count", 0)) >= 1
 
 
+@pytest.mark.asyncio
+async def test_loop_counter_reconcile_recovers_no_slot_without_watchdog(monkeypatch):
+    fixture = Path(
+        "tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel/"
+        "heavy_payload_pipeline_in_step_parallel.yaml"
+    )
+    playbook = yaml.safe_load(fixture.read_text(encoding="utf-8"))
+    run_batch_workers = next(
+        step for step in playbook["workflow"] if step.get("step") == "run_batch_workers"
+    )
+    run_batch_workers["args"] = {
+        "claimed_batch": "{{ iter.batch.batch_number }}",
+        "claimed_index": "{{ loop_index }}",
+    }
+
+    parsed_playbook = engine_module.Playbook(**playbook)
+    playbook_repo = PlaybookRepo()
+    state_store = StateStore(playbook_repo)
+    engine = ControlFlowEngine(playbook_repo, state_store)
+    state = ExecutionState(
+        "9403c",
+        parsed_playbook,
+        payload={
+            "build_batch_plan": {
+                "batches": [
+                    {"batch_number": 1},
+                    {"batch_number": 2},
+                    {"batch_number": 3},
+                    {"batch_number": 4},
+                    {"batch_number": 5},
+                    {"batch_number": 6},
+                ]
+            }
+        },
+    )
+
+    recent_progress_at = datetime.now(timezone.utc).isoformat()
+    fake_cache = RepairingNATSCache(
+        {
+            "collection_size": 6,
+            "completed_count": 2,
+            "scheduled_count": 5,
+            "last_progress_at": recent_progress_at,
+        }
+    )
+
+    async def fake_get_nats_cache():
+        return fake_cache
+
+    async def fake_find_missing(*_args, **_kwargs):
+        return []
+
+    async def fake_count_step_events(*_args, **_kwargs):
+        return 4
+
+    monkeypatch.setattr(engine_module, "get_nats_cache", fake_get_nats_cache)
+    monkeypatch.setattr(engine, "_find_missing_loop_iteration_indices", fake_find_missing)
+    monkeypatch.setattr(engine, "_count_step_events", fake_count_step_events)
+    monkeypatch.setattr(engine_module, "_LOOP_COUNTER_RECONCILE_COOLDOWN_SECONDS", 0.0)
+    monkeypatch.setattr(engine_module, "_LOOP_STALL_WATCHDOG_SECONDS", 300.0)
+
+    step_def = state.get_step("run_batch_workers")
+    step_def.loop.spec.max_in_flight = 3
+    command = await engine._create_command_for_step(state, step_def, {})
+
+    assert command is not None
+    assert command.args.get("claimed_batch") == 6
+    assert command.args.get("claimed_index") == 5
+    assert int(fake_cache.state.get("completed_count", 0)) == 4
+    assert int(fake_cache.state.get("scheduled_count", 0)) == 6
+    assert fake_cache.state.get("last_counter_reconcile_at")
+
+
 def test_restore_loop_collection_snapshot_when_replay_shrinks_collection():
     fixture = Path(
         "tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel/"
@@ -671,6 +744,17 @@ def test_loop_event_ids_compatible_does_not_treat_exec_as_wildcard():
     assert (
         ControlFlowEngine._loop_event_ids_compatible("exec_123", "987654")
         is False
+    )
+
+
+def test_node_name_candidates_include_task_sequence_alias():
+    assert engine_module._node_name_candidates("load_data") == (
+        "load_data",
+        "load_data:task_sequence",
+    )
+    assert engine_module._node_name_candidates("load_data:task_sequence") == (
+        "load_data:task_sequence",
+        "load_data",
     )
 
 


### PR DESCRIPTION
## Summary
- add fast loop counter reconciliation when distributed loop state reports no claimable slot
- recover loop progress from persisted call.done counts and retry claim in the same scheduling pass
- normalize loop recovery/count queries to treat step and step:task_sequence node names as aliases
- add targeted regression tests for counter reconcile and node-name alias behavior

## Why
Executions could go inactive when loop counters drifted and no further events arrived to trigger watchdog recovery. This patch recovers claim slots proactively and prevents silent stalls.

## Validation
- PYTHONPATH=. uv run --python 3.12 python -m pytest -q tests/unit/dsl/v2/test_loop_parallel_dispatch.py -k "watchdog or counter_reconcile or node_name_candidates"
- PYTHONPATH=. uv run --python 3.12 python -m pytest -q tests/unit/dsl/v2/test_task_sequence_loop_completion.py -k "terminal_events_emit_when_pending_key_is_task_sequence_suffix or task_sequence_loop_uses_nats_collection_size_when_local_collection_missing"