### PR TITLE
refactor: enforce strict reference-only task result contract

### DIFF
--- a/noetl/core/dsl/render.py
+++ b/noetl/core/dsl/render.py
@@ -37,15 +37,6 @@ class TaskResultProxy:
             return val
         if isinstance(data, dict) and name in data:
             return _wrap(data[name])
-        # Backward-compatibility shim for reference-only contract:
-        # step results are often persisted as {"status": "...", "context": {...}}
-        # while legacy templates still access top-level command_* keys
-        # (e.g., {{ step.command_0.rows[0].id }}). Resolve those from
-        # result.context when not present at top level.
-        if isinstance(data, dict):
-            context = data.get("context")
-            if isinstance(context, dict) and name in context:
-                return _wrap(context[name])
         raise AttributeError(f"'{type(data).__name__}' object has no attribute '{name}'")
 
     def __getitem__(self, key):
@@ -57,9 +48,6 @@ class TaskResultProxy:
                 return val
             if key in data:
                 return _wrap(data[key])
-            context = data.get("context") if isinstance(data, dict) else None
-            if isinstance(context, dict) and key in context:
-                return _wrap(context[key])
             return data[key]
         except Exception as e:
             raise KeyError(key) from e
@@ -67,11 +55,6 @@ class TaskResultProxy:
     def get(self, key, default=None):
         data = object.__getattribute__(self, "_data")
         if isinstance(data, dict):
-            if key in data:
-                return data.get(key, default)
-            context = data.get("context")
-            if isinstance(context, dict):
-                return context.get(key, default)
             return data.get(key, default)
         return default
 
@@ -83,10 +66,7 @@ class TaskResultProxy:
 
     def __contains__(self, key):
         data = object.__getattribute__(self, "_data")
-        if key in data:
-            return True
-        context = data.get("context") if isinstance(data, dict) else None
-        return isinstance(context, dict) and key in context
+        return key in data
 
     def __iter__(self):
         return iter(object.__getattribute__(self, "_data"))

