### PR TITLE
fix: align distributed runtime command context with DSL v2 input

### DIFF
--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -1979,18 +1979,18 @@ class ControlFlowEngine:
         self,
         state: "ExecutionState",
         step_def: Step,
-        args: dict[str, Any],
+        step_input: dict[str, Any],
     ) -> list[Command]:
         """Issue one or more loop commands based on loop mode and max_in_flight."""
         if not step_def.loop:
-            command = await self._create_command_for_step(state, step_def, args)
+            command = await self._create_command_for_step(state, step_def, step_input)
             return [command] if command else []
 
         issue_budget = self._get_loop_max_in_flight(step_def)
         commands: list[Command] = []
 
         for _ in range(issue_budget):
-            command = await self._create_command_for_step(state, step_def, args)
+            command = await self._create_command_for_step(state, step_def, step_input)
             if not command:
                 break
             commands.append(command)
@@ -2059,9 +2059,9 @@ class ControlFlowEngine:
         Example:
             next:
               - step: success_handler
-                when: "{{ outcome.status == 'success' }}"
+                when: "{{ output.status == 'success' }}"
               - step: error_handler
-                when: "{{ outcome.status == 'error' }}"
+                when: "{{ output.status == 'error' }}"
               - step: default_handler  # No when = always matches
         """
         commands = []
@@ -2862,7 +2862,7 @@ class ControlFlowEngine:
                 kind=tool_kind,
                 config=rendered_tool_config
             ),
-            args={},
+            input={},
             render_context=context,
             attempt=1,
             priority=0,
@@ -2925,7 +2925,7 @@ class ControlFlowEngine:
                     "remaining_actions": remaining_actions,
                 }
             ),
-            args={},
+            input={},
             render_context=context,
             attempt=1,
             priority=0,
@@ -2942,10 +2942,10 @@ class ControlFlowEngine:
         self,
         state: ExecutionState,
         step: Step,
-        args: dict[str, Any]
+        transition_input: dict[str, Any]
     ) -> Optional[Command]:
         """Create a command to execute a step."""
-        control_args = args if isinstance(args, dict) else {}
+        control_args = transition_input if isinstance(transition_input, dict) else {}
         loop_retry_requested = bool(control_args.get("__loop_retry"))
         loop_retry_index_raw = control_args.get("__loop_retry_index")
         loop_continue_requested = bool(control_args.get("__loop_continue"))
@@ -3557,7 +3557,7 @@ class ControlFlowEngine:
                 context.get("loop_index", "NOT_FOUND"),
             )
 
-        # Build args separately - for step inputs
+        # Build input bindings separately for step execution.
         step_args = {}
         if step.input:
             step_args.update(step.input)
@@ -3565,15 +3565,15 @@ class ControlFlowEngine:
             # Backward compat: accept legacy step.args if step.input not set
             step_args.update(step.args)
 
-        # Merge transition args
+        # Merge transition-scoped input published by prior routing/actions.
         filtered_args = {
-            k: v for k, v in args.items()
+            k: v for k, v in control_args.items()
             if k not in {"__loop_retry", "__loop_retry_index", "__loop_continue"}
         }
         step_args.update(filtered_args)
 
-        # Render Jinja2 templates in args
-        rendered_args = recursive_render(self.jinja_env, step_args, context)
+        # Render Jinja2 templates in merged input.
+        rendered_input = recursive_render(self.jinja_env, step_args, context)
 
         if step.tool is None:
             logger.info(
@@ -3690,7 +3690,7 @@ class ControlFlowEngine:
                 kind=tool_kind,
                 config=tool_config
             ),
-            input=rendered_args,
+            input=rendered_input,
             render_context=context,
             pipeline=pipeline,
             next_targets=next_targets,

--- a/noetl/core/dsl/v2/models.py
+++ b/noetl/core/dsl/v2/models.py
@@ -5,7 +5,7 @@ Canonical v10 implementation with:
 - `when` is the ONLY conditional keyword (no `expr`)
 - All knobs live under `spec` (at any level)
 - Policies live under `spec.policy` and are typed by scope
-- Task outcome handling uses `task.spec.policy` object with required `rules:`
+- Task output-status handling uses `task.spec.policy` object with required `rules:`
 - Routing uses Petri-net arcs: `step.next` is object with `next.spec` + `next.arcs[]`
 - No special "sink" tool kind - storage is just tools returning references
 - Loop is a step modifier (not a tool kind)
@@ -38,14 +38,14 @@ class StepEnterPayload(BaseModel):
 
 class CallDonePayload(BaseModel):
     """Payload for call.done event (tool execution result)."""
-    result: Any = Field(None, description="Tool execution result")
+    result: Any = Field(None, description="Control-plane result envelope (status/reference/context)")
     error: Optional[Union[str, dict[str, Any]]] = Field(None, description="Error details if tool failed (string or dict)")
     duration_ms: Optional[int] = Field(None, description="Tool execution duration in milliseconds")
 
 
 class StepExitPayload(BaseModel):
     """Payload for step.exit event."""
-    result: Any = Field(None, description="Final step result")
+    result: Any = Field(None, description="Final control-plane result envelope")
     error: Optional[Union[str, dict[str, Any]]] = Field(None, description="Error details if step failed (string or dict)")
     context: Optional[dict[str, Any]] = Field(None, description="Updated execution context")
 
@@ -54,7 +54,7 @@ class LifecycleEventPayload(BaseModel):
     """Payload for lifecycle events (workflow/playbook initialized/completed/failed)."""
     status: str = Field(..., description="Status: initialized, completed, failed")
     final_step: Optional[str] = Field(None, description="Final step name (for completion events)")
-    result: Any = Field(None, description="Final result (for completion events)")
+    result: Any = Field(None, description="Final control-plane result envelope (for completion events)")
     error: Optional[Union[str, dict[str, Any]]] = Field(None, description="Error details (for failed events, string or dict)")
 
 
@@ -82,6 +82,15 @@ class CommandIssuedPayload(BaseModel):
     priority: int = Field(default=0, description="Command priority")
     max_attempts: int = Field(default=3, description="Maximum retry attempts")
 
+    @model_validator(mode='before')
+    @classmethod
+    def _rename_legacy_fields(cls, obj):
+        """Accept legacy 'args' as alias for 'input'."""
+        if isinstance(obj, dict) and "args" in obj and "input" not in obj:
+            obj = dict(obj)
+            obj["input"] = obj.pop("args")
+        return obj
+
 
 class CommandClaimedPayload(BaseModel):
     """Payload for command.claimed event."""
@@ -100,7 +109,7 @@ class CommandCompletedPayload(BaseModel):
     """Payload for command.completed event."""
     command_id: str = Field(..., description="Command identifier")
     worker_id: str = Field(..., description="Worker that completed the command")
-    result: Any = Field(None, description="Command result")
+    result: Any = Field(None, description="Command control-plane result envelope")
 
 
 class CommandFailedPayload(BaseModel):
@@ -221,7 +230,7 @@ class PolicyRule(BaseModel):
     First matching rule wins (or else clause if no when).
 
     Example:
-        - when: "{{ outcome.status == 'error' and outcome.error.retryable }}"
+        - when: "{{ output.status == 'error' and output.error.retryable }}"
           then: { do: retry, attempts: 3, backoff: exponential }
         - else:
             then: { do: continue }
@@ -263,7 +272,7 @@ class AdmitPolicy(BaseModel):
 
 class TaskPolicy(BaseModel):
     """
