### PR TITLE
feat(dsl/v2): rename args→input, outcome→output, set_ctx→set across D…

### DIFF
--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -25,6 +25,7 @@ from psycopg.rows import dict_row
 from noetl.core.dsl.v2.models import Event, Command, Playbook, Step, ToolCall, CommandSpec
 from noetl.core.db.pool import get_pool_connection, get_snowflake_id
 from noetl.core.cache import get_nats_cache
+from noetl.core.storage import default_store
 
 from noetl.core.logger import setup_logger
 logger = setup_logger(__name__, include_location=True)
@@ -212,6 +213,95 @@ def _unwrap_event_payload(payload: Any) -> Any:
     if isinstance(payload, dict) and "kind" in payload and "data" in payload:
         return payload.get("data")
     return payload
+
+
+def _apply_set_mutations(variables: dict, mutations: dict) -> None:
+    """Apply DSL v2 `set` mutations to the execution variable store.
+
+    Handles scoped keys (ctx.x, iter.x, step.x) by stripping the scope prefix
+    and writing the bare key.  Bare keys (no dot prefix) are written as-is for
+    backward compatibility with legacy set_ctx usage.
+    """
+    for key, value in mutations.items():
+        if "." in key:
+            scope, bare_key = key.split(".", 1)
+            if scope in ("ctx", "iter", "step"):
+                variables[bare_key] = value
+                continue
+        variables[key] = value
+
+
+def _reference_to_result_ref(reference: Any) -> Optional[dict[str, Any]]:
+    """Convert a compact PRD reference envelope into a ResultStore-compatible ref."""
+    if not isinstance(reference, dict):
+        return None
+
+    locator = str(reference.get("locator") or reference.get("ref") or "").strip()
+    if not locator.startswith("noetl://"):
+        return None
+
+    store = str(reference.get("store") or "kv").strip().lower() or "kv"
+    ref_kind = "temp_ref" if store == "memory" else "result_ref"
+    return {
+        "kind": ref_kind,
+        "ref": locator,
+        "store": store,
+    }
+
+
+def _merge_hydrated_step_result(
+    resolved: Any,
+    compact_result: dict[str, Any],
+    ref_wrapper: dict[str, Any],
+) -> Any:
+    """Merge resolved result data with compact PRD metadata for runtime templating."""
+    reference = compact_result.get("reference")
+    compact_context = compact_result.get("context")
+    compact_status = compact_result.get("status")
+
+    if isinstance(resolved, dict):
+        hydrated = dict(resolved)
+        hydrated.setdefault("_ref", ref_wrapper)
+        if isinstance(reference, dict):
+            hydrated.setdefault("reference", reference)
+        if compact_status is not None:
+            hydrated.setdefault("status", compact_status)
+        if isinstance(compact_context, dict):
+            hydrated.setdefault("context", compact_context)
+        return hydrated
+
+    wrapped: dict[str, Any] = {
+        "_ref": ref_wrapper,
+        "reference": reference,
+        "status": compact_status,
+        "result": resolved,
+    }
+    if isinstance(compact_context, dict):
+        wrapped["context"] = compact_context
+    return wrapped
+
+
+async def _hydrate_reference_only_step_result(result: Any) -> Any:
+    """Resolve compact `result.reference` envelopes back into runtime step data."""
+    if not isinstance(result, dict):
+        return result
+
+    reference = result.get("reference")
+    ref_wrapper = _reference_to_result_ref(reference)
+    if not isinstance(ref_wrapper, dict):
+        return result
+
+    try:
+        resolved = await default_store.resolve(ref_wrapper)
+    except Exception as exc:
+        logger.warning(
+            "[RESULT-REF] Failed to resolve %s: %s",
+            ref_wrapper.get("ref"),
+            exc,
+        )
+        return result
+
+    return _merge_hydrated_step_result(resolved, result, ref_wrapper)
 
 
 def _pending_step_key(step_name: Optional[str]) -> str:
@@ -673,6 +763,13 @@ class ExecutionState:
                 # Keep response alias for existing condition expressions, but only
                 # from strict result envelope (never raw tool response payload).
                 context["response"] = event_payload["result"]
+            # Canonical DSL v2: expose result payload as 'output.data'
+            context["output"] = {
+                "data": event_payload.get("result"),
+                "ref": event_payload.get("result_ref") or event_payload.get("ref"),
+                "error": event_payload.get("error"),
+                "status": "error" if event_payload.get("error") else "ok",
+            }
 
         return context
 
@@ -1085,10 +1182,12 @@ class StateStore:
                             if isinstance(event_payload, dict)
                             else event_payload
                         )
+                        step_result = await _hydrate_reference_only_step_result(step_result)
                         state.mark_step_completed(node_name, step_result)
 
                         step_def = state.get_step(node_name)
-                        if step_def and step_def.set_ctx:
+                        step_set = getattr(step_def, "set", None) if step_def else None
+                        if step_def and step_set:
                             replay_event = Event(
                                 execution_id=execution_id,
                                 step=node_name,
@@ -1096,26 +1195,27 @@ class StateStore:
                                 payload=event_payload if isinstance(event_payload, dict) else {"result": event_payload},
                             )
                             context = state.get_render_context(replay_event)
-                            for key, value_template in step_def.set_ctx.items():
+                            rendered_set: dict = {}
+                            for key, value_template in step_set.items():
                                 try:
                                     if isinstance(value_template, str) and "{{" in value_template:
