### PR TITLE
refactor: migrate fixture playbooks to canonical dsl v2 fields

### DIFF
--- a/tests/fixtures/playbooks/api_integration/amadeus_ai_api/amadeus_ai_api.yaml
+++ b/tests/fixtures/playbooks/api_integration/amadeus_ai_api/amadeus_ai_api.yaml
@@ -133,7 +133,7 @@ workflow:
     desc: Parse OpenAI response and build Amadeus query
     tool:
       kind: python
-      args:
+      input:
         openai_response: "{{ openai_translate_query }}"
       code: |
         import json
@@ -318,7 +318,7 @@ workflow:
     desc: Extract and compact flight offers from Amadeus response
     tool:
       kind: python
-      args:
+      input:
         amadeus: "{{ amadeus_search }}"
       code: |
         import json
@@ -409,7 +409,7 @@ workflow:
     desc: Extract summary text from OpenAI response
     tool:
       kind: python
-      args:
+      input:
         openai_resp: "{{ openai_translate_response }}"
         amadeus_query: "{{ build_amadeus_query }}"
       code: |

--- a/tests/fixtures/playbooks/api_integration/amadeus_ai_chat_request_query/amadeus_ai_chat_request_query.yaml
+++ b/tests/fixtures/playbooks/api_integration/amadeus_ai_chat_request_query/amadeus_ai_chat_request_query.yaml
@@ -122,7 +122,7 @@ workflow:
       libs:
         json: json
         re: re
-      args:
+      input:
         response: "{{ analyze_user_intent }}"
       code: |
         result = None
@@ -181,7 +181,7 @@ workflow:
     desc: Validate endpoint and normalize query parameters
     tool:
       kind: python
-      args:
+      input:
         intent: "{{ parse_intent_result }}"
         api_url: "{{ workload.api_url }}"
       code: |

--- a/tests/fixtures/playbooks/api_integration/amadeus_ai_token_smoke/amadeus_ai_token_smoke.yaml
+++ b/tests/fixtures/playbooks/api_integration/amadeus_ai_token_smoke/amadeus_ai_token_smoke.yaml
@@ -86,7 +86,7 @@ workflow:
     desc: Build compact smoke test report
     tool:
       kind: python
-      args:
+      input:
         openai_response: "{{ check_openai_models }}"
         amadeus_response: "{{ check_amadeus_airport_lookup }}"
       code: |

--- a/tests/fixtures/playbooks/api_integration/auth0/auth0_login.yaml
+++ b/tests/fixtures/playbooks/api_integration/auth0/auth0_login.yaml
@@ -82,7 +82,7 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: continue
             - else:
@@ -154,7 +154,7 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: continue
             - else:
@@ -266,7 +266,7 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: continue
             - else:

--- a/tests/fixtures/playbooks/api_integration/auth0/auth0_login_optimized.yaml
+++ b/tests/fixtures/playbooks/api_integration/auth0/auth0_login_optimized.yaml
@@ -76,7 +76,7 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: continue
             - else:
@@ -148,7 +148,7 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: continue
             - else:
@@ -204,7 +204,7 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: continue
             - else:

--- a/tests/fixtures/playbooks/api_integration/auth0/auth0_validate_session.yaml
+++ b/tests/fixtures/playbooks/api_integration/auth0/auth0_validate_session.yaml
@@ -151,7 +151,7 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: continue
         - else:

--- a/tests/fixtures/playbooks/api_integration/auth0/check_playbook_access.yaml
+++ b/tests/fixtures/playbooks/api_integration/auth0/check_playbook_access.yaml
@@ -101,7 +101,7 @@ workflow:
     desc: Return allowed
     tool:
       kind: python
-      args:
+      input:
         playbook_path: "{{ playbook_path }}"
         action: "{{ action }}"
         user_id: "{{ get_user_from_session.command_0.rows[0].user_id }}"
@@ -154,7 +154,7 @@ workflow:
     desc: Return denied
     tool:
       kind: python
-      args:
+      input:
         playbook_path: "{{ playbook_path }}"
         action: "{{ action }}"
       code: |

--- a/tests/fixtures/playbooks/api_integration/auth0/get_auth0_token.yaml
+++ b/tests/fixtures/playbooks/api_integration/auth0/get_auth0_token.yaml
@@ -42,7 +42,7 @@ workflow:
     desc: Begin token acquisition
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -80,7 +80,7 @@ workflow:
     desc: Return token
     tool:
       kind: python
-      args:
+      input:
         access_token: "{{ get_token.data.access_token }}"
         token_type: "{{ get_token.data.token_type }}"
         expires_in: "{{ get_token.data.expires_in }}"
@@ -102,7 +102,7 @@ workflow:
     desc: Token acquisition failed
     tool:
       kind: python
-      args:
+      input:
         status: "{{ get_token.status_code }}"
         error: "{{ get_token.data }}"
       code: |
@@ -122,6 +122,6 @@ workflow:
     desc: Complete
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/api_integration/auth0/provision_auth_schema.yaml
+++ b/tests/fixtures/playbooks/api_integration/auth0/provision_auth_schema.yaml
@@ -208,7 +208,7 @@ workflow:
     desc: Schema provisioned successfully
     tool:
       kind: python
-      args:
+      input:
         verification: "{{ verify_schema.command_0.rows[0] }}"
       code: |
         result = {

--- a/tests/fixtures/playbooks/api_integration/auth0/test_auth0_full_flow.yaml
+++ b/tests/fixtures/playbooks/api_integration/auth0/test_auth0_full_flow.yaml
@@ -34,7 +34,7 @@ workflow:
     desc: Begin full Auth0 flow test
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "starting", "test": "auth0_full_flow"}
     next:
@@ -48,7 +48,7 @@ workflow:
     tool:
       kind: playbook
       path: api_integration/auth0/get_auth0_token
-      args:
+      input:
         username: "{{ username }}"
         password: "{{ password }}"
         auth0_domain: "{{ auth0_domain }}"
@@ -68,7 +68,7 @@ workflow:
     tool:
       kind: playbook
       path: api_integration/auth0/auth0_login
-      args:
+      input:
         auth0_token: "{{ get_auth0_token.access_token }}"
         client_ip: "127.0.0.1"
     next:
@@ -84,7 +84,7 @@ workflow:
     desc: Return successful test result
     tool:
       kind: python
-      args:
+      input:
         session_token: "{{ login_with_token.session_token }}"
         user_id: "{{ login_with_token.user.user_id }}"
         email: "{{ login_with_token.user.email }}"
@@ -111,7 +111,7 @@ workflow:
     desc: Auth0 token acquisition failed
     tool:
       kind: python
-      args:
+      input:
         error: "{{ get_auth0_token }}"
       code: |
         # Arguments injected: error
@@ -130,7 +130,7 @@ workflow:
     desc: NoETL login failed
     tool:
       kind: python
-      args:
+      input:
         error: "{{ login_with_token }}"
       code: |
         # Arguments injected: error
@@ -149,6 +149,6 @@ workflow:
     desc: Complete
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/api_integration/github_metrics/github_metrics.yaml
+++ b/tests/fixtures/playbooks/api_integration/github_metrics/github_metrics.yaml
@@ -16,7 +16,7 @@ workflow:
     desc: Start GitHub Metrics Workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized", "message": "Starting GitHub metrics workflow"}
     next:
@@ -169,6 +169,6 @@ workflow:
     desc: End of GitHub metrics workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/api_integration/quantum_networking/quantum_networking_runner.yaml
+++ b/tests/fixtures/playbooks/api_integration/quantum_networking/quantum_networking_runner.yaml
@@ -29,7 +29,7 @@ workflow:
     desc: Validate mode and route execution
     tool:
       kind: python
-      args:
+      input:
         provider: "{{ provider }}"
         shots: "{{ shots }}"
       code: |
@@ -63,7 +63,7 @@ workflow:
     desc: Run Bell-state simulation for quantum networking baseline
     tool:
       kind: python
-      args:
+      input:
         shots: "{{ shots }}"
         nvidia_use_gpu: "{{ nvidia_use_gpu }}"
       code: |
@@ -138,7 +138,7 @@ workflow:
     desc: Submit and monitor a Bell-state sampler job via IBM Quantum Runtime REST API
     tool:
       kind: python
-      args:
+      input:
         ibm_api_base: "{{ ibm_api_base }}"
         ibm_api_version: "{{ ibm_api_version }}"
         ibm_api_key: "{{ ibm_api_key }}"
@@ -332,7 +332,7 @@ workflow:
     desc: Handle unsupported provider values
     tool:
       kind: python
-      args:
+      input:
         provider: "{{ provider }}"
       code: |
         result = {
@@ -350,7 +350,7 @@ workflow:
     desc: Final response envelope
     tool:
       kind: python
-      args:
+      input:
         provider: "{{ provider }}"
       code: |
         selected = None

--- a/tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_chunk_worker/heavy_payload_pipeline_chunk_worker.yaml
+++ b/tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_chunk_worker/heavy_payload_pipeline_chunk_worker.yaml
@@ -19,7 +19,7 @@ workflow:
     desc: Initialize worker chunk inputs
     tool:
       kind: python
-      args:
+      input:
         batch_number: '{{ batch_number }}'
         offset: '{{ offset }}'
         batch_size: '{{ batch_size }}'
@@ -66,7 +66,7 @@ workflow:
     desc: Normalize fetched ID rows for loop processing
     tool:
       kind: python
-      args:
+      input:
         db_result: '{{ fetch_batch_ids }}'
       code: |
         rows = db_result.get("command_0", {}).get("rows", []) if isinstance(db_result, dict) else []
@@ -96,7 +96,7 @@ workflow:
     tool:
       - name: build_large_request
         kind: python
-        args:
+        input:
           item: '{{ iter.item }}'
           payload_kb_per_item: '{{ payload_kb_per_item }}'
         code: |
@@ -133,9 +133,9 @@ workflow:
         spec:
           policy:
             rules:
-              - when: '{{ outcome.status == "error" and (outcome.http.status in [429, 500, 502, 503, 504]) }}'
+              - when: '{{ output.status == "error" and (output.http.status in [429, 500, 502, 503, 504]) }}'
                 then: { do: retry, attempts: 4, backoff: exponential, delay: 1.0 }
-              - when: '{{ outcome.status == "error" }}'
+              - when: '{{ output.status == "error" }}'
                 then: { do: fail }
               - else:
                   then: { do: continue }
@@ -143,7 +143,7 @@ workflow:
         kind: python
         libs:
           json: json
-        args:
+        input:
           request_payload: '{{ build_large_request }}'
           http_result: '{{ fetch_detail }}'
           mode: chunked_optimal
@@ -217,7 +217,7 @@ workflow:
             processed_at = NOW();
       - name: finalize
         kind: python
-        args:
+        input:
           projected: '{{ project_result }}'
         code: |
           result = projected
@@ -232,7 +232,7 @@ workflow:
     desc: Return chunk summary
     tool:
       kind: python
-      args:
+      input:
         normalize: '{{ normalize_batch }}'
         processed: '{{ process_batch_pipeline | default({}) }}'
         batch_number: '{{ batch_number }}'

--- a/tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step/heavy_payload_pipeline_in_step.yaml
+++ b/tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step/heavy_payload_pipeline_in_step.yaml
@@ -99,7 +99,7 @@ workflow:
     desc: Resolve mode for this run
     tool:
       kind: python
-      args:
+      input:
         execution_mode: '{{ execution_mode }}'
       code: |
         mode = str(execution_mode or "chunked_optimal").strip().lower()
@@ -132,7 +132,7 @@ workflow:
     tool:
       - name: build_large_request
         kind: python
-        args:
+        input:
           item: '{{ iter.item }}'
           payload_kb_per_item: '{{ payload_kb_per_item }}'
         code: |
@@ -169,9 +169,9 @@ workflow:
         spec:
           policy:
             rules:
-              - when: '{{ outcome.status == "error" and (outcome.http.status in [429, 500, 502, 503, 504]) }}'
+              - when: '{{ output.status == "error" and (output.http.status in [429, 500, 502, 503, 504]) }}'
                 then: { do: retry, attempts: 4, backoff: exponential, delay: 1.0 }
-              - when: '{{ outcome.status == "error" }}'
+              - when: '{{ output.status == "error" }}'
                 then: { do: fail }
               - else:
                   then: { do: continue }
@@ -179,7 +179,7 @@ workflow:
         kind: python
         libs:
           json: json
-        args:
+        input:
           request_payload: '{{ build_large_request }}'
           http_result: '{{ fetch_detail }}'
           mode: direct_stress
@@ -253,7 +253,7 @@ workflow:
             processed_at = NOW();
       - name: finalize
         kind: python
-        args:
+        input:
           projected: '{{ project_result }}'
         code: |
           result = projected
@@ -268,7 +268,7 @@ workflow:
     desc: Build chunk windows for bounded-memory batch execution
     tool:
       kind: python
-      args:
+      input:
         batch_size: '{{ batch_size }}'
         max_batches: '{{ max_batches }}'
       code: |
@@ -312,7 +312,7 @@ workflow:
       path: '{{ batch_worker_path }}'
       return_step: end
       timeout: 1200
-      args:
+      input:
         pg_auth: '{{ pg_auth }}'
         parent_execution_id: '{{ job.execution_id }}'
         batch_number: '{{ iter.batch.batch_number }}'
@@ -380,7 +380,7 @@ workflow:
     desc: Summarize execution for mode and data checks
     tool:
       kind: python
-      args:
+      input:
         mode: '{{ resolve_mode.mode }}'
         validation: '{{ validate_persisted_results }}'
         direct_loop: '{{ run_direct_stress | default({}) }}'

--- a/tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel/heavy_payload_pipeline_in_step_parallel.yaml
+++ b/tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel/heavy_payload_pipeline_in_step_parallel.yaml
@@ -99,7 +99,7 @@ workflow:
     desc: Resolve mode for this run
     tool:
       kind: python
-      args:
+      input:
         execution_mode: '{{ execution_mode }}'
       code: |
         mode = str(execution_mode or "chunked_optimal").strip().lower()
@@ -132,7 +132,7 @@ workflow:
     tool:
       - name: build_large_request
         kind: python
-        args:
+        input:
           item: '{{ iter.item }}'
           payload_kb_per_item: '{{ payload_kb_per_item }}'
         code: |
@@ -169,9 +169,9 @@ workflow:
         spec:
           policy:
             rules:
-              - when: '{{ outcome.status == "error" and (outcome.http.status in [429, 500, 502, 503, 504]) }}'
+              - when: '{{ output.status == "error" and (output.http.status in [429, 500, 502, 503, 504]) }}'
                 then: { do: retry, attempts: 4, backoff: exponential, delay: 1.0 }
-              - when: '{{ outcome.status == "error" }}'
+              - when: '{{ output.status == "error" }}'
                 then: { do: fail }
               - else:
                   then: { do: continue }
@@ -179,7 +179,7 @@ workflow:
         kind: python
         libs:
           json: json
-        args:
+        input:
           request_payload: '{{ build_large_request }}'
           http_result: '{{ fetch_detail }}'
           mode: direct_stress
@@ -253,7 +253,7 @@ workflow:
             processed_at = NOW();
       - name: finalize
         kind: python
-        args:
+        input:
           projected: '{{ project_result }}'
         code: |
           result = projected
@@ -268,7 +268,7 @@ workflow:
     desc: Build chunk windows for bounded-memory batch execution
     tool:
       kind: python
-      args:
+      input:
         batch_size: '{{ batch_size }}'
         max_batches: '{{ max_batches }}'
       code: |
@@ -313,7 +313,7 @@ workflow:
       path: '{{ batch_worker_path }}'
       return_step: end
       timeout: 1200
-      args:
+      input:
         pg_auth: '{{ pg_auth }}'
         parent_execution_id: '{{ job.execution_id }}'
         batch_number: '{{ iter.batch.batch_number }}'
@@ -381,7 +381,7 @@ workflow:
     desc: Summarize execution for mode and data checks
     tool:
       kind: python
-      args:
+      input:
         mode: '{{ resolve_mode.mode }}'
         validation: '{{ validate_persisted_results }}'
         direct_loop: '{{ run_direct_stress | default({}) }}'

--- a/tests/fixtures/playbooks/batch_execution/kind_playbook_lease_expiry/kind_playbook_lease_expiry.yaml
+++ b/tests/fixtures/playbooks/batch_execution/kind_playbook_lease_expiry/kind_playbook_lease_expiry.yaml
@@ -61,7 +61,7 @@ workflow:
     desc: Initialize test
     tool:
       kind: python
-      args:
+      input:
         batch_size: '{{ batch_size }}'
         item_delay_seconds: '{{ item_delay_seconds }}'
       code: |
@@ -109,8 +109,8 @@ workflow:
                 "row_count": 5000,
             },
         }
-    set_ctx:
-      patients_rows: "{{ ctx_step_02.command_1.rows }}"
+    set:
+      ctx.patients_rows: "{{ ctx_step_02.command_1.rows }}"
     next:
       spec: { mode: exclusive }
       arcs:
@@ -127,8 +127,8 @@ workflow:
                 "row_count": 5000,
             },
         }
-    set_ctx:
-      patients_needing_assessments: "{{ ctx_step_03.command_0.rows }}"
+    set:
+      ctx.patients_needing_assessments: "{{ ctx_step_03.command_0.rows }}"
     next:
       spec: { mode: exclusive }
       arcs:
@@ -145,8 +145,8 @@ workflow:
                 "row_count": 5000,
             },
         }
-    set_ctx:
-      patients_needing_demographics: "{{ ctx_step_04.command_0.rows }}"
+    set:
+      ctx.patients_needing_demographics: "{{ ctx_step_04.command_0.rows }}"
     next:
       spec: { mode: exclusive }
       arcs:
@@ -163,8 +163,8 @@ workflow:
                 "row_count": 5000,
             },
         }
-    set_ctx:
-      patients_needing_conditions: "{{ ctx_step_05.command_0.rows }}"
+    set:
+      ctx.patients_needing_conditions: "{{ ctx_step_05.command_0.rows }}"
     next:
       spec: { mode: exclusive }
       arcs:
@@ -181,8 +181,8 @@ workflow:
                 "row_count": 5000,
             },
         }
-    set_ctx:
-      patients_needing_medications: "{{ ctx_step_06.command_0.rows }}"
+    set:
+      ctx.patients_needing_medications: "{{ ctx_step_06.command_0.rows }}"
     next:
       spec: { mode: exclusive }
       arcs:
@@ -199,8 +199,8 @@ workflow:
                 "row_count": 5000,
             },
         }
-    set_ctx:
-      patients_needing_adt: "{{ ctx_step_07.command_0.rows }}"
+    set:
+      ctx.patients_needing_adt: "{{ ctx_step_07.command_0.rows }}"
     next:
       spec: { mode: exclusive }
       arcs:
@@ -225,13 +225,13 @@ workflow:
       code: |
         result = {"command_0": {"status": "success", "message": "Command executed. 3450 rows affected.", "row_count": 3450},
                   "command_1": {"status": "success", "message": "Command executed. 3450 rows affected.", "row_count": 3450}}
-    set_ctx:
-      patients_rows: ""
-      patients_needing_assessments: ""
-      patients_needing_demographics: ""
-      patients_needing_conditions: ""
-      patients_needing_medications: ""
-      patients_needing_adt: ""
+    set:
+      ctx.patients_rows: ""
+      ctx.patients_needing_assessments: ""
+      ctx.patients_needing_demographics: ""
+      ctx.patients_needing_conditions: ""
+      ctx.patients_needing_medications: ""
+      ctx.patients_needing_adt: ""
     next:
       spec: { mode: exclusive }
       arcs:
@@ -272,7 +272,7 @@ workflow:
       Each batch gets a unique, non-overlapping slice of stress_test_items.
     tool:
       kind: python
-      args:
+      input:
         total_count: "{{ count_items.command_0.rows[0].item_count }}"
         batch_size: '{{ batch_size }}'
       code: |
@@ -343,7 +343,7 @@ workflow:
       path: '{{ chunk_worker_path }}'
       return_step: end
       timeout: 900
-      args:
+      input:
         pg_auth: 'pg_k8s'
         batch_number: '{{ iter.batch.batch_number }}'
         offset: '{{ iter.batch.offset }}'
@@ -378,7 +378,7 @@ workflow:
     desc: Test complete
     tool:
       kind: python
-      args:
+      input:
         result_summary: '{{ summarize }}'
         batch_plan: '{{ build_batch_plan }}'
       code: |

--- a/tests/fixtures/playbooks/batch_execution/kind_playbook_lease_expiry_worker/kind_playbook_lease_expiry_worker.yaml
+++ b/tests/fixtures/playbooks/batch_execution/kind_playbook_lease_expiry_worker/kind_playbook_lease_expiry_worker.yaml
@@ -52,7 +52,7 @@ workflow:
     desc: Initialize chunk worker inputs
     tool:
       kind: python
