### PR TITLE
fix(runtime): fail no-progress task_sequence and normalize terminal filters

### DIFF
--- a/noetl/server/api/execution/endpoint.py
+++ b/noetl/server/api/execution/endpoint.py
@@ -1845,7 +1845,7 @@ async def cleanup_stuck_executions(request: CleanupStuckExecutionsRequest = Body
     Marks executions as CANCELLED if they:
     - Have a 'playbook.initialized' event
     - Are older than specified minutes (default: 5)
-    - Have no terminal event (playbook.completed, playbook.failed, execution.cancelled)
+    - Have no terminal event (playbook/workflow completed|failed, execution.cancelled)
     
     This is useful for cleaning up executions interrupted by server restarts.
     """
@@ -1867,7 +1867,13 @@ async def cleanup_stuck_executions(request: CleanupStuckExecutionsRequest = Body
                   AND NOT EXISTS (
                     SELECT 1 FROM event e2 
                     WHERE e2.execution_id = e1.execution_id 
-                      AND e2.event_type IN ('playbook.completed', 'playbook.failed', 'execution.cancelled')
+                      AND e2.event_type IN (
+                          'playbook.completed',
+                          'workflow.completed',
+                          'playbook.failed',
+                          'workflow.failed',
+                          'execution.cancelled'
+                      )
                   )
                 ORDER BY e1.execution_id
             """, (request.older_than_minutes,))

--- a/noetl/server/auto_resume.py
+++ b/noetl/server/auto_resume.py
@@ -253,7 +253,13 @@ async def get_execution_status(execution_id: int) -> str:
                 SELECT event_type, status
                 FROM noetl.event
                 WHERE execution_id = %s
-                  AND event_type IN ('playbook.completed', 'playbook.failed', 'execution.cancelled')
+                  AND event_type IN (
+                      'playbook.completed',
+                      'workflow.completed',
+                      'playbook.failed',
+                      'workflow.failed',
+                      'execution.cancelled'
+                  )
                 ORDER BY created_at DESC
                 LIMIT 1
                 """,
@@ -261,9 +267,9 @@ async def get_execution_status(execution_id: int) -> str:
             )
             row = await cur.fetchone()
             if row:
-                if row["event_type"] == "playbook.completed":
+                if row["event_type"] in {"playbook.completed", "workflow.completed"}:
                     return "completed"
-                if row["event_type"] == "playbook.failed":
+                if row["event_type"] in {"playbook.failed", "workflow.failed"}:
                     return "failed"
                 if row["event_type"] == "execution.cancelled":
                     return "cancelled"
@@ -308,7 +314,13 @@ async def get_recovery_candidates() -> list[Dict[str, Any]]:
                     SELECT 1
                     FROM noetl.event t
                     WHERE t.execution_id = e.execution_id
-                      AND t.event_type IN ('playbook.completed', 'playbook.failed', 'execution.cancelled')
+                      AND t.event_type IN (
+                          'playbook.completed',
+                          'workflow.completed',
+                          'playbook.failed',
+                          'workflow.failed',
+                          'execution.cancelled'
+                      )
                   )
                 ORDER BY e.created_at DESC
                 LIMIT %s

--- a/noetl/worker/task_sequence_executor.py
+++ b/noetl/worker/task_sequence_executor.py
@@ -222,7 +222,17 @@ class TaskSequenceExecutor:
     NO BACKWARD COMPATIBILITY - rejects eval, expr, set_vars.
     """
     _MISSING_REFERENCE_CODE = "REFERENCE_NOT_AVAILABLE"
+    _NO_PROGRESS_CODE = "TASK_SEQUENCE_NO_PROGRESS"
     _SPECIAL_PREVIOUS_TARGETS = {"previous", "prev", "_previous", "@previous"}
