### PR TITLE
fix: prefer terminal lifecycle state in executions list

### DIFF
--- a/noetl/server/api/execution/endpoint.py
+++ b/noetl/server/api/execution/endpoint.py
@@ -829,7 +829,10 @@ async def get_executions(
                             le.node_name,
                             le.status,
                             le.created_at AS end_time,
-                            le.error
+                            le.error,
+                            te.event_type AS terminal_event_type,
+                            te.status AS terminal_status,
+                            te.created_at AS terminal_end_time
                         FROM recent_executions re
                         JOIN LATERAL (
                             SELECT
@@ -843,6 +846,24 @@ async def get_executions(
                             ORDER BY e.event_id DESC
                             LIMIT 1
                         ) le ON TRUE
+                        LEFT JOIN LATERAL (
+                            SELECT
+                                e.event_type,
+                                e.status,
+                                e.created_at
+                            FROM noetl.event e
+                            WHERE e.execution_id = re.execution_id
+                              AND e.event_type IN (
+                                'execution.cancelled',
+                                'playbook.failed',
+                                'workflow.failed',
+                                'command.failed',
+                                'playbook.completed',
+                                'workflow.completed'
+                              )
+                            ORDER BY e.event_id DESC
+                            LIMIT 1
+                        ) te ON TRUE
                     )
                     SELECT
                         le.execution_id,
@@ -856,6 +877,9 @@ async def get_executions(
                         NULL::jsonb AS result,
                         le.error,
                         le.parent_execution_id,
+                        le.terminal_event_type,
+                        le.terminal_status,
+                        le.terminal_end_time,
                         COALESCE(c.path, 'unknown') AS path,
                         COALESCE(c.version, 0) AS version
                     FROM latest_event le
@@ -868,6 +892,7 @@ async def get_executions(
                     for row in rows
                     if row.get("derived_event_type") == "batch.completed"
                     and str(row.get("status") or "").upper() == "COMPLETED"
+                    and row.get("terminal_event_type") is None
                 ]
                 pending_counts = await _fetch_pending_command_counts_for_executions(
                     cursor,
@@ -889,19 +914,12 @@ async def get_executions(
                     "status": row_dict.get("status"),
                 }
                 terminal_event = None
-                derived_event_type = row_dict.get("derived_event_type")
-                if derived_event_type in {
-                    "execution.cancelled",
-                    "playbook.failed",
-                    "workflow.failed",
-                    "command.failed",
-                    "playbook.completed",
-                    "workflow.completed",
-                }:
+                terminal_event_type = row_dict.get("terminal_event_type")
+                if terminal_event_type:
                     terminal_event = {
-                        "event_type": derived_event_type,
-                        "created_at": row_dict.get("end_time"),
-                        "status": row_dict.get("status"),
+                        "event_type": terminal_event_type,
+                        "created_at": row_dict.get("terminal_end_time"),
+                        "status": row_dict.get("terminal_status"),
                     }
                 derived_status, inferred_end_time = _infer_execution_completion_from_events(
                     latest_event,

--- a/tests/api/execution/test_executions_status_consistency.py
+++ b/tests/api/execution/test_executions_status_consistency.py
@@ -195,6 +195,43 @@ async def test_get_executions_keeps_terminal_completed(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_executions_prefers_terminal_event_even_if_latest_is_non_terminal(monkeypatch):
+    start = datetime(2026, 3, 21, 7, 0, 0, tzinfo=timezone.utc)
+    latest = datetime(2026, 3, 21, 7, 5, 0, tzinfo=timezone.utc)
+    terminal = datetime(2026, 3, 21, 7, 4, 30, tzinfo=timezone.utc)
+    rows = [
+        {
+            "execution_id": "123",
+            "catalog_id": "321",
+            "event_type": "batch.completed",
+            "status": "COMPLETED",
+            "derived_event_type": "batch.completed",
+            "start_time": start,
+            "end_time": latest,
+            "result": None,
+            "error": None,
+            "parent_execution_id": None,
+            "terminal_event_type": "execution.cancelled",
+            "terminal_status": "CANCELLED",
+            "terminal_end_time": terminal,
+            "path": "bhs/state_report_generation_prod_v10",
+            "version": 1,
+        }
+    ]
+
+    monkeypatch.setattr(
+        execution_api,
+        "get_pool_connection",
+        lambda: _ConnCtx(_FakeConn(_FakeCursor(rows))),
+    )
+
+    result = await execution_api.get_executions()
+    assert len(result) == 1
+    assert result[0].status == "CANCELLED"
+    assert result[0].end_time == terminal
+
+
+@pytest.mark.asyncio
 async def test_get_executions_infers_completed_from_batch_done_without_pending(monkeypatch):
     now = datetime(2026, 3, 21, 7, 0, 0, tzinfo=timezone.utc)
     rows = [


### PR DESCRIPTION
## Summary
- make /api/executions derive status using the latest terminal lifecycle event, not only the latest event overall
- keep pending-command checks only for executions without terminal lifecycle events
- add regression coverage for terminal precedence when latest event is non-terminal

## Why
 could show CANCELLED/FAILED while  still showed RUNNING when a later non-terminal event existed after terminal lifecycle emission.

## Validation
- python3 -m py_compile noetl/server/api/execution/endpoint.py tests/api/execution/test_executions_status_consistency.py
- pytest could not be executed in this shell due missing local deps (psycopg)