-      args:
+      input:
         batch_number: '{{ batch_number }}'
         offset: '{{ offset }}'
         batch_size: '{{ batch_size }}'
@@ -100,7 +100,7 @@ workflow:
     desc: Extract rows. Mirrors mds_batch_worker.normalize_mds_batch.
     tool:
       kind: python
-      args:
+      input:
         db_result: '{{ fetch_batch }}'
       code: |
         rows = db_result.get("command_0", {}).get("rows", []) if isinstance(db_result, dict) else []
@@ -189,7 +189,7 @@ workflow:
     desc: Return batch summary
     tool:
       kind: python
-      args:
+      input:
         normalize: '{{ normalize_batch }}'
         batch_number: '{{ batch_number }}'
       code: |

--- a/tests/fixtures/playbooks/batch_execution/multi_playbook_batch/multi_playbook_batch.yaml
+++ b/tests/fixtures/playbooks/batch_execution/multi_playbook_batch/multi_playbook_batch.yaml
@@ -24,7 +24,7 @@ workflow:
     desc: Start Multiple Playbook Batch Workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized", "message": "Starting batch workflow"}
     next:
@@ -46,8 +46,8 @@ workflow:
         mode: exclusive
       arcs:
         - step: run_weather_processing
-          args:
-            http_result: '{{ run_http_test }}'
+          set:
+            ctx.http_result: '{{ run_http_test }}'
 
   - step: run_weather_processing
     desc: Run weather processing playbook
@@ -63,8 +63,8 @@ workflow:
         mode: exclusive
       arcs:
         - step: run_data_transformation
-          args:
-            weather_result: '{{ run_weather_processing }}'
+          set:
+            ctx.weather_result: '{{ run_weather_processing }}'
 
   - step: run_data_transformation
     desc: Run data transformation playbook
@@ -124,6 +124,6 @@ workflow:
     desc: End of batch workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/batch_execution/parallel_distributed_claim_regression/parallel_distributed_claim_regression.yaml
+++ b/tests/fixtures/playbooks/batch_execution/parallel_distributed_claim_regression/parallel_distributed_claim_regression.yaml
@@ -23,7 +23,7 @@ workflow:
   - step: start
     tool:
       kind: python
-      args:
+      input:
         total_items: '{{ total_items }}'
         batch_size: '{{ batch_size }}'
       code: |
@@ -74,7 +74,7 @@ workflow:
   - step: build_batch_plan
     tool:
       kind: python
-      args:
+      input:
         total_items: '{{ total_items }}'
         batch_size: '{{ batch_size }}'
       code: |
@@ -112,7 +112,7 @@ workflow:
       path: '{{ chunk_worker_path }}'
       return_step: end
       timeout: 1200
-      args:
+      input:
         pg_auth: '{{ pg_auth }}'
         batch_number: '{{ iter.batch.batch_number }}'
         offset: '{{ iter.batch.offset }}'
@@ -141,7 +141,7 @@ workflow:
   - step: assert_no_duplicate_batch_runs
     tool:
       kind: python
-      args:
+      input:
         db_result: '{{ verify_batch_run_uniqueness }}'
       code: |
         rows = db_result.get("command_0", {}).get("rows", []) if isinstance(db_result, dict) else []
@@ -168,7 +168,7 @@ workflow:
   - step: assert_result_count
     tool:
       kind: python
-      args:
+      input:
         expected_total: '{{ total_items }}'
         db_result: '{{ verify_results }}'
       code: |

--- a/tests/fixtures/playbooks/batch_execution/parallel_distributed_claim_regression_worker/parallel_distributed_claim_regression_worker.yaml
+++ b/tests/fixtures/playbooks/batch_execution/parallel_distributed_claim_regression_worker/parallel_distributed_claim_regression_worker.yaml
@@ -19,7 +19,7 @@ workflow:
   - step: start
     tool:
       kind: python
-      args:
+      input:
         batch_number: '{{ batch_number }}'
         offset: '{{ offset }}'
         batch_size: '{{ batch_size }}'
@@ -117,7 +117,7 @@ workflow:
   - step: summarize
     tool:
       kind: python
-      args:
+      input:
         fetched: '{{ fetch_batch }}'
         batch_number: '{{ batch_number }}'
       code: |

--- a/tests/fixtures/playbooks/batch_execution/server_oom_stress_chunk_worker/server_oom_stress_chunk_worker.yaml
+++ b/tests/fixtures/playbooks/batch_execution/server_oom_stress_chunk_worker/server_oom_stress_chunk_worker.yaml
@@ -24,7 +24,7 @@ workflow:
     desc: Initialize chunk worker inputs
     tool:
       kind: python
-      args:
+      input:
         batch_number: '{{ batch_number }}'
         offset: '{{ offset }}'
         batch_size: '{{ batch_size }}'
@@ -68,7 +68,7 @@ workflow:
     desc: Extract rows from DB result for loop processing
     tool:
       kind: python
-      args:
+      input:
         db_result: '{{ fetch_batch }}'
       code: |
         rows = db_result.get("command_0", {}).get("rows", []) if isinstance(db_result, dict) else []
@@ -107,7 +107,7 @@ workflow:
     tool:
       - name: compute
         kind: python
-        args:
+        input:
           item_id: '{{ iter.item.item_id }}'
           group_id: '{{ iter.item.group_id }}'
           payload: '{{ iter.item.payload }}'
@@ -152,7 +152,7 @@ workflow:
     desc: Return chunk summary
     tool:
       kind: python
-      args:
+      input:
         normalize: '{{ normalize_batch }}'
         processed: '{{ process_items | default({}) }}'
         batch_number: '{{ batch_number }}'

--- a/tests/fixtures/playbooks/batch_execution/server_oom_stress_chunk_worker_v2/server_oom_stress_chunk_worker_v2.yaml
+++ b/tests/fixtures/playbooks/batch_execution/server_oom_stress_chunk_worker_v2/server_oom_stress_chunk_worker_v2.yaml
@@ -25,7 +25,7 @@ workflow:
     desc: Initialize chunk worker inputs (v2 batch upsert variant)
     tool:
       kind: python
-      args:
+      input:
         batch_number: '{{ batch_number }}'
         offset: '{{ offset }}'
         batch_size: '{{ batch_size }}'
@@ -101,7 +101,7 @@ workflow:
     desc: Return chunk summary for v2 batch upsert worker
     tool:
       kind: python
-      args:
+      input:
         upsert_result: '{{ upsert_batch }}'
         batch_number: '{{ batch_number }}'
         batch_size: '{{ batch_size }}'

--- a/tests/fixtures/playbooks/batch_execution/server_oom_stress_test/server_oom_stress_test.yaml
+++ b/tests/fixtures/playbooks/batch_execution/server_oom_stress_test/server_oom_stress_test.yaml
@@ -43,7 +43,7 @@ workflow:
     desc: Initialize stress test
     tool:
       kind: python
-      args:
+      input:
         total_items: '{{ total_items }}'
         batch_size: '{{ batch_size }}'
       code: |
@@ -336,7 +336,7 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then: { do: retry, attempts: 5, backoff: exponential, delay: 2.0 }
             - else:
                 then: { do: break }
@@ -358,7 +358,7 @@ workflow:
     desc: Compute batch windows for parallel chunk worker dispatch
     tool:
       kind: python
-      args:
+      input:
         total_items: '{{ total_items }}'
         batch_size: '{{ batch_size }}'
       code: |
@@ -399,7 +399,7 @@ workflow:
       path: '{{ chunk_worker_path }}'
       return_step: end
       timeout: 900
-      args:
+      input:
         pg_auth: '{{ pg_auth }}'
         parent_execution_id: '{{ job.execution_id }}'
         batch_number: '{{ iter.batch.batch_number }}'
@@ -441,7 +441,7 @@ workflow:
     desc: Return stress test summary with throughput metrics
     tool:
       kind: python
-      args:
+      input:
         verify_result: '{{ verify_completion_counts }}'
         batch_plan: '{{ build_batch_plan }}'
         worker_loop: '{{ run_batch_workers | default({}) }}'

--- a/tests/fixtures/playbooks/batch_execution/server_oom_stress_test_v2/server_oom_stress_test_v2.yaml
+++ b/tests/fixtures/playbooks/batch_execution/server_oom_stress_test_v2/server_oom_stress_test_v2.yaml
@@ -43,7 +43,7 @@ workflow:
     desc: Initialize stress test
     tool:
       kind: python
-      args:
+      input:
         total_items: '{{ total_items }}'
         batch_size: '{{ batch_size }}'
       code: |
@@ -336,7 +336,7 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then: { do: retry, attempts: 5, backoff: exponential, delay: 2.0 }
             - else:
                 then: { do: break }
@@ -358,7 +358,7 @@ workflow:
     desc: Compute batch windows for parallel chunk worker dispatch
     tool:
       kind: python
-      args:
+      input:
         total_items: '{{ total_items }}'
         batch_size: '{{ batch_size }}'
       code: |
@@ -399,7 +399,7 @@ workflow:
       path: '{{ chunk_worker_path }}'
       return_step: end
       timeout: 900
-      args:
+      input:
         pg_auth: '{{ pg_auth }}'
         parent_execution_id: '{{ job.execution_id }}'
         batch_number: '{{ iter.batch.batch_number }}'
@@ -441,7 +441,7 @@ workflow:
     desc: Return stress test summary with throughput metrics
     tool:
       kind: python
-      args:
+      input:
         verify_result: '{{ verify_completion_counts }}'
         batch_plan: '{{ build_batch_plan }}'
         worker_loop: '{{ run_batch_workers | default({}) }}'

--- a/tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_chunk_worker/traveler_batch_enrichment_chunk_worker.yaml
+++ b/tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_chunk_worker/traveler_batch_enrichment_chunk_worker.yaml
@@ -18,7 +18,7 @@ workflow:
     desc: Initialize chunk worker
     tool:
       kind: python
-      args:
+      input:
         batch_number: '{{ batch_number }}'
         offset: '{{ offset }}'
         batch_size: '{{ batch_size }}'
@@ -63,7 +63,7 @@ workflow:
     desc: Normalize fetched rows for loop processing
     tool:
       kind: python
-      args:
+      input:
         db_result: '{{ fetch_batch }}'
       code: |
         rows = db_result.get("command_0", {}).get("rows", []) if isinstance(db_result, dict) else []
@@ -110,7 +110,7 @@ workflow:
       kind: python
       libs:
         hashlib: hashlib
-      args:
+      input:
         http_loop_result: '{{ process_batch_http }}'
         batch_rows: '{{ normalize_batch.batch_rows }}'
       code: |
@@ -248,7 +248,7 @@ workflow:
     desc: Return chunk processing summary
     tool:
       kind: python
-      args:
+      input:
         normalize: '{{ normalize_batch }}'
         transformed: '{{ transform_http_results }}'
         batch_number: '{{ batch_number }}'

--- a/tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step/traveler_batch_enrichment_in_step.yaml
+++ b/tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step/traveler_batch_enrichment_in_step.yaml
@@ -79,7 +79,7 @@ workflow:
     desc: Build configurable batch windows for traveler processing
     tool:
       kind: python
-      args:
+      input:
         batch_size: '{{ batch_size }}'
         max_batches: '{{ max_batches }}'
       code: |
@@ -123,7 +123,7 @@ workflow:
       path: '{{ batch_worker_path }}'
       return_step: end
       timeout: 900
-      args:
+      input:
         pg_auth: '{{ pg_auth }}'
         parent_execution_id: '{{ job.execution_id }}'
         batch_number: '{{ iter.batch.batch_number }}'
@@ -182,7 +182,7 @@ workflow:
     desc: Summarize batch worker execution and persistence checks
     tool:
       kind: python
-      args:
+      input:
         validation: '{{ validate_persisted_results }}'
         worker_loop: '{{ run_batch_workers }}'
         batch_size: '{{ batch_size }}'

--- a/tests/fixtures/playbooks/cache_test/test_cache_simple.yaml
+++ b/tests/fixtures/playbooks/cache_test/test_cache_simple.yaml
@@ -14,7 +14,7 @@ workflow:
     desc: Start cache test
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -75,6 +75,6 @@ workflow:
     desc: End of workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/control_flow/weather_control_flow/weather_control_flow.yaml
+++ b/tests/fixtures/playbooks/control_flow/weather_control_flow/weather_control_flow.yaml
@@ -17,7 +17,7 @@ workflow:
     desc: "Start weather control flow workflow"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -35,7 +35,7 @@ workflow:
       kind: python
       libs:
         httpx: httpx
-      args: {}
+      input: {}
       code: "threshold = 20\ncity_dict = {\"name\": \"New York\", \"lat\": 40.71, \"lon\": -74.01}\nurl = f\"https://api.open-meteo.com/v1/forecast\"\nparams = {\n    \"latitude\": city_dict[\"lat\"],\n    \"longitude\": city_dict[\"lon\"],\n    \"hourly\": \"temperature_2m\",\n    \"forecast_days\": 1\n}\n\nresponse = httpx.get(url, params=params)\nforecast_data = response.json()\n\n# Extract max temperature from forecast\ntemperatures = forecast_data.get('hourly', {}).get('temperature_2m', [])\nmax_temp = max(temperatures) if temperatures else 15\n\nresult = {\n    'city': city_dict,\n    'max_temp': max_temp,\n    'alert': max_temp > threshold\n}"
     next:
       spec:
@@ -43,22 +43,22 @@ workflow:
       arcs:
         - step: report_warm
           when: "{{ fetch_weather.max_temp > spec.temperature_threshold }}"
-          args:
-            city: "{{ fetch_weather.city }}"
-            temperature: "{{ fetch_weather.max_temp }}"
+          set:
+            ctx.city: "{{ fetch_weather.city }}"
+            ctx.temperature: "{{ fetch_weather.max_temp }}"
         - step: report_cold
           when: "{{ fetch_weather.max_temp <= spec.temperature_threshold }}"
-          args:
-            city: "{{ fetch_weather.city }}"
-            temperature: "{{ fetch_weather.max_temp }}"
+          set:
+            ctx.city: "{{ fetch_weather.city }}"
+            ctx.temperature: "{{ fetch_weather.max_temp }}"
 
   - step: report_warm
     desc: "Report warm weather"
     tool:
       kind: python
-      args:
-        city: "{{ city }}"
-        temperature: "{{ temperature }}"
+      input:
+        city: "{{ ctx.city }}"
+        temperature: "{{ ctx.temperature }}"
       code: "city_name = city[\"name\"] if isinstance(city, dict) else str(city)\nprint(f\"It's warm in {city_name} ({temperature}°C)\")\nresult = {\"status\": \"warm\", \"city\": city_name, \"temperature\": temperature}"
     next:
       spec:
@@ -70,9 +70,9 @@ workflow:
     desc: "Report cold weather"
     tool:
       kind: python
-      args:
-        city: "{{ city }}"
-        temperature: "{{ temperature }}"
+      input:
+        city: "{{ ctx.city }}"
+        temperature: "{{ ctx.temperature }}"
       code: "city_name = city[\"name\"] if isinstance(city, dict) else str(city)\nprint(f\"It's cold in {city_name} ({temperature}°C)\")\nresult = {\"status\": \"cold\", \"city\": city_name, \"temperature\": temperature}"
     next:
       spec:
@@ -84,6 +84,6 @@ workflow:
     desc: "End of weather control flow workflow"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/control_flow_workbook/control_flow_workbook.yaml
+++ b/tests/fixtures/playbooks/control_flow_workbook/control_flow_workbook.yaml
@@ -13,7 +13,7 @@ workbook:
   - name: compute_flag
     tool:
       kind: python
-      args:
+      input:
         temperature_c: null
       code: |
         is_hot = float(temperature_c) >= 25.0
@@ -31,7 +31,7 @@ workflow:
     desc: "Begin"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -45,7 +45,7 @@ workflow:
     tool:
       kind: workbook
       name: compute_flag
-      args:
+      input:
         temperature_c: "{{ temperature_c }}"
     next:
       spec:
@@ -60,7 +60,7 @@ workflow:
     desc: "Hot branch; fan out to two steps in PARALLEL"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "routing_to_parallel"}
     next:
@@ -73,7 +73,7 @@ workflow:
   - step: hot_task_a
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"who": "A"}
     next:
@@ -85,7 +85,7 @@ workflow:
   - step: hot_task_b
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"who": "B"}
     next:
@@ -98,7 +98,7 @@ workflow:
     desc: "Cold branch single continuation"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "routing_to_cold"}
     next:
@@ -110,7 +110,7 @@ workflow:
   - step: cold_task
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"who": "C"}
     next:
@@ -123,6 +123,6 @@ workflow:
     desc: "Finish"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/data_processing/wikipedia_processing/wikipedia_processing.yaml
+++ b/tests/fixtures/playbooks/data_processing/wikipedia_processing/wikipedia_processing.yaml
@@ -20,7 +20,7 @@ workflow:
     desc: "Start Wikipedia Data Processing Workflow"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -116,6 +116,6 @@ workflow:
     desc: "End of Wikipedia processing workflow"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/data_transfer/http_iterator_save_postgres/http_iterator_save_postgres.yaml
+++ b/tests/fixtures/playbooks/data_transfer/http_iterator_save_postgres/http_iterator_save_postgres.yaml
@@ -22,7 +22,7 @@ workflow:
   desc: Start HTTP iterator save test
   tool:
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "initialized"}
 
       '
@@ -73,7 +73,7 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: continue
         - else:
@@ -120,7 +120,7 @@ workflow:
   desc: Validate that all cities have data
   tool:
     kind: python
-    args:
+    input:
       verify_results: '{{ verify_results }}'
     code: "\"\"\"Validate that all expected cities have data saved.\"\"\"\n# Get verification\
       \ results - verify_results is already the dict with command_0\nverify_result\
@@ -147,7 +147,7 @@ workflow:
   desc: Test completed
   tool:
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "completed"}
 
       '

--- a/tests/fixtures/playbooks/data_transfer/http_to_databases/http_to_databases.yaml
+++ b/tests/fixtures/playbooks/data_transfer/http_to_databases/http_to_databases.yaml
@@ -18,7 +18,7 @@ workflow:
     desc: Start HTTP to databases transfer pipeline
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -153,7 +153,7 @@ workflow:
     desc: Transform HTTP JSON data and prepare for database insertion
     tool:
       kind: python
-      args:
+      input:
         fetch_http_data: "{{ fetch_http_data }}"
       code: |
         """Transform HTTP API response and prepare for database insertion."""
@@ -418,7 +418,7 @@ workflow:
     desc: Cross-verify data across all databases (Postgres, Snowflake, DuckDB, DuckLake)
     tool:
       kind: python
-      args:
+      input:
         verify_pg_data: "{{ verify_pg_data }}"
         verify_sf_data: "{{ verify_sf_data }}"
         verify_duckdb_data: "{{ verify_duckdb_data }}"
@@ -512,6 +512,6 @@ workflow:
     desc: End HTTP to databases transfer pipeline
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/data_transfer/http_to_postgres_direct/http_to_postgres_direct.yaml
+++ b/tests/fixtures/playbooks/data_transfer/http_to_postgres_direct/http_to_postgres_direct.yaml
@@ -11,7 +11,7 @@ workflow:
   desc: Start workflow
   tool:
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "initialized"}
 
       '
@@ -43,13 +43,13 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.http.status in [500, 502, 503] }}'
+        - when: '{{ output.http.status in [500, 502, 503] }}'
           then:
             do: retry
             attempts: 3
             backoff: exponential
             delay: 0.5
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
@@ -69,7 +69,7 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: continue
         - else:
@@ -97,7 +97,7 @@ workflow:
   desc: Fail if no rows stored
   tool:
     kind: python
-    args:
+    input:
       show_count: '{{ show_count }}'
     code: "count = int(show_count.get('command_0', {}).get('rows', [{}])[0].get('records',\
       \ 0))\nif count == 0:\n    raise ValueError(\"No rows stored in http_to_postgres_direct\"\
@@ -111,7 +111,7 @@ workflow:
   desc: End workflow
   tool:
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "completed"}
 
       '

--- a/tests/fixtures/playbooks/data_transfer/http_to_postgres_simple/http_to_postgres_simple.yaml
+++ b/tests/fixtures/playbooks/data_transfer/http_to_postgres_simple/http_to_postgres_simple.yaml
@@ -15,7 +15,7 @@ workflow:
     desc: Start HTTP to PostgreSQL transfer
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -60,7 +60,7 @@ workflow:
     desc: Transform and insert posts into PostgreSQL
     tool:
       kind: python
-      args:
+      input:
         input_data: "{{ fetch_posts }}"
       code: |
         """Transform JSON posts and insert into PostgreSQL."""