-                                        rendered_value = recursive_render(
+                                        rendered_set[key] = recursive_render(
                                             replay_render_env,
                                             value_template,
                                             context,
                                             strict_keys=True,
                                         )
                                     else:
-                                        rendered_value = value_template
-                                    state.variables[key] = rendered_value
-                                    logger.debug("[STATE-LOAD] Replayed set_ctx %s from %s", key, node_name)
+                                        rendered_set[key] = value_template
+                                    logger.debug("[STATE-LOAD] Replayed set %s from %s", key, node_name)
                                 except Exception as exc:
                                     logger.warning(
-                                        "[STATE-LOAD] Failed to replay set_ctx %s for %s: %s",
+                                        "[STATE-LOAD] Failed to replay set %s for %s: %s",
                                         key,
                                         node_name,
                                         exc,
                                     )
+                            _apply_set_mutations(state.variables, rendered_set)
                 
                 # Initialize loop_state for loop steps with collected iteration results
                 for step_name in loop_steps:
@@ -2007,7 +2107,9 @@ class ControlFlowEngine:
         for idx, next_target in enumerate(next_items):
             target_step = next_target.get("step")
             when_condition = next_target.get("when")
-            target_args = next_target.get("args", {})
+            # Canonical DSL v2: arc.set contains transition-scoped mutations.
+            # Legacy arc.args treated as backward-compat alias for arc.set.
+            arc_set = next_target.get("set") or next_target.get("args") or {}
 
             if not target_step:
                 logger.warning(f"[NEXT-EVAL] Skipping next entry {idx} with no step")
@@ -2040,15 +2142,16 @@ class ControlFlowEngine:
                 logger.warning(f"[NEXT-EVAL] Skipping duplicate command for step '{target_step}' - already in issued_steps")
                 continue
 
-            # Render target args
-            rendered_args = {}
-            if target_args:
+            # Apply arc-level set mutations to state before issuing the command.
+            # Canonical DSL v2: arc.set writes to ctx/iter/step scopes.
+            if arc_set:
                 from noetl.core.dsl.render import render_template as recursive_render
-                rendered_args = recursive_render(self.jinja_env, target_args, context)
+                rendered_arc_set = recursive_render(self.jinja_env, arc_set, context)
+                _apply_set_mutations(state.variables, rendered_arc_set)
 
             # Create command(s) for target step. Loop steps may issue multiple commands
             # immediately up to max_in_flight when parallel mode is configured.
-            issued_cmds = await self._issue_loop_commands(state, target_step_def, rendered_args)
+            issued_cmds = await self._issue_loop_commands(state, target_step_def, {})
             if issued_cmds:
                 commands.extend(issued_cmds)
                 # Steps can be revisited in loopback workflows; clear old completion marker
@@ -2289,40 +2392,33 @@ class ControlFlowEngine:
                     if isinstance(next_item, str):
                         # Simple step name
                         target_step = next_item
-                        args = {}
+                        arc_set_legacy = {}
                     elif isinstance(next_item, dict):
-                        # {step: name, args: {...}}
+                        # {step: name, set: {...}} (canonical) or {step: name, args: {...}} (legacy)
                         target_step = next_item.get("step")
-                        args = next_item.get("args", {})
-                        
-                        # Render args
-                        rendered_args = {}
-                        for key, value in args.items():
-                            if isinstance(value, str) and "{{" in value:
-                                rendered_args[key] = self._render_template(value, context)
-                            else:
-                                rendered_args[key] = value
-                        args = rendered_args
+                        arc_set_legacy = next_item.get("set") or next_item.get("args") or {}
+
+                        # Render and apply arc-level set mutations
+                        if arc_set_legacy:
+                            rendered_arc = {}
+                            for key, value in arc_set_legacy.items():
+                                if isinstance(value, str) and "{{" in value:
+                                    rendered_arc[key] = self._render_template(value, context)
+                                else:
+                                    rendered_arc[key] = value
+                            _apply_set_mutations(state.variables, rendered_arc)
                     else:
                         continue
-                    
-                    # Auto-inject loop_results when transitioning from loop.done event
-                    # The loop step acts as an aggregator, and its result should be passed as loop_results
-                    if event.name == "loop.done" and event.step in state.step_results:
-                        loop_result = state.step_results[event.step]
-                        if "loop_results" not in args:
-                            args["loop_results"] = loop_result
-                            logger.info(f"Auto-injected loop_results for {target_step} from loop step {event.step}")
-                    
+
                     # Get target step definition
                     step_def = state.get_step(target_step)
                     if not step_def:
                         logger.error(f"Target step not found: {target_step}")
                         continue
-                    
+
                     # Create command for target step
                     issued_cmds = await self._issue_loop_commands(
-                        state, step_def, args
+                        state, step_def, {}
                     )
                     if issued_cmds:
                         commands.extend(issued_cmds)
@@ -2491,7 +2587,7 @@ class ControlFlowEngine:
                 # Call/invoke a step with new arguments
                 call_spec = action["call"]
                 target_step = call_spec.get("step")
-                args = call_spec.get("args", {})
+                args = call_spec.get("input") or call_spec.get("args") or {}
                 
                 if not target_step:
                     logger.warning("Call action missing 'step' attribute")
@@ -2677,19 +2773,20 @@ class ControlFlowEngine:
             for next_item in next_items:
                 if isinstance(next_item, str):
                     target_step = next_item
-                    args = {}
+                    deferred_arc_set: dict = {}
                 elif isinstance(next_item, dict):
                     target_step = next_item.get("step")
-                    args = next_item.get("args", {})
+                    deferred_arc_set = next_item.get("set") or next_item.get("args") or {}
 
-                    # Render args
-                    rendered_args = {}
-                    for key, value in args.items():
-                        if isinstance(value, str) and "{{" in value:
-                            rendered_args[key] = self._render_template(value, context)
-                        else:
-                            rendered_args[key] = value
-                    args = rendered_args
+                    # Render and apply arc-level set mutations
+                    if deferred_arc_set:
+                        rendered_deferred: dict = {}
+                        for key, value in deferred_arc_set.items():
+                            if isinstance(value, str) and "{{" in value:
+                                rendered_deferred[key] = self._render_template(value, context)
+                            else:
+                                rendered_deferred[key] = value
+                        _apply_set_mutations(state.variables, rendered_deferred)
                 else:
                     continue
 
@@ -2700,7 +2797,7 @@ class ControlFlowEngine:
                     continue
 
                 # Create command for target step
-                issued_cmds = await self._issue_loop_commands(state, step_def, args)
+                issued_cmds = await self._issue_loop_commands(state, step_def, {})
                 if issued_cmds:
                     commands.extend(issued_cmds)
                     logger.info(
@@ -3462,7 +3559,10 @@ class ControlFlowEngine:
 
         # Build args separately - for step inputs
         step_args = {}
-        if step.args:
+        if step.input:
+            step_args.update(step.input)
+        elif getattr(step, "args", None):
+            # Backward compat: accept legacy step.args if step.input not set
             step_args.update(step.args)
 
         # Merge transition args
@@ -3590,7 +3690,7 @@ class ControlFlowEngine:
                 kind=tool_kind,
                 config=tool_config
             ),
-            args=rendered_args,
+            input=rendered_args,
             render_context=context,
             pipeline=pipeline,
             next_targets=next_targets,
@@ -3749,7 +3849,7 @@ class ControlFlowEngine:
         if event.step.endswith(":task_sequence") and event.name == "call.done":
             parent_step = event.step.rsplit(":", 1)[0]
             response_data = (
-                normalized_payload.get("result", normalized_payload)
+                normalized_payload.get("response", normalized_payload)
                 if isinstance(normalized_payload, dict)
                 else normalized_payload
             )
@@ -3783,34 +3883,36 @@ class ControlFlowEngine:
             else:
                 _promoted_data = response_data
 
-            # For non-loop steps: mark parent step completed BEFORE set_ctx processing.
-            # set_ctx templates like {{ fetch_with_limit.collected_data }} need the step result
+            # For non-loop steps: mark parent step completed BEFORE set processing.
+            # set templates like {{ fetch_with_limit.collected_data }} need the step result
             # to already be in state.step_results when get_render_context() is called.
             _is_loop_step = parent_step_def and parent_step_def.loop and parent_step in state.loop_state
             if not _is_loop_step:
                 state.mark_step_completed(parent_step, _promoted_data)
-                logger.debug("[TASK_SEQ] Pre-marked parent step '%s' completed with promoted result (before set_ctx)", parent_step)
+                logger.debug("[TASK_SEQ] Pre-marked parent step '%s' completed with promoted result (before set)", parent_step)
 
-            # Process step-level set_ctx for task sequence steps
+            # Process step-level set for task sequence steps
             # This must happen BEFORE next transitions are evaluated so updated variables are available
-            if parent_step_def and parent_step_def.set_ctx:
+            _parent_set = getattr(parent_step_def, "set", None) if parent_step_def else None
+            if parent_step_def and _parent_set:
                 # Get render context with the task sequence result available
                 context = state.get_render_context(event)
                 logger.debug(
-                    "[SET_CTX] Processing step-level set_ctx for task sequence %s: keys=%s",
+                    "[SET] Processing step-level set for task sequence %s: keys=%s",
                     parent_step,
-                    list(parent_step_def.set_ctx.keys()),
+                    list(_parent_set.keys()),
                 )
-                for key, value_template in parent_step_def.set_ctx.items():
+                _ts_set_rendered: dict = {}
+                for key, value_template in _parent_set.items():
                     try:
                         if isinstance(value_template, str) and "{{" in value_template:
-                            rendered_value = self._render_template(value_template, context)
+                            _ts_set_rendered[key] = self._render_template(value_template, context)
                         else:
-                            rendered_value = value_template
-                        state.variables[key] = rendered_value
-                        logger.debug("[SET_CTX] Set %s (type=%s)", key, type(rendered_value).__name__)
+                            _ts_set_rendered[key] = value_template
+                        logger.debug("[SET] Rendered %s (type=%s)", key, type(_ts_set_rendered[key]).__name__)
                     except Exception as e:
-                        logger.error(f"[SET_CTX] Failed to render {key}: {e}")
+                        logger.error(f"[SET] Failed to render {key}: {e}")
+                _apply_set_mutations(state.variables, _ts_set_rendered)
 
             # Handle loop iteration tracking for task sequence steps
             if parent_step_def and parent_step_def.loop and parent_step in state.loop_state:
@@ -4129,10 +4231,12 @@ class ControlFlowEngine:
         # This ensures the result is available in render context for subsequent steps
         if event.name == "call.done":
             response_data = (
-                normalized_payload.get("result", normalized_payload)
+                normalized_payload.get("response",
+                    normalized_payload.get("result", normalized_payload))
                 if isinstance(normalized_payload, dict)
                 else normalized_payload
             )
+            response_data = await _hydrate_reference_only_step_result(response_data)
             state.mark_step_completed(event.step, response_data)
             logger.debug(f"[CALL.DONE] Stored result for step {event.step} in state BEFORE next evaluation")
         elif event.name == "call.error":
@@ -4150,26 +4254,27 @@ class ControlFlowEngine:
         # Get render context AFTER storing call.done response
         context = state.get_render_context(event)
 
-        # Process step-level set_ctx BEFORE evaluating next transitions
-        # This ensures variables set by set_ctx are available in routing conditions
-        if event.name == "call.done" and step_def.set_ctx:
+        # Process step-level set BEFORE evaluating next transitions
+        # This ensures variables written by set are available in routing conditions
+        step_set = getattr(step_def, "set", None)
+        if event.name == "call.done" and step_set:
             logger.debug(
-                "[SET_CTX] Processing step-level set_ctx for %s: keys=%s",
+                "[SET] Processing step-level set for %s: keys=%s",
                 event.step,
-                list(step_def.set_ctx.keys()),
+                list(step_set.keys()),
             )
-            for key, value_template in step_def.set_ctx.items():
+            rendered_step_set: dict = {}
+            for key, value_template in step_set.items():
                 try:
-                    # Render the value template with current context (including step result)
                     if isinstance(value_template, str) and "{{" in value_template:
-                        rendered_value = self._render_template(value_template, context)
+                        rendered_step_set[key] = self._render_template(value_template, context)
                     else:
-                        rendered_value = value_template
-                    state.variables[key] = rendered_value
-                    logger.debug("[SET_CTX] Set %s (type=%s)", key, type(rendered_value).__name__)
+                        rendered_step_set[key] = value_template
+                    logger.debug("[SET] Rendered %s (type=%s)", key, type(rendered_step_set[key]).__name__)
                 except Exception as e:
-                    logger.error(f"[SET_CTX] Failed to render {key}: {e}")
-            # Refresh context after set_ctx to include new variables
+                    logger.error(f"[SET] Failed to render {key}: {e}")
+            _apply_set_mutations(state.variables, rendered_step_set)
+            # Refresh context after set to include new variables
             context = state.get_render_context(event)
 
         # Evaluate next[].when transitions ONCE and store results
@@ -4197,7 +4302,8 @@ class ControlFlowEngine:
         # never triggers handle_event().
         if event.name == "call.done" and is_loop_step:
             response_data = (
-                normalized_payload.get("result", normalized_payload)
+                normalized_payload.get("response",
+                    normalized_payload.get("result", normalized_payload))
                 if isinstance(normalized_payload, dict)
                 else normalized_payload
             )
@@ -4432,7 +4538,8 @@ class ControlFlowEngine:
                 if event.step.endswith(":task_sequence"):
                     logger.debug(f"Skipping step.exit result storage for task sequence step {event.step} (already handled on call.done)")
                 else:
-                    state.mark_step_completed(event.step, event.payload["result"])
+                    hydrated_result = await _hydrate_reference_only_step_result(event.payload["result"])
+                    state.mark_step_completed(event.step, hydrated_result)
                     logger.debug(f"Stored result for step {event.step} in state")
         
         # Note: call.done response was stored earlier (before next evaluation) to ensure

--- a/noetl/core/dsl/v2/models.py
+++ b/noetl/core/dsl/v2/models.py
@@ -12,7 +12,7 @@ Canonical v10 implementation with:
 - NO `step.when` field - step admission via `step.spec.policy.admit.rules`
 """
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from typing import Any, Literal, Optional, Union
 from datetime import datetime
 
@@ -23,8 +23,17 @@ from datetime import datetime
 
 class StepEnterPayload(BaseModel):
     """Payload for step.enter event."""
-    args: dict[str, Any] = Field(default_factory=dict, description="Step input arguments")
+    input: dict[str, Any] = Field(default_factory=dict, description="Step input bindings")
     context: Optional[dict[str, Any]] = Field(None, description="Execution context")
+
+    @model_validator(mode='before')
+    @classmethod
+    def _rename_legacy_fields(cls, obj):
+        """Accept legacy 'args' as alias for 'input'."""
+        if isinstance(obj, dict) and "args" in obj and "input" not in obj:
+            obj = dict(obj)
+            obj["input"] = obj.pop("args")
+        return obj
 
 
 class CallDonePayload(BaseModel):
@@ -68,7 +77,7 @@ class CommandIssuedPayload(BaseModel):
     step: str = Field(..., description="Step name")
     tool_kind: str = Field(..., description="Tool type")
     tool_config: dict[str, Any] = Field(default_factory=dict, description="Tool configuration")
-    args: dict[str, Any] = Field(default_factory=dict, description="Step arguments")
+    input: dict[str, Any] = Field(default_factory=dict, description="Step input bindings")
     render_context: dict[str, Any] = Field(default_factory=dict, description="Render context for templates")
     priority: int = Field(default=0, description="Command priority")
     max_attempts: int = Field(default=3, description="Maximum retry attempts")
@@ -178,16 +187,30 @@ class PolicyRuleThen(BaseModel):
     delay: Optional[float] = Field(None, description="Initial delay in seconds")
     # Jump option
     to: Optional[str] = Field(None, description="Target task label for jump action")
-    # Variable mutations
-    set_ctx: Optional[dict[str, Any]] = Field(
-        None, description="Patches to execution-scoped context"
-    )
-    set_iter: Optional[dict[str, Any]] = Field(
-        None, description="Patches to iteration-scoped context"
+    # Unified scoped mutation (replaces set_ctx / set_iter)
+    set: Optional[dict[str, Any]] = Field(
+        None, description="Scoped variable mutations: ctx.*, iter.*, step.*"
     )
 
     class Config:
         extra = "allow"
+
+    @model_validator(mode='before')
+    @classmethod
+    def _rename_legacy_fields(cls, obj):
+        """Accept legacy set_ctx/set_iter as aliases for set."""
+        if isinstance(obj, dict) and "set" not in obj:
+            obj = dict(obj)
+            legacy: dict[str, Any] = {}
+            if "set_ctx" in obj:
+                for k, v in obj.pop("set_ctx").items():
+                    legacy[f"ctx.{k}" if "." not in k else k] = v
+            if "set_iter" in obj:
+                for k, v in obj.pop("set_iter").items():
+                    legacy[f"iter.{k}" if "." not in k else k] = v
+            if legacy:
+                obj["set"] = legacy
+        return obj
 
 
 class PolicyRule(BaseModel):
@@ -457,12 +480,12 @@ class ToolOutcome(BaseModel):
     """
     Structured result of tool execution (canonical v10).
 
-    Available in policy rule expressions as 'outcome'.
+    Available in policy rule expressions as 'output'.
 
     IMPORTANT: status is "ok" or "error" (not "success").
 
-    Example outcome:
-        outcome = {
+    Example output:
+        output = {
             "status": "error",
             "error": {
                 "kind": "rate_limit",
@@ -475,7 +498,8 @@ class ToolOutcome(BaseModel):
         }
     """
     status: Literal["ok", "error"] = Field(..., description="Execution status: ok or error")
-    result: Any = Field(None, description="Tool output (if ok)")
+    data: Any = Field(None, description="Tool output payload (if ok)")
+    ref: Optional[dict[str, Any]] = Field(None, description="Reference to externalized payload")
     error: Optional[dict[str, Any]] = Field(
         None, description="Structured error {kind, retryable, code, message, details}"
     )
@@ -592,7 +616,8 @@ class Arc(BaseModel):
         arcs:
           - step: success_handler
             when: "{{ event.name == 'step.done' }}"
-            args: { data: "{{ ctx.result }}" }
+            set:
+              ctx.result_ref: "{{ output.ref }}"
           - step: error_handler
             when: "{{ event.name == 'step.failed' }}"
     """
@@ -600,12 +625,21 @@ class Arc(BaseModel):
     when: Optional[str] = Field(
         None, description="Arc guard expression (Jinja2). Default true if omitted."
     )
-    args: Optional[dict[str, Any]] = Field(
-        None, description="Token payload to pass to target step (arc inscription)"
+    set: Optional[dict[str, Any]] = Field(
+        None, description="Transition-scoped variable mutations (ctx.*, step.*, iter.*)"
     )
     spec: Optional[dict[str, Any]] = Field(
         None, description="Arc-level spec (placeholder for future)"
     )
+
+    @model_validator(mode='before')
+    @classmethod
+    def _rename_legacy_fields(cls, obj):
+        """Accept legacy 'args' as alias for 'set' on arcs."""
+        if isinstance(obj, dict) and "args" in obj and "set" not in obj:
+            obj = dict(obj)
+            obj["set"] = obj.pop("args")
+        return obj
 
 
 class NextRouter(BaseModel):
@@ -727,7 +761,7 @@ class Step(BaseModel):
     # NOTE: step.when is REMOVED in v10 - use step.spec.policy.admit.rules
     # when: REMOVED
 
-    args: Optional[dict[str, Any]] = Field(None, description="Input arguments for this step")
+    input: Optional[dict[str, Any]] = Field(None, description="Input bindings for this step")
     loop: Optional[Loop] = Field(None, description="Loop configuration")
 
     # Tool: single ToolSpec (shorthand) or list of labeled tasks (pipeline)
@@ -742,10 +776,10 @@ class Step(BaseModel):
         description="Next router with spec and arcs"
     )
 
-    # Step-level context mutation (processed after tool completes)
-    set_ctx: Optional[dict[str, Any]] = Field(
+    # Step-level scoped mutation (processed after tool completes)
+    set: Optional[dict[str, Any]] = Field(
         None,
-        description="Variables to set in execution context after step completes"
+        description="Scoped variable mutations after step completes (ctx.*, step.*, iter.*)"
     )
 
     # NOTE: Legacy fields (output, result, vars) removed in v10
@@ -837,6 +871,18 @@ class Step(BaseModel):
             return {"spec": {"mode": "exclusive"}, "arcs": arcs}
 
         return v
+
+    @model_validator(mode='before')
+    @classmethod
+    def _rename_legacy_fields(cls, obj):
+        """Accept legacy field names as aliases for canonical ones."""
+        if isinstance(obj, dict):
+            obj = dict(obj)
+            if "args" in obj and "input" not in obj:
+                obj["input"] = obj.pop("args")
+            if "set_ctx" in obj and "set" not in obj:
+                obj["set"] = obj.pop("set_ctx")
+        return obj
 
 
 # ============================================================================
@@ -997,7 +1043,7 @@ class Command(BaseModel):
     execution_id: str = Field(..., description="Execution identifier")
     step: str = Field(..., description="Step name")
     tool: ToolCall = Field(..., description="Tool invocation details")
-    args: Optional[dict[str, Any]] = Field(None, description="Step input arguments")
+    input: Optional[dict[str, Any]] = Field(None, description="Step input bindings")
     render_context: dict[str, Any] = Field(default_factory=dict, description="Full render context")
 
     # Pipeline: list of labeled tasks
@@ -1031,7 +1077,7 @@ class Command(BaseModel):
             "step": self.step,
             "tool_kind": self.tool.kind,
             "tool_config": self.tool.config,
-            "args": self.args or {},
+            "input": self.input or {},
             "pipeline": self.pipeline,
             "next_router": self.next_router,
             "next_targets": self.next_targets,
@@ -1045,10 +1091,14 @@ class Command(BaseModel):
         }
 
 
-# NOTE: All legacy aliases and deprecated models have been removed in v10.
-# Use canonical v10 patterns only:
-# - task.spec.policy.rules (not eval)
+# NOTE: Legacy aliases accepted via model_validate for backward compat:
+# - 'args' -> 'input'  (Step, Arc, Command, StepEnterPayload)
+# - 'set_ctx'/'set_iter' -> 'set'  (Step, PolicyRuleThen)
+# - 'outcome' -> 'output'  (template context key, see engine.py)
+# - 'result' -> 'data'  (ToolOutcome payload field)
+# Canonical v10 patterns:
+# - step.input / arc.set / output.data / output.ref
+# - set: { ctx.*, iter.*, step.* }
 # - when (not expr)
-# - set_ctx (not set_vars)
 # - next.arcs[] (not next[])
-# - outcome.status: "ok" | "error" (not "success")
+# - output.status: "ok" | "error"

--- a/noetl/worker/task_sequence_executor.py
+++ b/noetl/worker/task_sequence_executor.py
@@ -82,11 +82,25 @@ class TaskSequenceContext:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dict for template rendering."""
+        # Canonical DSL v2: expose result as 'output.data'/'output.ref'.
+        # Keep 'outcome' for backward compat with existing playbooks.
+        output_view: dict[str, Any] = {}
+        if isinstance(self.outcome, dict):
+            output_view = {
+                "status": self.outcome.get("status", "ok"),
+                "data": self.outcome.get("data") or self.outcome.get("result"),
+                "ref": self.outcome.get("ref"),
+                "error": self.outcome.get("error"),
+            }
+            for k in ("http", "pg", "py", "meta"):
+                if k in self.outcome:
+                    output_view[k] = self.outcome[k]
         return {
             "_task": self._task,
             "_prev": self._prev,
             "_attempt": self._attempt,
-            "outcome": self.outcome,
+            "outcome": self.outcome,   # backward compat
+            "output": output_view,     # canonical DSL v2
             "results": self.results,
             "ctx": self.ctx,
             "iter": self.iter,
@@ -121,8 +135,7 @@ class ControlAction:
     attempts: int = 3  # Max retry attempts
     backoff: str = "none"  # none, linear, exponential
     delay: float = 1.0  # Initial delay seconds
-    set_ctx: Optional[dict[str, Any]] = None  # Execution-scoped vars
-    set_iter: Optional[dict[str, Any]] = None  # Iteration-scoped vars
+    set: Optional[dict[str, Any]] = None  # Scoped mutations: ctx.*, iter.*, step.*
 
 
 def build_outcome(
@@ -169,7 +182,8 @@ def build_outcome(
     }
 
     if status == "ok":
-        outcome["result"] = result
+        outcome["result"] = result   # backward compat
+        outcome["data"] = result     # canonical DSL v2: output.data
     else:
         outcome["error"] = error or {"kind": "unknown", "retryable": False, "message": "Unknown error"}
 
@@ -550,48 +564,32 @@ class TaskSequenceExecutor:
                 "_task": latest_task_dict["_task"],
                 "_prev": latest_task_dict["_prev"],
                 "_attempt": latest_task_dict["_attempt"],
-                "outcome": latest_task_dict["outcome"],
+                "outcome": latest_task_dict["outcome"],   # backward compat
+                "output": latest_task_dict["output"],     # canonical DSL v2
                 "results": latest_task_dict["results"],
                 # Keep merged ctx and iter from render_ctx (don't override with empty task seq ctx)
             }
             action = self._evaluate_policy_rules(policy_rules, eval_ctx, ctx.outcome)
 
-            # Apply set_ctx
-            if action.set_ctx:
-                rendered_ctx = {}
-                for key, value in action.set_ctx.items():
+            # Apply unified 'set' mutations (canonical DSL v2: ctx.*, iter.*, step.*)
+            if action.set:
+                for key, value in action.set.items():
                     if isinstance(value, str) and "{{" in value:
                         try:
-                            rendered_ctx[key] = self.render_template(value, eval_ctx)
+                            value = self.render_template(value, eval_ctx)
                         except Exception as e:
-                            logger.warning(f"[TASK_SEQ] Error rendering set_ctx.{key}: {e}")
-                            rendered_ctx[key] = value
+                            logger.warning(f"[TASK_SEQ] Error rendering set.{key}: {e}")
+                    # Route to ctx or iter based on scope prefix
+                    if key.startswith("ctx."):
+                        ctx.set_ctx_vars({key[4:]: value})
+                    elif key.startswith("iter."):
+                        ctx.set_iter_vars({key[5:]: value})
+                    elif key.startswith("step."):
+                        ctx.set_ctx_vars({key[5:]: value})  # step scope → ctx for now
                     else:
-                        rendered_ctx[key] = value
-                ctx.set_ctx_vars(rendered_ctx)
-                logger.debug(f"[TASK_SEQ] Set ctx vars: {list(rendered_ctx.keys())}")
-
-            # Apply set_iter
-            if action.set_iter:
-                rendered_iter = {}
-                for key, value in action.set_iter.items():
-                    if isinstance(value, str) and "{{" in value:
-                        try:
-                            rendered_iter[key] = self.render_template(value, eval_ctx)
-                            logger.debug(
-                                f"[TASK_SEQ] Rendered set_iter.{key}: {type(rendered_iter[key]).__name__}"
-                            )
-                        except Exception as e:
-                            logger.warning(f"[TASK_SEQ] Error rendering set_iter.{key}: {e}")
-                            rendered_iter[key] = value
-                    else:
-                        rendered_iter[key] = value
-                ctx.set_iter_vars(rendered_iter)
-                logger.debug(
-                    "[TASK_SEQ] Applied set_iter keys=%s iter_key_count=%s",
-                    list(rendered_iter.keys()),
-                    len(ctx.iter.keys()),
-                )
+                        # Bare key: backward compat — write to ctx
+                        ctx.set_ctx_vars({key: value})
+                logger.debug(f"[TASK_SEQ] Applied set keys={list(action.set.keys())}")
 
             # Apply control action
             if action.action == "continue":
@@ -939,7 +937,7 @@ class TaskSequenceExecutor:
         if "set_vars" in then_data:
             raise ValueError(
                 "Policy rule uses 'set_vars' which is not allowed in v10. "
-                "Use 'set_ctx' for execution-scoped variables."
+                "Use 'set' for scoped variable mutations."
             )
 
         # STRICT v10: Require 'do' field
@@ -956,14 +954,24 @@ class TaskSequenceExecutor:
             except ValueError:
                 delay = 1.0
 
+        # Canonical DSL v2: unified 'set' with scoped keys (ctx.*, iter.*, step.*).
+        # Accept legacy set_ctx / set_iter as backward-compat aliases.
+        merged_set: Optional[dict[str, Any]] = then_data.get("set")
+        if merged_set is None:
+            legacy: dict[str, Any] = {}
+            for key, val in (then_data.get("set_ctx") or {}).items():
+                legacy[f"ctx.{key}" if "." not in key else key] = val
+            for key, val in (then_data.get("set_iter") or {}).items():
+                legacy[f"iter.{key}" if "." not in key else key] = val
+            merged_set = legacy or None
+
         return ControlAction(
             action=then_data["do"],
             to=then_data.get("to"),
             attempts=then_data.get("attempts", 3),
             backoff=then_data.get("backoff", "none"),
             delay=delay,
-            set_ctx=then_data.get("set_ctx"),
-            set_iter=then_data.get("set_iter"),
+            set=merged_set,
         )
 
     def _calculate_delay(self, action: ControlAction, attempt: int) -> float:

--- a/noetl/worker/v2_worker_nats.py
+++ b/noetl/worker/v2_worker_nats.py
@@ -582,6 +582,35 @@ class V2Worker:
             envelope["error"] = error
         return envelope
 
+    @staticmethod
+    def _normalize_output_config(tool_config: dict[str, Any]) -> dict[str, Any]:
+        """Bridge canonical `tool.output` config to the legacy ResultHandler shape."""
+        if not isinstance(tool_config, dict):
+            return {}
+
+        raw_output = tool_config.get("output")
+        if not isinstance(raw_output, dict):
+            raw_output = tool_config.get("result")
+        if not isinstance(raw_output, dict):
+            return {}
+
+        normalized = dict(raw_output)
+
+        select_config = normalized.pop("select", None)
+        if "output_select" not in normalized and isinstance(select_config, list):
+            select_paths: list[str] = []
+            for item in select_config:
+                if isinstance(item, str) and item.strip():
+                    select_paths.append(item.strip())
+                elif isinstance(item, dict):
+                    path_value = item.get("path")
+                    if isinstance(path_value, str) and path_value.strip():
+                        select_paths.append(path_value.strip())
+            if select_paths:
+                normalized["output_select"] = select_paths
+
+        return normalized
+
     def _normalize_payload_reference_only(
         self,
         *,
@@ -1649,9 +1678,10 @@ class V2Worker:
             step=step,
             execution_id=execution_id,
         )
+        # Canonical DSL v2: command carries 'input'. Accept 'args' as backward-compat alias.
         args = self._normalize_command_context_mapping(
-            context.get("args"),
-            field_name="args",
+            context.get("input") or context.get("args"),
+            field_name="input",
             step=step,
             execution_id=execution_id,
         )
@@ -1682,13 +1712,12 @@ class V2Worker:
             eval_mode = spec.get("eval_mode", "on_entry")
             logger.debug(f"[SPEC] Step '{step}' spec: case_mode={case_mode}, eval_mode={eval_mode}")
         
-        # CRITICAL: Merge tool_config.args with top-level args
-        # In V2 DSL, step args are often defined within the tool block
-        # e.g., tool: {kind: python, args: {name: "value"}, script: {...}}
-        # The engine puts these in tool_config.args, but the worker needs them in args
-        if "args" in tool_config:
+        # CRITICAL: Merge tool_config input/args with top-level args.
+        # Canonical DSL v2: tool.input replaces tool.args; accept both for backward compat.
+        tool_input = tool_config.get("input") or tool_config.get("args")
+        if tool_input and isinstance(tool_input, dict):
             # Merge with top-level args taking precedence
-            merged_args = {**tool_config["args"], **args}
+            merged_args = {**tool_input, **args}
             args = merged_args
             logger.debug("Args config: merged_from_tool_config | keys=%s", _safe_keys(args))
         else:
@@ -1791,8 +1820,7 @@ class V2Worker:
             else:
                 try:
                     result_handler = ResultHandler(execution_id=execution_id)
-                    # Get output config from tool_config if present
-                    output_config = tool_config.get("result", {})
+                    output_config = self._normalize_output_config(tool_config)
                     processed_response = await result_handler.process_result(
                         step_name=step,
                         result=response,
@@ -2221,7 +2249,7 @@ class V2Worker:
         
         # Use render_context from engine (includes workload, step results, execution_id, etc.)
         # This allows plugins to render Jinja2 templates with full state
-        context = render_context if render_context else {"args": args, "step": step}
+        context = render_context if render_context else {"input": args, "step": step}
         
         logger.debug(
             "WORKER: initial context keys=%s execution_id=%s has_catalog_id=%s",
@@ -2291,10 +2319,11 @@ class V2Worker:
         # For workbook tool, preserve 'name' field from config (it's the workbook action name)
         # For other tools, add 'name' as step name for logging
         task_config = {**config}
-        # Merge args: config["args"] (from pipeline tool spec) + args parameter
-        # This preserves tool args from pipeline while allowing parameter override
-        config_args = config.get("args", {})
+        # Merge input: config["input"] (canonical DSL v2) or config["args"] (legacy) + args parameter
+        # This preserves tool input from pipeline while allowing parameter override
+        config_args = config.get("input") or config.get("args") or {}
         task_config["args"] = {**config_args, **args} if config_args or args else {}
+        task_config["input"] = task_config["args"]  # canonical alias
         if "name" not in config:
             task_config["name"] = step
         

--- a/tests/fixtures/playbooks/pagination/basic/test_pagination_basic.yaml
+++ b/tests/fixtures/playbooks/pagination/basic/test_pagination_basic.yaml
@@ -17,10 +17,10 @@ workflow:
     desc: Initialize pagination
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
-    set_ctx:
+    set:
       current_page: "{{ workload.current_page }}"
       page_size: "{{ workload.page_size }}"
       collected_items: "{{ workload.collected_items }}"
@@ -43,13 +43,13 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' and outcome.error.retryable }}"
+            - when: "{{ output.status == 'error' and output.error.retryable }}"
               then:
                 do: retry
                 attempts: 5
                 backoff: exponential
                 delay: 1.0
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: fail
             - else:
@@ -65,7 +65,7 @@ workflow:
     desc: Check if more pages exist and collect results
     tool:
       kind: python
-      args:
+      input:
         response: "{{ fetch_page }}"
         collected: "{{ ctx.collected_items }}"
         current_page: "{{ ctx.current_page }}"
@@ -86,7 +86,7 @@ workflow:
             'next_page': next_page,
             'total_collected': len(all_items)
         }
-    set_ctx:
+    set:
       collected_items: "{{ check_pagination.collected_items }}"
       current_page: "{{ check_pagination.next_page }}"
       has_more: "{{ check_pagination.has_more }}"
@@ -103,7 +103,7 @@ workflow:
     desc: Validate merged results
     tool:
       kind: python
-      args:
+      input:
         items: "{{ ctx.collected_items }}"
       code: |
         data = items if isinstance(items, list) else []
@@ -140,6 +140,6 @@ workflow:
     desc: Workflow complete
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/pagination/cursor/test_pagination_cursor.yaml
+++ b/tests/fixtures/playbooks/pagination/cursor/test_pagination_cursor.yaml
@@ -17,10 +17,10 @@ workflow:
     desc: Initialize cursor pagination
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
-    set_ctx:
+    set:
       cursor: "{{ workload.cursor }}"
       limit: "{{ workload.limit }}"
       collected_events: "{{ workload.collected_events }}"
@@ -43,13 +43,13 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' and outcome.error.retryable }}"
+            - when: "{{ output.status == 'error' and output.error.retryable }}"
               then:
                 do: retry
                 attempts: 5
                 backoff: exponential
                 delay: 1.0
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: fail
             - else:
@@ -65,7 +65,7 @@ workflow:
     desc: Check if more pages exist and collect results
     tool:
       kind: python
-      args:
+      input:
         response: "{{ fetch_page }}"
         collected: "{{ ctx.collected_events }}"
       code: |
@@ -84,7 +84,7 @@ workflow:
             'next_cursor': next_cursor if has_more else '',
             'total_collected': len(all_events)
         }
-    set_ctx:
+    set:
       collected_events: "{{ check_pagination.collected_events }}"
       cursor: "{{ check_pagination.next_cursor }}"
       has_more: "{{ check_pagination.has_more }}"
@@ -101,7 +101,7 @@ workflow:
     desc: Validate merged results
     tool:
       kind: python
-      args:
+      input:
         events: "{{ ctx.collected_events }}"
       code: |
         data = events if isinstance(events, list) else []
@@ -137,6 +137,6 @@ workflow:
     desc: Workflow complete
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/pagination/fetch_load_test/test_fetch_load.yaml
+++ b/tests/fixtures/playbooks/pagination/fetch_load_test/test_fetch_load.yaml
@@ -16,8 +16,13 @@ metadata:
 workload:
   api_url: http://paginated-api.test-server.svc.cluster.local:5555
   num_patients: 500
+  patients: ["P-0001", "P-0002", "P-0003", "P-0004", "P-0005", "P-0006", "P-0007", "P-0008", "P-0009", "P-0010", "P-0011", "P-0012", "P-0013", "P-0014", "P-0015", "P-0016", "P-0017", "P-0018", "P-0019", "P-0020", "P-0021", "P-0022", "P-0023", "P-0024", "P-0025", "P-0026", "P-0027", "P-0028", "P-0029", "P-0030", "P-0031", "P-0032", "P-0033", "P-0034", "P-0035", "P-0036", "P-0037", "P-0038", "P-0039", "P-0040", "P-0041", "P-0042", "P-0043", "P-0044", "P-0045", "P-0046", "P-0047", "P-0048", "P-0049", "P-0050", "P-0051", "P-0052", "P-0053", "P-0054", "P-0055", "P-0056", "P-0057", "P-0058", "P-0059", "P-0060", "P-0061", "P-0062", "P-0063", "P-0064", "P-0065", "P-0066", "P-0067", "P-0068", "P-0069", "P-0070", "P-0071", "P-0072", "P-0073", "P-0074", "P-0075", "P-0076", "P-0077", "P-0078", "P-0079", "P-0080", "P-0081", "P-0082", "P-0083", "P-0084", "P-0085", "P-0086", "P-0087", "P-0088", "P-0089", "P-0090", "P-0091", "P-0092", "P-0093", "P-0094", "P-0095", "P-0096", "P-0097", "P-0098", "P-0099", "P-0100", "P-0101", "P-0102", "P-0103", "P-0104", "P-0105", "P-0106", "P-0107", "P-0108", "P-0109", "P-0110", "P-0111", "P-0112", "P-0113", "P-0114", "P-0115", "P-0116", "P-0117", "P-0118", "P-0119", "P-0120", "P-0121", "P-0122", "P-0123", "P-0124", "P-0125", "P-0126", "P-0127", "P-0128", "P-0129", "P-0130", "P-0131", "P-0132", "P-0133", "P-0134", "P-0135", "P-0136", "P-0137", "P-0138", "P-0139", "P-0140", "P-0141", "P-0142", "P-0143", "P-0144", "P-0145", "P-0146", "P-0147", "P-0148", "P-0149", "P-0150", "P-0151", "P-0152", "P-0153", "P-0154", "P-0155", "P-0156", "P-0157", "P-0158", "P-0159", "P-0160", "P-0161", "P-0162", "P-0163", "P-0164", "P-0165", "P-0166", "P-0167", "P-0168", "P-0169", "P-0170", "P-0171", "P-0172", "P-0173", "P-0174", "P-0175", "P-0176", "P-0177", "P-0178", "P-0179", "P-0180", "P-0181", "P-0182", "P-0183", "P-0184", "P-0185", "P-0186", "P-0187", "P-0188", "P-0189", "P-0190", "P-0191", "P-0192", "P-0193", "P-0194", "P-0195", "P-0196", "P-0197", "P-0198", "P-0199", "P-0200", "P-0201", "P-0202", "P-0203", "P-0204", "P-0205", "P-0206", "P-0207", "P-0208", "P-0209", "P-0210", "P-0211", "P-0212", "P-0213", "P-0214", "P-0215", "P-0216", "P-0217", "P-0218", "P-0219", "P-0220", "P-0221", "P-0222", "P-0223", "P-0224", "P-0225", "P-0226", "P-0227", "P-0228", "P-0229", "P-0230", "P-0231", "P-0232", "P-0233", "P-0234", "P-0235", "P-0236", "P-0237", "P-0238", "P-0239", "P-0240", "P-0241", "P-0242", "P-0243", "P-0244", "P-0245", "P-0246", "P-0247", "P-0248", "P-0249", "P-0250", "P-0251", "P-0252", "P-0253", "P-0254", "P-0255", "P-0256", "P-0257", "P-0258", "P-0259", "P-0260", "P-0261", "P-0262", "P-0263", "P-0264", "P-0265", "P-0266", "P-0267", "P-0268", "P-0269", "P-0270", "P-0271", "P-0272", "P-0273", "P-0274", "P-0275", "P-0276", "P-0277", "P-0278", "P-0279", "P-0280", "P-0281", "P-0282", "P-0283", "P-0284", "P-0285", "P-0286", "P-0287", "P-0288", "P-0289", "P-0290", "P-0291", "P-0292", "P-0293", "P-0294", "P-0295", "P-0296", "P-0297", "P-0298", "P-0299", "P-0300", "P-0301", "P-0302", "P-0303", "P-0304", "P-0305", "P-0306", "P-0307", "P-0308", "P-0309", "P-0310", "P-0311", "P-0312", "P-0313", "P-0314", "P-0315", "P-0316", "P-0317", "P-0318", "P-0319", "P-0320", "P-0321", "P-0322", "P-0323", "P-0324", "P-0325", "P-0326", "P-0327", "P-0328", "P-0329", "P-0330", "P-0331", "P-0332", "P-0333", "P-0334", "P-0335", "P-0336", "P-0337", "P-0338", "P-0339", "P-0340", "P-0341", "P-0342", "P-0343", "P-0344", "P-0345", "P-0346", "P-0347", "P-0348", "P-0349", "P-0350", "P-0351", "P-0352", "P-0353", "P-0354", "P-0355", "P-0356", "P-0357", "P-0358", "P-0359", "P-0360", "P-0361", "P-0362", "P-0363", "P-0364", "P-0365", "P-0366", "P-0367", "P-0368", "P-0369", "P-0370", "P-0371", "P-0372", "P-0373", "P-0374", "P-0375", "P-0376", "P-0377", "P-0378", "P-0379", "P-0380", "P-0381", "P-0382", "P-0383", "P-0384", "P-0385", "P-0386", "P-0387", "P-0388", "P-0389", "P-0390", "P-0391", "P-0392", "P-0393", "P-0394", "P-0395", "P-0396", "P-0397", "P-0398", "P-0399", "P-0400", "P-0401", "P-0402", "P-0403", "P-0404", "P-0405", "P-0406", "P-0407", "P-0408", "P-0409", "P-0410", "P-0411", "P-0412", "P-0413", "P-0414", "P-0415", "P-0416", "P-0417", "P-0418", "P-0419", "P-0420", "P-0421", "P-0422", "P-0423", "P-0424", "P-0425", "P-0426", "P-0427", "P-0428", "P-0429", "P-0430", "P-0431", "P-0432", "P-0433", "P-0434", "P-0435", "P-0436", "P-0437", "P-0438", "P-0439", "P-0440", "P-0441", "P-0442", "P-0443", "P-0444", "P-0445", "P-0446", "P-0447", "P-0448", "P-0449", "P-0450", "P-0451", "P-0452", "P-0453", "P-0454", "P-0455", "P-0456", "P-0457", "P-0458", "P-0459", "P-0460", "P-0461", "P-0462", "P-0463", "P-0464", "P-0465", "P-0466", "P-0467", "P-0468", "P-0469", "P-0470", "P-0471", "P-0472", "P-0473", "P-0474", "P-0475", "P-0476", "P-0477", "P-0478", "P-0479", "P-0480", "P-0481", "P-0482", "P-0483", "P-0484", "P-0485", "P-0486", "P-0487", "P-0488", "P-0489", "P-0490", "P-0491", "P-0492", "P-0493", "P-0494", "P-0495", "P-0496", "P-0497", "P-0498", "P-0499", "P-0500"]
   page_size: 10
   max_in_flight: 5
+  api_min_delay: 2.0
+  api_max_delay: 4.0
+  api_payload_kb: 100
+  api_rate_limit: 50
 
 workflow:
   - step: start
@@ -45,18 +50,25 @@ workflow:
       spec:
         mode: exclusive
       arcs:
-        - step: generate_patients
+        - step: fetch_all_patients
 
   - step: generate_patients
     desc: Generate list of 500 synthetic patient IDs
     tool:
       kind: python
-      args:
+      input:
         num_patients: '{{ num_patients }}'
       code: |
         n = int(num_patients or 500)
         patients = [{"patient_id": f"P-{i:04d}"} for i in range(1, n + 1)]
         result = {"patients": patients, "count": len(patients)}
+    output:
+      output_select:
+        - patients
+        - count
+    set:
+      patients: "{{ generate_patients.patients }}"
+      patient_count: "{{ generate_patients.count }}"
     next:
       spec:
         mode: exclusive
@@ -66,11 +78,12 @@ workflow:
   - step: fetch_all_patients
     desc: "Fetch all pages for each patient in parallel (max_in_flight: {{ max_in_flight }})"
     loop:
-      in: '{{ generate_patients.patients }}'
+      in: '{{ patients }}'
       iterator: item
       spec:
         mode: parallel
-        max_in_flight: '{{ max_in_flight }}'
+        # Distributed runtime validation currently requires a literal integer here.
+        max_in_flight: 5
     tool:
       - name: init_page
         kind: noop
@@ -80,7 +93,7 @@ workflow:
               - else:
                   then:
                     do: continue
-                    set_iter:
+                    set:
                       page: 1
                       pages_fetched: 0
                       records_fetched: 0
@@ -89,28 +102,32 @@ workflow:
         method: GET
         url: "{{ api_url }}/api/v1/patient-records"
         params:
-          patientId: "{{ iter.item.patient_id }}"
+          patientId: "{{ iter.item }}"
           page: "{{ iter.page }}"
           pageSize: "{{ page_size }}"
+          min_delay: "{{ api_min_delay }}"
+          max_delay: "{{ api_max_delay }}"
+          payload_kb: "{{ api_payload_kb }}"
+          rate_limit: "{{ api_rate_limit }}"
         spec:
           policy:
             rules:
-              - when: "{{ outcome.status == 'error' and outcome.http.status == 429 }}"
+              - when: "{{ output.status == 'error' and output.http.status == 429 }}"
                 then: { do: retry, attempts: 30, backoff: fixed, delay: 1.0 }
-              - when: "{{ outcome.status == 'error' and outcome.http.status == 404 }}"
+              - when: "{{ output.status == 'error' and output.http.status == 404 }}"
                 then:
                   do: continue
-                  set_iter:
+                  set:
                     has_more: false
-              - when: "{{ outcome.status == 'error' }}"
+              - when: "{{ output.status == 'error' }}"
                 then: { do: retry, attempts: 3, backoff: exponential, delay: 5.0 }
               - else:
                   then:
                     do: continue
-                    set_iter:
-                      has_more: "{{ outcome.result.data.meta.page < outcome.result.data.meta.totalPages }}"
+                    set:
+                      has_more: "{{ output.data.meta.page < output.data.meta.totalPages }}"
                       pages_fetched: "{{ (iter.pages_fetched | int) + 1 }}"
-                      records_fetched: "{{ (iter.records_fetched | int) + (outcome.result.data.entry | length) }}"
+                      records_fetched: "{{ (iter.records_fetched | int) + (output.data.entry | length) }}"
       - name: paginate
         kind: noop
         spec:
@@ -120,7 +137,7 @@ workflow:
                 then:
                   do: jump
                   to: fetch_page
-                  set_iter:
+                  set:
                     page: "{{ (iter.page | int) + 1 }}"
               - else:
                   then: { do: continue }
@@ -137,7 +154,7 @@ workflow:
           )
           VALUES (
             '{{ execution_id }}',
-            '{{ iter.item.patient_id }}',
+            '{{ iter.item }}',
             {{ iter.pages_fetched }},
             {{ iter.records_fetched }},
             true
@@ -150,9 +167,9 @@ workflow:
         spec:
           policy:
             rules:
-              - when: "{{ outcome.status == 'error' and outcome.error.retryable }}"
+              - when: "{{ output.status == 'error' and output.error.retryable }}"
                 then: { do: retry, attempts: 3, backoff: linear, delay: 1.0 }
-              - when: "{{ outcome.status == 'error' }}"
+              - when: "{{ output.status == 'error' }}"
                 then: { do: fail }
               - else:
                   then: { do: continue }
@@ -164,7 +181,7 @@ workflow:
           when: '{{ event.name == "loop.done" }}'
 
   - step: validate_results
-    desc: Query completion stats and surface any missing patients
+    desc: Query completion stats
     tool:
       kind: postgres
       auth: pg_k8s
@@ -177,13 +194,34 @@ workflow:
           COUNT(*) FILTER (WHERE completed = FALSE) AS failed_count
         FROM public.fetch_load_test_results
         WHERE execution_id = '{{ execution_id }}';
+      output:
+        store:
+          kind: kv
+        # Persist query output behind a ResultRef so downstream checks resolve through
+        # the reference-only event contract instead of relying on inline event payloads.
+        inline_max_bytes: 0
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: load_failed_results
 
+  - step: load_failed_results
+    desc: Query failed patients for error reporting
+    tool:
+      kind: postgres
+      auth: pg_k8s
+      query: |
         SELECT patient_id, error_message
         FROM public.fetch_load_test_results
         WHERE execution_id = '{{ execution_id }}'
           AND completed = FALSE
         ORDER BY patient_id
         LIMIT 20;
+      output:
+        store:
+          kind: kv
+        inline_max_bytes: 0
     next:
       spec:
         mode: exclusive
@@ -194,15 +232,15 @@ workflow:
     desc: Assert all 500 patients completed; fail loudly if any are missing
     tool:
       kind: python
-      args:
-        stats: '{{ validate_results.data.result.command_0.rows }}'
-        failed: '{{ validate_results.data.result.command_1.rows }}'
+      input:
+        stats: '{{ validate_results.rows }}'
+        failed: '{{ load_failed_results.rows }}'
         expected: '{{ num_patients }}'
       code: |
         row = stats[0] if isinstance(stats, list) and stats else {}
         total     = int(row.get("total_patients", 0) or 0)
         completed = int(row.get("completed_count", 0) or 0)
-        failed    = int(row.get("failed_count", 0) or 0)
+        failed_count = int(row.get("failed_count", 0) or 0)
         exp       = int(expected or 500)
         failed_rows = failed if isinstance(failed, list) else []
         failed_ids = [r["patient_id"] for r in failed_rows]
@@ -213,13 +251,19 @@ workflow:
         )
         assert completed == exp, (
             f"Expected {exp} completed patients, got {completed}. "
-            f"Failed patients ({failed}): {failed_ids[:10]}"
+            f"Failed patients ({failed_count}): {failed_ids[:10]}"
+        )
+        assert failed_count == 0, (
+            f"Expected 0 failed patients, got {failed_count}. "
+            f"Failed patient IDs: {failed_ids[:10]}"
         )
 
         result = {
             "status": "passed",
             "total_patients": total,
             "completed": completed,
+            "failed_patients": failed_count,
+            "failed_patient_ids": failed_ids[:10],
             "total_pages": int(row.get("total_pages", 0) or 0),
             "total_records": int(row.get("total_records", 0) or 0),
             "avg_pages_per_patient": round(
@@ -236,7 +280,7 @@ workflow:
     desc: Load test complete — all 500 patients processed without worker crash
     tool:
       kind: python
-      args:
+      input:
         summary: '{{ check_results }}'
       code: |
         result = {

--- a/tests/fixtures/playbooks/pagination/loop_with_pagination/test_loop_with_pagination.yaml
+++ b/tests/fixtures/playbooks/pagination/loop_with_pagination/test_loop_with_pagination.yaml
@@ -38,7 +38,7 @@ workflow:
       \  items_count INTEGER NOT NULL,\n  has_more BOOLEAN NOT NULL,\n  created_at\
       \ TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP\n);\nDELETE FROM pagination_test_results\
       \ WHERE execution_id = {{ execution_id }};\nSELECT 'Table ready' as status;\n"
-  set_ctx:
+  set:
     current_endpoint_index: '{{ workload.current_endpoint_index }}'
     current_page: '{{ workload.current_page }}'
     current_endpoint: '{{ workload.current_endpoint }}'
@@ -51,7 +51,7 @@ workflow:
   desc: Initialize endpoint loop
   tool:
     kind: python
-    args:
+    input:
       endpoints: '{{ endpoints }}'
       endpoint_index: '{{ ctx.current_endpoint_index }}'
     code: "# Convert to int - may be string from template rendering\nendpoint_index\
@@ -60,7 +60,7 @@ workflow:
       \    result = {\n        'has_more_endpoints': True,\n        'endpoint': current,\n\
       \        'index': endpoint_index\n    }\nelse:\n    result = {\n        'has_more_endpoints':\
       \ False,\n        'endpoint': None,\n        'index': endpoint_index\n    }\n"
-  set_ctx:
+  set:
     current_endpoint: '{{ init_endpoint_loop.endpoint }}'
     current_page: 1
   next:
@@ -84,13 +84,13 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.error.retryable }}'
+        - when: '{{ output.error.retryable }}'
           then:
             do: retry
             attempts: 3
             backoff: linear
             delay: 1.0
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
@@ -108,13 +108,13 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.error.retryable }}'
+        - when: '{{ output.error.retryable }}'
           then:
             do: retry
             attempts: 3
             backoff: linear
             delay: 1.0
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
@@ -122,12 +122,12 @@ workflow:
               do: continue
   - name: check_pagination
     kind: python
-    args:
+    input:
       http_response: '{{ fetch }}'
     code: "paging = http_response.get('data', {}).get('paging', {})\nresult = {\n\
       \    'has_more': paging.get('hasMore', False),\n    'current_page': paging.get('page',\
       \ 1)\n}\n"
-  set_ctx:
+  set:
     current_page: '{{ (ctx.current_page | int) + 1 }}'
   next:
     spec:
@@ -144,7 +144,7 @@ workflow:
     code: 'result = {"status": "moving_to_next_endpoint"}
 
       '
-  set_ctx:
+  set:
     current_endpoint_index: '{{ (ctx.current_endpoint_index | int) + 1 }}'
   next:
     spec:
@@ -170,8 +170,8 @@ workflow:
   desc: Verify data was stored correctly
   tool:
     kind: python
-    args:
-      db_results: '{{ validate_results.data.result.command_0.rows }}'
+    input:
+      db_results: '{{ validate_results.data.command_0.rows }}'
       workload: '{{ workload }}'
     code: "\"\"\"\nValidate data was stored in Postgres via sink (each page saved\
       \ individually).\nEach pagination request created a separate row in the table.\n\

--- a/tests/fixtures/playbooks/pagination/max_iterations/test_pagination_max_iterations.yaml
+++ b/tests/fixtures/playbooks/pagination/max_iterations/test_pagination_max_iterations.yaml
@@ -19,7 +19,7 @@ workflow:
     code: 'result = {"status": "initialized"}
 
       '
-  set_ctx:
+  set:
     current_page: '{{ workload.current_page }}'
     page_size: '{{ workload.page_size }}'
     max_iterations: '{{ workload.max_iterations }}'
@@ -43,13 +43,13 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.error.retryable }}'
+        - when: '{{ output.error.retryable }}'
           then:
             do: retry
             attempts: 3
             backoff: linear
             delay: 1.0
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
@@ -57,7 +57,7 @@ workflow:
               do: continue
   - name: collect
     kind: python
-    args:
+    input:
       http_response: '{{ _prev }}'
       existing_data: '{{ ctx.collected_data }}'
     code: "response_body = http_response.get('data', {})\nitems = response_body.get('data',\
@@ -66,7 +66,7 @@ workflow:
       \ else []\ncollected.extend(items)\n\nresult = {\n    'collected_data': collected,\n\
       \    'has_more': paging.get('hasMore', False),\n    'current_page': paging.get('page',\
       \ 1)\n}\n"
-  set_ctx:
+  set:
     collected_data: '{{ fetch_with_limit.collected_data }}'
     current_page: '{{ (ctx.current_page | int) + 1 }}'
     iteration_count: '{{ (ctx.iteration_count | int) + 1 }}'
@@ -84,7 +84,7 @@ workflow:
   desc: Validate limited results
   tool:
     kind: python
-    args:
+    input:
       input_data: '{{ ctx.collected_data }}'
     code: "# Should only get 2 pages = 20 items (not all 35) - handle server wrapping\n\
       raw_data = input_data\n\n# Unwrap if server wrapped in {'value': ...}\nif isinstance(raw_data,\

--- a/tests/fixtures/playbooks/pagination/offset/test_pagination_offset.yaml
+++ b/tests/fixtures/playbooks/pagination/offset/test_pagination_offset.yaml
@@ -17,10 +17,10 @@ workflow:
     desc: Initialize offset pagination
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
-    set_ctx:
+    set:
       offset: "{{ workload.offset }}"
       limit: "{{ workload.limit }}"
       collected_users: "{{ workload.collected_users }}"
@@ -43,13 +43,13 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' and outcome.error.retryable }}"
+            - when: "{{ output.status == 'error' and output.error.retryable }}"
               then:
                 do: retry
                 attempts: 5
                 backoff: exponential
                 delay: 1.0
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: fail
             - else:
@@ -65,7 +65,7 @@ workflow:
     desc: Check if more pages exist and collect results
     tool:
       kind: python
-      args:
+      input:
         response: "{{ fetch_page }}"
         collected: "{{ ctx.collected_users }}"
         current_offset: "{{ ctx.offset }}"
@@ -86,7 +86,7 @@ workflow:
             'next_offset': next_offset,
             'total_collected': len(all_users)
         }
-    set_ctx:
+    set:
       collected_users: "{{ check_pagination.collected_users }}"
       offset: "{{ check_pagination.next_offset }}"
       has_more: "{{ check_pagination.has_more }}"
@@ -103,7 +103,7 @@ workflow:
     desc: Validate merged results
     tool:
       kind: python
-      args:
+      input:
         users: "{{ ctx.collected_users }}"
       code: |
         data = users if isinstance(users, list) else []
@@ -139,6 +139,6 @@ workflow:
     desc: Workflow complete
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/pagination/pipeline/test_pagination_pipeline.yaml
+++ b/tests/fixtures/playbooks/pagination/pipeline/test_pagination_pipeline.yaml
@@ -16,7 +16,7 @@ metadata:
 
     - Retry, break, fail, continue control actions
 
-    - outcome object for accessing execution results
+    - output object for accessing execution results
 
     '
 workload:
@@ -37,7 +37,7 @@ workflow:
     kind: python
     code: "result = {\n  \"status\": \"initialized\",\n  \"message\": \"Starting pagination\
       \ pipeline test\"\n}\n"
-  set_ctx:
+  set:
     current_page: '{{ workload.current_page }}'
     page_size: '{{ workload.page_size }}'
     total_fetched: '{{ workload.total_fetched }}'
@@ -78,18 +78,18 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.error.kind == ''rate_limit'' }}'
+        - when: '{{ output.error.kind == ''rate_limit'' }}'
           then:
             do: retry
             attempts: 10
             delay: 5.0
-        - when: '{{ outcome.error.retryable }}'
+        - when: '{{ output.error.retryable }}'
           then:
             do: retry
             attempts: 5
             backoff: exponential
             delay: 1.0
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
@@ -97,7 +97,7 @@ workflow:
               do: continue
   - name: transform
     kind: python
-    args:
+    input:
       http_response: '{{ _prev }}'
       page_num: '{{ ctx.current_page }}'
       execution_id: '{{ execution_id }}'
@@ -113,7 +113,7 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: continue
         - else:
@@ -121,7 +121,7 @@ workflow:
               do: continue
   - name: store
     kind: python
-    args:
+    input:
       data: '{{ _prev }}'
       db_host: '{{ db_host }}'
       db_port: '{{ db_port }}'
@@ -143,13 +143,13 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.error.retryable }}'
+        - when: '{{ output.error.retryable }}'
           then:
             do: retry
             attempts: 3
             backoff: linear
             delay: 2.0
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
@@ -164,7 +164,7 @@ workflow:
   desc: Check if more pages to fetch
   tool:
     kind: python
-    args:
+    input:
       pipeline_result: '{{ fetch_transform_store }}'
       current_page: '{{ ctx.current_page }}'
       total_fetched: '{{ ctx.total_fetched }}'
@@ -172,7 +172,7 @@ workflow:
       \ dict) else False\n\nresult = {\n  \"has_more\": has_more,\n  \"current_page\"\
       : current_page,\n  \"total_fetched\": total_fetched,\n  \"action\": \"continue\"\
       \ if has_more else \"complete\"\n}\n"
-  set_ctx:
+  set:
     current_page: '{{ (ctx.current_page | int) + 1 }}'
   next:
     spec:
@@ -199,7 +199,7 @@ workflow:
   desc: Generate final test report
   tool:
     kind: python
-    args:
+    input:
       validation: '{{ validate_results }}'
       pages_processed: '{{ ctx.current_page }}'
       total_fetched: '{{ ctx.total_fetched }}'
@@ -214,7 +214,7 @@ workflow:
       ,\n    \"avg_score\": round(float(avg_score), 2) if avg_score else 0\n  },\n\
       \  \"features_tested\": [\n    \"Tool pipeline (list of labeled tasks)\",\n\
       \    \"tool.spec.policy.rules: per-task flow control\",\n    \"_prev data threading\
-      \ between tasks\",\n    \"outcome object for result/error inspection\",\n  \
+      \ between tasks\",\n    \"output object for result/error inspection\",\n  \
       \  \"Retry with exponential backoff\",\n    \"Control actions: continue, retry,\
       \ fail\"\n  ]\n}\n\nif not success:\n    result[\"error\"] = f\"Expected {expected_items}\
       \ records, got {total_records}\"\n"

--- a/tests/fixtures/playbooks/pagination/pipeline/test_pipeline_error_handling.yaml
+++ b/tests/fixtures/playbooks/pagination/pipeline/test_pipeline_error_handling.yaml
@@ -17,7 +17,7 @@ metadata:
 
     - Fail on auth errors (401, 403)
 
-    - outcome variable access in policy conditions
+    - output variable access in policy conditions
 
     '
 workload:
@@ -32,7 +32,7 @@ workflow:
     code: "result = {\n  \"status\": \"initialized\",\n  \"tests_to_run\": [\n   \
       \ \"retry_on_500\",\n    \"retry_on_rate_limit\",\n    \"skip_transform_error\"\
       ,\n    \"fail_on_auth_error\"\n  ]\n}\n"
-  set_ctx:
+  set:
     test_results: '{{ workload.test_results }}'
     current_test: '{{ workload.current_test }}'
   next:
@@ -57,14 +57,14 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.error.retryable and outcome.error.kind == ''server_error''
+        - when: '{{ output.error.retryable and output.error.kind == ''server_error''
             }}'
           then:
             do: retry
             attempts: 3
             backoff: linear
             delay: 0.5
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
@@ -72,7 +72,7 @@ workflow:
               do: continue
   - name: validate
     kind: python
-    args:
+    input:
       http_response: '{{ _prev }}'
     code: "response_body = http_response.get('data', {})\ndata = response_body.get('data',\
       \ [])\nresult = {\n  'test': 'retry_on_500',\n  'status': 'passed' if len(data)\
@@ -96,16 +96,16 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.error.kind == ''rate_limit'' }}'
+        - when: '{{ output.error.kind == ''rate_limit'' }}'
           then:
             do: retry
             attempts: 5
             delay: 2.0
-        - when: '{{ outcome.error.retryable }}'
+        - when: '{{ output.error.retryable }}'
           then:
             do: retry
             attempts: 3
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
@@ -121,16 +121,16 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.error.kind == ''rate_limit'' }}'
+        - when: '{{ output.error.kind == ''rate_limit'' }}'
           then:
             do: retry
             attempts: 5
             delay: 2.0
-        - when: '{{ outcome.error.retryable }}'
+        - when: '{{ output.error.retryable }}'
           then:
             do: retry
             attempts: 3
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
@@ -138,7 +138,7 @@ workflow:
               do: continue
   - name: validate
     kind: python
-    args:
+    input:
       http_response: '{{ _prev }}'
     code: "response_body = http_response.get('data', {})\ndata = response_body.get('data',\
       \ [])\nresult = {\n  'test': 'retry_on_rate_limit',\n  'status': 'passed',\n\
@@ -160,7 +160,7 @@ workflow:
       page: 1
   - name: transform_bad
     kind: python
-    args:
+    input:
       http_response: '{{ _prev }}'
     code: 'broken = http_response[''nonexistent_key''][''also_missing'']
 
@@ -170,7 +170,7 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: continue
         - else:
@@ -178,7 +178,7 @@ workflow:
               do: continue
   - name: validate
     kind: python
-    args:
+    input:
       prev_data: '{{ _prev }}'
     code: "result = {\n  'test': 'skip_transform_error',\n  'status': 'passed',\n\
       \  'skipped': True,\n  'prev_after_skip': prev_data,\n  'message': 'Transform\
@@ -200,7 +200,7 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.error.kind == ''auth'' }}'
+        - when: '{{ output.error.kind == ''auth'' }}'
           then:
             do: fail
         - else:
@@ -220,7 +220,7 @@ workflow:
   desc: Generate test results report
   tool:
     kind: python
-    args:
+    input:
       results: '{{ ctx.test_results }}'
     code: "passed = sum(1 for r in results if r.get('status') == 'passed')\nfailed\
       \ = sum(1 for r in results if r.get('status') == 'failed')\ntotal = len(results)\n\
@@ -229,8 +229,8 @@ workflow:
       \  },\n  \"test_results\": results,\n  \"policy_features_tested\": [\n    \"\
       retry with exponential backoff\",\n    \"retry with Retry-After header\",\n\
       \    \"continue on error (skip pattern)\",\n    \"fail on non-retryable errors\"\
-      ,\n    \"outcome.error.kind condition matching\",\n    \"outcome.error.retryable\
-      \ boolean check\",\n    \"outcome.status check\"\n  ]\n}\n"
+      ,\n    \"output.error.kind condition matching\",\n    \"output.error.retryable\
+      \ boolean check\",\n    \"output.status check\"\n  ]\n}\n"
   next:
     spec:
       mode: exclusive

--- a/tests/fixtures/playbooks/pagination/pipeline/test_pipeline_heavy_payload.yaml
+++ b/tests/fixtures/playbooks/pagination/pipeline/test_pipeline_heavy_payload.yaml
@@ -35,7 +35,7 @@ workflow:
       ,\n  \"config\": {\n    \"payload_kb_per_item\": {{ payload_kb_per_item }},\n\
       \    \"page_size\": {{ page_size }},\n    \"estimated_kb_per_page\": {{ payload_kb_per_item\
       \ }} * {{ page_size }}\n  }\n}\n"
-  set_ctx:
+  set:
     current_page: '{{ workload.current_page }}'
     pages_processed: '{{ workload.pages_processed }}'
     total_bytes_processed: '{{ workload.total_bytes_processed }}'
@@ -61,13 +61,13 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.error.retryable }}'
+        - when: '{{ output.error.retryable }}'
           then:
             do: retry
             attempts: 3
             backoff: exponential
             delay: 2.0
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
@@ -75,7 +75,7 @@ workflow:
               do: continue
   - name: process
     kind: python
-    args:
+    input:
       http_response: '{{ _prev }}'
       page_num: '{{ ctx.current_page }}'
     code: "import sys\n\nresponse_body = http_response.get('data', {})\nitems = response_body.get('data',\
@@ -91,7 +91,7 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: continue
         - else:
@@ -99,7 +99,7 @@ workflow:
               do: continue
   - name: summarize
     kind: python
-    args:
+    input:
       processed: '{{ _prev }}'
     code: "result = {\n    'page': processed['page'],\n    'items_processed': processed['items_count'],\n\
       \    'payload_kb': processed['total_payload_kb'],\n    'has_more': processed['has_more'],\n\
@@ -113,7 +113,7 @@ workflow:
   desc: Update progress and check continuation
   tool:
     kind: python
-    args:
+    input:
       result: '{{ fetch_heavy_page }}'
       current_page: '{{ ctx.current_page }}'
       max_pages: '{{ max_pages }}'
@@ -132,7 +132,7 @@ workflow:
         - else:
             then:
               do: continue
-              set_ctx:
+              set:
                 current_page: '{{ (ctx.current_page | int) + 1 }}'
                 pages_processed: '{{ (ctx.pages_processed | int) + 1 }}'
                 total_bytes_processed: '{{ update_progress.total_bytes_processed }}'
@@ -148,7 +148,7 @@ workflow:
   desc: Generate test summary
   tool:
     kind: python
-    args:
+    input:
       pages_processed: '{{ ctx.pages_processed }}'
       total_bytes: '{{ ctx.total_bytes_processed }}'
       payload_kb_per_item: '{{ payload_kb_per_item }}'

--- a/tests/fixtures/playbooks/pagination/pipeline/test_pipeline_simple.yaml
+++ b/tests/fixtures/playbooks/pagination/pipeline/test_pipeline_simple.yaml
@@ -34,13 +34,13 @@ workflow:
         spec:
           policy:
             rules:
-              - when: "{{ outcome.error.retryable }}"
+              - when: "{{ output.error.retryable }}"
                 then:
                   do: retry
                   attempts: 3
                   backoff: linear
                   delay: 1.0
-              - when: "{{ outcome.status == 'error' }}"
+              - when: "{{ output.status == 'error' }}"
                 then:
                   do: fail
               - else:
@@ -49,7 +49,7 @@ workflow:
 
       - name: transform
         kind: python
-        args:
+        input:
           http_response: "{{ _prev }}"
         code: |
           response_body = http_response.get('data', {})
@@ -62,7 +62,7 @@ workflow:
 
       - name: validate
         kind: python
-        args:
+        input:
           transformed: "{{ _prev }}"
         code: |
           assert transformed['count'] == 5, f"Expected 5 items, got {transformed['count']}"
@@ -82,7 +82,7 @@ workflow:
     desc: Report test result
     tool:
       kind: python
-      args:
+      input:
         pipeline_result: "{{ run_pipeline }}"
       code: |
         status = pipeline_result.get('status', 'unknown') if isinstance(pipeline_result, dict) else 'unknown'

--- a/tests/fixtures/playbooks/pagination/pipeline_v2/test_pagination_pipeline_v2.yaml
+++ b/tests/fixtures/playbooks/pagination/pipeline_v2/test_pagination_pipeline_v2.yaml
@@ -16,7 +16,7 @@ metadata:
 
     - Retry, jump, fail, break, continue control actions
 
-    - outcome object for accessing execution results
+    - output object for accessing execution results
 
     '
 workload:
@@ -37,7 +37,7 @@ workflow:
     kind: python
     code: "result = {\n  \"status\": \"initialized\",\n  \"message\": \"Starting pagination\
       \ test with tool.spec.policy.rules flow control\"\n}\n"
-  set_ctx:
+  set:
     current_page: '{{ workload.current_page }}'
     page_size: '{{ workload.page_size }}'
     total_fetched: '{{ workload.total_fetched }}'
@@ -78,18 +78,18 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.error.kind == ''rate_limit'' }}'
+        - when: '{{ output.error.kind == ''rate_limit'' }}'
           then:
             do: retry
             attempts: 10
             delay: 5.0
-        - when: '{{ outcome.error.retryable }}'
+        - when: '{{ output.error.retryable }}'
           then:
             do: retry
             attempts: 5
             backoff: exponential
             delay: 1.0
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
@@ -97,7 +97,7 @@ workflow:
               do: continue
   - name: transform
     kind: python
-    args:
+    input:
       http_response: '{{ _prev }}'
       page_num: '{{ ctx.current_page }}'
       execution_id: '{{ execution_id }}'
@@ -113,7 +113,7 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: continue
         - else:
@@ -121,7 +121,7 @@ workflow:
               do: continue
   - name: store
     kind: python
-    args:
+    input:
       data: '{{ _prev }}'
       db_host: '{{ db_host }}'
       db_port: '{{ db_port }}'
@@ -143,13 +143,13 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.error.retryable }}'
+        - when: '{{ output.error.retryable }}'
           then:
             do: retry
             attempts: 3
             backoff: linear
             delay: 2.0
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
@@ -164,7 +164,7 @@ workflow:
   desc: Check if more pages to fetch
   tool:
     kind: python
-    args:
+    input:
       pipeline_result: '{{ fetch_transform_store }}'
       current_page: '{{ ctx.current_page }}'
       total_fetched: '{{ ctx.total_fetched }}'
@@ -172,7 +172,7 @@ workflow:
       \ dict) else False\n\nresult = {\n  \"has_more\": has_more,\n  \"current_page\"\
       : current_page,\n  \"total_fetched\": total_fetched,\n  \"action\": \"continue\"\
       \ if has_more else \"complete\"\n}\n"
-  set_ctx:
+  set:
     current_page: '{{ (ctx.current_page | int) + 1 }}'
   next:
     spec:
@@ -199,7 +199,7 @@ workflow:
   desc: Generate final test report
   tool:
     kind: python
-    args:
+    input:
       validation: '{{ validate_results }}'
       pages_processed: '{{ ctx.current_page }}'
       total_fetched: '{{ ctx.total_fetched }}'
@@ -214,7 +214,7 @@ workflow:
       ,\n    \"avg_score\": round(float(avg_score), 2) if avg_score else 0\n  },\n\
       \  \"features_tested\": [\n    \"Labeled tasks in tool: pipeline\",\n    \"\
       tool.spec.policy.rules: per-task flow control\",\n    \"_prev data threading\
-      \ between tasks\",\n    \"outcome object for result/error inspection\",\n  \
+      \ between tasks\",\n    \"output object for result/error inspection\",\n  \
       \  \"Retry with exponential backoff\",\n    \"Control actions: continue, retry,\
       \ fail\"\n  ]\n}\n\nif not success:\n    result[\"error\"] = f\"Expected {expected_items}\
       \ records, got {total_records}\"\n"

--- a/tests/fixtures/playbooks/pagination/retry/test_pagination_retry.yaml
+++ b/tests/fixtures/playbooks/pagination/retry/test_pagination_retry.yaml
@@ -17,7 +17,7 @@ workflow:
     code: 'result = {"status": "initialized"}
 
       '
-  set_ctx:
+  set:
     current_page: '{{ workload.current_page }}'
     page_size: '{{ workload.page_size }}'
     collected_data: '{{ workload.collected_data }}'
@@ -39,19 +39,19 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.error.status in [500, 502, 503] }}'
+        - when: '{{ output.error.status in [500, 502, 503] }}'
           then:
             do: retry
             attempts: 3
             backoff: exponential
             delay: 0.5
-        - when: '{{ outcome.error.retryable }}'
+        - when: '{{ output.error.retryable }}'
           then:
             do: retry
             attempts: 3
             backoff: linear
             delay: 1.0
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
@@ -59,7 +59,7 @@ workflow:
               do: continue
   - name: collect
     kind: python
-    args:
+    input:
       http_response: '{{ _prev }}'
       existing_data: '{{ ctx.collected_data }}'
     code: "response_body = http_response.get('data', {})\nitems = response_body.get('data',\
@@ -68,7 +68,7 @@ workflow:
       \ else []\ncollected.extend(items)\n\nresult = {\n    'collected_data': collected,\n\
       \    'has_more': paging.get('hasMore', False),\n    'current_page': paging.get('page',\
       \ 1)\n}\n"
-  set_ctx:
+  set:
     collected_data: '{{ fetch_with_retry.collected_data }}'
     current_page: '{{ (ctx.current_page | int) + 1 }}'
   next:
@@ -83,7 +83,7 @@ workflow:
   desc: Validate retry succeeded
   tool:
     kind: python
-    args:
+    input:
       input_data: '{{ ctx.collected_data }}'
     code: "# Check we got all items despite failures - handle server wrapping\nraw_data\
       \ = input_data\n\n# Unwrap if server wrapped in {'value': ...}\nif isinstance(raw_data,\

--- a/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
+++ b/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
@@ -149,8 +149,8 @@ async def test_parallel_loop_issues_up_to_max_in_flight(monkeypatch):
     commands = await engine._issue_loop_commands(state, step_def, {})
 
     assert len(commands) == 3  # loop.spec.max_in_flight
-    assert [cmd.args.get("claimed_batch") for cmd in commands] == [1, 2, 3]
-    assert [cmd.args.get("claimed_index") for cmd in commands] == [0, 1, 2]
+    assert [cmd.input.get("claimed_batch") for cmd in commands] == [1, 2, 3]
+    assert [cmd.input.get("claimed_index") for cmd in commands] == [0, 1, 2]
 
     # The 4th command should not be claimable until one in-flight iteration completes.
     no_slot_command = await engine._create_command_for_step(state, step_def, {})
@@ -215,8 +215,8 @@ async def test_transition_into_loop_step_issues_commands_without_name_error(monk
 
     assert len(commands) == 1
     assert all(command.step == "loop_step" for command in commands)
-    assert [command.args.get("value") for command in commands] == [10]
-    assert [command.args.get("index") for command in commands] == [0]
+    assert [command.input.get("value") for command in commands] == [10]
+    assert [command.input.get("index") for command in commands] == [0]
 
 
 @pytest.mark.asyncio
@@ -268,8 +268,8 @@ async def test_loop_continue_reuses_cached_collection_when_ctx_key_missing(monke
 
     first = await engine._create_command_for_step(state, step_def, {})
     assert first is not None
-    assert first.args.get("claimed_patient_id") == 101
-    assert first.args.get("claimed_index") == 0
+    assert first.input.get("claimed_patient_id") == 101
+    assert first.input.get("claimed_index") == 0
 
     # Simulate in-place mutation of original source list after loop init.
     source_patients.clear()
@@ -284,8 +284,8 @@ async def test_loop_continue_reuses_cached_collection_when_ctx_key_missing(monke
         {"__loop_continue": True},
     )
     assert second is not None
-    assert second.args.get("claimed_patient_id") == 102
-    assert second.args.get("claimed_index") == 1
+    assert second.input.get("claimed_patient_id") == 102
+    assert second.input.get("claimed_index") == 1
 
 
 @pytest.mark.asyncio
@@ -338,8 +338,8 @@ async def test_loop_claim_repairs_zero_collection_size_metadata(monkeypatch):
     command = await engine._create_command_for_step(state, step_def, {})
 
     assert command is not None
-    assert command.args.get("claimed_batch") == 1
-    assert command.args.get("claimed_index") == 0
+    assert command.input.get("claimed_batch") == 1
+    assert command.input.get("claimed_index") == 0
     assert int(fake_cache.state.get("collection_size", 0)) == 3
 
 
@@ -419,8 +419,8 @@ async def test_loop_continue_rerenders_when_replayed_cached_collection_is_empty(
 
     assert command is not None
     assert render_calls["count"] >= 1
-    assert command.args.get("claimed_batch") == 2
-    assert command.args.get("claimed_index") == 1
+    assert command.input.get("claimed_batch") == 2
+    assert command.input.get("claimed_index") == 1
     assert len(state.loop_state["run_batch_workers"]["collection"]) == 3
 
 
@@ -483,8 +483,8 @@ async def test_loop_watchdog_recovers_stalled_scheduled_counts(monkeypatch):
     command = await engine._create_command_for_step(state, step_def, {})
 
     assert command is not None
-    assert command.args.get("claimed_batch") == 2
-    assert command.args.get("claimed_index") == 1
+    assert command.input.get("claimed_batch") == 2
+    assert command.input.get("claimed_index") == 1
     assert int(fake_cache.state.get("scheduled_count", 0)) == 4
     assert int(state.loop_state["run_batch_workers"].get("watchdog_repair_count", 0)) >= 1
 
@@ -551,8 +551,8 @@ async def test_loop_watchdog_recovers_stale_inflight_saturation(monkeypatch):
     command = await engine._create_command_for_step(state, step_def, {})
 
     assert command is not None
-    assert command.args.get("claimed_batch") == 4
-    assert command.args.get("claimed_index") == 3
+    assert command.input.get("claimed_batch") == 4
+    assert command.input.get("claimed_index") == 3
     assert int(fake_cache.state.get("scheduled_count", 0)) == 5
     assert int(state.loop_state["run_batch_workers"].get("watchdog_repair_count", 0)) >= 1
 
@@ -623,8 +623,8 @@ async def test_loop_counter_reconcile_recovers_no_slot_without_watchdog(monkeypa
     command = await engine._create_command_for_step(state, step_def, {})
 
     assert command is not None
-    assert command.args.get("claimed_batch") == 6
-    assert command.args.get("claimed_index") == 5
+    assert command.input.get("claimed_batch") == 6
+    assert command.input.get("claimed_index") == 5
     assert int(fake_cache.state.get("completed_count", 0)) == 4
     assert int(fake_cache.state.get("scheduled_count", 0)) == 6
     assert fake_cache.state.get("last_counter_reconcile_at")

--- a/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
+++ b/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
@@ -788,6 +788,117 @@ workflow:
     assert context["patient_count"] == 17
 
 
+@pytest.mark.asyncio
+async def test_state_replay_restores_set_ctx_from_reference_only_result_ref(monkeypatch):
+    playbook = Playbook(**yaml.safe_load(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: replay_set_ctx_reference_only_ref
+  path: tests/replay_set_ctx_reference_only_ref
+workload:
+  pg_auth: pg_k8s
+workflow:
+  - step: load_next_facility
+    tool:
+      kind: postgres
+      auth: pg_k8s
+      query: SELECT 1;
+    set_ctx:
+      facility_mapping_id: "{{ load_next_facility.data.result.command_0.rows[0].facility_mapping_id }}"
+      facility_id: "{{ load_next_facility.data.result.command_0.rows[0].facility_id }}"
+  - step: load_patients_for_assessments
+    tool:
+      kind: postgres
+      auth: pg_k8s
+      query: |
+        SELECT w.patient_id
+        FROM public.patient_ids_work w
+        WHERE w.facility_mapping_id = {{ facility_mapping_id }};
+        """
+    ))
+    playbook_repo = PlaybookRepo()
+    state_store = StateStore(playbook_repo)
+
+    async def fake_load_playbook_by_id(_catalog_id):
+        return playbook
+
+    async def fake_resolve(ref):
+        assert ref["ref"] == "noetl://execution/9025/result/load_next_facility/abcd1234"
+        return {
+            "data": {
+                "result": {
+                    "command_0": {
+                        "rows": [
+                            {
+                                "facility_mapping_id": 119,
+                                "facility_id": 8123,
+                            }
+                        ],
+                        "row_count": 1,
+                    }
+                }
+            }
+        }
+
+    monkeypatch.setattr(playbook_repo, "load_playbook_by_id", fake_load_playbook_by_id)
+    monkeypatch.setattr(engine_module.default_store, "resolve", fake_resolve)
+
+    class FakeCursor:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, query, _params):
+            self.last_query = query
+
+        async def fetchone(self):
+            return {
+                "catalog_id": "cat-ctx-ref-hydrated",
+                "context": {"workload": {"pg_auth": "pg_k8s"}},
+                "result": {"status": "COMPLETED"},
+            }
+
+        async def fetchall(self):
+            return [
+                {
+                    "node_name": "load_next_facility",
+                    "event_type": "step.exit",
+                    "result": {
+                        "status": "COMPLETED",
+                        "reference": {
+                            "type": "nats",
+                            "store": "kv",
+                            "locator": "noetl://execution/9025/result/load_next_facility/abcd1234",
+                        },
+                    },
+                    "meta": None,
+                },
+            ]
+
+    class FakeConnection:
+        def cursor(self, row_factory=None):  # noqa: ARG002
+            return FakeCursor()
+
+    class FakeConnectionContext:
+        async def __aenter__(self):
+            return FakeConnection()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(engine_module, "get_pool_connection", lambda: FakeConnectionContext())
+
+    state = await state_store.load_state("9025")
+
+    assert state is not None
+    assert state.variables["facility_mapping_id"] == 119
+    assert state.variables["facility_id"] == 8123
+
+
 def test_mark_step_completed_adds_context_alias_for_plain_dict_results():
     playbook = Playbook(**yaml.safe_load(
         """

--- a/tests/unit/dsl/v2/test_wrapped_event_payloads.py
+++ b/tests/unit/dsl/v2/test_wrapped_event_payloads.py
@@ -1,5 +1,6 @@
 import pytest
 
+import noetl.core.dsl.v2.engine as engine_module
 from noetl.core.dsl.v2.engine import ControlFlowEngine, ExecutionState, PlaybookRepo, StateStore
 from noetl.core.dsl.v2.models import Event
 from noetl.core.dsl.v2.parser import DSLParser
@@ -144,3 +145,73 @@ workflow:
     assert len(commands) == 1
     assert commands[0].step == "verify"
     assert commands[0].tool.config["args"]["user_id"] == "999"
+
+
+@pytest.mark.asyncio
+async def test_reference_only_call_done_resolves_result_ref_for_follow_up_step(monkeypatch):
+    engine, state_store, state = _build_engine(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: wrapped_reference_result
+
+workflow:
+  - step: validate_results
+    tool:
+      kind: postgres
+      query: SELECT 1;
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: check_results
+
+  - step: check_results
+    tool:
+      kind: python
+      args:
+        stats: "{{ validate_results.data.result.command_0.rows }}"
+      code: |
+        result = {"stats": stats}
+""",
+        "exec-wrapped-ref",
+    )
+    await state_store.save_state(state)
+
+    async def fake_resolve(ref):
+        assert ref["ref"] == "noetl://execution/123/result/validate_results/abcd1234"
+        return {
+            "data": {
+                "result": {
+                    "command_0": {
+                        "rows": [{"total_patients": 500}],
+                    }
+                }
+            }
+        }
+
+    monkeypatch.setattr(engine_module.default_store, "resolve", fake_resolve)
+
+    commands = await engine.handle_event(
+        Event(
+            execution_id="exec-wrapped-ref",
+            step="validate_results",
+            name="call.done",
+            payload={
+                "result": {
+                    "status": "completed",
+                    "reference": {
+                        "type": "nats",
+                        "store": "kv",
+                        "locator": "noetl://execution/123/result/validate_results/abcd1234",
+                    },
+                }
+            },
+        ),
+        already_persisted=True,
+    )
+
+    assert len(commands) == 1
+    assert commands[0].step == "check_results"
+    assert commands[0].tool.config["args"]["stats"] == [{"total_patients": 500}]

--- a/tests/worker/test_v2_worker_batch_emit.py
+++ b/tests/worker/test_v2_worker_batch_emit.py
@@ -35,6 +35,30 @@ class _SequenceHttpClient:
         return self._responses.pop(0)
 
 
+def test_normalize_output_config_supports_canonical_tool_output():
+    worker = V2Worker(worker_id="worker-test")
+
+    normalized = worker._normalize_output_config(
+        {
+            "output": {
+                "store": {"kind": "kv"},
+                "inline_max_bytes": 0,
+                "select": [
+                    {"path": "data.result.command_0.rows"},
+                    "status",
+                ],
+            }
+        }
+    )
+
+    assert normalized["store"] == {"kind": "kv"}
+    assert normalized["inline_max_bytes"] == 0
+    assert normalized["output_select"] == [
+        "data.result.command_0.rows",
+        "status",
+    ]
+
+
 @pytest.mark.asyncio
 async def test_emit_batch_events_reuses_idempotency_key_across_retries():
     worker = V2Worker(worker_id="worker-test")


### PR DESCRIPTION
…SL v2

Canonical field rename per DSL v2 spec:
- Step.args → Step.input (backward-compat via @model_validator(mode='before'))
- Step.set_ctx / set_iter → Step.set
- Arc.args → Arc.set
- StepEnterPayload.args → StepEnterPayload.input
- PolicyRuleThen.set_ctx/set_iter → PolicyRuleThen.set (prefixed ctx./iter.)
- ToolOutcome.result → ToolOutcome.data; result_ref → output.ref
- task_sequence_executor: outcome template var → output
- v2_worker_nats: command.args → command.input in batch emit path
- engine.py: revert incorrect "result" key rename back to "response" (worker call.done payloads use "response", not "result")
- Fix @model_validator usage: use mode='before' decorator instead of classmethod override (Pydantic v2 does not call model_validate on nested construction)
- Update test fixtures (pagination playbooks) to use canonical field names
- Add tests: test_wrapped_event_payloads.py, test_v2_worker_batch_emit.py
- Update test assertions in test_loop_parallel_dispatch.py: command.args → command.input