+    _PATIENT_COUNT_KEYS = {
+        "patient_count",
+        "patients_count",
+        "active_patient_count",
+        "active_patients_count",
+        "total_patient_count",
+        "total_patients",
+        "patient_total",
+    }
 
     def __init__(
         self,
@@ -241,6 +251,112 @@ class TaskSequenceExecutor:
         self.tool_executor = tool_executor
         self.render_template = render_template
         self.render_dict = render_dict
+
+    @staticmethod
+    def _coerce_positive_int(value: Any) -> Optional[int]:
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value if value > 0 else None
+        if isinstance(value, float):
+            value_int = int(value)
+            return value_int if value_int > 0 else None
+        if isinstance(value, str):
+            raw = value.strip()
+            if raw.isdigit():
+                parsed = int(raw)
+                return parsed if parsed > 0 else None
+        return None
+
+    @classmethod
+    def _extract_positive_patient_count(
+        cls,
+        value: Any,
+        *,
+        depth: int = 0,
+        max_depth: int = 8,
+    ) -> Optional[int]:
+        if depth > max_depth:
+            return None
+        max_found: Optional[int] = None
+        if isinstance(value, dict):
+            for key, child in value.items():
+                key_norm = str(key).strip().lower()
+                if key_norm in cls._PATIENT_COUNT_KEYS:
+                    count = cls._coerce_positive_int(child)
+                    if count is not None:
+                        max_found = max(max_found or 0, count)
+            for child in value.values():
+                nested = cls._extract_positive_patient_count(
+                    child,
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                )
+                if nested is not None:
+                    max_found = max(max_found or 0, nested)
+            return max_found
+        if isinstance(value, list):
+            for child in value:
+                nested = cls._extract_positive_patient_count(
+                    child,
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                )
+                if nested is not None:
+                    max_found = max(max_found or 0, nested)
+            return max_found
+        return None
+
+    @staticmethod
+    def _extract_task_name(task_def: Any, idx: int) -> str:
+        if isinstance(task_def, dict):
+            name = task_def.get("name")
+            if isinstance(name, str) and name.strip():
+                return name.strip()
+        return f"task_{idx}"
+
+    @classmethod
+    def _looks_like_fetch_pagination_break(cls, remaining_tasks: list[Any]) -> bool:
+        if not remaining_tasks:
+            return False
+        names = [cls._extract_task_name(task_def, idx) for idx, task_def in enumerate(remaining_tasks)]
+        normalized = {name.strip().lower() for name in names if isinstance(name, str)}
+        has_paginate = "paginate" in normalized
+        has_fetch_or_save = bool({"fetch_page", "save_page"} & normalized)
+        return has_paginate and has_fetch_or_save
+
+    def _build_no_progress_error(
+        self,
+        *,
+        task_name: str,
+        base_context: dict[str, Any],
+        remaining_tasks: list[Any],
+        results: dict[str, Any],
+    ) -> Optional[dict[str, Any]]:
+        if set(results.keys()) != {"init_page"}:
+            return None
+        if not self._looks_like_fetch_pagination_break(remaining_tasks):
+            return None
+        patient_count = self._extract_positive_patient_count(base_context)
+        if patient_count is None:
+            return None
+        remaining_names = [
+            self._extract_task_name(task_def, idx)
+            for idx, task_def in enumerate(remaining_tasks)
+        ]
+        return {
+            "kind": "logic",
+            "code": self._NO_PROGRESS_CODE,
+            "retryable": False,
+            "message": (
+                f"Task sequence broke at '{task_name}' without page fetch progress "
+                f"while patient_count={patient_count}."
+            ),
+            "details": {
+                "patient_count": patient_count,
+                "remaining_tasks": remaining_names,
+            },
+        }
 
     async def execute(
         self,
@@ -547,6 +663,26 @@ class TaskSequenceExecutor:
 
             elif action.action == "break":
                 remaining = tasks[current_idx + 1:] if current_idx + 1 < len(tasks) else []
+                no_progress_error = self._build_no_progress_error(
+                    task_name=task_name,
+                    base_context=base_context,
+                    remaining_tasks=remaining,
+                    results=ctx.results,
+                )
+                if no_progress_error:
+                    logger.error(
+                        "[TASK_SEQ] No-progress break detected at '%s' with patient_count=%s",
+                        task_name,
+                        no_progress_error.get("details", {}).get("patient_count"),
+                    )
+                    return {
+                        "status": "failed",
+                        "_prev": ctx._prev,
+                        "results": ctx.results,
+                        "ctx": ctx.ctx,
+                        "error": no_progress_error,
+                        "failed_task": task_name,
+                    }
                 logger.info(f"[TASK_SEQ] Breaking from task sequence at '{task_name}'")
                 return {
                     "status": "break",

--- a/tests/test_auto_resume.py
+++ b/tests/test_auto_resume.py
@@ -191,3 +191,64 @@ def test_should_recover_candidate_allows_stale_inflight_execution(monkeypatch):
 
 async def _async_value(value):
     return value
+
+
+class _FakeCursor:
+    def __init__(self, row):
+        self._row = row
+
+    async def execute(self, _query, _params=None):
+        return None
+
+    async def fetchone(self):
+        return self._row
+
+
+class _FakeCursorCtx:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    async def __aenter__(self):
+        return self._cursor
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeConn:
+    def __init__(self, row):
+        self._row = row
+
+    def cursor(self, row_factory=None):
+        return _FakeCursorCtx(_FakeCursor(self._row))
+
+
+class _FakeConnCtx:
+    def __init__(self, row):
+        self._row = row
+
+    async def __aenter__(self):
+        return _FakeConn(self._row)
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_get_execution_status_treats_workflow_completed_as_completed(monkeypatch):
+    row = {"event_type": "workflow.completed", "status": "COMPLETED"}
+    monkeypatch.setattr(auto_resume, "get_pool_connection", lambda *args, **kwargs: _FakeConnCtx(row))
+
+    status = await auto_resume.get_execution_status(123)
+
+    assert status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_get_execution_status_treats_workflow_failed_as_failed(monkeypatch):
+    row = {"event_type": "workflow.failed", "status": "FAILED"}
+    monkeypatch.setattr(auto_resume, "get_pool_connection", lambda *args, **kwargs: _FakeConnCtx(row))
+
+    status = await auto_resume.get_execution_status(456)
+
+    assert status == "failed"

--- a/tests/worker/test_task_sequence_executor.py
+++ b/tests/worker/test_task_sequence_executor.py
@@ -373,3 +373,95 @@ def test_task_sequence_missing_reference_detection_avoids_refresh_false_positive
     assert TaskSequenceExecutor._is_missing_reference_error(
         "refresh token missing for upstream auth provider"
     ) is False
+
+
+@pytest.mark.asyncio
+async def test_task_sequence_break_with_only_init_page_fails_when_patient_count_positive():
+    async def fake_tool_executor(_kind: str, _config: dict, _ctx: dict):
+        return {"status": "noop"}
+
+    executor = TaskSequenceExecutor(
+        tool_executor=fake_tool_executor,
+        render_template=_render_template,
+        render_dict=_render_dict,
+    )
+
+    tasks = [
+        {
+            "name": "init_page",
+            "kind": "noop",
+            "spec": {"policy": {"rules": [{"else": {"then": {"do": "break"}}}]}},
+        },
+        {
+            "name": "fetch_page",
+            "kind": "http",
+            "spec": {"policy": {"rules": [{"else": {"then": {"do": "continue"}}}]}},
+        },
+        {
+            "name": "save_page",
+            "kind": "postgres",
+            "spec": {"policy": {"rules": [{"else": {"then": {"do": "continue"}}}]}},
+        },
+        {
+            "name": "paginate",
+            "kind": "noop",
+            "spec": {"policy": {"rules": [{"else": {"then": {"do": "continue"}}}]}},
+        },
+    ]
+
+    result = await executor.execute(
+        tasks=tasks,
+        base_context={"ctx": {"patient_count": 4}},
+    )
+
+    assert result["status"] == "failed"
+    assert result["failed_task"] == "init_page"
+    assert result["error"]["code"] == "TASK_SEQUENCE_NO_PROGRESS"
+    assert result["error"]["retryable"] is False
+
+
+@pytest.mark.asyncio
+async def test_task_sequence_break_with_only_init_page_allows_zero_or_missing_patient_count():
+    async def fake_tool_executor(_kind: str, _config: dict, _ctx: dict):
+        return {"status": "noop"}
+
+    executor = TaskSequenceExecutor(
+        tool_executor=fake_tool_executor,
+        render_template=_render_template,
+        render_dict=_render_dict,
+    )
+
+    tasks = [
+        {
+            "name": "init_page",
+            "kind": "noop",
+            "spec": {"policy": {"rules": [{"else": {"then": {"do": "break"}}}]}},
+        },
+        {
+            "name": "fetch_page",
+            "kind": "http",
+            "spec": {"policy": {"rules": [{"else": {"then": {"do": "continue"}}}]}},
+        },
+        {
+            "name": "save_page",
+            "kind": "postgres",
+            "spec": {"policy": {"rules": [{"else": {"then": {"do": "continue"}}}]}},
+        },
+        {
+            "name": "paginate",
+            "kind": "noop",
+            "spec": {"policy": {"rules": [{"else": {"then": {"do": "continue"}}}]}},
+        },
+    ]
+
+    zero_count_result = await executor.execute(
+        tasks=tasks,
+        base_context={"ctx": {"patient_count": 0}},
+    )
+    missing_count_result = await executor.execute(
+        tasks=tasks,
+        base_context={},
+    )
+
+    assert zero_count_result["status"] == "break"
+    assert missing_count_result["status"] == "break"


### PR DESCRIPTION
## Summary
- add a guard in task_sequence execution to fail when a pagination sequence breaks at init_page with only init_page result and positive patient count
- emit structured TASK_SEQUENCE_NO_PROGRESS error to prevent false-success runs
- normalize terminal-state checks in auto-resume/cleanup paths to include workflow terminal events with execution.cancelled
- add unit coverage for both changes

## Validation
- python3 -m py_compile noetl/worker/task_sequence_executor.py noetl/server/auto_resume.py noetl/server/api/execution/endpoint.py tests/worker/test_task_sequence_executor.py tests/test_auto_resume.py
- full pytest run in this environment is blocked by missing local dependencies (psycopg / package import path)