@@ -147,6 +147,6 @@ workflow:
     desc: End HTTP to PostgreSQL transfer
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/data_transfer/http_to_postgres_transfer/http_to_postgres_transfer.yaml
+++ b/tests/fixtures/playbooks/data_transfer/http_to_postgres_transfer/http_to_postgres_transfer.yaml
@@ -13,7 +13,7 @@ workflow:
     desc: Start workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -86,6 +86,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/data_transfer/postgres_jsonb_test/postgres_jsonb_test.yaml
+++ b/tests/fixtures/playbooks/data_transfer/postgres_jsonb_test/postgres_jsonb_test.yaml
@@ -91,7 +91,7 @@ workflow:
       kind: python
       libs:
         json: json
-      args:
+      input:
         test_table: "{{ test_table }}"
         sample_json_data: "{{ sample_json_data }}"
       code: |
@@ -262,7 +262,7 @@ workflow:
     desc: Validate JSONB operations and cleanup test table
     tool:
       kind: python
-      args:
+      input:
         query_jsonb_data: "{{ query_jsonb_data }}"
         test_truncate: "{{ test_truncate }}"
       code: |

--- a/tests/fixtures/playbooks/data_transfer/snowflake_postgres/snowflake_postgres.yaml
+++ b/tests/fixtures/playbooks/data_transfer/snowflake_postgres/snowflake_postgres.yaml
@@ -18,7 +18,7 @@ workflow:
     desc: Start data transfer pipeline
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -265,6 +265,6 @@ workflow:
     desc: End data transfer test pipeline
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/ducklake_test/playbook.yaml
+++ b/tests/fixtures/playbooks/ducklake_test/playbook.yaml
@@ -115,8 +115,8 @@ workflow:
             - else:
                 then:
                   do: continue
-                  set_ctx:
-                    user_count: "{{ query_users.data | length }}"
+                  set:
+                    ctx.user_count: "{{ query_users.data | length }}"
     next:
       spec:
         mode: exclusive
@@ -166,8 +166,8 @@ workflow:
             - else:
                 then:
                   do: continue
-                  set_ctx:
-                    event_count: "{{ count_events.data[0].event_count | default(0) }}"
+                  set:
+                    ctx.event_count: "{{ count_events.data[0].event_count | default(0) }}"
     next:
       spec:
         mode: exclusive
@@ -191,9 +191,9 @@ workflow:
             - else:
                 then:
                   do: continue
-                  set_ctx:
-                    snapshot_count: "{{ get_catalog_info.data[0] | length }}"
-                    table_count: "{{ get_catalog_info.data[1] | length }}"
+                  set:
+                    ctx.snapshot_count: "{{ get_catalog_info.data[0] | length }}"
+                    ctx.table_count: "{{ get_catalog_info.data[1] | length }}"
     next:
       spec:
         mode: exclusive

--- a/tests/fixtures/playbooks/examples/http_pagination_v2.yaml
+++ b/tests/fixtures/playbooks/examples/http_pagination_v2.yaml
@@ -21,9 +21,9 @@ workflow:
       code: 'result = {"status": "initialized"}
 
         '
-  set_ctx:
-    current_page: '{{ workload.current_page }}'
-    all_pages: '{{ workload.all_pages }}'
+  set:
+    ctx.current_page: '{{ workload.current_page }}'
+    ctx.all_pages: '{{ workload.all_pages }}'
   next:
     spec:
       mode: exclusive
@@ -39,10 +39,10 @@ workflow:
         rules:
         - else:
             do: continue
-            set_iter:
-              page: 1
-              has_more: true
-              items: []
+            set:
+              iter.page: 1
+              iter.has_more: true
+              iter.items: []
   - name: fetch_page
     kind: http
     spec:
@@ -53,26 +53,26 @@ workflow:
         pageSize: '{{ page_size }}'
       policy:
         rules:
-        - when: '{{ outcome.status == ''error'' and outcome.http.status in [500, 502,
+        - when: '{{ output.status == ''error'' and output.http.status in [500, 502,
             503] }}'
           then:
             do: retry
             attempts: 3
             backoff: exponential
             delay: 0.5
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
             do: continue
-            set_iter:
-              has_more: '{{ outcome.result.data.paging.hasMore | default(false) }}'
-              page: '{{ outcome.result.data.paging.page | default(iter.page) }}'
-              items: '{{ outcome.result.data.items | default([]) }}'
+            set:
+              iter.has_more: '{{ output.data.paging.hasMore | default(false) }}'
+              iter.page: '{{ output.data.paging.page | default(iter.page) }}'
+              iter.items: '{{ output.data.items | default([]) }}'
   - name: collect_items
     kind: python
     spec:
-      args:
+      input:
         items: '{{ iter.items }}'
         all_pages: '{{ ctx.all_pages }}'
       code: '# Extend collection with new items
@@ -86,8 +86,8 @@ workflow:
         rules:
         - else:
             do: continue
-            set_ctx:
-              all_pages: '{{ outcome.result.all_pages }}'
+            set:
+              ctx.all_pages: '{{ output.data.all_pages }}'
   - name: paginate
     kind: noop
     spec:
@@ -97,8 +97,8 @@ workflow:
           then:
             do: jump
             to: fetch_page
-            set_iter:
-              page: '{{ (iter.page | int) + 1 }}'
+            set:
+              iter.page: '{{ (iter.page | int) + 1 }}'
         - else:
             do: break
   next:
@@ -106,15 +106,15 @@ workflow:
       mode: exclusive
     arcs:
     - step: process_results
-      args:
-        items: '{{ ctx.all_pages }}'
+      set:
+        ctx.paginated_items: '{{ ctx.all_pages }}'
 - step: process_results
   desc: Process collected results
   tool:
     kind: python
     spec:
-      args:
-        items: '{{ args.items }}'
+      input:
+        items: '{{ ctx.paginated_items }}'
       code: 'print(f"Processing {len(items)} items")
 
         result = {"count": len(items), "status": "processed"}

--- a/tests/fixtures/playbooks/examples/simple_http_v2.yaml
+++ b/tests/fixtures/playbooks/examples/simple_http_v2.yaml
@@ -25,13 +25,13 @@ workflow:
           test: "hello"
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' and outcome.error.retryable }}"
+            - when: "{{ output.status == 'error' and output.error.retryable }}"
               then:
                 do: retry
                 attempts: 3
                 backoff: exponential
                 delay: 0.5
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: fail
             - else:
@@ -41,16 +41,16 @@ workflow:
         mode: exclusive
       arcs:
         - step: process
-          args:
-            data: "{{ start.data }}"
+          set:
+            ctx.response_data: "{{ start.data }}"
 
   - step: process
     desc: "Process HTTP response"
     tool:
       kind: python
       spec:
-        args:
-          data: "{{ data }}"
+        input:
+          data: "{{ ctx.response_data }}"
         code: |
           print(f"Processing data: {data}")
           result = {"status": "processed", "data": data}
@@ -65,7 +65,7 @@ workflow:
     tool:
       kind: python
       spec:
-        args: {}
+        input: {}
         code: |
           print("Workflow complete")
           result = {"status": "done"}

--- a/tests/fixtures/playbooks/examples/variable_lifecycle_example.yaml
+++ b/tests/fixtures/playbooks/examples/variable_lifecycle_example.yaml
@@ -23,12 +23,12 @@ workflow:
       code: 'result = {"status": "initialized"}
 
         '
-  set_ctx:
-    user_email: '{{ workload.user_email }}'
-    user_status: '{{ workload.user_status }}'
-    user_created: '{{ workload.user_created }}'
-    email_domain: '{{ workload.email_domain }}'
-    user_score: '{{ workload.user_score }}'
+  set:
+    ctx.user_email: '{{ workload.user_email }}'
+    ctx.user_status: '{{ workload.user_status }}'
+    ctx.user_created: '{{ workload.user_created }}'
+    ctx.email_domain: '{{ workload.email_domain }}'
+    ctx.user_score: '{{ workload.user_score }}'
   next:
     spec:
       mode: exclusive
@@ -46,15 +46,15 @@ workflow:
         X-Environment: '{{ environment }}'
       policy:
         rules:
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
             do: continue
-            set_ctx:
-              user_email: '{{ outcome.result.email }}'
-              user_status: '{{ outcome.result.status }}'
-              user_created: '{{ outcome.result.created_at }}'
+            set:
+              ctx.user_email: '{{ output.data.email }}'
+              ctx.user_status: '{{ output.data.status }}'
+              ctx.user_created: '{{ output.data.created_at }}'
   next:
     spec:
       mode: exclusive
@@ -65,7 +65,7 @@ workflow:
   tool:
     kind: python
     spec:
-      args:
+      input:
         email: '{{ ctx.user_email }}'
         status: '{{ ctx.user_status }}'
         retry_count: '{{ retry_limit }}'
@@ -77,18 +77,15 @@ workflow:
         rules:
         - else:
             do: continue
-            set_ctx:
-              email_domain: '{{ outcome.result.email_domain }}'
-              user_score: '{{ outcome.result.score }}'
+            set:
+              ctx.email_domain: '{{ output.data.email_domain }}'
+              ctx.user_score: '{{ output.data.score }}'
   next:
     spec:
       mode: exclusive
     arcs:
     - step: active_user_flow
       when: '{{ ctx.user_status == ''active'' }}'
-      args:
-        domain: '{{ ctx.email_domain }}'
-        score: '{{ ctx.user_score }}'
     - step: inactive_user_flow
       when: '{{ ctx.user_status != ''active'' }}'
 - step: active_user_flow
@@ -96,9 +93,9 @@ workflow:
   tool:
     kind: python
     spec:
-      args:
-        domain: '{{ args.domain }}'
-        score: '{{ args.score }}'
+      input:
+        domain: '{{ ctx.email_domain }}'
+        score: '{{ ctx.user_score }}'
         global_env: '{{ environment }}'
       code: "result = {\n    \"message\": f\"Active user in {global_env}\",\n    \"\
         domain\": domain,\n    \"bonus_score\": score + 10\n}\n"
@@ -112,7 +109,7 @@ workflow:
   tool:
     kind: python
     spec:
-      args:
+      input:
         email: '{{ ctx.user_email }}'
         status: '{{ ctx.user_status }}'
       code: "result = {\n    \"message\": f\"Inactive user: {email}\",\n    \"status\"\
@@ -127,7 +124,7 @@ workflow:
   tool:
     kind: python
     spec:
-      args:
+      input:
         user_email: '{{ ctx.user_email }}'
         user_score: '{{ ctx.user_score }}'
         environment: '{{ environment }}'

--- a/tests/fixtures/playbooks/examples/weather_loop_v2.yaml
+++ b/tests/fixtures/playbooks/examples/weather_loop_v2.yaml
@@ -24,7 +24,7 @@ workbook:
   tool:
     kind: python
     spec:
-      args:
+      input:
         city: null
         threshold: null
       code: "# Evaluate weather data\ntemp = city.get(\"temperature\", 0)\nalert =\
@@ -40,9 +40,9 @@ workflow:
       code: 'result = {"status": "initialized", "timestamp": "2025-12-10T00:00:00Z"}
 
         '
-  set_ctx:
-    weather_results: '{{ workload.weather_results }}'
-    alerts: '{{ workload.alerts }}'
+  set:
+    ctx.weather_results: '{{ workload.weather_results }}'
+    ctx.alerts: '{{ workload.alerts }}'
   next:
     spec:
       mode: exclusive
@@ -68,28 +68,28 @@ workflow:
         temperature_unit: celsius
       policy:
         rules:
-        - when: '{{ outcome.status == ''error'' and outcome.http.status in [500, 502,
+        - when: '{{ output.status == ''error'' and output.http.status in [500, 502,
             503, 504] }}'
           then:
             do: retry
             attempts: 3
             backoff: exponential
             delay: 1.0
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:
             do: continue
-            set_iter:
-              current_temp: '{{ outcome.result.current_weather.temperature }}'
-              city_data:
+            set:
+              iter.current_temp: '{{ output.data.current_weather.temperature }}'
+              iter.city_data:
                 name: '{{ iter.city.name }}'
-                temperature: '{{ outcome.result.current_weather.temperature }}'
-                windspeed: '{{ outcome.result.current_weather.windspeed }}'
+                temperature: '{{ output.data.current_weather.temperature }}'
+                windspeed: '{{ output.data.current_weather.windspeed }}'
   - name: evaluate_and_route
     kind: python
     spec:
-      args:
+      input:
         city_data: '{{ iter.city_data }}'
         threshold: '{{ alert_threshold }}'
         weather_results: '{{ ctx.weather_results }}'
@@ -108,9 +108,9 @@ workflow:
         rules:
         - else:
             do: continue
-            set_ctx:
-              weather_results: '{{ outcome.result.weather_results }}'
-              alerts: '{{ outcome.result.alerts }}'
+            set:
+              ctx.weather_results: '{{ output.data.weather_results }}'
+              ctx.alerts: '{{ output.data.alerts }}'
   next:
     spec:
       mode: exclusive
@@ -122,7 +122,7 @@ workflow:
   - name: compute_summary
     kind: python
     spec:
-      args:
+      input:
         weather_results: '{{ ctx.weather_results }}'
         alerts: '{{ ctx.alerts }}'
       code: "total_cities = len(weather_results) + len(alerts)\nalert_count = len(alerts)\n\
@@ -134,8 +134,8 @@ workflow:
         rules:
         - else:
             do: continue
-            set_ctx:
-              summary: '{{ outcome.result }}'
+            set:
+              ctx.summary: '{{ output.data }}'
   - name: save_summary
     kind: postgres
     spec:
@@ -146,7 +146,7 @@ workflow:
         \ }},\n  $json${{ ctx.summary | tojson }}$json$::jsonb,\n  NOW()\n);\n"
       policy:
         rules:
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - else:

--- a/tests/fixtures/playbooks/hello_world/hello_world.yaml
+++ b/tests/fixtures/playbooks/hello_world/hello_world.yaml
@@ -16,7 +16,7 @@ workflow:
     desc: "Start hello world test"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -29,7 +29,7 @@ workflow:
     desc: "Hello world test step"
     tool:
       kind: python
-      args:
+      input:
         message: "{{ message }}"
       code: |
         print(f"HELLO_WORLD: {message}")
@@ -44,6 +44,6 @@ workflow:
     desc: "End hello world test"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/interactive_brokers/ib_gateway_test.yaml
+++ b/tests/fixtures/playbooks/interactive_brokers/ib_gateway_test.yaml
@@ -15,7 +15,7 @@ workflow:
     desc: Start IB Gateway test
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -44,7 +44,7 @@ workflow:
     desc: Parse authentication status
     tool:
       kind: python
