### PR TITLE
fix: normalize reference-only result status aliases

### DIFF
--- a/noetl/server/api/v2.py
+++ b/noetl/server/api/v2.py
@@ -2264,18 +2264,29 @@ def _bounded_context(context_obj: Optional[dict[str, Any]]) -> Optional[dict[str
     return context_obj
 
 
+def _normalize_result_status(value: Any) -> str:
+    raw = str(value or "").strip().upper()
+    if raw in {"OK", "SUCCESS"}:
+        return "COMPLETED"
+    if raw in {"ERROR", "FAILED"}:
+        return "FAILED"
+    if raw:
+        return raw
+    return "UNKNOWN"
+
+
 def _build_reference_only_result(
     *,
     payload: dict[str, Any],
     status: str,
 ) -> dict[str, Any]:
-    result_obj: dict[str, Any] = {"status": status}
+    result_obj: dict[str, Any] = {"status": _normalize_result_status(status)}
     payload_result = payload.get("result")
 
     if isinstance(payload_result, dict):
         payload_status = payload_result.get("status")
         if isinstance(payload_status, str) and payload_status.strip():
-            result_obj["status"] = payload_status.strip().upper()
+            result_obj["status"] = _normalize_result_status(payload_status)
         reference = payload_result.get("reference")
         if isinstance(reference, dict):
             result_obj["reference"] = reference

--- a/tests/api/test_v2_reference_only_result_helpers.py
+++ b/tests/api/test_v2_reference_only_result_helpers.py
@@ -43,6 +43,17 @@ def test_build_reference_only_result_keeps_compact_top_level_context_fields():
     assert result["context"]["commands_generated"] == 3
 
 
+def test_build_reference_only_result_normalizes_status_aliases():
+    success_payload = {"result": {"status": "success"}}
+    failed_payload = {"result": {"status": "error"}}
+
+    success_result = v2_api._build_reference_only_result(payload=success_payload, status="running")
+    failed_result = v2_api._build_reference_only_result(payload=failed_payload, status="running")
+
+    assert success_result["status"] == "COMPLETED"
+    assert failed_result["status"] == "FAILED"
+
+
 def test_validate_reference_only_payload_rejects_legacy_response_key():
     with pytest.raises(ValueError, match="forbidden inline output keys"):
         v2_api._validate_reference_only_payload(


### PR DESCRIPTION
## Summary
- normalize reference-only `result.status` aliases at ingest (`ok`/`success` -> `COMPLETED`, `error`/`failed` -> `FAILED`)
- keep canonical uppercase statuses in `event.result` regardless of worker/tool status flavor
- add API helper test coverage for status alias normalization

## Why
- merged PR #342 used `refactor:` commit prefix, so release/deploy automation did not trigger
- this follow-up uses `fix:` commit prefix and includes a real Python runtime change

## Validation
- `python3 -m py_compile noetl/server/api/v2.py tests/api/test_v2_reference_only_result_helpers.py`
- pytest collection for this environment is blocked by missing `psycopg`