--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -443,31 +443,6 @@ class ExecutionState:
         """
         self.completed_steps.add(step_name)
         if result is not None:
-            if isinstance(result, dict):
-                # Reference-only compatibility:
-                # worker/server store compact step output under result.context, while
-                # many existing templates still read step.command_0.*.
-                # Promote only known command keys to avoid flattening arbitrary
-                # user payloads that may legitimately use a nested "context".
-                context_obj = result.get("context")
-                if isinstance(context_obj, dict):
-                    has_reference_shape = "reference" in result or "_ref" in result
-                    has_command_context = any(
-                        str(key).startswith("command_") for key in context_obj.keys()
-                    )
-                    if has_reference_shape or has_command_context:
-                        for key, value in context_obj.items():
-                            key_str = str(key)
-                            if key_str.startswith("command_") or key_str == "command_id":
-                                result.setdefault(key, value)
-                else:
-                    # Also support templates that expect step.context.* when the
-                    # payload is already a plain dict of compact fields.
-                    result["context"] = {
-                        k: v
-                        for k, v in result.items()
-                        if k not in {"reference", "_ref", "context"}
-                    }
             self.step_results[step_name] = result
             self.variables[step_name] = result
 
@@ -689,29 +664,15 @@ class ExecutionState:
             }
             # Note: Iterator variable itself (e.g., {{ num }}) comes from state.variables
         
-        # Add event-specific data
-        if isinstance(event_payload, dict) and "response" in event_payload:
-            context["response"] = event_payload["response"]
-        elif isinstance(event_payload, dict) and "result" in event_payload:
-            # Fallback: expose result as response for templates that expect {{ response.* }} on step.exit
-            context["response"] = event_payload["result"]
-        if isinstance(event_payload, dict) and "error" in event_payload:
-            context["error"] = event_payload["error"]
-        if isinstance(event_payload, dict) and "result" in event_payload:
-            context["result"] = event_payload["result"]
-        else:
-            # CRITICAL FIX: For call.done events, the worker sends the tool response
-            # directly as the payload (not wrapped in a "result" key). Make the entire
-            # payload available as "result" so case conditions like
-            # {{ result.sub is defined }} work correctly.
-            if event.name == "call.done" and event_payload:
-                context["result"] = event_payload
-                # Only set response if not already extracted from "response" key
-                # Worker may send {"response": actual_response} where actual_response
-                # was already extracted at line 413
-                if "response" not in context:
-                    context["response"] = event_payload
-                logger.debug(f"[RENDER_CTX] Set result/response from call.done payload for {event.step}")
+        # Add event-specific data (strict reference-only contract).
+        if isinstance(event_payload, dict):
+            if "error" in event_payload:
+                context["error"] = event_payload["error"]
+            if "result" in event_payload:
+                context["result"] = event_payload["result"]
+                # Keep response alias for existing condition expressions, but only
+                # from strict result envelope (never raw tool response payload).
+                context["response"] = event_payload["result"]
 
         return context
 
@@ -1058,17 +1019,13 @@ class StateStore:
                                 event_type,
                             )
 
-                    # Compatibility: older rows may still use {"kind":"...","data":...} wrappers.
-                    # Replay should work against payload semantics, not storage transport details.
                     event_payload = result_data
-                    if isinstance(result_data, dict) and "kind" in result_data and "data" in result_data:
-                        event_payload = result_data.get("data")
 
                     # Task-sequence policy rules can mutate ctx on the worker. Replay must
                     # restore those execution-scoped variables from persisted call.done events
                     # so a cache miss on another server does not lose them.
                     if event_type == 'call.done' and isinstance(event_payload, dict) and isinstance(node_name, str) and node_name.endswith(":task_sequence"):
-                        response_data = event_payload.get("response", event_payload)
+                        response_data = event_payload.get("result", event_payload)
                         if isinstance(response_data, dict):
                             task_ctx = response_data.get("ctx", {})
                             if isinstance(task_ctx, dict):
@@ -2410,13 +2367,11 @@ class ControlFlowEngine:
                         "pending_retry": False
                     }
 
-                # Extract data from response using path
-                result_data = event.payload.get("response")
-                if result_data is None and "result" in event.payload:
-                    result_data = event.payload["result"]
+                # Extract data from strict result envelope.
+                result_data = event.payload.get("result")
 
                 if result_data is None:
-                    logger.warning(f"[COLLECT] No response or result payload to collect for step {step_name}")
+                    logger.warning(f"[COLLECT] No result payload to collect for step {step_name}")
                 else:
                     data_to_collect = result_data
                     if path and isinstance(result_data, dict):
@@ -3794,7 +3749,7 @@ class ControlFlowEngine:
         if event.step.endswith(":task_sequence") and event.name == "call.done":
             parent_step = event.step.rsplit(":", 1)[0]
             response_data = (
-                normalized_payload.get("response", normalized_payload)
+                normalized_payload.get("result", normalized_payload)
                 if isinstance(normalized_payload, dict)
                 else normalized_payload
             )
@@ -4170,17 +4125,16 @@ class ControlFlowEngine:
         worker_eval_action = normalized_payload.get("eval_action") if isinstance(normalized_payload, dict) else None
         has_worker_retry = worker_eval_action and worker_eval_action.get("type") == "retry"
 
-        # CRITICAL: Store call.done/call.error response in state BEFORE evaluating next transitions
+        # CRITICAL: Store call.done/call.error result in state BEFORE evaluating next transitions
         # This ensures the result is available in render context for subsequent steps
-        # Worker sends response directly as payload (not wrapped in "response" key)
         if event.name == "call.done":
             response_data = (
-                normalized_payload.get("response", normalized_payload)
+                normalized_payload.get("result", normalized_payload)
                 if isinstance(normalized_payload, dict)
                 else normalized_payload
             )
             state.mark_step_completed(event.step, response_data)
-            logger.debug(f"[CALL.DONE] Stored response for step {event.step} in state BEFORE next evaluation")
+            logger.debug(f"[CALL.DONE] Stored result for step {event.step} in state BEFORE next evaluation")
         elif event.name == "call.error":
             # Mark step as completed even on error - it finished executing (with failure)
             error_data = (
@@ -4243,7 +4197,7 @@ class ControlFlowEngine:
         # never triggers handle_event().
         if event.name == "call.done" and is_loop_step:
             response_data = (
-                normalized_payload.get("response", normalized_payload)
+                normalized_payload.get("result", normalized_payload)
                 if isinstance(normalized_payload, dict)
                 else normalized_payload
             )
@@ -5169,8 +5123,17 @@ class ControlFlowEngine:
                     if event.step in state.step_event_ids:
                         meta["previous_step_event_id"] = str(state.step_event_ids[event.step])
                 
-                # Merge with existing context metadata
-                context_data = event.payload.get("context", {})
+                # Merge with existing context metadata from strict result envelope.
+                context_data = {}
+                payload_result = event.payload.get("result")
+                if isinstance(payload_result, dict):
+                    payload_context = payload_result.get("context")
+                    if isinstance(payload_context, dict):
+                        context_data = dict(payload_context)
+                elif isinstance(event.payload.get("context"), dict):
+                    # Transitional guard for non-step events that may still provide top-level context.
+                    context_data = dict(event.payload.get("context") or {})
+
                 if isinstance(context_data, dict):
                     # CRITICAL: Convert all IDs to strings to prevent JavaScript precision loss with Snowflake IDs
                     context_data["execution_id"] = str(event.execution_id)
@@ -5178,15 +5141,6 @@ class ControlFlowEngine:
                     context_data["root_event_id"] = str(state.root_event_id) if state.root_event_id else None
                 else:
                     context_data = {}
-
-                # Persist payload result details in context column (not event.result).
-                # event.result is reserved for control-plane status + optional reference/context.
-                payload_result = event.payload.get("result")
-                if isinstance(payload_result, dict):
-                    for key, value in payload_result.items():
-                        context_data.setdefault(key, value)
-                elif payload_result is not None:
-                    context_data.setdefault("result_value", payload_result)
                 
                 # Determine status: Use payload status if provided, otherwise infer from event name
                 payload_status = event.payload.get("status")
@@ -5198,7 +5152,11 @@ class ControlFlowEngine:
                     status = "FAILED" if "failed" in event.name else "COMPLETED" if ("step.exit" == event.name or "completed" in event.name) else "RUNNING"
 
                 result_obj: dict[str, Any] = {"status": status}
-                payload_reference = event.payload.get("reference")
+                payload_reference = None
+                if isinstance(payload_result, dict):
+                    payload_reference = payload_result.get("reference")
+                if not isinstance(payload_reference, dict):
+                    payload_reference = event.payload.get("reference")
                 if isinstance(payload_reference, dict):
                     result_obj["reference"] = payload_reference
 

--- a/noetl/server/api/v2.py
+++ b/noetl/server/api/v2.py
@@ -446,11 +446,87 @@ def _extract_event_command_id(req: "EventRequest") -> Optional[str]:
     payload_context = payload.get("context")
     if isinstance(payload_context, dict):
         candidates.append(payload_context.get("command_id"))
+    payload_result = payload.get("result")
+    if isinstance(payload_result, dict):
+        candidates.append(payload_result.get("command_id"))
+        result_context = payload_result.get("context")
+        if isinstance(result_context, dict):
+            candidates.append(result_context.get("command_id"))
 
     for value in candidates:
         if isinstance(value, str) and value.strip():
             return value.strip()
     return None
+
+
+_STRICT_RESULT_ALLOWED_KEYS = {"status", "error", "reference", "context", "meta", "command_id"}
+_STRICT_PAYLOAD_FORBIDDEN_KEYS = {"response", "inputs", "data", "data_reference", "_internal_data", "_inline"}
+_STRICT_CONTEXT_FORBIDDEN_KEYS = {"response", "result", "payload", "data", "_ref", "_inline", "_internal_data"}
+
+
+def _contains_forbidden_payload_keys(value: Any, forbidden_keys: set[str], *, depth: int = 0) -> bool:
+    if depth > 8:
+        return False
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if str(key) in forbidden_keys:
+                return True
+            if _contains_forbidden_payload_keys(child, forbidden_keys, depth=depth + 1):
+                return True
+    elif isinstance(value, list):
+        for child in value:
+            if _contains_forbidden_payload_keys(child, forbidden_keys, depth=depth + 1):
+                return True
+    return False
+
+
+def _contains_legacy_command_keys(value: Any, *, depth: int = 0) -> bool:
+    if depth > 8:
+        return False
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if str(key).startswith("command_"):
+                return True
+            if _contains_legacy_command_keys(child, depth=depth + 1):
+                return True
+    elif isinstance(value, list):
+        for child in value:
+            if _contains_legacy_command_keys(child, depth=depth + 1):
+                return True
+    return False
+
+
+def _validate_reference_only_payload(payload: dict[str, Any]) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("event payload must be an object")
+
+    if any(key in payload for key in _STRICT_PAYLOAD_FORBIDDEN_KEYS):
+        bad = sorted(key for key in payload.keys() if key in _STRICT_PAYLOAD_FORBIDDEN_KEYS)
+        raise ValueError(f"payload includes forbidden inline output keys: {', '.join(bad)}")
+
+    result_obj = payload.get("result")
+    if result_obj is None:
+        return
+
+    if not isinstance(result_obj, dict):
+        raise ValueError("payload.result must be an object")
+
+    unknown = sorted(str(k) for k in result_obj.keys() if str(k) not in _STRICT_RESULT_ALLOWED_KEYS)
+    if unknown:
+        raise ValueError(f"payload.result includes unsupported keys: {', '.join(unknown)}")
+
+    reference_obj = result_obj.get("reference")
+    if reference_obj is not None and not isinstance(reference_obj, dict):
+        raise ValueError("payload.result.reference must be an object")
+
+    context_obj = result_obj.get("context")
+    if context_obj is not None:
+        if not isinstance(context_obj, dict):
+            raise ValueError("payload.result.context must be an object")
+        if _contains_forbidden_payload_keys(context_obj, _STRICT_CONTEXT_FORBIDDEN_KEYS):
+            raise ValueError("payload.result.context includes forbidden inline data keys")
+        if _contains_legacy_command_keys(context_obj):
+            raise ValueError("payload.result.context includes legacy command_* keys")
 
 
 _EVENT_TYPE_TERMINAL_PREDICATE = (
@@ -1173,10 +1249,6 @@ class EventRequest(BaseModel):
     payload: dict[str, Any] = Field(default_factory=dict)
     meta: Optional[dict[str, Any]] = None
     worker_id: Optional[str] = None
-    # Legacy result transport hints (normalized into reference-only result shape)
-    result_kind: Literal["data", "ref", "refs"] = "data"
-    result_uri: Optional[str] = None  # For kind=ref
-    event_ids: Optional[list[int]] = None  # For kind=refs
     # Control flags (stored in meta column)
     actionable: bool = True  # If True, server should take action (evaluate case, route)
     informative: bool = True  # If True, event is for logging/observability
@@ -1851,6 +1923,13 @@ async def handle_event(req: EventRequest) -> EventResponse:
         
         # For command.claimed, use fully atomic claiming with advisory lock + insert in same transaction
         if req.name == "command.claimed":
+            try:
+                _validate_reference_only_payload(req.payload)
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"Invalid reference-only event payload for step '{req.step}' event '{req.name}': {exc}",
+                ) from exc
             command_id = req.payload.get("command_id") or (req.meta or {}).get("command_id")
             if command_id:
                 async with get_pool_connection() as conn:
@@ -1904,9 +1983,6 @@ async def handle_event(req: EventRequest) -> EventResponse:
                         result_obj = _build_reference_only_result(
                             payload=req.payload,
                             status="RUNNING",
-                            result_kind=req.result_kind,
-                            result_uri=req.result_uri,
-                            event_ids=req.event_ids,
                         )
 
                         await cur.execute("""