-    Task outcome policy (worker-side, canonical v10).
+    Task output-status policy (worker-side, canonical v10).
 
     MUST be an object with required `rules:` list.
     This is the ONLY place where control actions (retry/jump/break/fail/continue) are allowed.
@@ -272,12 +281,15 @@ class TaskPolicy(BaseModel):
         spec:
           policy:
             rules:
-              - when: "{{ outcome.status == 'error' and outcome.http.status in [429,500,502,503] }}"
+              - when: "{{ output.status == 'error' and output.http.status in [429,500,502,503] }}"
                 then: { do: retry, attempts: 5, backoff: exponential, delay: 1.0 }
-              - when: "{{ outcome.status == 'error' }}"
+              - when: "{{ output.status == 'error' }}"
                 then: { do: fail }
               - else:
-                  then: { do: continue, set_iter: { has_more: "{{ outcome.result.paging.hasMore }}" } }
+                  then:
+                    do: continue
+                    set:
+                      iter.has_more: "{{ output.data.paging.hasMore }}"
     """
     mode: Literal["exclusive", "inclusive"] = Field(
         default="exclusive",
@@ -405,14 +417,14 @@ class TaskSpec(BaseModel):
     """
     Task-level spec configuration (canonical v10).
 
-    Contains task policy for outcome handling.
+    Contains task policy for output-status handling.
     Policy is the ONLY place where control actions are allowed.
     """
     timeout: Optional[dict[str, Any]] = Field(
         None, description="Timeout config { connect: 5, read: 15 }"
     )
     policy: Optional[TaskPolicy] = Field(
-        None, description="Task outcome policy with rules"
+        None, description="Task output-status policy with rules"
     )
 
     class Config:
@@ -460,7 +472,7 @@ class ToolSpec(BaseModel):
     # Task-level spec with policy (canonical v10)
     spec: Optional[TaskSpec] = Field(
         default=None,
-        description="Task spec with policy.rules for outcome handling"
+        description="Task spec with policy.rules for output-status handling"
     )
     # Output configuration at tool level
     output: Optional[ToolOutput] = Field(
@@ -719,7 +731,7 @@ class Step(BaseModel):
 
     Key changes from previous versions:
     - NO `step.when` field - use `step.spec.policy.admit.rules` for admission
-    - NO `tool.eval` - use `task.spec.policy.rules` for outcome handling
+    - NO `tool.eval` - use `task.spec.policy.rules` for output-status handling
     - `next` is a router object with `spec` + `arcs[]`
 
     Canonical step structure:
@@ -743,7 +755,7 @@ class Step(BaseModel):
                 spec:
                   policy:
                     rules:
-                      - when: "{{ outcome.status == 'error' }}"
+                      - when: "{{ output.status == 'error' }}"
                         then: { do: retry, attempts: 3 }
                       - else:
                           then: { do: continue }
@@ -1069,6 +1081,15 @@ class Command(BaseModel):
     retry_delay: Optional[float] = Field(None, description="Initial retry delay")
     retry_backoff: Optional[str] = Field(None, description="Retry backoff strategy")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
+
+    @model_validator(mode='before')
+    @classmethod
+    def _rename_legacy_fields(cls, obj):
+        """Accept legacy 'args' as alias for 'input'."""
+        if isinstance(obj, dict) and "args" in obj and "input" not in obj:
+            obj = dict(obj)
+            obj["input"] = obj.pop("args")
+        return obj
 
     def to_queue_record(self) -> dict[str, Any]:
         """Convert to queue table record format."""

--- a/noetl/core/dsl/v2/parser.py
+++ b/noetl/core/dsl/v2/parser.py
@@ -5,7 +5,7 @@ Class-based YAML parser for v2 playbooks with canonical v10 format:
 - `when` is the ONLY conditional keyword (reject `expr`)
 - All knobs live under `spec` at any level
 - Policies under `spec.policy` typed by scope
-- Task outcome via `task.spec.policy.rules` (reject `eval`)
+- Task output policy via `task.spec.policy.rules` (reject `eval`)
 - Routing via `next.spec` + `next.arcs[]` (Petri-net arcs)
 - NO `step.when` field (use `step.spec.policy.admit.rules`)
 - NO root `vars` (use ctx/iter via policy)
@@ -24,7 +24,7 @@ class DSLParser:
     Validates:
     - tool.kind pattern (rejects old 'type' field)
     - tool as single object or pipeline list
-    - task.spec.policy.rules for outcome handling (rejects eval)
+    - task.spec.policy.rules for output handling (rejects eval)
     - next.spec + next.arcs[] for routing (rejects simple next[] list)
     - step.spec.policy.admit.rules for admission (rejects step.when)
     - loop.spec.mode for iteration
@@ -240,7 +240,7 @@ class DSLParser:
             raise ValueError(
                 f"Step '{step_name}': 'case' blocks are not allowed in v10. "
                 "Use 'step.spec.policy.admit.rules' for admission, "
-                "'task.spec.policy.rules' for outcome handling, "
+                "'task.spec.policy.rules' for output handling, "
                 "and 'next.arcs[].when' for routing."
             )
 
@@ -290,7 +290,7 @@ class DSLParser:
             if "eval" in tool_data:
                 raise ValueError(
                     f"Step '{step_name}': 'eval' is not allowed in v10. "
-                    "Use 'task.spec.policy.rules' for outcome handling instead."
+                    "Use 'task.spec.policy.rules' for output handling instead."
                 )
             # Validate task.spec.policy if present
             if "spec" in tool_data:
@@ -364,7 +364,7 @@ class DSLParser:
             if "eval" in task_config:
                 raise ValueError(
                     f"Step '{step_name}': tool[{i}].{label}: 'eval' is not allowed in v10. "
-                    "Use 'spec.policy.rules' for outcome handling instead."
+                    "Use 'spec.policy.rules' for output handling instead."
                 )
 
             # Validate task.spec.policy if present

--- a/noetl/server/api/v2.py
+++ b/noetl/server/api/v2.py
@@ -975,6 +975,42 @@ def _estimate_json_size(value: Any) -> int:
         return len(str(value).encode("utf-8"))
 
 
+def _command_input_from_context(context: Any) -> dict[str, Any]:
+    """Return canonical command input map from context, accepting legacy args alias."""
+    if not isinstance(context, dict):
+        return {}
+    input_map = context.get("input")
+    if isinstance(input_map, dict):
+        return input_map
+    legacy_args = context.get("args")
+    if isinstance(legacy_args, dict):
+        return legacy_args
+    return {}
+
+
+def _command_input_from_model(cmd: Any) -> dict[str, Any]:
+    """Read command input from canonical field first, then legacy args."""
+    cmd_input = getattr(cmd, "input", None)
+    if isinstance(cmd_input, dict):
+        return cmd_input
+    legacy_args = getattr(cmd, "args", None)
+    if isinstance(legacy_args, dict):
+        return legacy_args
+    return {}
+
+
+def _build_command_context(cmd: Any) -> dict[str, Any]:
+    """Build command context envelope emitted in command.issued events."""
+    return {
+        "tool_config": cmd.tool.config,
+        "input": _command_input_from_model(cmd),
+        "render_context": cmd.render_context,
+        "next_targets": cmd.next_targets,  # Canonical v2: routing via next[].when
+        "pipeline": cmd.pipeline,  # Canonical v2: task pipeline
+        "spec": cmd.spec.model_dump() if cmd.spec else None,  # Step behavior (next_mode)
+    }
+
+
 def _validate_postgres_command_context(*, step: str, tool_kind: str, context: dict[str, Any]) -> None:
     """
     Enforce postgres command contract before command.issued is persisted.