-      args:
+      input:
         api_response: "{{ check_gateway_status }}"
       code: |
         """
@@ -129,7 +129,7 @@ workflow:
     desc: Parse account information
     tool:
       kind: python
-      args:
+      input:
         api_response: "{{ get_accounts }}"
       code: |
         """Parse IB accounts."""
@@ -169,7 +169,7 @@ workflow:
     desc: Get portfolio summary for first account
     tool:
       kind: python
-      args:
+      input:
         accounts_data: "{{ parse_accounts }}"
       code: |
         """Extract first account ID."""
@@ -210,7 +210,7 @@ workflow:
     desc: Parse account ledger
     tool:
       kind: python
-      args:
+      input:
         api_response: "{{ get_account_ledger }}"
       code: |
         """Parse IB account ledger."""
@@ -249,7 +249,7 @@ workflow:
     desc: Verify IB Gateway test completed
     tool:
       kind: python
-      args:
+      input:
         auth_status: "{{ parse_auth_status }}"
         accounts: "{{ parse_accounts }}"
         ledger: "{{ parse_ledger }}"
@@ -287,7 +287,7 @@ workflow:
     desc: Gateway not available
     tool:
       kind: python
-      args:
+      input:
         error_info: "{{ parse_auth_status }}"
       code: |
         """Report gateway error."""
@@ -312,6 +312,6 @@ workflow:
     desc: IB Gateway test completed
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/interactive_brokers/ibkr_api.yaml
+++ b/tests/fixtures/playbooks/interactive_brokers/ibkr_api.yaml
@@ -46,7 +46,7 @@ workflow:
     desc: Route to requested target
     tool:
       kind: python
-      args:
+      input:
         target: "{{ target }}"
         credential_name: "{{ credential_name }}"
         override_gateway_url: "{{ gateway_url }}"
@@ -121,7 +121,7 @@ workflow:
     desc: Parse and return auth status
     tool:
       kind: python
-      args:
+      input:
         response: "{{ check_auth_status }}"
       code: |
         data = response.get('data', {})
@@ -160,7 +160,7 @@ workflow:
       libs:
         pyotp: pyotp
         time: time
-      args:
+      input:
         totp_secret: "{{ start.totp_secret }}"
       code: |
         if not totp_secret:
@@ -207,7 +207,7 @@ workflow:
     desc: Parse tickle response
     tool:
       kind: python
-      args:
+      input:
         response: "{{ tickle_session }}"
       code: |
         data = response.get('data', {})
@@ -246,7 +246,7 @@ workflow:
     desc: Pick futures contract
     tool:
       kind: python
-      args:
+      input:
         response: "{{ get_futures }}"
         symbol: "{{ symbol }}"
         index: "{{ contract_index }}"
@@ -295,7 +295,7 @@ workflow:
     desc: Summarize historical data
     tool:
       kind: python
-      args:
+      input:
         contract: "{{ pick_contract.contract }}"
         history: "{{ get_history }}"
       code: |
@@ -340,7 +340,7 @@ workflow:
     desc: Parse accounts response
     tool:
       kind: python
-      args:
+      input:
         response: "{{ get_accounts }}"
       code: |
         data = response.get('data', [])
@@ -389,8 +389,8 @@ workflow:
       headers:
         Content-Type: application/json
       verify_ssl: false
-    set_ctx:
-      account_id: "{{ result.data[0].accountId if result.data else '' }}"
+    set:
+      ctx.account_id: "{{ result.data[0].accountId if result.data else '' }}"
     next:
       spec:
         mode: exclusive
@@ -417,7 +417,7 @@ workflow:
     desc: Parse positions response
     tool:
       kind: python
-      args:
+      input:
         response: "{{ fetch_positions }}"
         account_id: "{{ ctx.account_id }}"
       code: |
@@ -484,7 +484,7 @@ workflow:
     desc: Parse orders response
     tool:
       kind: python
-      args:
+      input:
         response: "{{ get_orders }}"
       code: |
         data = response.get('data', {})
@@ -505,7 +505,7 @@ workflow:
     desc: Workflow complete
     tool:
       kind: python
-      args:
+      input:
         status: "{{ result.status if result is defined else 'completed' }}"
       code: |
         result = {"status": status}

--- a/tests/fixtures/playbooks/interactive_brokers/ibkr_gateway_maintain.yaml
+++ b/tests/fixtures/playbooks/interactive_brokers/ibkr_gateway_maintain.yaml
@@ -22,7 +22,7 @@ workflow:
     desc: Resolve gateway URL
     tool:
       kind: python
-      args:
+      input:
         credential_name: "{{ credential_name }}"
         override_gateway_url: "{{ gateway_url }}"
         override_base_url: "{{ base_url }}"
@@ -62,7 +62,7 @@ workflow:
     desc: Tickle, decide, and reauthenticate if needed
     tool:
       kind: python
-      args:
+      input:
         base_url: "{{ start.base_url }}"
         gateway_url: "{{ start.gateway_url }}"
       code: |
@@ -142,6 +142,6 @@ workflow:
     desc: Done
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/interactive_brokers/ibkr_gateway_verify.yaml
+++ b/tests/fixtures/playbooks/interactive_brokers/ibkr_gateway_verify.yaml
@@ -21,7 +21,7 @@ workflow:
     desc: Resolve gateway URL
     tool:
       kind: python
-      args:
+      input:
         credential_name: "{{ credential_name }}"
         override_gateway_url: "{{ gateway_url }}"
         override_base_url: "{{ base_url }}"
@@ -61,7 +61,7 @@ workflow:
     desc: Validate session and check tickle/auth status
     tool:
       kind: python
-      args:
+      input:
         base_url: "{{ start.base_url }}"
       code: |
         import httpx
@@ -98,7 +98,7 @@ workflow:
     desc: Summarize verification
     tool:
       kind: python
-      args:
+      input:
         gateway_url: "{{ start.gateway_url }}"
         base_url: "{{ start.base_url }}"
         validate_resp: "{{ call_api.validate }}"
@@ -152,7 +152,7 @@ workflow:
     desc: Done
     tool:
       kind: python
-      args:
+      input:
         summary: "{{ summarize }}"
       code: |
         result = {

--- a/tests/fixtures/playbooks/interactive_brokers/ibkr_history.yaml
+++ b/tests/fixtures/playbooks/interactive_brokers/ibkr_history.yaml
@@ -22,7 +22,7 @@ workflow:
     desc: Resolve gateway URL
     tool:
       kind: python
-      args:
+      input:
         credential_name: "{{ credential_name }}"
         override_gateway_url: "{{ gateway_url }}"
         override_base_url: "{{ base_url }}"
@@ -80,7 +80,7 @@ workflow:
     desc: Pick futures contract
     tool:
       kind: python
-      args:
+      input:
         response: "{{ get_futures }}"
         symbol: "{{ symbol }}"
         index: "{{ contract_index }}"
@@ -129,7 +129,7 @@ workflow:
     desc: Summarize historical data
     tool:
       kind: python
-      args:
+      input:
         contract: "{{ pick_contract.contract }}"
         history: "{{ get_history }}"
       code: |
@@ -154,7 +154,7 @@ workflow:
     desc: Done
     tool:
       kind: python
-      args:
+      input:
         summary: "{{ summarize }}"
       code: |
         result = {"status": "completed", "summary": summary}

--- a/tests/fixtures/playbooks/iterator_save_test.yaml
+++ b/tests/fixtures/playbooks/iterator_save_test.yaml
@@ -48,7 +48,7 @@ workflow:
   tool:
   - name: transform
     kind: python
-    args:
+    input:
       item: '{{ item }}'
     code: "result = {\n    'item_name': item.get('name', 'unknown'),\n    'item_value':\
       \ item.get('value', 0)\n}\n"

--- a/tests/fixtures/playbooks/iterator_save_test/iterator_save_test.yaml
+++ b/tests/fixtures/playbooks/iterator_save_test/iterator_save_test.yaml
@@ -48,7 +48,7 @@ workflow:
   tool:
   - name: process_item
     kind: python
-    args:
+    input:
       item: '{{ iter.item }}'
     code: "result = {\n    'item_name': item.get('name', 'unknown'),\n    'item_value':\
       \ item.get('value', 0)\n}\n"
@@ -58,8 +58,8 @@ workflow:
         - when: true
           then:
             do: continue
-            set_iter:
-              processed_item: '{{ outcome.result }}'
+            set:
+              iter.processed_item: '{{ output.data }}'
   - name: save_item
     kind: postgres
     auth: '{{ pg_auth }}'
@@ -71,7 +71,7 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - when: true

--- a/tests/fixtures/playbooks/json_serialization_save.yaml
+++ b/tests/fixtures/playbooks/json_serialization_save.yaml
@@ -35,7 +35,7 @@ workflow:
   tool:
   - name: generate_data
     kind: python
-    args:
+    input:
       input_data: {}
     code: "# Return a dict that will be saved to JSONB\nresult = {\n    \"data\":\
       \ {\n        \"string_field\": \"test_value\",\n        \"number_field\": 42,\n\
@@ -48,8 +48,8 @@ workflow:
         - when: '{{ true }}'
           then:
             do: continue
-            set_ctx:
-              json_data: '{{ outcome.result.data }}'
+            set:
+              ctx.json_data: '{{ output.data }}'
   - name: save_json
     kind: postgres
     auth: '{{ pg_auth }}'
@@ -61,7 +61,7 @@ workflow:
     spec:
       policy:
         rules:
-        - when: '{{ outcome.status == ''error'' }}'
+        - when: '{{ output.status == ''error'' }}'
           then:
             do: fail
         - when: '{{ true }}'

--- a/tests/fixtures/playbooks/json_serialization_save/json_serialization_save.yaml
+++ b/tests/fixtures/playbooks/json_serialization_save/json_serialization_save.yaml
@@ -43,7 +43,7 @@ workflow:
     tool:
       - name: generate_data
         kind: python
-        args:
+        input:
           input_data: {}
         code: |
           # Return a dict that will be saved to JSONB
@@ -64,8 +64,8 @@ workflow:
               - when: true
                 then:
                   do: continue
-                  set_ctx:
-                    json_data: "{{ outcome.result.data }}"
+                  set:
+                    ctx.json_data: "{{ output.data }}"
 
       - name: save_json
         kind: postgres
@@ -76,7 +76,7 @@ workflow:
         spec:
           policy:
             rules:
-              - when: "{{ outcome.status == 'error' }}"
+              - when: "{{ output.status == 'error' }}"
                 then:
                   do: fail
               - when: true

--- a/tests/fixtures/playbooks/keychain/google_id_token/google_id_token_comparison_test.yaml
+++ b/tests/fixtures/playbooks/keychain/google_id_token/google_id_token_comparison_test.yaml
@@ -165,7 +165,7 @@ workflow:
     desc: Compare both modes and verify they work identically
     tool:
       kind: python
-      args:
+      input:
         sm_status: "{{ test_secret_manager_mode.status_code }}"
         cred_status: "{{ test_credential_table_mode.status_code }}"
       code: |

--- a/tests/fixtures/playbooks/keychain/google_id_token/google_id_token_test.yaml
+++ b/tests/fixtures/playbooks/keychain/google_id_token/google_id_token_test.yaml
@@ -60,7 +60,7 @@ workflow:
     desc: Verify ID token was generated and is accessible in keychain
     tool:
       kind: python
-      args:
+      input:
         id_token: "{{ keychain.cloud_run_id_token.id_token }}"
         token_type: "{{ keychain.cloud_run_id_token.token_type }}"
         audience: "{{ keychain.cloud_run_id_token.audience }}"
@@ -144,7 +144,7 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: continue
             - else:
@@ -198,7 +198,7 @@ workflow:
     desc: Verify token auto-renewal metadata is stored correctly
     tool:
       kind: python
-      args:
+      input:
         execution_id: "{{ job.uuid }}"
       code: |
         # In a real scenario, this would check if the token can be renewed

--- a/tests/fixtures/playbooks/load_test/heavy_loop_aggregation/heavy_loop_aggregation.yaml
+++ b/tests/fixtures/playbooks/load_test/heavy_loop_aggregation/heavy_loop_aggregation.yaml
@@ -33,7 +33,7 @@ workflow:
   desc: Initialize the heavy load test
   tool:
     kind: python
-    args:
+    input:
       item_count: '{{ item_count }}'
     code: "import time\n\n# Generate a list of items to process\nitems = []\nfor i\
       \ in range(int(item_count)):\n    items.append({\n        \"id\": i,\n     \
@@ -44,8 +44,8 @@ workflow:
       ,\n    \"total_items\": len(items),\n    \"items\": items,\n    \"start_time\"\
       : time.time()\n}\nprint(f\"Initialized with {len(items)} items to process\"\
       )\n"
-  set_ctx:
-    loop_results: '{{ workload.loop_results }}'
+  set:
+    ctx.loop_results: '{{ workload.loop_results }}'
   next:
     spec:
       mode: exclusive
@@ -61,7 +61,7 @@ workflow:
   tool:
   - name: process_item
     kind: python
-    args:
+    input:
       item: '{{ iter.item }}'
       padding_size: '{{ result_padding_size }}'
       delay: '{{ processing_delay }}'
@@ -86,21 +86,21 @@ workflow:
         rules:
         - else:
             do: continue
-            set_ctx:
-              loop_results: '{{ outcome.result.loop_results }}'
+            set:
+              ctx.loop_results: '{{ output.data.loop_results }}'
   next:
     spec:
       mode: exclusive
     arcs:
     - step: aggregate_results
-      args:
-        loop_results: '{{ ctx.loop_results }}'
+      set:
+        ctx.loop_results: '{{ ctx.loop_results }}'
 - step: aggregate_results
   desc: Aggregate all loop results and compute statistics
   tool:
     kind: python
-    args:
-      loop_results: '{{ args.loop_results }}'
+    input:
+      loop_results: '{{ ctx.loop_results }}'
       start_time: '{{ start.start_time }}'
     code: "import time\n\n# Extract results from loop aggregation\nresults = loop_results\
       \ if loop_results else []\n\n# Compute aggregation statistics\ntotal_items =\
@@ -138,7 +138,7 @@ workflow:
   desc: Validate that the test completed successfully
   tool:
     kind: python
-    args:
+    input:
       aggregation: '{{ aggregate_results }}'
       expected_count: '{{ item_count }}'
     code: "# Validate test results\nsummary = aggregation.get(\"summary\", {})\ntotal_processed\
@@ -176,7 +176,7 @@ workflow:
   desc: End of heavy load test
   tool:
     kind: python
-    args:
+    input:
       validation: '{{ validate_results }}'
     code: "result = {\n    \"status\": \"completed\",\n    \"test_name\": \"heavy_loop_aggregation\"\
       ,\n    \"test_result\": validation.get(\"status\"),\n    \"all_passed\": validation.get(\"\

--- a/tests/fixtures/playbooks/load_test/reference_chain_loop_stress/reference_chain_loop_stress.yaml
+++ b/tests/fixtures/playbooks/load_test/reference_chain_loop_stress/reference_chain_loop_stress.yaml
@@ -30,12 +30,12 @@ workflow:
       kind: python
       code: |
         result = {"status": "initialized"}
-    set_ctx:
-      current_page: "{{ workload.current_page }}"
-      has_more: "{{ workload.has_more }}"
-      chain_contract_ok: "{{ workload.chain_contract_ok }}"
-      pages_fetched: "{{ workload.pages_fetched }}"
-      processed_total: "{{ workload.processed_total }}"
+    set:
+      ctx.current_page: "{{ workload.current_page }}"
+      ctx.has_more: "{{ workload.has_more }}"
+      ctx.chain_contract_ok: "{{ workload.chain_contract_ok }}"
+      ctx.pages_fetched: "{{ workload.pages_fetched }}"
+      ctx.processed_total: "{{ workload.processed_total }}"
     next:
       spec:
         mode: exclusive
@@ -58,13 +58,13 @@ workflow:
         spec:
           policy:
             rules:
-              - when: "{{ outcome.status == 'error' and (outcome.error.retryable or (outcome.error.message is defined and ('Connection reset' in outcome.error.message or 'timed out' in outcome.error.message))) }}"
+              - when: "{{ output.status == 'error' and (output.error.retryable or (output.error.message is defined and ('Connection reset' in output.error.message or 'timed out' in output.error.message))) }}"
                 then:
                   do: retry
                   attempts: 6
                   backoff: exponential
                   delay: 0.8
-              - when: "{{ outcome.status == 'error' }}"
+              - when: "{{ output.status == 'error' }}"
                 then:
                   do: fail
               - else:
@@ -72,7 +72,7 @@ workflow:
                     do: continue
       - name: reduce_page
         kind: python
-        args:
+        input:
           response: "{{ _prev.data }}"
           current_chain_ok: "{{ ctx.chain_contract_ok }}"
           pages_fetched: "{{ ctx.pages_fetched }}"
@@ -109,7 +109,7 @@ workflow:
             "mode": mode,
             "pages_fetched": int(pages_fetched or 0) + 1,
           }
-    result:
+    output:
       output_select:
         - page_records
         - page_record_count
@@ -119,11 +119,11 @@ workflow:
         - linked_chain_length
         - mode
         - pages_fetched
-    set_ctx:
-      has_more: "{{ fetch_page.has_more }}"
-      current_page: "{{ fetch_page.next_page }}"
-      chain_contract_ok: "{{ fetch_page.chain_contract_ok }}"
-      pages_fetched: "{{ fetch_page.pages_fetched }}"
+    set:
+      ctx.has_more: "{{ fetch_page.has_more }}"
+      ctx.current_page: "{{ fetch_page.next_page }}"
+      ctx.chain_contract_ok: "{{ fetch_page.chain_contract_ok }}"
+      ctx.pages_fetched: "{{ fetch_page.pages_fetched }}"
     next:
       spec:
         mode: exclusive
@@ -140,7 +140,7 @@ workflow:
       iterator: record
     tool:
       kind: python
-      args:
+      input:
         record: "{{ iter.record }}"
       code: |
         record_id = int(record.get("record_id", 0))
@@ -162,7 +162,7 @@ workflow:
     desc: Aggregate page progress and decide next page
     tool:
       kind: python
-      args:
+      input:
         loop_summary: "{{ process_records }}"
         merge_result: "{{ fetch_page }}"
         processed_total: "{{ ctx.processed_total }}"
@@ -200,12 +200,12 @@ workflow:
           "expected_page_total": expected_page_total,
           "duplicate_margin": duplicate_margin,
         }
-    set_ctx:
-      processed_total: "{{ update_progress.processed_total }}"
-      has_more: "{{ update_progress.has_more }}"
-      current_page: "{{ update_progress.next_page }}"
-      pages_fetched: "{{ update_progress.pages_fetched }}"
-      chain_contract_ok: "{{ update_progress.chain_contract_ok }}"
+    set:
+      ctx.processed_total: "{{ update_progress.processed_total }}"
+      ctx.has_more: "{{ update_progress.has_more }}"
+      ctx.current_page: "{{ update_progress.next_page }}"
+      ctx.pages_fetched: "{{ update_progress.pages_fetched }}"
+      ctx.chain_contract_ok: "{{ update_progress.chain_contract_ok }}"
     next:
       spec:
         mode: exclusive
@@ -219,7 +219,7 @@ workflow:
     desc: Validate full run counters
     tool:
       kind: python
-      args:
+      input:
         expected_total: "{{ total_records }}"
         processed_total: "{{ ctx.processed_total }}"
         chain_contract_ok: "{{ ctx.chain_contract_ok }}"

--- a/tests/fixtures/playbooks/load_test/state_report_synthetic_load/state_report_synthetic_load.yaml
+++ b/tests/fixtures/playbooks/load_test/state_report_synthetic_load/state_report_synthetic_load.yaml
@@ -38,7 +38,7 @@ workflow:
     desc: Initialize synthetic state-report load test
     tool:
       kind: python
-      args:
+      input:
         total_items: '{{ total_items }}'
         batch_size: '{{ batch_size }}'
       code: |
@@ -352,7 +352,7 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then: { do: retry, attempts: 5, backoff: exponential, delay: 2.0 }
             - else:
                 then: { do: break }
@@ -365,7 +365,7 @@ workflow:
     desc: Compute batch windows for synthetic patient work
     tool:
       kind: python
-      args:
+      input:
         total_items: '{{ total_items }}'
         batch_size: '{{ batch_size }}'
       code: |
@@ -413,7 +413,7 @@ workflow:
       path: '{{ chunk_worker_path }}'
       return_step: end
       timeout: 900
-      args:
+      input:
         pg_auth: '{{ pg_auth }}'
         parent_execution_id: '{{ job.execution_id }}'
         batch_number: '{{ iter.batch.batch_number }}'
@@ -453,7 +453,7 @@ workflow:
     desc: Return synthetic load summary with throughput metrics
     tool:
       kind: python
-      args:
+      input:
         verify_result: '{{ verify_completion_counts }}'
         batch_plan: '{{ build_batch_plan }}'
         worker_loop: '{{ run_batch_workers | default({}) }}'
@@ -500,7 +500,7 @@ workflow:
     desc: Fail when verification finds missing or mismatched synthetic results
     tool:
       kind: python
-      args:
+      input:
         summary: '{{ summarize }}'
       code: |
         raise RuntimeError(f"synthetic state-report load did not reconcile: {summary}")

--- a/tests/fixtures/playbooks/load_test/state_report_synthetic_load/state_report_synthetic_load_worker.yaml
+++ b/tests/fixtures/playbooks/load_test/state_report_synthetic_load/state_report_synthetic_load_worker.yaml
@@ -25,7 +25,7 @@ workflow:
     desc: Initialize chunk worker inputs (batch upsert variant)
     tool:
       kind: python
-      args:
+      input:
         batch_number: '{{ batch_number }}'
         offset: '{{ offset }}'
         batch_size: '{{ batch_size }}'
@@ -101,7 +101,7 @@ workflow:
     desc: Return chunk summary for batch upsert worker
     tool:
       kind: python
-      args:
+      input:
         upsert_result: '{{ upsert_batch }}'
         batch_number: '{{ batch_number }}'
         batch_size: '{{ batch_size }}'

--- a/tests/fixtures/playbooks/oauth/google_gcs/google_gcs_oauth.yaml
+++ b/tests/fixtures/playbooks/oauth/google_gcs/google_gcs_oauth.yaml
@@ -22,7 +22,7 @@ workflow:
     desc: Start GCS OAuth test
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized", "message": "Starting GCS OAuth test"}
     next:
@@ -50,7 +50,7 @@ workflow:
     desc: Parse bucket list response
     tool:
       kind: python
-      args:
+      input:
         api_response: "{{ list_buckets }}"
       code: |
         """Parse GCS bucket list response."""
@@ -87,7 +87,7 @@ workflow:
     desc: Final OAuth verification
     tool:
       kind: python
-      args:
+      input:
         bucket_result: "{{ parse_bucket_list }}"
       code: |
         """Verify OAuth flow completed successfully."""
@@ -119,6 +119,6 @@ workflow:
     desc: GCS OAuth test completed
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/oauth/google_secret_manager/google_secret_manager.yaml
+++ b/tests/fixtures/playbooks/oauth/google_secret_manager/google_secret_manager.yaml
@@ -17,7 +17,7 @@ workflow:
     desc: Start Google Secret Manager OAuth test
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized", "message": "Starting Secret Manager OAuth test"}
     next:
@@ -30,7 +30,7 @@ workflow:
     desc: Generate OAuth token for Secret Manager API
     tool:
       kind: python
-      args:
+      input:
         google_auth: "{{ google_auth }}"
         project_id: "{{ project_id }}"
       code: |
@@ -73,7 +73,7 @@ workflow:
       kind: python
       libs:
         base64: base64
-      args:
+      input:
         api_response: "{{ call_secret_manager_api }}"
       code: |
         """Parse the Secret Manager API response."""
@@ -126,7 +126,7 @@ workflow:
     desc: Verify token-based authentication worked
     tool:
       kind: python
-      args:
+      input:
         parse_result: "{{ parse_secret_response }}"
       code: |
         """Verify the entire OAuth flow worked."""
@@ -156,6 +156,6 @@ workflow:
     desc: OAuth test completed
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/ops/execution_ai_analyze/execution_ai_analyze.yaml
+++ b/tests/fixtures/playbooks/ops/execution_ai_analyze/execution_ai_analyze.yaml
@@ -44,7 +44,7 @@ workflow:
     desc: Validate mode and approval gates
     tool:
       kind: python
-      args:
+      input:
         auto_fix_mode: '{{ auto_fix_mode }}'
         approval_required: '{{ approval_required }}'
         approved: '{{ approved }}'
@@ -82,7 +82,7 @@ workflow:
     desc: Return guardrail report when apply mode is not approved
     tool:
       kind: python
-      args:
+      input:
         default_dry_run_commands: '{{ default_dry_run_commands }}'
         default_test_commands: '{{ default_test_commands }}'
       code: |
@@ -135,7 +135,7 @@ workflow:
       kind: python
       libs:
         json: json
-      args:
+      input:
         target_execution_id: '{{ target_execution_id }}'
         target_playbook_path: '{{ target_playbook_path }}'
         target_playbook_status: '{{ target_playbook_status }}'
@@ -348,7 +348,7 @@ workflow:
       libs:
         json: json
         re: re
-      args:
+      input:
         openai_response: '{{ openai_triage }}'
         auto_fix_mode: '{{ start.mode }}'
         include_patch_diff: '{{ include_patch_diff }}'

--- a/tests/fixtures/playbooks/ops/playbook_ai_explain/playbook_ai_explain.yaml
+++ b/tests/fixtures/playbooks/ops/playbook_ai_explain/playbook_ai_explain.yaml
@@ -34,7 +34,7 @@ workflow:
       kind: python
       libs:
         json: json
-      args:
+      input:
         target_playbook_catalog_id: "{{ target_playbook_catalog_id }}"
         target_playbook_path: "{{ target_playbook_path }}"
         target_playbook_version: "{{ target_playbook_version }}"
@@ -135,7 +135,7 @@ workflow:
       libs:
         json: json
         re: re
-      args:
+      input:
         openai_response: "{{ openai_explain }}"
       code: |
         raw = ""

--- a/tests/fixtures/playbooks/ops/playbook_ai_generate/playbook_ai_generate.yaml
+++ b/tests/fixtures/playbooks/ops/playbook_ai_generate/playbook_ai_generate.yaml
@@ -27,7 +27,7 @@ workflow:
     desc: Normalize prompt and set generation guardrails
     tool:
       kind: python
-      args:
+      input:
         prompt: "{{ prompt }}"
       code: |
         normalized_prompt = str(prompt or "").strip()
@@ -98,7 +98,7 @@ workflow:
       kind: python
       libs:
         json: json
-      args:
+      input:
         openai_response: "{{ openai_generate }}"
       code: |
         raw = ""

--- a/tests/fixtures/playbooks/pagination/basic/test_pagination_basic.yaml
+++ b/tests/fixtures/playbooks/pagination/basic/test_pagination_basic.yaml
@@ -21,10 +21,10 @@ workflow:
       code: |
         result = {"status": "initialized"}
     set:
-      current_page: "{{ workload.current_page }}"
-      page_size: "{{ workload.page_size }}"
-      collected_items: "{{ workload.collected_items }}"
-      has_more: "{{ workload.has_more }}"
+      ctx.current_page: "{{ workload.current_page }}"
+      ctx.page_size: "{{ workload.page_size }}"
+      ctx.collected_items: "{{ workload.collected_items }}"
+      ctx.has_more: "{{ workload.has_more }}"
     next:
       spec:
         mode: exclusive
@@ -87,9 +87,9 @@ workflow:
             'total_collected': len(all_items)
         }
     set:
-      collected_items: "{{ check_pagination.collected_items }}"
-      current_page: "{{ check_pagination.next_page }}"
-      has_more: "{{ check_pagination.has_more }}"
+      ctx.collected_items: "{{ check_pagination.collected_items }}"
+      ctx.current_page: "{{ check_pagination.next_page }}"
+      ctx.has_more: "{{ check_pagination.has_more }}"
     next:
       spec:
         mode: exclusive

--- a/tests/fixtures/playbooks/pagination/cursor/test_pagination_cursor.yaml
+++ b/tests/fixtures/playbooks/pagination/cursor/test_pagination_cursor.yaml
@@ -21,10 +21,10 @@ workflow:
       code: |
         result = {"status": "initialized"}
     set:
-      cursor: "{{ workload.cursor }}"
-      limit: "{{ workload.limit }}"
-      collected_events: "{{ workload.collected_events }}"
-      has_more: "{{ workload.has_more }}"
+      ctx.cursor: "{{ workload.cursor }}"
+      ctx.limit: "{{ workload.limit }}"
+      ctx.collected_events: "{{ workload.collected_events }}"
+      ctx.has_more: "{{ workload.has_more }}"
     next:
       spec:
         mode: exclusive
@@ -85,9 +85,9 @@ workflow:
             'total_collected': len(all_events)
         }
     set:
-      collected_events: "{{ check_pagination.collected_events }}"
-      cursor: "{{ check_pagination.next_cursor }}"
-      has_more: "{{ check_pagination.has_more }}"
+      ctx.collected_events: "{{ check_pagination.collected_events }}"
+      ctx.cursor: "{{ check_pagination.next_cursor }}"
+      ctx.has_more: "{{ check_pagination.has_more }}"
     next:
       spec:
         mode: exclusive

--- a/tests/fixtures/playbooks/pagination/fetch_load_test/test_fetch_load.yaml
+++ b/tests/fixtures/playbooks/pagination/fetch_load_test/test_fetch_load.yaml
@@ -67,8 +67,8 @@ workflow:
         - patients
         - count
     set:
-      patients: "{{ generate_patients.patients }}"
-      patient_count: "{{ generate_patients.count }}"
+      ctx.patients: "{{ generate_patients.patients }}"
+      ctx.patient_count: "{{ generate_patients.count }}"
     next:
       spec:
         mode: exclusive
@@ -94,9 +94,9 @@ workflow:
                   then:
                     do: continue
                     set:
-                      page: 1
-                      pages_fetched: 0
-                      records_fetched: 0
+                      iter.page: 1
+                      iter.pages_fetched: 0
+                      iter.records_fetched: 0
       - name: fetch_page
         kind: http
         method: GET
@@ -118,16 +118,16 @@ workflow:
                 then:
                   do: continue
                   set:
-                    has_more: false
+                    iter.has_more: false
               - when: "{{ output.status == 'error' }}"
                 then: { do: retry, attempts: 3, backoff: exponential, delay: 5.0 }
               - else:
                   then:
                     do: continue
                     set:
-                      has_more: "{{ output.data.meta.page < output.data.meta.totalPages }}"
-                      pages_fetched: "{{ (iter.pages_fetched | int) + 1 }}"
-                      records_fetched: "{{ (iter.records_fetched | int) + (output.data.entry | length) }}"
+                      iter.has_more: "{{ output.data.meta.page < output.data.meta.totalPages }}"
+                      iter.pages_fetched: "{{ (iter.pages_fetched | int) + 1 }}"
+                      iter.records_fetched: "{{ (iter.records_fetched | int) + (output.data.entry | length) }}"
       - name: paginate
         kind: noop
         spec:
@@ -138,7 +138,7 @@ workflow:
                   do: jump
                   to: fetch_page
                   set:
-                    page: "{{ (iter.page | int) + 1 }}"
+                    iter.page: "{{ (iter.page | int) + 1 }}"
               - else:
                   then: { do: continue }
       - name: save_result

--- a/tests/fixtures/playbooks/pagination/loop_with_pagination/test_loop_with_pagination.yaml
+++ b/tests/fixtures/playbooks/pagination/loop_with_pagination/test_loop_with_pagination.yaml
@@ -39,9 +39,9 @@ workflow:
       \ TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP\n);\nDELETE FROM pagination_test_results\
       \ WHERE execution_id = {{ execution_id }};\nSELECT 'Table ready' as status;\n"
   set:
-    current_endpoint_index: '{{ workload.current_endpoint_index }}'
-    current_page: '{{ workload.current_page }}'
-    current_endpoint: '{{ workload.current_endpoint }}'
+    ctx.current_endpoint_index: '{{ workload.current_endpoint_index }}'
+    ctx.current_page: '{{ workload.current_page }}'
+    ctx.current_endpoint: '{{ workload.current_endpoint }}'
   next:
     spec:
       mode: exclusive
@@ -61,8 +61,8 @@ workflow:
       \        'index': endpoint_index\n    }\nelse:\n    result = {\n        'has_more_endpoints':\
       \ False,\n        'endpoint': None,\n        'index': endpoint_index\n    }\n"
   set:
-    current_endpoint: '{{ init_endpoint_loop.endpoint }}'
-    current_page: 1
+    ctx.current_endpoint: '{{ init_endpoint_loop.endpoint }}'
+    ctx.current_page: 1
   next:
     spec:
       mode: exclusive
@@ -128,7 +128,7 @@ workflow:
       \    'has_more': paging.get('hasMore', False),\n    'current_page': paging.get('page',\
       \ 1)\n}\n"
   set:
-    current_page: '{{ (ctx.current_page | int) + 1 }}'
+    ctx.current_page: '{{ (ctx.current_page | int) + 1 }}'
   next:
     spec:
       mode: exclusive
@@ -145,7 +145,7 @@ workflow:
 
       '
   set:
-    current_endpoint_index: '{{ (ctx.current_endpoint_index | int) + 1 }}'
+    ctx.current_endpoint_index: '{{ (ctx.current_endpoint_index | int) + 1 }}'
   next:
     spec:
       mode: exclusive

--- a/tests/fixtures/playbooks/pagination/max_iterations/test_pagination_max_iterations.yaml
+++ b/tests/fixtures/playbooks/pagination/max_iterations/test_pagination_max_iterations.yaml
@@ -20,11 +20,11 @@ workflow:
 
       '
   set:
-    current_page: '{{ workload.current_page }}'
-    page_size: '{{ workload.page_size }}'
-    max_iterations: '{{ workload.max_iterations }}'
-    iteration_count: '{{ workload.iteration_count }}'
-    collected_data: '{{ workload.collected_data }}'
+    ctx.current_page: '{{ workload.current_page }}'
+    ctx.page_size: '{{ workload.page_size }}'
+    ctx.max_iterations: '{{ workload.max_iterations }}'
+    ctx.iteration_count: '{{ workload.iteration_count }}'
+    ctx.collected_data: '{{ workload.collected_data }}'
   next:
     spec:
       mode: exclusive
@@ -67,9 +67,9 @@ workflow:
       \    'has_more': paging.get('hasMore', False),\n    'current_page': paging.get('page',\
       \ 1)\n}\n"
   set:
-    collected_data: '{{ fetch_with_limit.collected_data }}'
-    current_page: '{{ (ctx.current_page | int) + 1 }}'
-    iteration_count: '{{ (ctx.iteration_count | int) + 1 }}'
+    ctx.collected_data: '{{ fetch_with_limit.collected_data }}'
+    ctx.current_page: '{{ (ctx.current_page | int) + 1 }}'
+    ctx.iteration_count: '{{ (ctx.iteration_count | int) + 1 }}'
   next:
     spec:
       mode: exclusive

--- a/tests/fixtures/playbooks/pagination/offset/test_pagination_offset.yaml
+++ b/tests/fixtures/playbooks/pagination/offset/test_pagination_offset.yaml
@@ -21,10 +21,10 @@ workflow:
       code: |
         result = {"status": "initialized"}
     set:
-      offset: "{{ workload.offset }}"
-      limit: "{{ workload.limit }}"
-      collected_users: "{{ workload.collected_users }}"
-      has_more: "{{ workload.has_more }}"
+      ctx.offset: "{{ workload.offset }}"
+      ctx.limit: "{{ workload.limit }}"
+      ctx.collected_users: "{{ workload.collected_users }}"
+      ctx.has_more: "{{ workload.has_more }}"
     next:
       spec:
         mode: exclusive
@@ -87,9 +87,9 @@ workflow:
             'total_collected': len(all_users)
         }
     set:
-      collected_users: "{{ check_pagination.collected_users }}"
-      offset: "{{ check_pagination.next_offset }}"
-      has_more: "{{ check_pagination.has_more }}"
+      ctx.collected_users: "{{ check_pagination.collected_users }}"
+      ctx.offset: "{{ check_pagination.next_offset }}"
+      ctx.has_more: "{{ check_pagination.has_more }}"
     next:
       spec:
         mode: exclusive

--- a/tests/fixtures/playbooks/pagination/pipeline/test_pagination_pipeline.yaml
+++ b/tests/fixtures/playbooks/pagination/pipeline/test_pagination_pipeline.yaml
@@ -38,10 +38,10 @@ workflow:
     code: "result = {\n  \"status\": \"initialized\",\n  \"message\": \"Starting pagination\
       \ pipeline test\"\n}\n"
   set:
-    current_page: '{{ workload.current_page }}'
-    page_size: '{{ workload.page_size }}'
-    total_fetched: '{{ workload.total_fetched }}'
-    all_pages_done: '{{ workload.all_pages_done }}'
+    ctx.current_page: '{{ workload.current_page }}'
+    ctx.page_size: '{{ workload.page_size }}'
+    ctx.total_fetched: '{{ workload.total_fetched }}'
+    ctx.all_pages_done: '{{ workload.all_pages_done }}'
   next:
     spec:
       mode: exclusive
@@ -173,7 +173,7 @@ workflow:
       : current_page,\n  \"total_fetched\": total_fetched,\n  \"action\": \"continue\"\
       \ if has_more else \"complete\"\n}\n"
   set:
-    current_page: '{{ (ctx.current_page | int) + 1 }}'
+    ctx.current_page: '{{ (ctx.current_page | int) + 1 }}'
   next:
     spec:
       mode: exclusive

--- a/tests/fixtures/playbooks/pagination/pipeline/test_pipeline_error_handling.yaml
+++ b/tests/fixtures/playbooks/pagination/pipeline/test_pipeline_error_handling.yaml
@@ -33,8 +33,8 @@ workflow:
       \ \"retry_on_500\",\n    \"retry_on_rate_limit\",\n    \"skip_transform_error\"\
       ,\n    \"fail_on_auth_error\"\n  ]\n}\n"
   set:
-    test_results: '{{ workload.test_results }}'
-    current_test: '{{ workload.current_test }}'
+    ctx.test_results: '{{ workload.test_results }}'
+    ctx.current_test: '{{ workload.current_test }}'
   next:
     spec:
       mode: exclusive

--- a/tests/fixtures/playbooks/pagination/pipeline/test_pipeline_heavy_payload.yaml
+++ b/tests/fixtures/playbooks/pagination/pipeline/test_pipeline_heavy_payload.yaml
@@ -36,9 +36,9 @@ workflow:
       \    \"page_size\": {{ page_size }},\n    \"estimated_kb_per_page\": {{ payload_kb_per_item\
       \ }} * {{ page_size }}\n  }\n}\n"
   set:
-    current_page: '{{ workload.current_page }}'
-    pages_processed: '{{ workload.pages_processed }}'
-    total_bytes_processed: '{{ workload.total_bytes_processed }}'
+    ctx.current_page: '{{ workload.current_page }}'
+    ctx.pages_processed: '{{ workload.pages_processed }}'
+    ctx.total_bytes_processed: '{{ workload.total_bytes_processed }}'
   next:
     spec:
       mode: exclusive
@@ -133,9 +133,9 @@ workflow:
             then:
               do: continue
               set:
-                current_page: '{{ (ctx.current_page | int) + 1 }}'
-                pages_processed: '{{ (ctx.pages_processed | int) + 1 }}'
-                total_bytes_processed: '{{ update_progress.total_bytes_processed }}'
+                ctx.current_page: '{{ (ctx.current_page | int) + 1 }}'
+                ctx.pages_processed: '{{ (ctx.pages_processed | int) + 1 }}'
+                ctx.total_bytes_processed: '{{ update_progress.total_bytes_processed }}'
   next:
     spec:
       mode: exclusive

--- a/tests/fixtures/playbooks/pagination/pipeline_v2/test_pagination_pipeline_v2.yaml
+++ b/tests/fixtures/playbooks/pagination/pipeline_v2/test_pagination_pipeline_v2.yaml
@@ -38,10 +38,10 @@ workflow:
     code: "result = {\n  \"status\": \"initialized\",\n  \"message\": \"Starting pagination\
       \ test with tool.spec.policy.rules flow control\"\n}\n"
   set:
-    current_page: '{{ workload.current_page }}'
-    page_size: '{{ workload.page_size }}'
-    total_fetched: '{{ workload.total_fetched }}'
-    all_pages_done: '{{ workload.all_pages_done }}'
+    ctx.current_page: '{{ workload.current_page }}'
+    ctx.page_size: '{{ workload.page_size }}'
+    ctx.total_fetched: '{{ workload.total_fetched }}'
+    ctx.all_pages_done: '{{ workload.all_pages_done }}'
   next:
     spec:
       mode: exclusive
@@ -173,7 +173,7 @@ workflow:
       : current_page,\n  \"total_fetched\": total_fetched,\n  \"action\": \"continue\"\
       \ if has_more else \"complete\"\n}\n"
   set:
-    current_page: '{{ (ctx.current_page | int) + 1 }}'
+    ctx.current_page: '{{ (ctx.current_page | int) + 1 }}'
   next:
     spec:
       mode: exclusive

--- a/tests/fixtures/playbooks/pagination/retry/test_pagination_retry.yaml
+++ b/tests/fixtures/playbooks/pagination/retry/test_pagination_retry.yaml
@@ -18,9 +18,9 @@ workflow:
 
       '
   set:
-    current_page: '{{ workload.current_page }}'
-    page_size: '{{ workload.page_size }}'
-    collected_data: '{{ workload.collected_data }}'
+    ctx.current_page: '{{ workload.current_page }}'
+    ctx.page_size: '{{ workload.page_size }}'
+    ctx.collected_data: '{{ workload.collected_data }}'
   next:
     spec:
       mode: exclusive
@@ -69,8 +69,8 @@ workflow:
       \    'has_more': paging.get('hasMore', False),\n    'current_page': paging.get('page',\
       \ 1)\n}\n"
   set:
-    collected_data: '{{ fetch_with_retry.collected_data }}'
-    current_page: '{{ (ctx.current_page | int) + 1 }}'
+    ctx.collected_data: '{{ fetch_with_retry.collected_data }}'
+    ctx.current_page: '{{ (ctx.current_page | int) + 1 }}'
   next:
     spec:
       mode: exclusive

--- a/tests/fixtures/playbooks/playbook_composition/playbook_composition.yaml
+++ b/tests/fixtures/playbooks/playbook_composition/playbook_composition.yaml
@@ -32,7 +32,7 @@ workflow:
   desc: Initialize user profile processing
   tool:
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "initialized"}
 
       '
@@ -68,7 +68,7 @@ workflow:
     task: process_users
     path: tests/fixtures/playbooks/playbook_composition/user_profile_scorer
     return_step: finalize_result
-    args:
+    input:
       user_data: '{{ user }}'
       execution_context: '{{ execution_id }}'
   - name: store_result
@@ -90,7 +90,7 @@ workflow:
   desc: Validate all profile scores are within expected range and categories are correct
   tool:
     kind: python
-    args:
+    input:
       user_results: '{{ process_users.data }}'
       expected_min_score: 0.0
       expected_max_score: 100.0
@@ -148,7 +148,7 @@ workflow:
   desc: Complete profile processing pipeline
   tool:
     kind: python
-    args:
+    input:
       validation_result: '{{ validate_results.data }}'
       user_count: '{{ users | length }}'
     code: "# Be robust to unexpected types (e.g., during early tracking states)\n\

--- a/tests/fixtures/playbooks/playbook_composition/user_profile_scorer.yaml
+++ b/tests/fixtures/playbooks/playbook_composition/user_profile_scorer.yaml
@@ -22,7 +22,7 @@ workbook:
   - name: calculate_experience_score
     tool:
       kind: python
-      args:
+      input:
         years_experience: null
       assert:
         expects:
@@ -52,7 +52,7 @@ workbook:
   - name: calculate_performance_score
     tool:
       kind: python
-      args:
+      input:
         performance_rating: null
       assert:
         expects:
@@ -74,7 +74,7 @@ workbook:
   - name: calculate_department_score
     tool:
       kind: python
-      args:
+      input:
         department: null
       assert:
         expects:
@@ -104,7 +104,7 @@ workbook:
   - name: calculate_age_factor
     tool:
       kind: python
-      args:
+      input:
         age: null
       assert:
         expects:
@@ -134,7 +134,7 @@ workbook:
   - name: determine_category
     tool:
       kind: python
-      args:
+      input:
         profile_score: null
         years_experience: null
       assert:
@@ -164,7 +164,7 @@ workflow:
     desc: "Begin user profile scoring"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -177,7 +177,7 @@ workflow:
     desc: "Extract and validate user data from input"
     tool:
       kind: python
-      args:
+      input:
         input_data: "{{ user_data | default({'name': 'TestUser', 'age': 30, 'department': 'Engineering', 'years_experience': 5, 'performance_rating': 4.0}) }}"
       code: |
         # input_data comes directly as a dict from workload
@@ -208,7 +208,7 @@ workflow:
     tool:
       kind: workbook
       name: calculate_experience_score
-      args:
+      input:
         years_experience: "{{ extract_user_data.years_experience }}"
     next:
       spec:
@@ -221,7 +221,7 @@ workflow:
     tool:
       kind: workbook
       name: calculate_performance_score
-      args:
+      input:
         performance_rating: "{{ extract_user_data.performance_rating }}"
     next:
       spec:
@@ -234,7 +234,7 @@ workflow:
     tool:
       kind: workbook
       name: calculate_department_score
-      args:
+      input:
         department: "{{ extract_user_data.department }}"
     next:
       spec:
@@ -247,7 +247,7 @@ workflow:
     tool:
       kind: workbook
       name: calculate_age_factor
-      args:
+      input:
         age: "{{ extract_user_data.age }}"
     next:
       spec:
@@ -259,7 +259,7 @@ workflow:
     desc: "Compute weighted total profile score"
     tool:
       kind: python
-      args:
+      input:
         user_name: "{{ extract_user_data.user_name }}"
         experience_data: "{{ score_experience }}"
         performance_data: "{{ score_performance }}"
@@ -305,7 +305,7 @@ workflow:
     tool:
       kind: workbook
       name: determine_category
-      args:
+      input:
         profile_score: "{{ compute_total_score.profile_score }}"
         years_experience: "{{ extract_user_data.years_experience }}"
     next:
@@ -318,7 +318,7 @@ workflow:
     desc: "Prepare final result for parent playbook"
     tool:
       kind: python
-      args:
+      input:
         score_data: "{{ compute_total_score }}"
         category_data: "{{ determine_score_category }}"
         execution_context: "{{ execution_context }}"

--- a/tests/fixtures/playbooks/postgres_excel_gcs_test/postgres_excel_gcs_test.yaml
+++ b/tests/fixtures/playbooks/postgres_excel_gcs_test/postgres_excel_gcs_test.yaml
@@ -91,7 +91,7 @@ workflow:
           import: storage
         io: io
         os: os
-      args:
+      input:
         bucket: "{{ gcs_bucket }}"
         prefix: "exports/{{ output_filename }}"
         output_filename: "{{ output_filename }}"

--- a/tests/fixtures/playbooks/python_psycopg/http_to_postgres_bulk/http_to_postgres_bulk_python.yaml
+++ b/tests/fixtures/playbooks/python_psycopg/http_to_postgres_bulk/http_to_postgres_bulk_python.yaml
@@ -19,7 +19,7 @@ workflow:
     desc: Start workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -68,7 +68,7 @@ workflow:
       kind: python
       libs:
         psycopg: psycopg
-      args:
+      input:
         http_data: "{{ fetch_http_data }}"
         pg_host: "{{ pg_host }}"
         pg_port: "{{ pg_port }}"
@@ -137,6 +137,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/quantum_cudaq/quantum_cudaq.yaml
+++ b/tests/fixtures/playbooks/quantum_cudaq/quantum_cudaq.yaml
@@ -61,7 +61,7 @@ workflow:
                 then: { allow: false }
     tool:
       kind: python
-      args:
+      input:
         sweeps: "{{ sweeps }}"
         tags: "{{ tags }}"
       code: |
@@ -79,9 +79,9 @@ workflow:
             - else:
                 then:
                   do: continue
-                  set_ctx:
-                    simulations: []
-                    ai_notes: []
+                  set:
+                    ctx.simulations: []
+                    ctx.ai_notes: []
     next:
       spec:
         mode: exclusive
@@ -100,26 +100,26 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' and outcome.http.status in [429, 500, 502, 503] }}"
+            - when: "{{ output.status == 'error' and output.http.status in [429, 500, 502, 503] }}"
               then:
                 do: retry
                 attempts: 3
                 delay: 1.5
                 backoff: exponential
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: continue
-                set_ctx:
-                  problem_spec:
+                set:
+                  ctx.problem_spec:
                     id: "fallback-maxcut"
                     qubits: 2
                     default_depth: 2
-                  ai_notes: "{{ (ctx.ai_notes or []) + ['Problem catalog unavailable; using fallback problem spec'] }}"
+                  ctx.ai_notes: "{{ (ctx.ai_notes or []) + ['Problem catalog unavailable; using fallback problem spec'] }}"
             - else:
                 then:
                   do: continue
-                  set_ctx:
-                    problem_spec: "{{ outcome.data }}"
+                  set:
+                    ctx.problem_spec: "{{ output.data }}"
     next:
       spec:
         mode: exclusive
@@ -131,7 +131,7 @@ workflow:
     desc: Build CUDA-Q kernel template and parameter sweep plan
     tool:
       kind: python
-      args:
+      input:
         problem: "{{ ctx.problem_spec or {} }}"
         sweeps: "{{ sweeps }}"
       code: |
@@ -181,10 +181,10 @@ workflow:
             - else:
                 then:
                   do: continue
-                  set_ctx:
-                    kernel_source: "{{ outcome.result.kernel_source }}"
-                    run_plan: "{{ outcome.result.run_plan }}"
-                    qubits: "{{ outcome.result.qubits }}"
+                  set:
+                    ctx.kernel_source: "{{ output.data.kernel_source }}"
+                    ctx.run_plan: "{{ output.data.run_plan }}"
+                    ctx.qubits: "{{ output.data.qubits }}"
     next:
       spec:
         mode: exclusive
@@ -206,7 +206,7 @@ workflow:
             preserve_order: true
     tool:
       kind: python
-      args:
+      input:
         kernel_source: "{{ ctx.kernel_source }}"
         run_config: "{{ iter.run }}"
         cudaq_target: "{{ cudaq_target }}"
@@ -251,7 +251,7 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: retry
                 attempts: 2
@@ -260,8 +260,8 @@ workflow:
             - else:
                 then:
                   do: continue
-                  set_ctx:
-                    simulations: "{{ (ctx.simulations or []) + [outcome.result] }}"
+                  set:
+                    ctx.simulations: "{{ (ctx.simulations or []) + [output.data] }}"
     next:
       spec:
         mode: exclusive
@@ -273,7 +273,7 @@ workflow:
     desc: Summarize quantum outcomes with AI Meta agent context
     tool:
       kind: python
-      args:
+      input:
         simulations: "{{ ctx.simulations }}"
         ai_review_prompt: "{{ ai_review_prompt }}"
         enable_ai_review: "{{ enable_ai_review }}"
@@ -331,15 +331,15 @@ workflow:
         VALUES (
           '{{ problem_id }}',
           '{{ cudaq_target }}',
-          {{ ai_analysis.result.aggregates.runs }},
+          {{ ai_analysis.data.aggregates.runs }},
           jsonb_build_object(
-            'run_count', {{ ai_analysis.result.aggregates.runs }},
-            'average_expectation', {{ ai_analysis.result.aggregates.average_expectation }},
-            'best_run_id', '{{ ai_analysis.result.aggregates.best_run.run_id }}'
+            'run_count', {{ ai_analysis.data.aggregates.runs }},
+            'average_expectation', {{ ai_analysis.data.aggregates.average_expectation }},
+            'best_run_id', '{{ ai_analysis.data.aggregates.best_run.run_id }}'
           ),
           jsonb_build_object(
             'agent', '{{ analysis_agent }}',
-            'insights', '{{ ai_analysis.result.summary.insights | tojson | replace("'", "''") }}'::jsonb
+            'insights', '{{ ai_analysis.data.summary.insights | tojson | replace("'", "''") }}'::jsonb
           ),
           NOW()
         )
@@ -351,16 +351,16 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: continue
-                set_ctx:
-                  ai_notes: "{{ (ctx.ai_notes or []) + ['Postgres persistence failed'] }}"
+                set:
+                  ctx.ai_notes: "{{ (ctx.ai_notes or []) + ['Postgres persistence failed'] }}"
             - else:
                 then:
                   do: continue
-                  set_ctx:
-                    ai_notes: "{{ (ctx.ai_notes or []) + ['Postgres persistence succeeded'] }}"
+                  set:
+                    ctx.ai_notes: "{{ (ctx.ai_notes or []) + ['Postgres persistence succeeded'] }}"
     next:
       spec:
         mode: exclusive
@@ -382,27 +382,27 @@ workflow:
       body:
         problem_id: "{{ problem_id }}"
         target: "{{ cudaq_target }}"
-        ai_summary: "{{ ai_analysis.result.summary }}"
-        aggregates: "{{ ai_analysis.result.aggregates }}"
+        ai_summary: "{{ ai_analysis.data.summary }}"
+        aggregates: "{{ ai_analysis.data.aggregates }}"
         simulations: "{{ ctx.simulations }}"
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' and outcome.http.status in [408, 500, 503] }}"
+            - when: "{{ output.status == 'error' and output.http.status in [408, 500, 503] }}"
               then:
                 do: retry
                 attempts: 2
                 delay: 2
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: continue
-                set_ctx:
-                  ai_notes: "{{ (ctx.ai_notes or []) + ['HTTP dispatch failed'] }}"
+                set:
+                  ctx.ai_notes: "{{ (ctx.ai_notes or []) + ['HTTP dispatch failed'] }}"
             - else:
                 then:
                   do: continue
-                  set_ctx:
-                    ai_notes: "{{ (ctx.ai_notes or []) + ['Dispatch accepted'] }}"
+                  set:
+                    ctx.ai_notes: "{{ (ctx.ai_notes or []) + ['Dispatch accepted'] }}"
     next:
       spec:
         mode: exclusive
@@ -416,7 +416,7 @@ workflow:
     desc: Finalize orchestration and emit execution digest
     tool:
       kind: python
-      args:
+      input:
         simulations: "{{ ctx.simulations }}"
         ai_notes: "{{ ctx.ai_notes }}"
       code: |

--- a/tests/fixtures/playbooks/regression_test/create_test_schema.yaml
+++ b/tests/fixtures/playbooks/regression_test/create_test_schema.yaml
@@ -14,7 +14,7 @@ workflow:
     desc: "Start schema creation"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -133,7 +133,7 @@ workflow:
     desc: "Schema creation completed"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {
             "status": "success",

--- a/tests/fixtures/playbooks/regression_test/master_regression_test.yaml
+++ b/tests/fixtures/playbooks/regression_test/master_regression_test.yaml
@@ -37,7 +37,7 @@ workflow:
     desc: "Start regression test suite - 53 playbooks (4 skipped)"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -800,7 +800,7 @@ workflow:
     desc: "Regression test suite completed"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         print("=== Regression test suite completed - 53 playbooks tested (4 skipped) ===")
         result = {"status": "success", "data": {"tests_run": 53, "skipped": 4}}

--- a/tests/fixtures/playbooks/regression_test/master_regression_test_parallel.yaml
+++ b/tests/fixtures/playbooks/regression_test/master_regression_test_parallel.yaml
@@ -97,7 +97,7 @@ workflow:
     desc: "Start parallel regression test suite - 51 playbooks (4 skipped)"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         print(f"Starting parallel regression test suite")
         print(f"Total playbooks: 51 (4 skipped)")
@@ -207,7 +207,7 @@ workflow:
     desc: "Regression test suite completed"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         print("=== Parallel regression test suite completed ===")
         print("Total playbooks: 51 (4 skipped)")

--- a/tests/fixtures/playbooks/retry_test/duckdb_retry_query.yaml
+++ b/tests/fixtures/playbooks/retry_test/duckdb_retry_query.yaml
@@ -12,7 +12,7 @@ workflow:
   - step: start
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -29,7 +29,7 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then: { do: retry, attempts: 3, delay: 0.5, backoff: exponential }
             - else:
                 then: { do: continue }
@@ -43,6 +43,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/retry_test/http_retry_status_code.yaml
+++ b/tests/fixtures/playbooks/retry_test/http_retry_status_code.yaml
@@ -18,9 +18,9 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.http.status in [500, 502, 503] }}"
+            - when: "{{ output.http.status in [500, 502, 503] }}"
               then: { do: retry, attempts: 3, delay: 0.5, backoff: exponential }
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then: { do: fail }
             - else:
                 then: { do: continue }
@@ -34,6 +34,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/retry_test/http_retry_with_stop.yaml
+++ b/tests/fixtures/playbooks/retry_test/http_retry_with_stop.yaml
@@ -18,9 +18,9 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.http.status in [500, 502, 503] }}"
+            - when: "{{ output.http.status in [500, 502, 503] }}"
               then: { do: retry, attempts: 3, delay: 0.5, backoff: exponential }
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then: { do: fail }
             - else:
                 then: { do: continue }
@@ -34,6 +34,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/retry_test/postgres_retry_connection.yaml
+++ b/tests/fixtures/playbooks/retry_test/postgres_retry_connection.yaml
@@ -19,7 +19,7 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then: { do: retry, attempts: 3, delay: 1.0, backoff: exponential }
             - else:
                 then: { do: continue }
@@ -33,6 +33,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/retry_test/python_retry_exception.yaml
+++ b/tests/fixtures/playbooks/retry_test/python_retry_exception.yaml
@@ -15,7 +15,7 @@ workflow:
       kind: python
       libs:
         random: random
-      args: {}
+      input: {}
       code: |
         # Simulate random failures for testing retry
         rand_val = random.randint(1, 100)
@@ -31,7 +31,7 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then: { do: retry, attempts: 5, delay: 0.2, backoff: exponential }
             - else:
                 then: { do: continue }
@@ -45,6 +45,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/retry_test/retry_simple_config.yaml
+++ b/tests/fixtures/playbooks/retry_test/retry_simple_config.yaml
@@ -14,7 +14,7 @@ workflow:
     desc: Initialize retry tests
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -35,9 +35,9 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.http.status in [500, 502, 503] }}"
+            - when: "{{ output.http.status in [500, 502, 503] }}"
               then: { do: retry, attempts: 3, delay: 0.5 }
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then: { do: fail }
             - else:
                 then: { do: continue }
@@ -59,9 +59,9 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.http.status in [500, 502, 503] }}"
+            - when: "{{ output.http.status in [500, 502, 503] }}"
               then: { do: retry, attempts: 5, delay: 0.5 }
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then: { do: fail }
             - else:
                 then: { do: continue }
@@ -83,9 +83,9 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.http.status in [500, 502, 503] }}"
+            - when: "{{ output.http.status in [500, 502, 503] }}"
               then: { do: retry, attempts: 3, backoff: exponential, delay: 0.5 }
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then: { do: fail }
             - else:
                 then: { do: continue }
@@ -99,6 +99,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/root_scripts/test_implicit_end_routing.yaml
+++ b/tests/fixtures/playbooks/root_scripts/test_implicit_end_routing.yaml
@@ -9,7 +9,7 @@ workflow:
     desc: Start workflow - router only
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "started"}
     next:
@@ -22,7 +22,7 @@ workflow:
     desc: Execute step1 - NO next field, should implicitly route to end
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "step1_complete"}
 
@@ -32,6 +32,6 @@ workflow:
     desc: End step - aggregates all workflow results
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "workflow_complete"}

--- a/tests/fixtures/playbooks/root_scripts/test_keychain.yaml
+++ b/tests/fixtures/playbooks/root_scripts/test_keychain.yaml
@@ -5,9 +5,9 @@ metadata:
   path: tests/keychain_test
 
 workload:
-  openai_key: "{{ args.openai_key | default('sk-default-key') }}"
-  amadeus_client_id: "{{ args.amadeus_client_id | default('default-client-id') }}"
-  amadeus_client_secret: "{{ args.amadeus_client_secret | default('default-secret') }}"
+  openai_key: "{{ input.openai_key | default('sk-default-key') }}"
+  amadeus_client_id: "{{ input.amadeus_client_id | default('default-client-id') }}"
+  amadeus_client_secret: "{{ input.amadeus_client_secret | default('default-secret') }}"
 
 keychain:
   - name: openai_token

--- a/tests/fixtures/playbooks/root_scripts/test_script_loading.yaml
+++ b/tests/fixtures/playbooks/root_scripts/test_script_loading.yaml
@@ -18,7 +18,7 @@ workflow:
         source:
           type: inline
           code: "{{ test_code }}"
-      args: {}
+      input: {}
     next:
       spec:
         mode: exclusive
@@ -29,7 +29,7 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args:
+      input:
         result: "{{ result }}"
       code: |
         print(f"Result: {result}")

--- a/tests/fixtures/playbooks/root_scripts/test_simple_loop.yaml
+++ b/tests/fixtures/playbooks/root_scripts/test_simple_loop.yaml
@@ -19,7 +19,7 @@ workflow:
     desc: Start workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "started"}
     next:
@@ -37,7 +37,7 @@ workflow:
       iterator: num
     tool:
       kind: python
-      args:
+      input:
         num: "{{ num }}"
       code: |
         print(f"Processing: {num}")
@@ -56,6 +56,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/save_storage_test/save_all_storage_types.yaml
+++ b/tests/fixtures/playbooks/save_storage_test/save_all_storage_types.yaml
@@ -61,7 +61,7 @@ workbook:
 - name: prepare_http_payload
   tool:
     kind: python
-    args:
+    input:
       input_data: '{{ test_duckdb_analytics }}'
     code: "# Simulate API payload preparation\nduckdb_result = input_data.get(\"data\"\
       , {})\n\napi_payload = {\n    \"webhook_type\": \"test_completion\",\n    \"\
@@ -115,7 +115,7 @@ workflow:
   tool:
   - name: generate_data
     kind: python
-    args:
+    input:
       input: '{{ start }}'
     code: "# Simple pass-through to test flat save structure\nresult = {\n    \"status\"\
       : \"success\",\n    \"data\": {\n        \"message\": \"Flat postgres save test\
@@ -138,7 +138,7 @@ workflow:
   tool:
   - name: generate_data
     kind: python
-    args:
+    input:
       input: '{{ test_flat_postgres_save }}'
     code: "# Simple pass-through to test nested save structure\nresult = {\n    \"\
       status\": \"success\",\n    \"data\": {\n        \"message\": \"Nested postgres\
@@ -163,7 +163,7 @@ workflow:
   tool:
   - name: generate_data
     kind: python
-    args:
+    input:
       input_data: '{{ test_nested_postgres_save }}'
     code: "result = {\n    \"status\": \"success\",\n    \"data\": {\n        \"summary_type\"\
       : \"department_stats\",\n        \"execution_id\": input_data.get(\"execution_id\"\
@@ -185,7 +185,7 @@ workflow:
   desc: Test python storage with custom processing code
   tool:
     kind: python
-    args:
+    input:
       input_data: '{{ test_postgres_statement_save }}'
     code: "result = {\n    \"status\": \"success\",\n    \"data\": {\n        \"processed_records\"\
       : 3,\n        \"validation_status\": \"passed\",\n        \"next_phase\": \"\
@@ -200,7 +200,7 @@ workflow:
   tool:
   - name: generate_data
     kind: python
-    args:
+    input:
       input: '{{ test_python_save }}'
     code: "result = {\n    \"status\": \"success\",\n    \"data\": {\n        \"analysis_type\"\
       : \"department_summary\",\n        \"test_type\": \"duckdb_analytics\"\n   \
@@ -224,7 +224,7 @@ workflow:
   desc: Test HTTP storage with webhook notification
   tool:
     kind: python
-    args:
+    input:
       input: '{{ test_duckdb_save }}'
     code: "result = {\n    \"status\": \"success\",\n    \"data\": {\n        \"webhook_type\"\
       : \"test_completion\",\n        \"test_type\": \"http_webhook\"\n    }\n}\n"
@@ -239,7 +239,7 @@ workflow:
     kind: python
     libs:
       json: json
-    args:
+    input:
       input_data: '{{ test_http_save }}'
     code: "summary = {\n    \"test_suite\": \"save_storage_comprehensive\",\n    \"\
       execution_id\": input_data.get(\"execution_id\", \"unknown\"),\n    \"storage_types_tested\"\

--- a/tests/fixtures/playbooks/save_storage_test/save_delegation_test.yaml
+++ b/tests/fixtures/playbooks/save_storage_test/save_delegation_test.yaml
@@ -25,7 +25,7 @@ workflow:
   tool:
     kind: playbook
     path: tests/fixtures/playbooks/save_storage_test/create_tables
-    args:
+    input:
       pg_auth: '{{ pg_auth }}'
   next:
     spec:

--- a/tests/fixtures/playbooks/save_storage_test/save_edge_cases.yaml
+++ b/tests/fixtures/playbooks/save_storage_test/save_edge_cases.yaml
@@ -42,7 +42,7 @@ workflow:
       Decimal:
         from: decimal
         import: Decimal
-    args:
+    input:
       input_data: {}
     code: "mixed_data = {\n  \"string_field\": \"test_string\",\n  \"integer_field\"\
       : 12345,\n  \"float_field\": 3.14159,\n  \"boolean_field\": True,\n  \"null_field\"\
@@ -73,7 +73,7 @@ workflow:
   tool:
   - name: generate_special
     kind: python
-    args:
+    input:
       input_data: '{{ test_mixed_types }}'
     code: "special_data = {\n    \"quotes\": \"This has 'single' and \\\"double\\\"\
       \ quotes\",\n    \"unicode\": \"Unicode: alphabetagammadeltaepsilon, zhongwen,\
@@ -100,7 +100,7 @@ workflow:
   desc: Test save with empty and null data
   tool:
     kind: python
-    args:
+    input:
       input_data: '{{ test_special_characters }}'
     code: "empty_scenarios = {\n    \"empty_string\": \"\",\n    \"empty_list\": [],\n\
       \    \"empty_dict\": {},\n    \"zero_value\": 0,\n    \"false_value\": False,\n\
@@ -115,7 +115,7 @@ workflow:
   tool:
   - name: generate_large
     kind: python
-    args:
+    input:
       input_data: '{{ test_empty_data }}'
     code: "# Generate moderately large dataset\nlarge_data = {\n    \"metadata\":\
       \ {\n        \"test_type\": \"large_payload\",\n        \"record_count\": 100\n\

--- a/tests/fixtures/playbooks/save_storage_test/save_simple_test.yaml
+++ b/tests/fixtures/playbooks/save_storage_test/save_simple_test.yaml
@@ -29,7 +29,7 @@ workflow:
   tool:
     kind: playbook
     path: tests/fixtures/playbooks/save_storage_test/create_tables
-    args:
+    input:
       pg_auth: '{{ pg_auth }}'
   next:
     spec:
@@ -92,7 +92,7 @@ workflow:
     kind: python
     libs:
       json: json
-    args:
+    input:
       test_data_value: '{{ test_data.value }}'
     code: "# Receive test_data_value as an argument\ntest_data = {\n    \"value\"\
       : test_data_value,\n    \"nested_indicator\": True,\n    \"test_type\": \"nested_structure\"\

--- a/tests/fixtures/playbooks/script_execution/k8s_job_python_gcs.yaml
+++ b/tests/fixtures/playbooks/script_execution/k8s_job_python_gcs.yaml
@@ -21,7 +21,7 @@ workflow:
     desc: Start Kubernetes job workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized", "message": "Starting K8s job workflow"}
     next:
@@ -39,7 +39,7 @@ workflow:
         source:
           type: gcs
           auth: "{{ gcp_credential }}"
-      args:
+      input:
         input_file: "{{ input_data }}"
         output_bucket: "{{ output_bucket }}"
         mode: "batch"
@@ -73,7 +73,7 @@ workflow:
       kind: python
       libs:
         json: json
-      args:
+      input:
         job_result: "{{ run_script_as_k8s_job }}"
       code: |
         print("=" * 80)
@@ -114,6 +114,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/script_execution/postgres_file_example.yaml
+++ b/tests/fixtures/playbooks/script_execution/postgres_file_example.yaml
@@ -13,7 +13,7 @@ workflow:
     desc: Start workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -67,6 +67,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/script_execution/postgres_s3_example.yaml
+++ b/tests/fixtures/playbooks/script_execution/postgres_s3_example.yaml
@@ -15,7 +15,7 @@ workflow:
     desc: Start workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -72,6 +72,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/script_execution/python_file_example.yaml
+++ b/tests/fixtures/playbooks/script_execution/python_file_example.yaml
@@ -14,7 +14,7 @@ workflow:
     desc: Start workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -31,7 +31,7 @@ workflow:
         uri: "{{ script_path }}"
         source:
           type: file
-      args:
+      input:
         name: "{{ greeting_name }}"
         count: "{{ greeting_count }}"
     next:
@@ -44,7 +44,7 @@ workflow:
     desc: Verify script execution result
     tool:
       kind: python
-      args:
+      input:
         result: "{{ run_python_from_file.data }}"
       code: |
         assert result['status'] == 'success', f"Expected success, got {result['status']}"
@@ -67,6 +67,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/script_execution/python_gcs_example.yaml
+++ b/tests/fixtures/playbooks/script_execution/python_gcs_example.yaml
@@ -14,7 +14,7 @@ workflow:
     desc: Start workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -32,7 +32,7 @@ workflow:
         source:
           type: gcs
           auth: "{{ gcp_credential }}"
-      args:
+      input:
         name: "{{ greeting_name }}"
         count: 2
     next:
@@ -45,7 +45,7 @@ workflow:
     desc: Verify GCS-loaded script executed correctly
     tool:
       kind: python
-      args:
+      input:
         result: "{{ run_python_from_gcs }}"
       code: |
         assert result['status'] == 'success', f"Expected success, got {result['status']}"
@@ -68,6 +68,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/script_execution/python_http_example.yaml
+++ b/tests/fixtures/playbooks/script_execution/python_http_example.yaml
@@ -13,7 +13,7 @@ workflow:
     desc: Start workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "initialized"}
     next:
@@ -33,7 +33,7 @@ workflow:
           endpoint: "{{ script_url }}"
           method: GET
           timeout: 30
-      args:
+      input:
         name: "{{ greeting_name }}"
         count: 2
     next:
@@ -46,7 +46,7 @@ workflow:
     desc: Verify HTTP-fetched script executed correctly
     tool:
       kind: python
-      args:
+      input:
         result: "{{ run_python_from_http }}"
       code: |
         assert result['status'] == 'success', f"Expected success, got {result['status']}"
@@ -68,6 +68,6 @@ workflow:
     desc: End workflow
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "complete"}

--- a/tests/fixtures/playbooks/test_args_passing.yaml
+++ b/tests/fixtures/playbooks/test_args_passing.yaml
@@ -19,17 +19,17 @@ workflow:
       mode: exclusive
     arcs:
     - step: use_vars
-      args:
-        test_var: '{{ initial_value }}'
-        computed: 200
+      set:
+        ctx.test_var: '{{ initial_value }}'
+        ctx.computed: 200
 - step: use_vars
   desc: Test that variables from data block are available
   tool:
   - name: compute
     kind: python
-    args:
-      test_var: '{{ args.test_var }}'
-      computed: '{{ args.computed }}'
+    input:
+      test_var: '{{ ctx.test_var }}'
+      computed: '{{ ctx.computed }}'
     code: '# These should be available from the args passed via next
 
       test_var = input_data.get(''test_var'', 0)

--- a/tests/fixtures/playbooks/test_end_with_action.yaml
+++ b/tests/fixtures/playbooks/test_end_with_action.yaml
@@ -32,20 +32,19 @@ workflow:
       mode: exclusive
     arcs:
     - step: end
-      args:
-        input_data:
-          temp_table: '{{ process_data.data.temp_table }}'
-          cleanup_required: '{{ cleanup_required }}'
+      set:
+        ctx.temp_table: '{{ process_data.data.temp_table }}'
+        ctx.cleanup_required: '{{ cleanup_required }}'
 - step: end
   desc: End step with cleanup action
   tool:
   - name: cleanup
     kind: python
-    args:
+    input:
       input_data:
-        temp_table: '{{ args.input_data.temp_table | default(process_data.data.temp_table)
+        temp_table: '{{ ctx.temp_table | default(process_data.data.temp_table)
           }}'
-        cleanup_required: '{{ args.input_data.cleanup_required | default(cleanup_required)
+        cleanup_required: '{{ ctx.cleanup_required | default(cleanup_required)
           }}'
     code: "temp_table = input_data.get('temp_table', 'unknown')\ncleanup = input_data.get('cleanup_required',\
       \ False)\n\nresult = {\n    'status': 'completed',\n    'message': f'Cleanup\

--- a/tests/fixtures/playbooks/test_gcs_storage.yaml
+++ b/tests/fixtures/playbooks/test_gcs_storage.yaml
@@ -16,14 +16,14 @@ workflow:
   tool:
   - name: generate_data
     kind: python
-    args:
+    input:
       count: '{{ item_count }}'
       size: '{{ item_size }}'
     code: "items = [{\"id\": i, \"data\": \"G\" * size, \"type\": \"gcs_test\"} for\
       \ i in range(count)]\nresult = {\n    \"status\": \"ok\",\n    \"tier\": \"\
       gcs\",\n    \"count\": len(items),\n    \"total_bytes\": count * size,\n   \
       \ \"items\": items\n}\n"
-  result:
+  output:
     store:
       kind: gcs
     output_select:
@@ -40,7 +40,7 @@ workflow:
   tool:
   - name: verify
     kind: python
-    args:
+    input:
       has_ref: '{{ start._ref is defined }}'
       store_type: '{{ start._store | default(''none'') }}'
       status: '{{ start.status }}'
@@ -62,7 +62,7 @@ workflow:
   - name: load_artifact
     kind: artifact
     action: get
-    args:
+    input:
       result_ref: '{{ start._ref }}'
   next:
     spec:
@@ -73,7 +73,7 @@ workflow:
   tool:
   - name: summarize
     kind: python
-    args:
+    input:
       tier_correct: '{{ verify_gcs_storage.correct_tier }}'
       loaded_count: '{{ load_from_gcs.count | default(0) }}'
       expected_count: '{{ item_count }}'

--- a/tests/fixtures/playbooks/test_gke_lifecycle/test_gke_lifecycle.yaml
+++ b/tests/fixtures/playbooks/test_gke_lifecycle/test_gke_lifecycle.yaml
@@ -36,9 +36,9 @@ workflow:
           echo "Region:   {{ region }}"
           echo "State DB: {{ state_database }}"
           echo ""
-    set_ctx:
-      test_cluster_name: "{{ cluster_name_prefix }}-$(date +%Y%m%d%H%M%S)"
-      test_start_time: "$(date +%s)"
+    set:
+      ctx.test_cluster_name: "{{ cluster_name_prefix }}-$(date +%Y%m%d%H%M%S)"
+      ctx.test_start_time: "$(date +%s)"
     next:
       spec:
         mode: exclusive
@@ -93,9 +93,9 @@ workflow:
       url: https://cloudresourcemanager.googleapis.com/v1/projects/{{ project_id }}
       auth:
         source: adc
-    set_ctx:
-      auth_success: "{{ result.status == 200 }}"
-      project_name: "{{ result.body.name | default('unknown') }}"
+    set:
+      ctx.auth_success: "{{ result.status == 200 }}"
+      ctx.project_name: "{{ result.body.name | default('unknown') }}"
     next:
       spec:
         mode: exclusive
@@ -162,9 +162,9 @@ workflow:
       url: https://container.googleapis.com/v1/projects/{{ project_id }}/locations/{{ region }}/clusters
       auth:
         source: adc
-    set_ctx:
-      list_status: "{{ result.status }}"
-      existing_clusters: "{{ result.body.clusters | default([]) | length }}"
+    set:
+      ctx.list_status: "{{ result.status }}"
+      ctx.existing_clusters: "{{ result.body.clusters | default([]) | length }}"
     next:
       spec:
         mode: exclusive
@@ -218,8 +218,8 @@ workflow:
           created_at
         FROM resources
         WHERE project = '{{ project_id }}';
-    set_ctx:
-      resource_count: "{{ result | length }}"
+    set:
+      ctx.resource_count: "{{ result | length }}"
     next:
       spec:
         mode: exclusive
@@ -287,8 +287,8 @@ workflow:
         SELECT status, current_state, last_synced_at
         FROM resources
         WHERE resource_id = '{{ project_id }}/{{ region }}/{{ ctx.test_cluster_name }}';
-    set_ctx:
-      updated_status: "{{ result[0].status if result else 'not_found' }}"
+    set:
+      ctx.updated_status: "{{ result[0].status if result else 'not_found' }}"
     next:
       spec:
         mode: exclusive
@@ -351,8 +351,8 @@ workflow:
         SELECT COUNT(*) as remaining
         FROM resources
         WHERE resource_id = '{{ project_id }}/{{ region }}/{{ ctx.test_cluster_name }}';
-    set_ctx:
-      remaining_count: "{{ result[0].remaining if result else -1 }}"
+    set:
+      ctx.remaining_count: "{{ result[0].remaining if result else -1 }}"
     next:
       spec:
         mode: exclusive

--- a/tests/fixtures/playbooks/test_large_result_extraction.yaml
+++ b/tests/fixtures/playbooks/test_large_result_extraction.yaml
@@ -23,13 +23,13 @@ workflow:
   tool:
   - name: generate_data
     kind: python
-    args:
+    input:
       count: '{{ item_count }}'
       data_size: '{{ item_data_size }}'
     code: "items = [{\"id\": i, \"data\": \"A\" * data_size, \"active\": True} for\
       \ i in range(count)]\nresult = {\n    \"status\": \"ok\",\n    \"count\": len(items),\n\
       \    \"items\": items,\n    \"metadata\": {\"generated_by\": \"test\"}\n}\n"
-  result:
+  output:
     output_select:
     - status
     - count
@@ -43,7 +43,7 @@ workflow:
   tool:
   - name: verify
     kind: python
-    args:
+    input:
       status: '{{ start.status }}'
       count: '{{ start.count }}'
       has_ref: '{{ start._ref is defined }}'

--- a/tests/fixtures/playbooks/test_loop_instance_isolation/playbook.yaml
+++ b/tests/fixtures/playbooks/test_loop_instance_isolation/playbook.yaml
@@ -47,7 +47,7 @@ workflow:
           "name": user["name"],
           "message": f"Processed user {user['name']}"
         }
-    args:
+    input:
       user: "{{ user }}"
     next:
       spec:
@@ -85,7 +85,7 @@ workflow:
           "name": product["name"],
           "message": f"Processed product {product['name']}"
         }
-    args:
+    input:
       product: "{{ product }}"
     next:
       spec:
@@ -112,7 +112,7 @@ workflow:
           "users_results": users_result,
           "products_results": products_result
         }
-    args:
+    input:
       users_result: "{{ process_items_users }}"
       products_result: "{{ process_items_products }}"
     next:

--- a/tests/fixtures/playbooks/test_output_select.yaml
+++ b/tests/fixtures/playbooks/test_output_select.yaml
@@ -25,7 +25,7 @@ workflow:
   tool:
   - name: generate_data
     kind: python
-    args:
+    input:
       count: '{{ item_count }}'
       size: '{{ item_size }}'
     code: "# Generate large result that exceeds inline threshold (64KB)\nitems = [\n\
@@ -33,7 +33,7 @@ workflow:
       : \"active\"}\n    for i in range(count)\n]\nresult = {\n    \"status\": \"\
       success\",\n    \"count\": len(items),\n    \"total_size\": sum(len(item[\"\
       data\"]) for item in items),\n    \"items\": items\n}\n"
-  result:
+  output:
     store:
       kind: auto
     output_select:
@@ -49,7 +49,7 @@ workflow:
   tool:
   - name: verify
     kind: python
-    args:
+    input:
       status: '{{ start.status }}'
       count: '{{ start.count }}'
       total_size: '{{ start.total_size }}'
@@ -68,7 +68,7 @@ workflow:
   - name: load_artifact
     kind: artifact
     action: get
-    args:
+    input:
       result_ref: '{{ start._ref }}'
   next:
     spec:
@@ -79,7 +79,7 @@ workflow:
   tool:
   - name: process
     kind: python
-    args:
+    input:
       data: '{{ lazy_load_full_data.data }}'
     code: "if isinstance(data, dict) and \"items\" in data:\n    items = data[\"items\"\
       ]\n    active_count = sum(1 for item in items if item.get(\"status\") == \"\
@@ -96,7 +96,7 @@ workflow:
   tool:
   - name: summarize
     kind: python
-    args:
+    input:
       extraction_verified: '{{ verify_extracted_fields.verified }}'
       was_externalized: '{{ verify_extracted_fields.was_externalized }}'
       full_data_processed: '{{ process_full_data.total_items }}'

--- a/tests/fixtures/playbooks/test_start_with_action.yaml
+++ b/tests/fixtures/playbooks/test_start_with_action.yaml
@@ -12,7 +12,7 @@ workflow:
   tool:
   - name: init_action
     kind: python
-    args:
+    input:
       input_data: '{{ workload }}'
     code: "result = {\n    'status': 'success',\n    'message': 'Start step executed\
       \ with action type',\n    'data': {'executed': True, 'input': input_data}\n\
@@ -22,15 +22,15 @@ workflow:
       mode: exclusive
     arcs:
     - step: process
-      args:
-        from_start: '{{ start.data.executed }}'
+      set:
+        ctx.from_start: '{{ start.data.executed }}'
 - step: process
   desc: Process step - executed after start
   tool:
   - name: process_action
     kind: python
-    args:
-      from_start: '{{ args.from_start | default(start.data.executed) }}'
+    input:
+      from_start: '{{ ctx.from_start | default(start.data.executed) }}'
     code: "result = {\n    'status': 'success',\n    'message': 'Process step executed',\n\
       \    'data': {\n        'from_start': from_start,\n        'processed': True\n\
       \    }\n}\n"

--- a/tests/fixtures/playbooks/test_storage_tiers.yaml
+++ b/tests/fixtures/playbooks/test_storage_tiers.yaml
@@ -31,13 +31,13 @@ workflow:
   tool:
   - name: generate_inline
     kind: python
-    args:
+    input:
       count: '{{ inline_items }}'
       size: '{{ inline_item_size }}'
     code: "items = [{\"id\": i, \"data\": \"x\" * size} for i in range(count)]\nresult\
       \ = {\n    \"status\": \"ok\",\n    \"tier\": \"inline\",\n    \"count\": len(items),\n\
       \    \"total_bytes\": count * size,\n    \"items\": items\n}\n"
-  result:
+  output:
     output_select:
     - status
     - tier
@@ -52,14 +52,14 @@ workflow:
   tool:
   - name: generate_kv
     kind: python
-    args:
+    input:
       count: '{{ kv_items }}'
       size: '{{ kv_item_size }}'
     code: "items = [{\"id\": i, \"data\": \"K\" * size, \"active\": True} for i in\
       \ range(count)]\nresult = {\n    \"status\": \"ok\",\n    \"tier\": \"kv_expected\"\
       ,\n    \"count\": len(items),\n    \"total_bytes\": count * size,\n    \"items\"\
       : items\n}\n"
-  result:
+  output:
     output_select:
     - status
     - tier
@@ -74,14 +74,14 @@ workflow:
   tool:
   - name: generate_object
     kind: python
-    args:
+    input:
       count: '{{ object_items }}'
       size: '{{ object_item_size }}'
     code: "items = [{\"id\": i, \"data\": \"O\" * size, \"active\": True} for i in\
       \ range(count)]\nresult = {\n    \"status\": \"ok\",\n    \"tier\": \"object_expected\"\
       ,\n    \"count\": len(items),\n    \"total_bytes\": count * size,\n    \"items\"\
       : items\n}\n"
-  result:
+  output:
     output_select:
     - status
     - tier
@@ -96,14 +96,14 @@ workflow:
   tool:
   - name: generate_large
     kind: python
-    args:
+    input:
       count: '{{ large_items }}'
       size: '{{ large_item_size }}'
     code: "items = [{\"id\": i, \"data\": \"L\" * size, \"active\": True} for i in\
       \ range(count)]\nresult = {\n    \"status\": \"ok\",\n    \"tier\": \"s3_or_object_expected\"\
       ,\n    \"count\": len(items),\n    \"total_bytes\": count * size,\n    \"items\"\
       : items\n}\n"
-  result:
+  output:
     output_select:
     - status
     - tier
@@ -118,7 +118,7 @@ workflow:
   tool:
   - name: verify_tiers
     kind: python
-    args:
+    input:
       inline_has_ref: '{{ start._ref is defined }}'
       inline_status: '{{ start.status }}'
       inline_bytes: '{{ start.total_bytes }}'
@@ -166,7 +166,7 @@ workflow:
   - name: load_kv
     kind: artifact
     action: get
-    args:
+    input:
       result_ref: '{{ test_nats_kv._ref }}'
   next:
     spec:
@@ -178,7 +178,7 @@ workflow:
   - name: load_object
     kind: artifact
     action: get
-    args:
+    input:
       result_ref: '{{ test_nats_object._ref }}'
   next:
     spec:
@@ -190,7 +190,7 @@ workflow:
   - name: load_large
     kind: artifact
     action: get
-    args:
+    input:
       result_ref: '{{ test_large_storage._ref }}'
   next:
     spec:
@@ -201,7 +201,7 @@ workflow:
   tool:
   - name: summarize
     kind: python
-    args:
+    input:
       tier_results: '{{ verify_storage_tiers.tier_results }}'
       kv_loaded_count: '{{ load_kv_data.count | default(0) }}'
       object_loaded_count: '{{ load_object_data.count | default(0) }}'

--- a/tests/fixtures/playbooks/tradedb/tradedb_bootstrap.yaml
+++ b/tests/fixtures/playbooks/tradedb/tradedb_bootstrap.yaml
@@ -16,7 +16,7 @@ workflow:
     desc: Start TradeDB bootstrap
     tool:
       kind: python
-      args:
+      input:
         db_name: "{{ db_name }}"
       code: |
         result = {"status": "starting", "db_name": db_name}
@@ -64,7 +64,7 @@ workflow:
     desc: Done
     tool:
       kind: python
-      args:
+      input:
         db_name: "{{ db_name }}"
       code: |
         result = {"status": "completed", "db_name": db_name}

--- a/tests/fixtures/playbooks/tradedb/tradedb_create_db.yaml
+++ b/tests/fixtures/playbooks/tradedb/tradedb_create_db.yaml
@@ -32,6 +32,6 @@ workflow:
     desc: Done
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/v10_canonical_example.yaml
+++ b/tests/fixtures/playbooks/v10_canonical_example.yaml
@@ -4,7 +4,7 @@
 # - `when` is the ONLY conditional keyword (no `expr`)
 # - All knobs live under `spec` at any level
 # - Policies under `spec.policy` typed by scope
-# - Task outcome via `task.spec.policy.rules` (not eval)
+# - Task output via `task.spec.policy.rules` (not eval)
 # - Routing via `next.spec` + `next.arcs[]` (Petri-net arcs)
 # - NO `step.when` field (use `step.spec.policy.admit.rules`)
 # - Outcome status uses "ok" | "error" (not "success")
@@ -71,7 +71,7 @@ workflow:
         - step: fetch_data
 
   # ==========================================================================
-  # Step 2: Single tool with task policy for outcome handling
+  # Step 2: Single tool with task policy for output handling
   # ==========================================================================
   - step: fetch_data
     desc: Fetch data with retry policy
@@ -84,21 +84,21 @@ workflow:
         policy:
           rules:
             # Use `when` not `expr`
-            - when: "{{ outcome.status == 'error' and outcome.http.status in [429, 500, 502, 503] }}"
+            - when: "{{ output.status == 'error' and output.http.status in [429, 500, 502, 503] }}"
               then:
                 do: retry
                 attempts: 3
                 backoff: exponential
                 delay: 1.0
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then:
                 do: fail
             - else:
                 then:
                   do: continue
                   # set_ctx updates execution-scoped variables
-                  set_ctx:
-                    fetch_completed: true
+                  set:
+                    ctx.fetch_completed: true
     next:
       spec:
         mode: exclusive
@@ -115,7 +115,7 @@ workflow:
       # Pipeline: list of tasks with explicit name: field (canonical format)
       - name: validate
         kind: python
-        args:
+        input:
           data: "{{ fetch_data.data }}"
         code: |
           if not data:
@@ -125,14 +125,14 @@ workflow:
         spec:
           policy:
             rules:
-              - when: "{{ outcome.result.status == 'error' }}"
+              - when: "{{ output.data.status == 'error' }}"
                 then: { do: fail }
               - else:
                   then: { do: continue }
 
       - name: transform
         kind: python
-        args:
+        input:
           # _prev contains previous task's result
           prev: "{{ _prev }}"
         code: |
@@ -141,10 +141,10 @@ workflow:
           policy:
             rules:
               - else:
-                  then:
+                then:
                     do: continue
-                    set_ctx:
-                      transform_done: true
+                    set:
+                      ctx.transform_done: true
     next:
       spec:
         mode: exclusive
@@ -174,9 +174,9 @@ workflow:
       spec:
         policy:
           rules:
-            - when: "{{ outcome.status == 'error' and outcome.error.retryable }}"
+            - when: "{{ output.status == 'error' and output.error.retryable }}"
               then: { do: retry, attempts: 2 }
-            - when: "{{ outcome.status == 'error' }}"
+            - when: "{{ output.status == 'error' }}"
               then: { do: continue }  # Continue on non-retryable errors
             - else:
                 then: { do: continue }
@@ -194,7 +194,7 @@ workflow:
     desc: Workflow complete
     tool:
       kind: python
-      args:
+      input:
         ctx_vars: "{{ ctx }}"
       code: |
         result = {

--- a/tests/fixtures/playbooks/v2_actions_test.yaml
+++ b/tests/fixtures/playbooks/v2_actions_test.yaml
@@ -38,7 +38,7 @@ workflow:
   tool:
   - name: double_number
     kind: python
-    args:
+    input:
       num: '{{ iter.num }}'
     code: 'num = input_data.get(''num'')
 
@@ -55,8 +55,8 @@ workflow:
         - when: '{{ true }}'
           then:
             do: continue
-            set_iter:
-              loop_result: '{{ outcome.result }}'
+            set:
+              iter.loop_result: '{{ output.data }}'
   next:
     spec:
       mode: exclusive
@@ -67,7 +67,7 @@ workflow:
   tool:
   - name: aggregate_results
     kind: python
-    args:
+    input:
       loop_results: '{{ ctx.loop_results | default([]) }}'
     code: "results = input_data.get('loop_results', [])\nprint(f\"[AGGREGATE] Processing\
       \ {len(results)} results\")\n\ntotal = sum(item['doubled'] for item in results)\n\
@@ -80,18 +80,18 @@ workflow:
     arcs:
     - step: helper
       when: '{{ aggregate.count > 0 }}'
-      args:
-        message: Aggregate completed with {{ aggregate.count }} items
-        data: '{{ aggregate }}'
+      set:
+        ctx.helper_message: Aggregate completed with {{ aggregate.count }} items
+        ctx.helper_data: '{{ aggregate }}'
     - step: test_secrets
 - step: helper
   desc: Helper step to demonstrate call action
   tool:
   - name: helper_action
     kind: python
-    args:
-      message: '{{ args.message | default(''No message'') }}'
-      data: '{{ args.data | default({}) }}'
+    input:
+      message: '{{ ctx.helper_message | default(''No message'') }}'
+      data: '{{ ctx.helper_data | default({}) }}'
     code: 'message = input_data.get(''message'', ''No message'')
 
       data = input_data.get(''data'', {})
@@ -124,7 +124,7 @@ workflow:
   tool:
   - name: verify_actions
     kind: python
-    args:
+    input:
       aggregate: '{{ aggregate | default({}) }}'
       helper: '{{ helper | default({}) }}'
     code: "print(\"[VERIFY] All actions completed successfully\")\n\n# Check if we\
@@ -144,7 +144,7 @@ workflow:
   tool:
   - name: complete
     kind: python
-    args:
+    input:
       verify: '{{ verify }}'
     code: 'verify_result = input_data.get(''verify'', {})
 

--- a/tests/fixtures/playbooks/v2_comprehensive_test.yaml
+++ b/tests/fixtures/playbooks/v2_comprehensive_test.yaml
@@ -14,7 +14,7 @@ workflow:
     desc: Initialize workflow with data preparation
     tool:
       kind: python
-      args:
+      input:
         initial_message: "{{ initial_message }}"
       code: |
         import random
@@ -39,7 +39,7 @@ workflow:
     desc: Process high values
     tool:
       kind: python
-      args:
+      input:
         value: "{{ start.random_value }}"
       code: |
         value = int(value)
@@ -62,7 +62,7 @@ workflow:
     desc: Process low values
     tool:
       kind: python
-      args:
+      input:
         value: "{{ start.random_value }}"
       code: |
         value = int(value)
@@ -85,7 +85,7 @@ workflow:
     desc: Generate final summary
     tool:
       kind: python
-      args:
+      input:
         start_value: "{{ start.random_value }}"
         category: "{{ process_high.category if process_high else process_low.category }}"
         final_value: "{{ process_high.processed if process_high else process_low.processed }}"

--- a/tests/fixtures/playbooks/v2_duckdb_test.yaml
+++ b/tests/fixtures/playbooks/v2_duckdb_test.yaml
@@ -30,7 +30,7 @@ workflow:
   tool:
   - name: process_results
     kind: python
-    args:
+    input:
       query_results: '{{ start }}'
     code: "print(f\"[PROCESS] Processing DuckDB query results\")\nprint(f\"[PROCESS]\
       \ Input data type: {type(input_data).__name__}\")\n\n# Extract query results\
@@ -54,7 +54,7 @@ workflow:
   tool:
   - name: verify_results
     kind: python
-    args:
+    input:
       process_result: '{{ process }}'
     code: "print(f\"[VERIFY] Verifying DuckDB test results\")\n\nprocess_result =\
       \ input_data.get('process_result', {})\n\nif isinstance(process_result, str):\n\
@@ -76,7 +76,7 @@ workflow:
   tool:
   - name: complete
     kind: python
-    args:
+    input:
       verify_result: '{{ verify }}'
     code: "print(f\"[END] DuckDB test completed successfully!\")\n\nverify_result\
       \ = input_data.get('verify_result', {})\n\nif isinstance(verify_result, str):\n\

--- a/tests/fixtures/playbooks/v2_http_test.yaml
+++ b/tests/fixtures/playbooks/v2_http_test.yaml
@@ -48,7 +48,7 @@ workflow:
                 }
 
             return {"status": "error", "message": "Invalid HTTP response format"}
-    args:
+    input:
       http_response: "{{ start }}"
     next:
       spec:
@@ -84,7 +84,7 @@ workflow:
 
             print(f"[VERIFY] Verification: {verification['status']}")
             return verification
-    args:
+    input:
       process_result: "{{ process }}"
     next:
       spec:
@@ -115,5 +115,5 @@ workflow:
             print(f"[END] HTTP status code: {status_code}")
 
             return {"status": "completed", "test_passed": status == "passed"}
-    args:
+    input:
       verify_result: "{{ verify }}"

--- a/tests/fixtures/playbooks/v2_loop_test.yaml
+++ b/tests/fixtures/playbooks/v2_loop_test.yaml
@@ -25,7 +25,7 @@ workflow:
       iterator: "num"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
             num = input_data.get('num')
             loop_index = input_data.get('loop_index', 0)
@@ -36,7 +36,7 @@ workflow:
             print(f"[LOOP] Result: {result}")
 
             return {"number": num, "doubled": result, "index": loop_index}
-    args:
+    input:
       num: "{{ num }}"
       loop_index: "{{ loop_index }}"
     next:
@@ -49,7 +49,7 @@ workflow:
     desc: Analyze loop results
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
             print(f"[PROCESS] Loop completed, analyzing results")
             print(f"[PROCESS] Input data type: {type(input_data).__name__}")
@@ -84,7 +84,7 @@ workflow:
       iterator: "user"
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
             user = input_data.get('user', {})
             loop_index = input_data.get('loop_index', 0)
@@ -103,7 +103,7 @@ workflow:
                 "category": category,
                 "index": loop_index
             }
-    args:
+    input:
       user: "{{ user }}"
       loop_index: "{{ loop_index }}"
     next:
@@ -116,7 +116,7 @@ workflow:
     desc: Verify loop execution
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
             print(f"[VERIFY] Verifying loop test results")
 
@@ -150,7 +150,7 @@ workflow:
 
             print(f"[VERIFY] Verification: {verification['status']}")
             return verification
-    args:
+    input:
       process_result: "{{ process }}"
     next:
       spec:
@@ -162,7 +162,7 @@ workflow:
     desc: Complete the test
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
             print(f"[END] Loop test completed successfully!")
 
@@ -185,5 +185,5 @@ workflow:
             print(f"[END] Original sum: {original_sum}, Doubled sum: {doubled_sum}")
 
             return {"status": "ok", "test_passed": status == "passed"}
-    args:
+    input:
       verify_result: "{{ verify }}"

--- a/tests/fixtures/playbooks/v2_postgres_test.yaml
+++ b/tests/fixtures/playbooks/v2_postgres_test.yaml
@@ -23,7 +23,7 @@ workflow:
   tool:
   - name: process_results
     kind: python
-    args:
+    input:
       query_results: '{{ start }}'
     code: "import json\nprint(f\"[PROCESS] Processing Postgres query results\")\n\
       print(f\"[PROCESS] Input data type: {type(input_data).__name__}\")\nprint(f\"\
@@ -48,7 +48,7 @@ workflow:
   tool:
   - name: verify_data
     kind: python
-    args:
+    input:
       process_result: '{{ process }}'
     code: "import json\nprint(f\"[VERIFY] Input data keys: {list(input_data.keys())}\"\
       )\nprint(f\"[VERIFY] Input data types: {[(k, type(v).__name__) for k, v in input_data.items()]}\"\

--- a/tests/fixtures/playbooks/v2_simple_python.yaml
+++ b/tests/fixtures/playbooks/v2_simple_python.yaml
@@ -16,7 +16,7 @@ workflow:
   - step: start
     tool:
       kind: python
-      args:
+      input:
         message: "{{ message }}"
       code: |
         print(f"Processing: {message}")
@@ -35,6 +35,6 @@ workflow:
     desc: Workflow complete
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"status": "completed"}

--- a/tests/fixtures/playbooks/vars_test/test_transient.yaml
+++ b/tests/fixtures/playbooks/vars_test/test_transient.yaml
@@ -14,7 +14,7 @@ workflow:
   tool:
   - name: start_task
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "initialized"}
 
       '
@@ -28,7 +28,7 @@ workflow:
   tool:
   - name: set_vars_task
     kind: python
-    args: {}
+    input: {}
     code: "# Return values that will be extracted via policy rules\nresult = {\n \
       \   \"status\": \"success\",\n    \"counter\": 0,\n    \"status_var\": \"initialized\"\
       ,\n    \"config\": {\"timeout\": 30, \"retries\": 3}\n}\n"
@@ -38,10 +38,10 @@ workflow:
         - else:
             then:
               do: continue
-              set_ctx:
-                counter: '{{ outcome.result.counter }}'
-                status_var: '{{ outcome.result.status_var }}'
-                config: '{{ outcome.result.config }}'
+              set:
+                ctx.counter: '{{ output.data.counter }}'
+                ctx.status_var: '{{ output.data.status_var }}'
+                ctx.config: '{{ output.data.config }}'
   next:
     spec:
       mode: exclusive
@@ -52,7 +52,7 @@ workflow:
   tool:
   - name: get_vars_task
     kind: python
-    args:
+    input:
       counter: '{{ ctx.counter }}'
       status_var: '{{ ctx.status_var }}'
       config: '{{ ctx.config }}'
@@ -72,7 +72,7 @@ workflow:
   tool:
   - name: update_vars_task
     kind: python
-    args: {}
+    input: {}
     code: "# Return updated values\nresult = {\n    \"status\": \"success\",\n   \
       \ \"counter\": 1,\n    \"status_var\": \"processing\"\n}\n"
     spec:
@@ -81,9 +81,9 @@ workflow:
         - else:
             then:
               do: continue
-              set_ctx:
-                counter: '{{ outcome.result.counter }}'
-                status_var: '{{ outcome.result.status_var }}'
+              set:
+                ctx.counter: '{{ output.data.counter }}'
+                ctx.status_var: '{{ output.data.status_var }}'
   next:
     spec:
       mode: exclusive
@@ -94,7 +94,7 @@ workflow:
   tool:
   - name: verify_task
     kind: python
-    args:
+    input:
       counter: '{{ ctx.counter }}'
       status_var: '{{ ctx.status_var }}'
       config: '{{ ctx.config }}'
@@ -114,7 +114,7 @@ workflow:
   tool:
   - name: end_task
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "complete"}
 
       '

--- a/tests/fixtures/playbooks/vars_test/test_vars_api.yaml
+++ b/tests/fixtures/playbooks/vars_test/test_vars_api.yaml
@@ -13,7 +13,7 @@ workflow:
   tool:
   - name: start_task
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "initialized"}
 
       '
@@ -27,7 +27,7 @@ workflow:
   tool:
   - name: create_vars_task
     kind: python
-    args: {}
+    input: {}
     code: "result = {\n  \"user_id\": 999,\n  \"username\": \"api_tester\",\n  \"\
       score\": 85,\n  \"metadata\": {\n    \"created\": \"2025-12-01\",\n    \"source\"\
       : \"test_playbook\"\n  }\n}\n"
@@ -37,11 +37,11 @@ workflow:
         - else:
             then:
               do: continue
-              set_ctx:
-                test_user_id: '{{ outcome.result.user_id }}'
-                test_username: '{{ outcome.result.username }}'
-                test_score: '{{ outcome.result.score }}'
-                test_metadata: '{{ outcome.result.metadata }}'
+              set:
+                ctx.test_user_id: '{{ output.data.user_id }}'
+                ctx.test_username: '{{ output.data.username }}'
+                ctx.test_score: '{{ output.data.score }}'
+                ctx.test_metadata: '{{ output.data.metadata }}'
   next:
     spec:
       mode: exclusive
@@ -54,7 +54,7 @@ workflow:
     kind: python
     libs:
       time: time
-    args: {}
+    input: {}
     code: '# Keep execution alive for API testing
 
       # In real test, external scripts will call API endpoints
@@ -74,7 +74,7 @@ workflow:
   tool:
   - name: verify_task
     kind: python
-    args:
+    input:
       user_id: '{{ ctx.test_user_id }}'
       username: '{{ ctx.test_username }}'
       score: '{{ ctx.test_score }}'
@@ -101,7 +101,7 @@ workflow:
   tool:
   - name: end_task
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "complete"}
 
       '

--- a/tests/fixtures/playbooks/vars_test/test_vars_block.yaml
+++ b/tests/fixtures/playbooks/vars_test/test_vars_block.yaml
@@ -12,7 +12,7 @@ workflow:
   tool:
   - name: start_task
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "initialized"}
 
       '
@@ -26,7 +26,7 @@ workflow:
   tool:
   - name: fetch_data_task
     kind: python
-    args: {}
+    input: {}
     code: "# Simulate fetching data from a database\nresult = {\n    \"status\": \"\
       success\",\n    \"users\": [\n        {\"user_id\": 123, \"email\": \"alice@example.com\"\
       , \"name\": \"Alice\"},\n        {\"user_id\": 456, \"email\": \"bob@example.com\"\
@@ -38,11 +38,11 @@ workflow:
         - else:
             then:
               do: continue
-              set_ctx:
-                first_user_id: '{{ outcome.response.users[0].user_id }}'
-                first_email: '{{ outcome.response.users[0].email }}'
-                user_count: '{{ outcome.response.metadata.count }}'
-                data_source: '{{ outcome.response.metadata.source }}'
+              set:
+                ctx.first_user_id: '{{ output.response.users[0].user_id }}'
+                ctx.first_email: '{{ output.response.users[0].email }}'
+                ctx.user_count: '{{ output.response.metadata.count }}'
+                ctx.data_source: '{{ output.response.metadata.source }}'
   next:
     spec:
       mode: exclusive
@@ -53,7 +53,7 @@ workflow:
   tool:
   - name: use_vars_task
     kind: python
-    args:
+    input:
       first_user_id: '{{ ctx.first_user_id }}'
       first_email: '{{ ctx.first_email }}'
       user_count: '{{ ctx.user_count }}'
@@ -74,7 +74,7 @@ workflow:
   tool:
   - name: verify_task
     kind: python
-    args:
+    input:
       first_user_id: '{{ ctx.first_user_id }}'
       first_email: '{{ ctx.first_email }}'
       user_count: '{{ ctx.user_count }}'
@@ -98,7 +98,7 @@ workflow:
   tool:
   - name: end_task
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "complete"}
 
       '

--- a/tests/fixtures/playbooks/vars_test/test_vars_simple.yaml
+++ b/tests/fixtures/playbooks/vars_test/test_vars_simple.yaml
@@ -9,7 +9,7 @@ workflow:
   tool:
   - name: start_task
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "initialized"}
 
       '
@@ -26,7 +26,7 @@ workflow:
     libs:
       os: os
       logging: logging
-    args: {}
+    input: {}
     code: "logger = logging.getLogger(__name__)\nlogger.info(f\"DEBUG: NOETL_WORKER_MODE\
       \ = {os.getenv('NOETL_WORKER_MODE')}\")\nlogger.info(f\"DEBUG: SERVER_API_URL\
       \ = {os.getenv('SERVER_API_URL')}\")\nlogger.info(f\"DEBUG: context keys = {list(context.keys())}\"\
@@ -39,9 +39,9 @@ workflow:
         - else:
             then:
               do: continue
-              set_ctx:
-                test_counter: '{{ outcome.result.test_counter }}'
-                set_message: '{{ outcome.result.message }}'
+              set:
+                ctx.test_counter: '{{ output.data.test_counter }}'
+                ctx.set_message: '{{ output.data.message }}'
   next:
     spec:
       mode: exclusive
@@ -52,7 +52,7 @@ workflow:
   tool:
   - name: get_vars
     kind: python
-    args:
+    input:
       counter_value: '{{ ctx.test_counter }}'
       previous_message: '{{ ctx.set_message }}'
     code: "# Access variable via args (passed from ctx context)\ncounter = counter_value\n\
@@ -70,7 +70,7 @@ workflow:
   tool:
   - name: end_task
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "complete"}
 
       '

--- a/tests/fixtures/playbooks/vars_test/test_vars_template_access.yaml
+++ b/tests/fixtures/playbooks/vars_test/test_vars_template_access.yaml
@@ -17,7 +17,7 @@ workflow:
   tool:
   - name: start_task
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "initialized"}
 
       '
@@ -31,7 +31,7 @@ workflow:
   tool:
   - name: set_vars_task
     kind: python
-    args: {}
+    input: {}
     code: "# Return values that will be extracted via policy rules\nresult = {\n \
       \   \"counter\": 42,\n    \"message\": \"Template access works!\",\n    \"config\"\
       : {\n        \"timeout\": 30,\n        \"retries\": 3\n    }\n}\n"
@@ -41,10 +41,10 @@ workflow:
         - else:
             then:
               do: continue
-              set_ctx:
-                counter: '{{ outcome.result.counter }}'
-                message: '{{ outcome.result.message }}'
-                config: '{{ outcome.result.config }}'
+              set:
+                ctx.counter: '{{ output.data.counter }}'
+                ctx.message: '{{ output.data.message }}'
+                ctx.config: '{{ output.data.config }}'
   next:
     spec:
       mode: exclusive
@@ -55,7 +55,7 @@ workflow:
   tool:
   - name: use_vars_task
     kind: python
-    args:
+    input:
       counter: '{{ ctx.counter }}'
       message: '{{ ctx.message }}'
       timeout: '{{ ctx.config.timeout }}'
@@ -74,7 +74,7 @@ workflow:
   tool:
   - name: verify_task
     kind: python
-    args: {}
+    input: {}
     code: "# Get previous step result\nprev_result = context.get('use_vars_in_template',\
       \ {})\nif isinstance(prev_result, dict) and 'data' in prev_result:\n    prev_result\
       \ = prev_result['data']\n\n# Verify values\ncounter = prev_result.get(\"received_counter\"\
@@ -99,7 +99,7 @@ workflow:
   tool:
   - name: end_task
     kind: python
-    args: {}
+    input: {}
     code: 'result = {"status": "complete"}
 
       '


### PR DESCRIPTION
## Summary
- Refactor fixture playbooks under `tests/fixtures/playbooks/**` to canonical DSL v2 author-facing fields aligned with PR #347 specs.
- Migrate legacy keys/patterns in fixtures:
  - `args` -> `input`
  - `set_ctx` / `set_iter` -> top-level scoped `set` (`ctx.*` / `iter.*`)
  - `next.arcs[].args` -> `next.arcs[].set`
  - template references from `outcome` to `output` where applicable
- Keep scope strictly to YAML playbook fixtures (no Python changes).

## Validation
- Residual-pattern scans in fixture YAML:
  - `^\s*args:` -> 0
  - `^\s*set_ctx:` / `^\s*set_iter:` -> 0
  - `{{ ... outcome ... }}` -> 0
- Local dry-run parser/planner validation:
  - `noetl exec <fixture> -r local --dry-run`
  - Result: `TOTAL=139 PASS=139 FAIL=0`

## Notes
- This PR intentionally updates fixture DSL usage only.
- Runtime regression observed in current local distributed deploy (`/api/execute` failing on `cmd.args`) is tracked separately and is not caused by fixture YAML syntax migration.