@@ -1926,12 +2002,17 @@ async def handle_event(req: EventRequest) -> EventResponse:
                         return EventResponse(status="ok", event_id=evt_id, commands_generated=0)
 
         status = _status_from_event_name(req.name)
+        try:
+            _validate_reference_only_payload(req.payload)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid reference-only event payload for step '{req.step}' event '{req.name}': {exc}",
+            ) from exc
+
         result_obj = _build_reference_only_result(
             payload=req.payload,
             status=status,
-            result_kind=req.result_kind,
-            result_uri=req.result_uri,
-            event_ids=req.event_ids,
         )
         command_id = _extract_event_command_id(req)
         event_meta = dict(req.meta or {})
@@ -2153,183 +2234,7 @@ def _status_from_event_name(event_name: str) -> str:
     return "RUNNING"
 
 
-def _reference_from_uri(uri: str) -> dict[str, Any]:
-    lowered = uri.lower()
-    if lowered.startswith(("gs://", "s3://", "http://", "https://")):
-        return {"type": "object_store", "url": uri}
-    if lowered.startswith("nats://"):
-        return {"type": "nats", "locator": uri}
-    if lowered.startswith(("postgres://", "postgresql://")):
-        return {"type": "relational", "db_url": uri}
-    return {"type": "external", "locator": uri}
-
-
-def _extract_reference_from_payload(
-    payload: dict[str, Any],
-    *,
-    result_kind: str = "data",
-    result_uri: Optional[str] = None,
-    event_ids: Optional[list[int]] = None,
-) -> Optional[dict[str, Any]]:
-    if result_kind == "ref" and result_uri:
-        return _reference_from_uri(result_uri)
-    if result_kind == "refs" and event_ids:
-        return {"type": "event_refs", "event_ids": [int(x) for x in event_ids if isinstance(x, int)]}
-
-    direct_reference = payload.get("reference")
-    if isinstance(direct_reference, dict):
-        return direct_reference
-
-    candidates = [
-        payload.get("response"),
-        payload.get("result"),
-        payload.get("context"),
-        payload.get("inputs"),
-        payload.get("data_reference"),
-    ]
-    for candidate in candidates:
-        if not isinstance(candidate, dict):
-            continue
-        ref_wrapper = candidate.get("_ref")
-        if not isinstance(ref_wrapper, dict):
-            continue
-
-        ref_value = str(ref_wrapper.get("ref") or "")
-        store = str(ref_wrapper.get("store") or "").lower()
-        meta = ref_wrapper.get("meta") if isinstance(ref_wrapper.get("meta"), dict) else {}
-        reference: dict[str, Any]
-        if store in {"kv", "nats", "nats_kv", "nats_object", "object"}:
-            reference = {"type": "nats", "locator": ref_value}
-        elif store in {"db", "postgres", "postgresql", "relational"}:
-            reference = {"type": "relational", "record_id": ref_value}
-        else:
-            reference = {"type": "object_store", "url": ref_value or meta.get("physical_uri") or ""}
-
-        if "bytes" in meta:
-            reference["bytes"] = meta.get("bytes")
-        if "sha256" in meta:
-            reference["sha256"] = meta.get("sha256")
-        if "content_type" in meta:
-            reference["content_type"] = meta.get("content_type")
-        if "compression" in meta:
-            reference["compression"] = meta.get("compression")
-        return reference
-    return None
-
-
-def _extract_context_from_payload(payload: dict[str, Any]) -> Optional[dict[str, Any]]:
-    def _json_size(obj: dict[str, Any]) -> int:
-        # Context dicts are mutated while being bounded; avoid stale cache-by-id sizing.
-        return _estimate_json_size(obj)
-
-    def _filter_context_obj(context_obj: dict[str, Any]) -> Optional[dict[str, Any]]:
-        filtered = {
-            key: value
-            for key, value in context_obj.items()
-            if key not in {
-                "_ref",
-                "_preview",
-                "_size_bytes",
-                "_store",
-                "_store_failed",
-                "_store_error",
-                "_inline",
-                "preview",
-                "extracted",
-            }
-        }
-        return filtered or None
-
-    def _bound_command_rows(
-        context_obj: Optional[dict[str, Any]],
-    ) -> Optional[dict[str, Any]]:
-        if not context_obj:
-            return None
-
-        bounded: dict[str, Any] = {}
-        for key, value in context_obj.items():
-            if (
-                isinstance(key, str)
-                and key.startswith("command_")
-                and isinstance(value, dict)
-            ):
-                command_obj = dict(value)
-                rows = command_obj.get("rows")
-                if isinstance(rows, list):
-                    max_rows = min(len(rows), _EVENT_RESULT_CONTEXT_MAX_ROWS_PER_COMMAND)
-                    command_obj["rows"] = rows[:max_rows]
-                bounded[key] = command_obj
-            else:
-                bounded[key] = value
-        return bounded
-
-    def _compact_response_for_context(response_obj: dict[str, Any]) -> Optional[dict[str, Any]]:
-        if not isinstance(response_obj, dict):
-            return None
-
-        # Postgres and several plugins wrap results in {"status", "data": {...}}.
-        source_obj = response_obj.get("data")
-        source = source_obj if isinstance(source_obj, dict) else response_obj
-        compact: dict[str, Any] = {}
-
-        for command_key, command_value in source.items():
-            if not isinstance(command_key, str) or not command_key.startswith("command_"):
-                continue
-            if not isinstance(command_value, dict):
-                continue
-
-            command_compact: dict[str, Any] = {}
-            for field in ("status", "row_count", "message", "error"):
-                value = command_value.get(field)
-                if value is not None:
-                    command_compact[field] = value
-
-            rows = command_value.get("rows")
-            if isinstance(rows, list):
-                max_rows = min(len(rows), _EVENT_RESULT_CONTEXT_MAX_ROWS_PER_COMMAND)
-                command_compact["rows"] = rows[:max_rows]
-
-            if command_compact:
-                compact[command_key] = command_compact
-
-        return compact or None
-
-    def _merge_and_bound_context(
-        candidate: Optional[dict[str, Any]],
-        compact_fields: dict[str, Any],
-    ) -> Optional[dict[str, Any]]:
-        if candidate:
-            merged = dict(candidate)
-            for key, value in compact_fields.items():
-                merged.setdefault(key, value)
-            if _json_size(merged) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
-                return merged
-
-            if not compact_fields:
-                if _json_size(candidate) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
-                    return candidate
-                return None
-
-            # Keep compact routing keys even when candidate is too large.
-            bounded = dict(compact_fields)
-            for key, value in candidate.items():
-                if key in bounded:
-                    continue
-                bounded[key] = value
-                if _json_size(bounded) > _EVENT_RESULT_CONTEXT_MAX_BYTES:
-                    del bounded[key]
-                    break
-            if bounded:
-                return bounded
-
-            if _json_size(compact_fields) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
-                return compact_fields
-            if not compact_fields and _json_size(candidate) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
-                return candidate
-        if compact_fields and _json_size(compact_fields) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
-            return compact_fields
-        return None
-
+def _collect_compact_context(payload: dict[str, Any]) -> Optional[dict[str, Any]]:
     compact: dict[str, Any] = {}
     for key in (
         "command_id",
@@ -2344,67 +2249,66 @@ def _extract_context_from_payload(payload: dict[str, Any]) -> Optional[dict[str,
     ):
         if key in payload and payload[key] is not None:
             compact[key] = payload[key]
-
-    context_obj = payload.get("context")
-    if isinstance(context_obj, dict):
-        filtered = _bound_command_rows(_filter_context_obj(context_obj))
-        return _merge_and_bound_context(filtered, compact)
-
-    # Reference-only contract persists context in event.result.context.
-    # If worker payload omits explicit context, try deriving a bounded context
-    # from response/result envelopes to preserve routing-critical fields.
-    for key in ("response", "result"):
-        candidate_obj = payload.get(key)
-        if not isinstance(candidate_obj, dict):
-            continue
-
-        # Prefer response.data/result.data when present so postgres-style
-        # payloads keep command_0/command_1 at the top level for templates.
-        source_obj = candidate_obj.get("data")
-        source_context = source_obj if isinstance(source_obj, dict) else candidate_obj
-
-        filtered_source = _bound_command_rows(_filter_context_obj(source_context))
-        if filtered_source:
-            merged_source = _merge_and_bound_context(filtered_source, compact)
-            if merged_source:
-                return merged_source
-
-        # Fallback to the full envelope if source-only extraction didn't fit.
-        if source_context is not candidate_obj:
-            filtered_envelope = _bound_command_rows(_filter_context_obj(candidate_obj))
-            if filtered_envelope:
-                merged_envelope = _merge_and_bound_context(filtered_envelope, compact)
-                if merged_envelope:
-                    return merged_envelope
-
-        compact_candidate = _compact_response_for_context(candidate_obj)
-        merged_compact = _merge_and_bound_context(compact_candidate, compact)
-        if merged_compact:
-            return merged_compact
-
     return compact or None
+
+
+def _bounded_context(context_obj: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    if not isinstance(context_obj, dict):
+        return None
+    if _contains_forbidden_payload_keys(context_obj, _STRICT_CONTEXT_FORBIDDEN_KEYS):
+        return None
+    if _contains_legacy_command_keys(context_obj):
+        return None
+    if _estimate_json_size(context_obj) > _EVENT_RESULT_CONTEXT_MAX_BYTES:
+        return None
+    return context_obj
 
 
 def _build_reference_only_result(
     *,
     payload: dict[str, Any],
     status: str,
-    result_kind: str = "data",
-    result_uri: Optional[str] = None,
-    event_ids: Optional[list[int]] = None,
 ) -> dict[str, Any]:
     result_obj: dict[str, Any] = {"status": status}
-    reference = _extract_reference_from_payload(
-        payload,
-        result_kind=result_kind,
-        result_uri=result_uri,
-        event_ids=event_ids,
-    )
-    if reference:
-        result_obj["reference"] = reference
-    context = _extract_context_from_payload(payload)
-    if context:
-        result_obj["context"] = context
+    payload_result = payload.get("result")
+
+    if isinstance(payload_result, dict):
+        payload_status = payload_result.get("status")
+        if isinstance(payload_status, str) and payload_status.strip():
+            result_obj["status"] = payload_status.strip().upper()
+        reference = payload_result.get("reference")
+        if isinstance(reference, dict):
+            result_obj["reference"] = reference
+        context = _bounded_context(payload_result.get("context"))
+        if isinstance(context, dict):
+            result_obj["context"] = context
+        error_obj = payload_result.get("error")
+        if error_obj is not None:
+            result_obj["error"] = error_obj
+        meta_obj = payload_result.get("meta")
+        if isinstance(meta_obj, dict):
+            result_obj["meta"] = meta_obj
+    else:
+        direct_reference = payload.get("reference")
+        if isinstance(direct_reference, dict):
+            result_obj["reference"] = direct_reference
+        direct_context = _bounded_context(payload.get("context"))
+        if isinstance(direct_context, dict):
+            result_obj["context"] = direct_context
+
+    compact = _collect_compact_context(payload)
+    if compact:
+        existing_context = result_obj.get("context")
+        if isinstance(existing_context, dict):
+            merged = {**compact, **existing_context}
+            if _estimate_json_size(merged) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
+                result_obj["context"] = merged
+        else:
+            if _estimate_json_size(compact) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
+                result_obj["context"] = compact
+
+    if "error" in payload and "error" not in result_obj:
+        result_obj["error"] = payload.get("error")
     return result_obj
 
 
@@ -2559,6 +2463,16 @@ async def _persist_batch_acceptance(
             last_actionable_event: Optional[Event] = None
             last_actionable_evt_id: Optional[int] = None
             for item in req.events:
+                try:
+                    _validate_reference_only_payload(item.payload)
+                except ValueError as exc:
+                    raise HTTPException(
+                        status_code=422,
+                        detail=(
+                            f"Invalid reference-only batch event payload for step '{item.step}' "
+                            f"event '{item.name}': {exc}"
+                        ),
+                    ) from exc
                 evt_id = await _next_snowflake_id(cur)
                 event_ids.append(evt_id)
                 meta_obj: dict[str, Any] = {

--- a/noetl/tools/postgres/executor.py
+++ b/noetl/tools/postgres/executor.py
@@ -23,7 +23,13 @@ from .auth import resolve_postgres_auth, validate_and_render_connection_params
 from .command import escape_task_with_params, decode_base64_commands, render_and_split_commands
 from .env import env_bool
 from .execution import execute_sql_with_connection
-from .response import process_results, format_success_response, format_error_response, format_exception_response
+from .response import (
+    process_results,
+    collapse_results_to_last_command,
+    format_success_response,
+    format_error_response,
+    format_exception_response,
+)
 from .models import validate_pool_config
 
 logger = setup_logger(__name__, include_location=True)
@@ -309,6 +315,7 @@ async def _execute_postgres_task_async(
         end_time = datetime.datetime.now()
         duration = (end_time - start_time).total_seconds()
         has_error, error_message = process_results(results)
+        collapsed_result = collapse_results_to_last_command(results)
         task_status = 'error' if has_error else 'success'
 
         # Step 10: Log completion event
@@ -322,9 +329,9 @@ async def _execute_postgres_task_async(
 
         # Step 11: Return error response if any (error logged via event system)
         if has_error:
-            return format_error_response(task_id, error_message, results)
+            return format_error_response(task_id, error_message, collapsed_result)
         else:
-            return format_success_response(task_id, results)
+            return format_success_response(task_id, collapsed_result)
 
     except Exception as e:
         # Handle unexpected errors

--- a/noetl/tools/postgres/response.py
+++ b/noetl/tools/postgres/response.py
@@ -7,7 +7,7 @@ This module handles:
 - Response formatting for task completion
 """
 
-from typing import Dict, Tuple
+from typing import Any, Dict, Tuple
 from noetl.core.logger import setup_logger
 
 logger = setup_logger(__name__, include_location=True)
@@ -34,13 +34,64 @@ def process_results(results: Dict[str, Dict]) -> Tuple[bool, str]:
     return has_error, error_message.strip()
 
 
-def format_success_response(task_id: str, results: Dict[str, Dict]) -> Dict:
+def _statement_sort_key(command_key: str) -> int:
+    try:
+        return int(str(command_key).split("_", 1)[1])
+    except Exception:
+        return -1
+
+
+def collapse_results_to_last_command(results: Dict[str, Dict]) -> Dict[str, Any]:
+    """
+    Collapse multi-command execution output into a single task result.
+
+    Runtime contract:
+    - Postgres tool returns a single result object
+    - If multiple SQL statements ran, the LAST command is the task result payload
+    - command_* keyed transport is not exposed outside the tool boundary
+    """
+    if not isinstance(results, dict) or not results:
+        return {"status": "success", "message": "No SQL statements executed", "statement_count": 0}
+
+    ordered_keys = sorted(results.keys(), key=_statement_sort_key)
+    last_key = ordered_keys[-1]
+    last_result = results.get(last_key)
+    payload: Dict[str, Any]
+    if isinstance(last_result, dict):
+        payload = dict(last_result)
+    else:
+        payload = {"value": last_result}
+
+    errors = []
+    for statement_idx, statement_key in enumerate(ordered_keys):
+        statement_result = results.get(statement_key) or {}
+        if isinstance(statement_result, dict) and statement_result.get("status") == "error":
+            errors.append(
+                {
+                    "statement_index": statement_idx,
+                    "message": str(statement_result.get("message") or statement_result.get("error") or "unknown error"),
+                }
+            )
+
+    payload["statement_count"] = len(ordered_keys)
+    if errors:
+        payload["status"] = "error"
+        payload["errors"] = errors
+        payload["message"] = "; ".join(
+            f"statement_{e['statement_index']}: {e['message']}" for e in errors
+        )
+    elif "status" not in payload:
+        payload["status"] = "success"
+    return payload
+
+
+def format_success_response(task_id: str, result_data: Dict[str, Any]) -> Dict:
     """
     Format successful task response.
     
     Args:
         task_id: The task identifier
-        results: Dictionary of command execution results
+        result_data: Collapsed task result payload
         
     Returns:
         Success response dictionary with task ID, status, and data
@@ -48,18 +99,18 @@ def format_success_response(task_id: str, results: Dict[str, Dict]) -> Dict:
     return {
         'id': task_id,
         'status': 'success',
-        'data': results
+        'data': result_data
     }
 
 
-def format_error_response(task_id: str, error_message: str, results: Dict[str, Dict] = None) -> Dict:
+def format_error_response(task_id: str, error_message: str, result_data: Dict[str, Any] = None) -> Dict:
     """
     Format error task response.
     
     Args:
         task_id: The task identifier
         error_message: The error message
-        results: Optional dictionary of command execution results
+        result_data: Optional collapsed task result payload
         
     Returns:
         Error response dictionary with task ID, status, error message, and optional data
@@ -70,8 +121,8 @@ def format_error_response(task_id: str, error_message: str, results: Dict[str, D
         'error': error_message
     }
     
-    if results is not None:
-        response['data'] = results
+    if result_data is not None:
+        response['data'] = result_data
     
     return response
 

--- a/noetl/worker/v2_worker_nats.py
+++ b/noetl/worker/v2_worker_nats.py
@@ -439,6 +439,190 @@ class V2Worker:
             )
             return value
 
+    @staticmethod
+    def _event_status_default(event_name: str, payload: Optional[dict[str, Any]] = None) -> str:
+        payload = payload or {}
+        explicit_status = payload.get("status")
+        if isinstance(explicit_status, str) and explicit_status.strip():
+            return explicit_status.strip().upper()
+        lowered = (event_name or "").lower()
+        if "error" in lowered or "failed" in lowered:
+            return "FAILED"
+        if lowered in {"call.done", "step.exit", "command.completed"} or "completed" in lowered:
+            return "COMPLETED"
+        return "RUNNING"
+
+    @staticmethod
+    def _reference_type_from_store(store: str) -> str:
+        normalized = (store or "").strip().lower()
+        if normalized in {"db", "postgres", "postgresql", "relational"}:
+            return "relational"
+        if normalized in {"s3", "gcs", "object_store"}:
+            return "object_store"
+        return "nats"
+
+    def _extract_reference_from_value(self, value: Any) -> Optional[dict[str, Any]]:
+        if not isinstance(value, dict):
+            return None
+
+        direct = value.get("reference")
+        if isinstance(direct, dict):
+            return direct
+
+        ref_wrapper = value.get("_ref")
+        if isinstance(ref_wrapper, dict):
+            ref_value = str(ref_wrapper.get("ref") or "").strip()
+            store_name = str(value.get("_store") or ref_wrapper.get("store") or "").strip()
+            reference: dict[str, Any] = {
+                "type": self._reference_type_from_store(store_name),
+                "locator": ref_value,
+            }
+            if store_name:
+                reference["store"] = store_name
+            meta = ref_wrapper.get("meta")
+            if isinstance(meta, dict):
+                for key in ("bytes", "sha256", "content_type", "compression"):
+                    if key in meta and meta.get(key) is not None:
+                        reference[key] = meta.get(key)
+            return reference
+
+        data_reference = value.get("data_reference")
+        if isinstance(data_reference, dict):
+            sink_type = str(data_reference.get("sink_type") or "").lower()
+            if sink_type in {"postgres", "postgresql", "db", "relational"}:
+                ref_type = "relational"
+            elif sink_type in {"s3", "gcs", "object_store"}:
+                ref_type = "object_store"
+            else:
+                ref_type = "nats"
+            return {"type": ref_type, **data_reference}
+        return None
+
+    @staticmethod
+    def _is_scalar(value: Any) -> bool:
+        return isinstance(value, (str, int, float, bool)) or value is None
+
+    def _extract_control_context(self, value: Any) -> Optional[dict[str, Any]]:
+        if not isinstance(value, dict):
+            return None
+
+        if isinstance(value.get("context"), dict):
+            candidate = value.get("context") or {}
+        else:
+            candidate = value
+
+        context: dict[str, Any] = {}
+        blocked_keys = {
+            "_ref",
+            "_preview",
+            "_size_bytes",
+            "_store",
+            "_store_failed",
+            "_store_error",
+            "_inline",
+            "_internal_data",
+            "data",
+            "response",
+            "result",
+            "payload",
+            "rows",
+            "columns",
+        }
+
+        for key, child in candidate.items():
+            key_str = str(key)
+            if key_str in blocked_keys:
+                continue
+            if key_str.startswith("command_"):
+                # Strict contract: command-indexed payloads are legacy transport shape.
+                continue
+            if self._is_scalar(child):
+                context[key_str] = child
+                continue
+            if isinstance(child, dict):
+                nested = {
+                    str(nk): nv
+                    for nk, nv in child.items()
+                    if self._is_scalar(nv) and str(nk) not in blocked_keys
+                }
+                if nested:
+                    context[key_str] = nested
+
+        if not context:
+            return None
+
+        max_context_bytes = max(
+            1024,
+            int(os.getenv("NOETL_EVENT_RESULT_CONTEXT_MAX_BYTES", "16384")),
+        )
+        try:
+            if estimate_size(context) <= max_context_bytes:
+                return context
+        except Exception:
+            pass
+        return None
+
+    def _build_strict_result_envelope(
+        self,
+        *,
+        value: Any,
+        event_name: str,
+        payload: Optional[dict[str, Any]] = None,
+        error: Optional[Any] = None,
+    ) -> dict[str, Any]:
+        status = self._event_status_default(event_name, payload)
+        envelope: dict[str, Any] = {"status": status}
+        reference = self._extract_reference_from_value(value)
+        if isinstance(reference, dict):
+            envelope["reference"] = reference
+        context = self._extract_control_context(value)
+        if isinstance(context, dict):
+            envelope["context"] = context
+        if error is not None:
+            envelope["error"] = error
+        return envelope
+
+    def _normalize_payload_reference_only(
+        self,
+        *,
+        event_name: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        normalized = dict(payload or {})
+        result_source = None
+        if isinstance(normalized.get("result"), dict):
+            result_source = normalized.get("result")
+        elif isinstance(normalized.get("response"), dict):
+            result_source = normalized.get("response")
+
+        if result_source is not None:
+            normalized["result"] = self._build_strict_result_envelope(
+                value=result_source,
+                event_name=event_name,
+                payload=normalized,
+                error=normalized.get("error"),
+            )
+        elif event_name in {"call.done", "step.exit", "call.error", "command.completed", "command.failed"}:
+            normalized["result"] = self._build_strict_result_envelope(
+                value={},
+                event_name=event_name,
+                payload=normalized,
+                error=normalized.get("error"),
+            )
+
+        top_level_context = normalized.pop("context", None)
+        if isinstance(top_level_context, dict) and isinstance(normalized.get("result"), dict):
+            safe_context = self._extract_control_context({"context": top_level_context})
+            if isinstance(safe_context, dict) and safe_context:
+                merged_context = dict(normalized["result"].get("context") or {})
+                merged_context.update(safe_context)
+                normalized["result"]["context"] = merged_context
+
+        # Strict reference-only contract: inline payload keys are never transported.
+        for field_name in ("response", "inputs", "data", "data_reference", "_internal_data", "_inline"):
+            normalized.pop(field_name, None)
+        return normalized
+
     async def _prepare_event_payload_for_transport(
         self,
         *,
@@ -448,21 +632,11 @@ class V2Worker:
         payload: dict[str, Any],
     ) -> dict[str, Any]:
         if not isinstance(payload, dict):
-            return payload
-
-        prepared = dict(payload)
-        bulky_fields = ("response", "result", "context", "inputs")
-        for field_name in bulky_fields:
-            if field_name not in prepared:
-                continue
-            prepared[field_name] = await self._externalize_event_value_if_needed(
-                execution_id=execution_id,
-                step=step,
+            return self._normalize_payload_reference_only(
                 event_name=event_name,
-                field_name=field_name,
-                value=prepared.get(field_name),
+                payload={"result": {"status": self._event_status_default(event_name)}},
             )
-        return prepared
+        return self._normalize_payload_reference_only(event_name=event_name, payload=payload)
     
     async def _register_worker(self, server_url: str) -> bool:
         """Register this worker in the runtime table via API."""

--- a/tests/api/test_v2_reference_only_result_helpers.py
+++ b/tests/api/test_v2_reference_only_result_helpers.py
@@ -1,209 +1,73 @@
+import pytest
+
 import noetl.server.api.v2 as v2_api
 
 
-def test_build_reference_only_result_supports_result_kind_ref():
-    result = v2_api._build_reference_only_result(
-        payload={},
-        status="RUNNING",
-        result_kind="ref",
-        result_uri="gs://bucket/key.json",
-    )
-
-    assert result == {
-        "status": "RUNNING",
-        "reference": {"type": "object_store", "url": "gs://bucket/key.json"},
-    }
-
-
-def test_build_reference_only_result_supports_result_kind_refs():
-    result = v2_api._build_reference_only_result(
-        payload={},
-        status="COMPLETED",
-        result_kind="refs",
-        event_ids=[101, "bad", 202],
-    )
-
-    assert result == {
-        "status": "COMPLETED",
-        "reference": {"type": "event_refs", "event_ids": [101, 202]},
-    }
-
-
-def test_extract_reference_from_worker_ref_wrapper():
+def test_build_reference_only_result_uses_strict_result_envelope():
     payload = {
-        "response": {
-            "_ref": {
-                "ref": "public.table:42",
-                "store": "postgres",
-                "meta": {
-                    "bytes": 512,
-                    "sha256": "abc",
-                    "content_type": "application/json",
-                    "compression": "gzip",
-                },
-            }
-        }
+        "result": {
+            "status": "completed",
+            "reference": {"type": "relational", "schema": "public", "table": "x", "record_id": "42"},
+            "context": {"facility_mapping_id": 46, "command_id": "cmd-1"},
+        },
+        "command_id": "cmd-1",
     }
-    result = v2_api._build_reference_only_result(payload=payload, status="COMPLETED")
+
+    result = v2_api._build_reference_only_result(payload=payload, status="RUNNING")
 
     assert result["status"] == "COMPLETED"
-    assert result["reference"] == {
-        "type": "relational",
-        "record_id": "public.table:42",
-        "bytes": 512,
-        "sha256": "abc",
-        "content_type": "application/json",
-        "compression": "gzip",
-    }
+    assert result["reference"]["type"] == "relational"
+    assert result["context"]["facility_mapping_id"] == 46
+    assert result["context"]["command_id"] == "cmd-1"
 
 
-def test_extract_context_filters_transport_wrappers_and_honors_size_limit(monkeypatch):
-    monkeypatch.setattr(v2_api, "_EVENT_RESULT_CONTEXT_MAX_BYTES", 64)
-
-    context = v2_api._extract_context_from_payload(
-        {
-            "context": {
-                "_ref": {"ref": "x"},
-                "_preview": {"x": 1},
-                "preview": {"y": 2},
-                "extracted": {"z": 3},
-                "safe": "x" * 200,
-            }
-        }
-    )
-    assert context is None
-
-    context = v2_api._extract_context_from_payload(
-        {
-            "context": {
-                "_ref": {"ref": "x"},
-                "_preview": {"x": 1},
-                "safe": "ok",
-                "command_id": "cmd-1",
-            }
-        }
-    )
-    assert context == {"safe": "ok", "command_id": "cmd-1"}
-
-
-def test_extract_context_derives_from_response_payload(monkeypatch):
-    monkeypatch.setattr(v2_api, "_EVENT_RESULT_CONTEXT_MAX_ROWS_PER_COMMAND", 1)
-    context = v2_api._extract_context_from_payload(
-        {
-            "command_id": "cmd-42",
-            "response": {
-                "status": "success",
-                "data": {
-                    "command_0": {
-                        "status": "success",
-                        "row_count": 2,
-                        "rows": [{"facility_mapping_id": 123}, {"facility_mapping_id": 456}],
-                    }
-                },
-            },
-        }
-    )
-
-    assert context is not None
-    assert context["command_id"] == "cmd-42"
-    assert "command_0" in context
-    assert context["command_0"]["row_count"] == 2
-    assert len(context["command_0"]["rows"]) == 1
-    assert context["command_0"]["rows"][0]["facility_mapping_id"] == 123
-
-
-def test_extract_context_derives_from_result_payload(monkeypatch):
-    monkeypatch.setattr(v2_api, "_EVENT_RESULT_CONTEXT_MAX_ROWS_PER_COMMAND", 1)
-    context = v2_api._extract_context_from_payload(
-        {
-            "command_id": "cmd-result-1",
-            "result": {
-                "status": "success",
-                "data": {
-                    "command_0": {
-                        "status": "success",
-                        "row_count": 3,
-                        "rows": [{"id": 11}, {"id": 22}, {"id": 33}],
-                    }
-                },
-            },
-        }
-    )
-
-    assert context is not None
-    assert context["command_id"] == "cmd-result-1"
-    assert context["command_0"]["row_count"] == 3
-    assert len(context["command_0"]["rows"]) == 1
-    assert context["command_0"]["rows"][0]["id"] == 11
-
-
-def test_extract_context_compacts_large_response_payload(monkeypatch):
-    monkeypatch.setattr(v2_api, "_EVENT_RESULT_CONTEXT_MAX_BYTES", 768)
-    monkeypatch.setattr(v2_api, "_EVENT_RESULT_CONTEXT_MAX_ROWS_PER_COMMAND", 1)
-
-    context = v2_api._extract_context_from_payload(
-        {
-            "command_id": "cmd-99",
-            "response": {
-                "status": "success",
-                "data": {
-                    "command_0": {
-                        "status": "success",
-                        "row_count": 2000,
-                        "rows": [{"id": i, "value": "x" * 32} for i in range(20)],
-                    }
-                },
-            },
-        }
-    )
-
-    assert context is not None
-    assert context["command_id"] == "cmd-99"
-    assert context["command_0"]["row_count"] == 2000
-    assert len(context["command_0"]["rows"]) == 1
-    assert context["command_0"]["rows"][0]["id"] == 0
-
-
-def test_extract_context_keeps_compact_fields_when_merge_exceeds_limit(monkeypatch):
-    monkeypatch.setattr(v2_api, "_EVENT_RESULT_CONTEXT_MAX_BYTES", 64)
-
-    original_estimate = v2_api._estimate_json_size
-
-    def fake_estimate(obj):
-        if isinstance(obj, dict):
-            if "safe" in obj and "command_id" in obj:
-                return 80
-            if "safe" in obj and "command_id" not in obj:
-                return 32
-            if "command_id" in obj and len(obj) == 1:
-                return 16
-        return original_estimate(obj)
-
-    monkeypatch.setattr(v2_api, "_estimate_json_size", fake_estimate)
-
-    context = v2_api._extract_context_from_payload(
-        {
-            "command_id": "cmd-keep",
-            "context": {
-                "safe": "x" * 16,
-            },
-        }
-    )
-
-    assert context is not None
-    assert context["command_id"] == "cmd-keep"
-
-
-def test_build_reference_only_result_outputs_contract_shape():
+def test_build_reference_only_result_does_not_derive_from_response_payload():
     payload = {
-        "reference": {"type": "nats", "locator": "nats://bucket/key"},
-        "context": {"command_id": "cmd-1", "status": "inner"},
-        "response": {"data": {"large": "ignored"}},
-        "random": {"will_not": "appear"},
+        "response": {"rows": [{"id": 1}]},
+        "result": {"status": "completed"},
     }
-    result = v2_api._build_reference_only_result(payload=payload, status="FAILED")
+    result = v2_api._build_reference_only_result(payload=payload, status="COMPLETED")
+    assert result == {"status": "COMPLETED"}
 
-    assert set(result.keys()).issubset({"status", "reference", "context"})
-    assert isinstance(result["status"], str)
-    assert isinstance(result.get("reference"), dict)
-    assert isinstance(result.get("context"), dict)
+
+def test_build_reference_only_result_keeps_compact_top_level_context_fields():
+    payload = {
+        "result": {"status": "RUNNING"},
+        "request_id": "req-1",
+        "event_ids": [10, 11],
+        "commands_generated": 3,
+    }
+    result = v2_api._build_reference_only_result(payload=payload, status="RUNNING")
+    assert result["context"]["request_id"] == "req-1"
+    assert result["context"]["event_ids"] == [10, 11]
+    assert result["context"]["commands_generated"] == 3
+
+
+def test_validate_reference_only_payload_rejects_legacy_response_key():
+    with pytest.raises(ValueError, match="forbidden inline output keys"):
+        v2_api._validate_reference_only_payload(
+            {"response": {"rows": [{"id": 1}]}}
+        )
+
+
+def test_validate_reference_only_payload_rejects_legacy_command_keys_in_context():
+    with pytest.raises(ValueError, match="legacy command_\\* keys"):
+        v2_api._validate_reference_only_payload(
+            {
+                "result": {
+                    "status": "completed",
+                    "context": {"command_0": {"status": "success", "row_count": 1}},
+                }
+            }
+        )
+
+
+def test_validate_reference_only_payload_accepts_compact_context():
+    v2_api._validate_reference_only_payload(
+        {
+            "result": {
+                "status": "completed",
+                "context": {"facility_mapping_id": 46, "command_id": "x-1"},
+            }
+        }
+    )

--- a/tests/unit/dsl/test_render_reference_only.py
+++ b/tests/unit/dsl/test_render_reference_only.py
@@ -1,0 +1,26 @@
+import pytest
+
+from noetl.core.dsl.render import TaskResultProxy
+
+
+def test_task_result_proxy_result_alias_returns_self_for_dict_payload():
+    proxy = TaskResultProxy({"rows": [{"id": 1}], "status": "success"})
+
+    assert proxy.result.rows[0]["id"] == 1
+    assert proxy.result.status == "success"
+
+
+def test_task_result_proxy_does_not_flatten_context_keys_to_top_level():
+    proxy = TaskResultProxy(
+        {
+            "status": "COMPLETED",
+            "context": {"facility_mapping_id": 46},
+        }
+    )
+
+    with pytest.raises(AttributeError):
+        _ = proxy.facility_mapping_id
+    with pytest.raises(KeyError):
+        _ = proxy["facility_mapping_id"]
+
+    assert proxy.context.facility_mapping_id == 46

--- a/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
+++ b/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
@@ -851,21 +851,19 @@ workflow:
     assert step_result["context"]["ctx_vars"]["foo"] == "bar"
 
 
-def test_task_result_proxy_getitem_wraps_context_dict_values():
+def test_task_result_proxy_keeps_context_scoped_access_only():
     proxy = TaskResultProxy(
         {
             "status": "COMPLETED",
             "context": {
-                "command_0": {
-                    "rows": [{"facility_mapping_id": 42}],
-                    "row_count": 1,
-                }
+                "facility_mapping_id": 42,
             },
         }
     )
-    command_result = proxy["command_0"]
-    assert isinstance(command_result, TaskResultProxy)
-    assert command_result.rows[0]["facility_mapping_id"] == 42
+    with pytest.raises(KeyError):
+        _ = proxy["facility_mapping_id"]
+
+    assert proxy.context.facility_mapping_id == 42
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tools/postgres/test_response_contract.py
+++ b/tests/unit/tools/postgres/test_response_contract.py
@@ -1,0 +1,28 @@
+from noetl.tools.postgres.response import collapse_results_to_last_command
+
+
+def test_collapse_results_returns_last_statement_payload_without_command_keys():
+    collapsed = collapse_results_to_last_command(
+        {
+            "command_0": {"status": "success", "rows": [{"id": 1}]},
+            "command_1": {"status": "success", "rows": [{"id": 2}]},
+        }
+    )
+
+    assert collapsed["rows"][0]["id"] == 2
+    assert collapsed["statement_count"] == 2
+    assert "command_count" not in collapsed
+    assert "last_command" not in collapsed
+
+
+def test_collapse_results_reports_statement_index_for_errors():
+    collapsed = collapse_results_to_last_command(
+        {
+            "command_0": {"status": "success", "rows": [{"id": 1}]},
+            "command_1": {"status": "error", "message": "syntax error"},
+        }
+    )
+
+    assert collapsed["status"] == "error"
+    assert collapsed["errors"] == [{"statement_index": 1, "message": "syntax error"}]
+    assert "command_1" not in collapsed["message"]

--- a/tests/worker/test_v2_worker_batch_emit.py
+++ b/tests/worker/test_v2_worker_batch_emit.py
@@ -3,7 +3,6 @@ import pytest
 
 import noetl.worker.v2_worker_nats as worker_module
 from noetl.worker.v2_worker_nats import V2Worker
-from noetl.core.storage.models import ResultRef, ResultRefMeta, Scope, StoreTier
 
 
 class _FakeResponse:
@@ -77,24 +76,22 @@ async def test_emit_batch_events_externalizes_large_response_payload(monkeypatch
         [_FakeResponse(202, payload={"status": "accepted", "request_id": "req-2"})]
     )
 
-    async def _fake_put(**kwargs):
-        return ResultRef.create(
-            execution_id=str(kwargs["execution_id"]),
-            name=str(kwargs["name"]),
-            store=StoreTier.KV,
-            scope=Scope.EXECUTION,
-            meta=ResultRefMeta(bytes=4096),
-        )
-
-    monkeypatch.setenv("NOETL_EVENT_INLINE_MAX_BYTES", "128")
-    monkeypatch.setattr(worker_module.default_store, "put", _fake_put)
-
     events = [
         {"step": "s1", "name": "command.started", "payload": {}, "actionable": False, "informative": True},
         {
             "step": "s1",
             "name": "call.done",
-            "payload": {"response": {"rows": ["x" * 8192]}},
+            "payload": {
+                "response": {
+                    "_ref": {
+                        "kind": "result_ref",
+                        "ref": "noetl://execution/123/result/s1/abcd1234",
+                        "store": "kv",
+                    },
+                    "_store": "kv",
+                    "_size_bytes": 8192,
+                }
+            },
             "actionable": True,
             "informative": True,
         },
@@ -110,10 +107,11 @@ async def test_emit_batch_events_externalizes_large_response_payload(monkeypatch
 
     assert ok is True
     sent = worker._http_client.json_seen[0]
-    response_payload = sent["events"][1]["payload"]["response"]
-    assert "_ref" in response_payload
-    assert response_payload["_ref"]["kind"] == "result_ref"
-    assert response_payload["_store"] == "kv"
+    result_payload = sent["events"][1]["payload"]["result"]
+    assert "response" not in sent["events"][1]["payload"]
+    assert result_payload["status"] == "COMPLETED"
+    assert result_payload["reference"]["locator"] == "noetl://execution/123/result/s1/abcd1234"
+    assert result_payload["reference"]["type"] == "nats"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- enforce strict reference-only event payload/result normalization across worker and server\n- remove legacy template fallback that flattened  keys to top-level access\n- keep in-chain access via  while rejecting legacy  context patterns\n- collapse postgres multi-statement outputs to a single task result payload (last statement) without  keyed output\n- add/adjust tests for strict proxy and postgres response contract\n\n## Validation\n-  on all touched runtime + test files\n- targeted pytest invocation attempted; local env is missing , so full test execution is blocked in this shell\n