@@ -984,10 +1020,10 @@ def _validate_postgres_command_context(*, step: str, tool_kind: str, context: di
     if str(tool_kind).lower() != "postgres":
         return
     tool_config = context.get("tool_config") if isinstance(context, dict) else {}
-    args = context.get("args") if isinstance(context, dict) else {}
+    command_input = _command_input_from_context(context)
     auth_cfg = tool_config.get("auth") if isinstance(tool_config, dict) else None
     if auth_cfg in (None, "", {}):
-        auth_cfg = args.get("auth") if isinstance(args, dict) else None
+        auth_cfg = command_input.get("auth") if isinstance(command_input, dict) else None
     if auth_cfg in (None, "", {}):
         raise ValueError(
             f"Postgres command for step '{step}' is missing auth in command context. "
@@ -1007,9 +1043,9 @@ def _validate_postgres_command_context(*, step: str, tool_kind: str, context: di
         direct_fields.update(
             key for key in forbidden_fields if tool_config.get(key) not in (None, "")
         )
-    if isinstance(args, dict):
+    if isinstance(command_input, dict):
         direct_fields.update(
-            key for key in forbidden_fields if args.get(key) not in (None, "")
+            key for key in forbidden_fields if command_input.get(key) not in (None, "")
         )
     if direct_fields:
         raise ValueError(
@@ -1384,14 +1420,7 @@ async def execute(req: ExecuteRequest) -> ExecuteResponse:
                     evt_id = await _next_snowflake_id(cur)
                     
                     # Build context for command execution (passes execution parameters, not results)
-                    context = {
-                        "tool_config": cmd.tool.config,
-                        "args": cmd.args or {},
-                        "render_context": cmd.render_context,
-                        "next_targets": cmd.next_targets,  # Canonical v2: routing via next[].when
-                        "pipeline": cmd.pipeline,  # Canonical v2: task pipeline
-                        "spec": cmd.spec.model_dump() if cmd.spec else None,  # Step behavior (next_mode)
-                    }
+                    context = _build_command_context(cmd)
                     _validate_postgres_command_context_or_422(
                         step=cmd.step,
                         tool_kind=cmd.tool.kind,
@@ -2097,14 +2126,7 @@ async def handle_event(req: EventRequest) -> EventResponse:
                     new_evt_id = await _next_snowflake_id(cur)
                     
                     # Build context for retry command (command execution parameters)
-                    context = {
-                        "tool_config": cmd.tool.config,
-                        "args": cmd.args or {},
-                        "render_context": cmd.render_context,
-                        "next_targets": cmd.next_targets,  # Canonical v2: routing via next[].when
-                        "pipeline": cmd.pipeline,  # Canonical v2: task pipeline
-                        "spec": cmd.spec.model_dump() if cmd.spec else None,  # Step behavior (next_mode)
-                    }
+                    context = _build_command_context(cmd)
                     _validate_postgres_command_context_or_422(
                         step=cmd.step,
                         tool_kind=cmd.tool.kind,
@@ -2616,14 +2638,7 @@ async def _issue_commands_for_batch(job: _BatchAcceptJob, commands: list) -> Non
                 cmd_suffix = await _next_snowflake_id(cur)
                 cmd_id = f"{cmd.execution_id}:{cmd.step}:{cmd_suffix}"
                 new_evt_id = await _next_snowflake_id(cur)
-                context = {
-                    "tool_config": cmd.tool.config,
-                    "args": cmd.args or {},
-                    "render_context": cmd.render_context,
-                    "next_targets": cmd.next_targets,
-                    "pipeline": cmd.pipeline,
-                    "spec": cmd.spec.model_dump() if cmd.spec else None,
-                }
+                context = _build_command_context(cmd)
                 _validate_postgres_command_context_or_422(
                     step=cmd.step,
                     tool_kind=cmd.tool.kind,

--- a/noetl/worker/v2_worker_nats.py
+++ b/noetl/worker/v2_worker_nats.py
@@ -1679,7 +1679,7 @@ class V2Worker:
             execution_id=execution_id,
         )
         # Canonical DSL v2: command carries 'input'. Accept 'args' as backward-compat alias.
-        args = self._normalize_command_context_mapping(
+        command_input = self._normalize_command_context_mapping(
             context.get("input") or context.get("args"),
             field_name="input",
             step=step,
@@ -1712,16 +1712,16 @@ class V2Worker:
             eval_mode = spec.get("eval_mode", "on_entry")
             logger.debug(f"[SPEC] Step '{step}' spec: case_mode={case_mode}, eval_mode={eval_mode}")
         
-        # CRITICAL: Merge tool_config input/args with top-level args.
+        # CRITICAL: Merge tool_config input/args with top-level command input.
         # Canonical DSL v2: tool.input replaces tool.args; accept both for backward compat.
         tool_input = tool_config.get("input") or tool_config.get("args")
         if tool_input and isinstance(tool_input, dict):
-            # Merge with top-level args taking precedence
-            merged_args = {**tool_input, **args}
-            args = merged_args
-            logger.debug("Args config: merged_from_tool_config | keys=%s", _safe_keys(args))
+            # Merge with top-level command input taking precedence.
+            merged_input = {**tool_input, **command_input}
+            command_input = merged_input
+            logger.debug("Input config: merged_from_tool_config | keys=%s", _safe_keys(command_input))
         else:
-            logger.debug("Args config: using_top_level | keys=%s", _safe_keys(args))
+            logger.debug("Input config: using_top_level | keys=%s", _safe_keys(command_input))
 
         logger.info(f"[EVENT] Executing {step} (tool={tool_kind}) for execution {execution_id}" + (f" command={command_id}" if command_id else ""))
 
@@ -1773,7 +1773,7 @@ class V2Worker:
             if str(tool_kind).lower() == "postgres":
                 postgres_auth = tool_config.get("auth")
                 if postgres_auth in (None, "", {}):
-                    postgres_auth = args.get("auth") if isinstance(args, dict) else None
+                    postgres_auth = command_input.get("auth") if isinstance(command_input, dict) else None
                 if postgres_auth in (None, "", {}):
                     raise ValueError(
                         f"Postgres step '{step}' is missing auth in command context. "
@@ -1792,9 +1792,9 @@ class V2Worker:
                     direct_fields.update(
                         key for key in forbidden_fields if tool_config.get(key) not in (None, "")
                     )
-                if isinstance(args, dict):
+                if isinstance(command_input, dict):
                     direct_fields.update(
-                        key for key in forbidden_fields if args.get(key) not in (None, "")
+                        key for key in forbidden_fields if command_input.get(key) not in (None, "")
                     )
                 if direct_fields:
                     raise ValueError(
@@ -1804,7 +1804,14 @@ class V2Worker:
 
             # Execute tool
             t_tool_start = time.perf_counter()
-            response = await self._execute_tool(tool_kind, tool_config, args, step, render_context, case_blocks=case_blocks)
+            response = await self._execute_tool(
+                tool_kind,
+                tool_config,
+                command_input,
+                step,
+                render_context,
+                case_blocks=case_blocks,
+            )
             t_tool_end = time.perf_counter()
             logger.info(f"[PERF] Tool execution for {step} took {(t_tool_end - t_tool_start)*1000:.1f}ms")
 
@@ -2592,7 +2599,7 @@ class V2Worker:
                 try:
                     rendered = jinja_env.from_string(template).render(**ctx)
                     # If result looks like JSON (dict or list), parse it back to object
-                    # This allows {{ outcome.result }} to return the actual dict, not a string
+                    # This allows {{ output.data }} to return the actual dict, not a string
                     if isinstance(rendered, str):
                         stripped = rendered.strip()
                         if (stripped.startswith('{') and stripped.endswith('}')) or \
@@ -2601,7 +2608,7 @@ class V2Worker:
                                 return json.loads(stripped)
                             except json.JSONDecodeError:
                                 # Fallback to ast.literal_eval for Python repr format (single quotes)
-                                # This handles {{ outcome.result }} which renders as "{'key': 'value'}"
+                                # This handles {{ output.data }} when rendered as "{'key': 'value'}"
                                 try:
                                     return ast.literal_eval(stripped)
                                 except (ValueError, SyntaxError):

--- a/tests/api/test_v2_command_context_transport.py
+++ b/tests/api/test_v2_command_context_transport.py
@@ -40,7 +40,7 @@ async def test_store_command_context_if_needed_keeps_small_context_inline(monkey
 
     context = {
         "tool_config": {"kind": "http"},
-        "args": {"page": 1},
+        "input": {"page": 1},
     }
     result = await v2_api._store_command_context_if_needed(
         execution_id=123,
@@ -59,21 +59,32 @@ def test_validate_postgres_command_context_requires_auth():
             tool_kind="postgres",
             context={
                 "tool_config": {},
-                "args": {},
+                "input": {},
             },
         )
 
 
-def test_validate_postgres_command_context_accepts_tool_or_args_auth():
+def test_validate_postgres_command_context_accepts_tool_or_input_auth():
     v2_api._validate_postgres_command_context(
         step="load_rows",
         tool_kind="postgres",
         context={
             "tool_config": {"auth": "pg_main"},
-            "args": {},
+            "input": {},
         },
     )
 
+    v2_api._validate_postgres_command_context(
+        step="load_rows",
+        tool_kind="postgres",
+        context={
+            "tool_config": {},
+            "input": {"auth": "pg_main"},
+        },
+    )
+
+
+def test_validate_postgres_command_context_accepts_legacy_args_alias():
     v2_api._validate_postgres_command_context(
         step="load_rows",
         tool_kind="postgres",
@@ -91,6 +102,6 @@ def test_validate_postgres_command_context_rejects_direct_connection_fields():
             tool_kind="postgres",
             context={
                 "tool_config": {"auth": "pg_main", "db_host": "localhost"},
-                "args": {},
+                "input": {},
             },
         )


### PR DESCRIPTION
## Summary
- Fix distributed runtime `/api/execute` regression after DSL v2 field rename by making command context canonical on `input` instead of `args`.
- Remove direct `cmd.args` access in server command emission paths (execute, handle_event, batch accept) and centralize context building in helpers.
- Keep backward compatibility by accepting legacy `args` as read aliases in:
  - server command context parsing
  - `CommandIssuedPayload` model
  - `Command` model
- Align DSL runtime language/examples away from `outcome` toward `output` and clarify internal `event.result` as control-plane envelope semantics.
- Update command-context transport tests to assert canonical `input` behavior and explicit legacy alias support.

## Why
PR #348 completed fixture migration to author-facing `input/output/set`, but distributed runtime still crashed because server code referenced `cmd.args` (attribute no longer present on canonical `Command`). This PR removes that mismatch.

## Validation
- Syntax validation:
  - `python3 -m py_compile` on touched runtime/test files: pass.
- Runtime validation on local kind:
  - redeploy via ops playbook using updated branch image
  - `POST /api/execute` for `tests/fixtures/playbooks/hello_world` now succeeds (returns `execution_id` + `started`)
  - no `cmd.args` attribute errors in server logs after execute call
  - fixture re-registration: `139/139` loaded
  - `master_regression_test_parallel` starts successfully in distributed mode

## Notes
- Could not run full pytest locally in this environment because `psycopg` dependency is missing at collection time.
- This PR keeps legacy aliases for compatibility but makes canonical runtime transport/use `input` first.
