### PR TITLE
feat: paginated-api mock endpoint + fetch-step load test playbook (http step)

### DIFF
--- a/tests/fixtures/playbooks/pagination/fetch_load_test/README.md
+++ b/tests/fixtures/playbooks/pagination/fetch_load_test/README.md
@@ -11,7 +11,7 @@ Validates that `max_in_flight: 5` on fetch steps holds under realistic load with
   - 2–5 pages per patient, deterministic per `patientId` (reproducible across runs)
   - ~100 KB per response page to trigger GCS externalization pressure
   - 2–4 second server-side delay to simulate real API latency
-- **Assertion**: all 500 patients processed, final record count matches expected total
+- **Assertion**: all 500 patients processed successfully (patient totals/completions; no explicit record-count assertion)
 - **Go/no-go criterion**: playbook completes without worker crash or OOM kill
 
 ## Dependencies
@@ -38,7 +38,9 @@ noetl exec tests/fixtures/playbooks/pagination/fetch_load_test/test_fetch_load.y
 noetl exec tests/fixtures/playbooks/pagination/fetch_load_test/test_fetch_load.yaml \
   --var num_patients=20
 
-# Reproduce the crash: increase max_in_flight to 20 in workload and run
+# Reproduce the crash: override max_in_flight to 20 via --var
+noetl exec tests/fixtures/playbooks/pagination/fetch_load_test/test_fetch_load.yaml \
+  --var max_in_flight=20
 # Expected: CrashLoopBackOff or OOM kill within the first few minutes
 ```
 

--- a/tests/fixtures/playbooks/pagination/fetch_load_test/test_fetch_load.yaml
+++ b/tests/fixtures/playbooks/pagination/fetch_load_test/test_fetch_load.yaml
@@ -10,7 +10,7 @@ metadata:
     worker crash or OOM — reproducing the structure of fetch_medications in
     state_report_generation_prod_v10.yaml that caused CrashLoopBackOff at max_in_flight: 20.
 
-    Go/no-go criterion: all 500 patients processed, no worker restart, final record count matches.
+    Go/no-go criterion: all 500 patients processed and no worker restart.
     Target execution time at max_in_flight: 5 — see README.md for timing expectations.
 
 workload:
@@ -64,13 +64,13 @@ workflow:
         - step: fetch_all_patients
 
   - step: fetch_all_patients
-    desc: "Fetch all pages for each patient in parallel (max_in_flight: 5)"
+    desc: "Fetch all pages for each patient in parallel (max_in_flight: {{ max_in_flight }})"
     loop:
       in: '{{ generate_patients.patients }}'
       iterator: item
       spec:
         mode: parallel
-        max_in_flight: 5
+        max_in_flight: '{{ max_in_flight }}'
     tool:
       - name: init_page
         kind: noop
@@ -98,7 +98,10 @@ workflow:
               - when: "{{ outcome.status == 'error' and outcome.http.status == 429 }}"
                 then: { do: retry, attempts: 30, backoff: fixed, delay: 1.0 }
               - when: "{{ outcome.status == 'error' and outcome.http.status == 404 }}"
-                then: { do: break }
+                then:
+                  do: continue
+                  set_iter:
+                    has_more: false
               - when: "{{ outcome.status == 'error' }}"
                 then: { do: retry, attempts: 3, backoff: exponential, delay: 5.0 }
               - else:

--- a/tests/fixtures/servers/paginated_api.py
+++ b/tests/fixtures/servers/paginated_api.py
@@ -658,8 +658,8 @@ def _fhir_entry(patient_id: str, entry_index: int, page: int, padding_chars: int
 async def get_patient_records(
     request: Request,
     patientId: str = Query(..., description="Patient ID"),
-    page: int = Query(default=1, description="Page number (1-based)"),
-    pageSize: int = Query(default=10, description="Items per page"),
+    page: int = Query(default=1, ge=1, description="Page number (1-based)"),
+    pageSize: int = Query(default=10, ge=1, description="Items per page"),
     min_delay: float = Query(default=None, description="Override min server-side delay in seconds"),
     max_delay: float = Query(default=None, description="Override max server-side delay in seconds"),
     payload_kb: int = Query(default=None, description="Override total response payload target in KB"),
@@ -673,7 +673,7 @@ async def get_patient_records(
     - ~100 KB response per page to trigger GCS externalization pressure
     - 2–4 second server-side delay per request
     - Hard cap of 50 requests/second globally; returns 429 + Retry-After: 1 on breach
-    - All parameters overridable via query params or env vars for test flexibility
+    - Runtime behavior (delays, payload size, rate limit, and page-count bounds) overridable via query params and/or env vars for test flexibility
 
     Response shape (FHIR Bundle):
     {


### PR DESCRIPTION
- [x] Remove duplicate `hashlib` import in `tests/fixtures/servers/paginated_api.py`

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.