### PR TITLE
chore(kind): expose local services via LAN hostname defaults

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -6,7 +6,7 @@ The following tools are available for in-cluster troubleshooting: [Tshoot](manif
 ## Available Components
 
 After deployment, the following components are available on the host system:
-- Noetl server: http://localhost:8082/
+- NoETL server: `http://<LocalHostName>.local:8082/` (fallback: `http://localhost:8082/`)
 - VictoriaLogs: http://localhost:39428/select/vmui
 - Grafana: http://localhost:3000
   - with login: `admin`; password: `admin`
@@ -116,7 +116,14 @@ The Rust CLI automatically:
 
 ---
 
-The noetl service port `8082` is exposed as port `8082` on the host system. Container folders `/opt/noetl/data` and `/opt/noetl/logs` are mounted to the host folders `ci/kind/cache/noetl-data` and `ci/kind/cache/noetl-logs`, respectively. The container status can be checked at http://localhost:8082/api/health
+The noetl service port `8082` is exposed as port `8082` on the host system and bound on `0.0.0.0` for LAN access. Container folders `/opt/noetl/data` and `/opt/noetl/logs` are mounted to the host folders `ci/kind/cache/noetl-data` and `ci/kind/cache/noetl-logs`, respectively. The container status can be checked at `http://<LocalHostName>.local:8082/api/health` (fallback: `http://localhost:8082/api/health`).
+
+If your cluster was created before this bind-address update, recreate it so new port mappings take effect:
+
+```bash
+kind delete cluster --name noetl
+noetl run ../ops/automation/infrastructure/kind.yaml --set action=create
+```
 
 ### Rust CLI Kubernetes Commands
 

--- a/ci/bootstrap/bootstrap.sh
+++ b/ci/bootstrap/bootstrap.sh
@@ -66,6 +66,29 @@ log_error() {
     echo -e "${RED}[ERROR]${NC} $1"
 }
 
+detect_lan_host() {
+    if [[ -n "${NOETL_HOST:-}" ]]; then
+        echo "$NOETL_HOST"
+        return
+    fi
+
+    local host=""
+    if command -v scutil >/dev/null 2>&1; then
+        host="$(scutil --get LocalHostName 2>/dev/null || true)"
+    fi
+    if [[ -z "$host" ]]; then
+        host="$(hostname -s 2>/dev/null || hostname 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$host" ]]; then
+        echo "localhost"
+    elif [[ "$host" == *.* ]]; then
+        echo "$host"
+    else
+        echo "${host}.local"
+    fi
+}
+
 # Help message
 show_help() {
     cat << EOF
@@ -538,18 +561,20 @@ setup_cluster() {
     log_info "Running NoETL bootstrap (this may take several minutes)..."
     noetl run "$OPS_AUTOMATION_DIR/boot.yaml"
 
+    local lan_host
+    lan_host="$(detect_lan_host)"
     log_success "NoETL infrastructure ready"
-    log_info "NoETL Server API: http://localhost:8082"
-    log_info "Gateway API: http://localhost:8090"
-    log_info "Gateway UI: http://localhost:8080"
+    log_info "NoETL Server API: http://${lan_host}:8082"
+    log_info "Gateway API: http://${lan_host}:8090"
+    log_info "Gateway UI: http://${lan_host}:8080"
     echo ""
     log_info "Observability Services:"
-    log_info "  - ClickHouse HTTP:    http://localhost:30123"
-    log_info "  - ClickHouse Native:  localhost:30900"
-    log_info "  - Qdrant HTTP:        http://localhost:30633"
-    log_info "  - Qdrant gRPC:        localhost:30634"
-    log_info "  - NATS Client:        nats://localhost:30422"
-    log_info "  - NATS Monitoring:    http://localhost:30822"
+    log_info "  - ClickHouse HTTP:    http://${lan_host}:30123"
+    log_info "  - ClickHouse Native:  ${lan_host}:30900"
+    log_info "  - Qdrant HTTP:        http://${lan_host}:30633"
+    log_info "  - Qdrant gRPC:        ${lan_host}:30634"
+    log_info "  - NATS Client:        nats://${lan_host}:30422"
+    log_info "  - NATS Monitoring:    http://${lan_host}:30822"
     echo ""
     log_info "Monitoring:"
     log_info "  - Grafana: kubectl port-forward -n vmstack svc/vmstack-grafana 3000:80"
@@ -717,14 +742,17 @@ main() {
     echo "========================================"
     echo ""
     log_success "NoETL development environment is ready"
+    local lan_host
+    lan_host="$(detect_lan_host)"
     echo ""
     echo "Services:"
-    echo "  - NoETL Server API:   http://localhost:8082"
-    echo "  - Gateway API:        http://localhost:8090"
-    echo "  - Gateway UI:         http://localhost:8080"
-    echo "  - ClickHouse HTTP:    http://localhost:30123"
-    echo "  - Qdrant HTTP:        http://localhost:30633"
-    echo "  - NATS Monitoring:    http://localhost:30822"
+    echo "  - NoETL Server API:   http://${lan_host}:8082"
+    echo "  - Gateway API:        http://${lan_host}:8090"
+    echo "  - Gateway UI:         http://${lan_host}:8080"
+    echo "  - ClickHouse HTTP:    http://${lan_host}:30123"
+    echo "  - Qdrant HTTP:        http://${lan_host}:30633"
+    echo "  - NATS Monitoring:    http://${lan_host}:30822"
+    echo "  - Local fallback:     http://localhost:8082"
     echo ""
     echo "Quick Start:"
     echo "  1. Activate venv:        source $VENV_PATH/bin/activate"
@@ -738,7 +766,7 @@ main() {
     echo "  noetl run $OPS_AUTOMATION_DIR/infrastructure/gateway.yaml --set action=status"
     echo ""
     echo "Execute Playbooks:"
-    echo "  noetl execute playbook <name> --host localhost --port 8082"
+    echo "  noetl execute playbook <name> --host ${lan_host} --port 8082"
     echo ""
     echo "Documentation:"
     echo "  - CI Setup: documentation/docs/operations/ci-setup.md"

--- a/ci/kind/config-alt-ports.yaml
+++ b/ci/kind/config-alt-ports.yaml
@@ -7,25 +7,25 @@ nodes:
         # NoETL API
       - containerPort: 30082
         hostPort: 18082
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # PostgreSQL
       - containerPort: 30321
         hostPort: 15432
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # NATS Client
       - containerPort: 30422
         hostPort: 31422
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # NATS Monitoring
       - containerPort: 30822
         hostPort: 31822
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
     # ci/kind/cache added to .gitignore

--- a/ci/kind/config-minimal.yaml
+++ b/ci/kind/config-minimal.yaml
@@ -7,25 +7,25 @@ nodes:
         # NoETL API
       - containerPort: 30082
         hostPort: 8082
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # PostgreSQL
       - containerPort: 30321
         hostPort: 54321
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # NATS Client
       - containerPort: 30422
         hostPort: 30422
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # NATS Monitoring
       - containerPort: 30822
         hostPort: 30822
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
     # ci/kind/cache added to .gitignore

--- a/ci/kind/config-no-ibkr.yaml
+++ b/ci/kind/config-no-ibkr.yaml
@@ -7,91 +7,91 @@ nodes:
         # NOETL
       - containerPort: 30082 
         hostPort: 8082
-        listenAddress: "127.0.0.1" # optional: set the bind address on the host. 0.0.0.0 is the current default
+        listenAddress: "0.0.0.0" # optional: set the bind address on the host. 0.0.0.0 is the current default
         protocol: TCP # optional: set the protocol to one of TCP, UDP, SCTP. TCP is the default
 
         # Postgers
       - containerPort: 30321
         hostPort: 54321
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # Grafana
       - containerPort: 30300
         hostPort: 3000
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # VictoriaLogs
       - containerPort: 30428
         hostPort: 9428
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # ClickHouse HTTP
       - containerPort: 30123
         hostPort: 30123
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # ClickHouse Native
       - containerPort: 30900
         hostPort: 30900
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # Qdrant HTTP
       - containerPort: 30633
         hostPort: 30633
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # Qdrant gRPC
       - containerPort: 30634
         hostPort: 30634
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # NATS Client
       - containerPort: 30422
         hostPort: 30422
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # NATS Monitoring
       - containerPort: 30822
         hostPort: 30822
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # Superset (Analytics)
       - containerPort: 30888
         hostPort: 30888
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # JupyterLab (Analytics)
       - containerPort: 30999
         hostPort: 30999
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # Pagination Test Server
       - containerPort: 30555
         hostPort: 30555
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # Gateway API
       - containerPort: 30090
         hostPort: 8090
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # Gateway UI
       - containerPort: 30080
         hostPort: 8080
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
     # ci/kind/cache added to .gitignore

--- a/ci/kind/config.yaml
+++ b/ci/kind/config.yaml
@@ -7,97 +7,97 @@ nodes:
         # NOETL
       - containerPort: 30082 
         hostPort: 8082
-        listenAddress: "127.0.0.1" # optional: set the bind address on the host. 0.0.0.0 is the current default
+        listenAddress: "0.0.0.0" # optional: set the bind address on the host. 0.0.0.0 is the current default
         protocol: TCP # optional: set the protocol to one of TCP, UDP, SCTP. TCP is the default
 
         # Postgers
       - containerPort: 30321
         hostPort: 54321
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # Grafana
       - containerPort: 30300
         hostPort: 33000
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # VictoriaLogs
       - containerPort: 30428
         hostPort: 39428
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # ClickHouse HTTP
       - containerPort: 30123
         hostPort: 30123
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # ClickHouse Native
       - containerPort: 30900
         hostPort: 30900
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # Qdrant HTTP
       - containerPort: 30633
         hostPort: 30633
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # Qdrant gRPC
       - containerPort: 30634
         hostPort: 30634
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # NATS Client
       - containerPort: 30422
         hostPort: 32422
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # NATS Monitoring
       - containerPort: 30822
         hostPort: 32822
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # Superset (Analytics)
       - containerPort: 30888
         hostPort: 32888
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # JupyterLab (Analytics)
       - containerPort: 30999
         hostPort: 32999
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # Pagination Test Server
       - containerPort: 30555
         hostPort: 32555
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # IBKR Client Portal Gateway
       - containerPort: 30500
         hostPort: 15000
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # Gateway API
       - containerPort: 30090
         hostPort: 38090
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
         # Gateway UI
       - containerPort: 30080
         hostPort: 38080
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         protocol: TCP
 
     # ci/kind/cache added to .gitignore

--- a/tests/fixtures/register_test_playbooks.sh
+++ b/tests/fixtures/register_test_playbooks.sh
@@ -3,9 +3,41 @@
 # Usage:
 #   ./tests/fixtures/register_test_playbooks.sh [host] [port]
 #   ./tests/fixtures/register_test_playbooks.sh [port] [host]
+# Defaults:
+#   host = ${NOETL_HOST:-<LocalHostName>.local}
+#   port = ${NOETL_PORT:-8082}
 
-ARG1=${1:-localhost}
-ARG2=${2:-8082}
+detect_default_host() {
+  if [[ -n "${NOETL_HOST:-}" ]]; then
+    echo "$NOETL_HOST"
+    return
+  fi
+
+  local host=""
+  if command -v scutil >/dev/null 2>&1; then
+    host="$(scutil --get LocalHostName 2>/dev/null || true)"
+  fi
+  if [[ -z "$host" ]]; then
+    host="$(hostname -s 2>/dev/null || hostname 2>/dev/null || true)"
+  fi
+
+  if [[ -z "$host" ]]; then
+    echo "localhost"
+    return
+  fi
+
+  if [[ "$host" == *.* ]]; then
+    echo "$host"
+  else
+    echo "${host}.local"
+  fi
+}
+
+DEFAULT_HOST="$(detect_default_host)"
+DEFAULT_PORT="${NOETL_PORT:-8082}"
+
+ARG1=${1:-$DEFAULT_HOST}
+ARG2=${2:-$DEFAULT_PORT}
 
 if [[ "$ARG1" =~ ^[0-9]+$ ]]; then
   PORT="$ARG1"
@@ -28,6 +60,7 @@ if ! command -v noetl >/dev/null 2>&1; then
 fi
 
 echo "Loading test fixture playbooks from $FIXTURE_ROOT on $HOST port $PORT"
+echo "NoETL endpoint: http://$HOST:$PORT"
 
 if [ ! -d "$FIXTURE_ROOT" ]; then
   echo "Fixture directory not found: $FIXTURE_ROOT" >&2


### PR DESCRIPTION
## Summary
- switch kind host port mappings to `listenAddress: 0.0.0.0` in all local kind configs
- update local bootstrap docs/scripts to prefer `http://<LocalHostName>.local:8082` with localhost fallback
- make `tests/fixtures/register_test_playbooks.sh` default to `NOETL_HOST` or detected `<LocalHostName>.local`

## Why
- local kind services were bound to loopback only, preventing home-network access by machine hostname
- this aligns local test/deploy flows with LAN-access requirements before redeploy/regression reruns

## Validation
- `bash -n tests/fixtures/register_test_playbooks.sh`
- `bash -n ci/bootstrap/bootstrap.sh`
- confirmed no `listenAddress: "127.0.0.1"` remains in `ci/kind/*.yaml`