### PR TITLE
fix: enforce worker-owned result storage and reference-only events

### DIFF
--- a/noetl/server/api/v2.py
+++ b/noetl/server/api/v2.py
@@ -459,7 +459,10 @@ def _extract_event_command_id(req: "EventRequest") -> Optional[str]:
     return None
 
 
-_STRICT_RESULT_ALLOWED_KEYS = {"status", "error", "reference", "context", "meta", "command_id"}
+# Reference-only result envelope persisted in noetl.event.result.
+# Keep command_id as a tolerated legacy input key for extraction, but do not
+# persist it in result (store it in meta/context only).
+_STRICT_RESULT_ALLOWED_KEYS = {"status", "reference", "context", "command_id"}
 _STRICT_PAYLOAD_FORBIDDEN_KEYS = {"response", "inputs", "data", "data_reference", "_internal_data", "_inline"}
 _STRICT_CONTEXT_FORBIDDEN_KEYS = {"response", "result", "payload", "data", "_ref", "_inline", "_internal_data"}
 
@@ -485,7 +488,8 @@ def _contains_legacy_command_keys(value: Any, *, depth: int = 0) -> bool:
         return False
     if isinstance(value, dict):
         for key, child in value.items():
-            if str(key).startswith("command_"):
+            key_str = str(key)
+            if key_str.startswith("command_") and key_str != "command_id":
                 return True
             if _contains_legacy_command_keys(child, depth=depth + 1):
                 return True
@@ -527,6 +531,38 @@ def _validate_reference_only_payload(payload: dict[str, Any]) -> None:
             raise ValueError("payload.result.context includes forbidden inline data keys")
         if _contains_legacy_command_keys(context_obj):
             raise ValueError("payload.result.context includes legacy command_* keys")
+
+
+def _extract_event_error(payload: dict[str, Any]) -> Optional[str]:
+    """Extract compact error text for noetl.event.error column."""
+    if not isinstance(payload, dict):
+        return None
+
+    direct_error = payload.get("error")
+    if isinstance(direct_error, str):
+        value = direct_error.strip()
+        return value[:2000] if value else None
+    if isinstance(direct_error, dict):
+        message = direct_error.get("message")
+        if isinstance(message, str) and message.strip():
+            return message.strip()[:2000]
+        compact = json.dumps(direct_error, default=str)
+        return compact[:2000] if compact else None
+
+    result_obj = payload.get("result")
+    if isinstance(result_obj, dict):
+        result_error = result_obj.get("error")
+        if isinstance(result_error, str):
+            value = result_error.strip()
+            return value[:2000] if value else None
+        if isinstance(result_error, dict):
+            message = result_error.get("message")
+            if isinstance(message, str) and message.strip():
+                return message.strip()[:2000]
+            compact = json.dumps(result_error, default=str)
+            return compact[:2000] if compact else None
+
+    return None
 
 
 _EVENT_TYPE_TERMINAL_PREDICATE = (
@@ -2043,6 +2079,7 @@ async def handle_event(req: EventRequest) -> EventResponse:
             payload=req.payload,
             status=status,
         )
+        error_text = _extract_event_error(req.payload)
         command_id = _extract_event_command_id(req)
         event_meta = dict(req.meta or {})
         event_meta["actionable"] = req.actionable
@@ -2069,12 +2106,12 @@ async def handle_event(req: EventRequest) -> EventResponse:
                 await cur.execute("""
                     INSERT INTO noetl.event (
                         event_id, execution_id, catalog_id, event_type,
-                        node_id, node_name, status, result, meta, created_at
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        node_id, node_name, status, result, meta, error, created_at
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """, (
                     evt_id, int(req.execution_id), catalog_id, req.name,
                     req.step, req.step, status,
-                    Json(result_obj), Json(event_meta), datetime.now(timezone.utc)
+                    Json(result_obj), Json(event_meta), error_text, datetime.now(timezone.utc)
                 ))
                 await conn.commit()
                 _record_db_operation_success()
@@ -2315,12 +2352,6 @@ def _build_reference_only_result(
         context = _bounded_context(payload_result.get("context"))
         if isinstance(context, dict):
             result_obj["context"] = context
-        error_obj = payload_result.get("error")
-        if error_obj is not None:
-            result_obj["error"] = error_obj
-        meta_obj = payload_result.get("meta")
-        if isinstance(meta_obj, dict):
-            result_obj["meta"] = meta_obj
     else:
         direct_reference = payload.get("reference")
         if isinstance(direct_reference, dict):
@@ -2339,9 +2370,6 @@ def _build_reference_only_result(
         else:
             if _estimate_json_size(compact) <= _EVENT_RESULT_CONTEXT_MAX_BYTES:
                 result_obj["context"] = compact
-
-    if "error" in payload and "error" not in result_obj:
-        result_obj["error"] = payload.get("error")
     return result_obj
 
 
@@ -2522,8 +2550,8 @@ async def _persist_batch_acceptance(
                     """
                     INSERT INTO noetl.event (
                         event_id, execution_id, catalog_id, event_type,
-                        node_id, node_name, status, result, meta, worker_id, created_at
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        node_id, node_name, status, result, meta, worker_id, error, created_at
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     """,
                     (
                         evt_id,
@@ -2541,6 +2569,7 @@ async def _persist_batch_acceptance(
                         ),
                         Json(meta_obj),
                         req.worker_id,
+                        _extract_event_error(item.payload),
                         datetime.now(timezone.utc),
                     ),
                 )
@@ -3099,8 +3128,8 @@ async def get_execution_status(execution_id: str, full: bool = False):
                 failed = False
                 completion_inferred = True
             elif terminal_type in terminal_failed_events:
-                completed = True
-                failed = terminal_type != "execution.cancelled"
+                completed = terminal_type == "execution.cancelled"
+                failed = terminal_type in {"playbook.failed", "workflow.failed"}
                 completion_inferred = True
             elif (
                 latest_event["node_name"] == "end"
@@ -3118,6 +3147,9 @@ async def get_execution_status(execution_id: str, full: bool = False):
                 completed = True
                 failed = False
                 completion_inferred = True
+
+            if failed:
+                completed = False
 
             completed_steps: list[str] = []
             seen_steps: set[str] = set()
@@ -3217,8 +3249,8 @@ async def get_execution_status(execution_id: str, full: bool = False):
                     completed = True
                     completion_inferred = True
                 elif terminal_type in terminal_failed_events:
-                    completed = True
-                    failed = terminal_type != "execution.cancelled"
+                    completed = terminal_type == "execution.cancelled"
+                    failed = terminal_type in {"playbook.failed", "workflow.failed"}
                     completion_inferred = True
                 elif latest_event and (
                     latest_event["node_name"] == "end"
@@ -3234,6 +3266,9 @@ async def get_execution_status(execution_id: str, full: bool = False):
                 ):
                     completed = True
                     completion_inferred = True
+
+        if failed:
+            completed = False
 
         duration_anchor = terminal_event or latest_event
 

--- a/noetl/worker/v2_worker_nats.py
+++ b/noetl/worker/v2_worker_nats.py
@@ -533,7 +533,7 @@ class V2Worker:
             key_str = str(key)
             if key_str in blocked_keys:
                 continue
-            if key_str.startswith("command_"):
+            if key_str.startswith("command_") and key_str != "command_id":
                 # Strict contract: command-indexed payloads are legacy transport shape.
                 continue
             if self._is_scalar(child):
@@ -543,7 +543,9 @@ class V2Worker:
                 nested = {
                     str(nk): nv
                     for nk, nv in child.items()
-                    if self._is_scalar(nv) and str(nk) not in blocked_keys
+                    if self._is_scalar(nv)
+                    and str(nk) not in blocked_keys
+                    and (not str(nk).startswith("command_") or str(nk) == "command_id")
                 }
                 if nested:
                     context[key_str] = nested
@@ -568,7 +570,6 @@ class V2Worker:
         value: Any,
         event_name: str,
         payload: Optional[dict[str, Any]] = None,
-        error: Optional[Any] = None,
     ) -> dict[str, Any]:
         status = self._event_status_default(event_name, payload)
         envelope: dict[str, Any] = {"status": status}
@@ -578,8 +579,6 @@ class V2Worker:
         context = self._extract_control_context(value)
         if isinstance(context, dict):
             envelope["context"] = context
-        if error is not None:
-            envelope["error"] = error
         return envelope
 
     @staticmethod
@@ -629,14 +628,12 @@ class V2Worker:
                 value=result_source,
                 event_name=event_name,
                 payload=normalized,
-                error=normalized.get("error"),
             )
         elif event_name in {"call.done", "step.exit", "call.error", "command.completed", "command.failed"}:
             normalized["result"] = self._build_strict_result_envelope(
                 value={},
                 event_name=event_name,
                 payload=normalized,
-                error=normalized.get("error"),
             )
 
         top_level_context = normalized.pop("context", None)
@@ -1815,38 +1812,37 @@ class V2Worker:
             t_tool_end = time.perf_counter()
             logger.info(f"[PERF] Tool execution for {step} took {(t_tool_end - t_tool_start)*1000:.1f}ms")
 
-            # Process result through ResultHandler for large result externalization
-            # This implements output_select pattern: large results stored externally,
-            # small extracted fields available in render_context for templating
-            # Skip for artifact.get since it's meant to provide full data inline for next step
+            # Process result through ResultHandler for event transport.
+            # Contract: worker owns payload persistence; events carry refs/metadata only.
             t_result_start = time.perf_counter()
-            skip_result_processing = tool_kind == "artifact" and tool_config.get("action") == "get"
-            if skip_result_processing:
-                logger.debug(f"[RESULT] Step {step}: skipping result processing (artifact.get)")
-                response_for_events = response
-            else:
-                try:
-                    result_handler = ResultHandler(execution_id=execution_id)
-                    output_config = self._normalize_output_config(tool_config)
-                    processed_response = await result_handler.process_result(
-                        step_name=step,
-                        result=response,
-                        output_config=output_config
+            try:
+                result_handler = ResultHandler(execution_id=execution_id)
+                output_config = self._normalize_output_config(tool_config)
+                event_output_config = dict(output_config)
+                # Enforce reference-only event payloads regardless of result size.
+                event_output_config["inline_max_bytes"] = 0
+                processed_response = await result_handler.process_result(
+                    step_name=step,
+                    result=response,
+                    output_config=event_output_config,
+                )
+                if is_result_ref(processed_response):
+                    logger.info(
+                        f"[RESULT] Step {step}: stored result for event transport | "
+                        f"store={processed_response.get('_store', 'unknown')} | "
+                        f"size={processed_response.get('_size_bytes', 0)}b"
                     )
-                    # If result was externalized, use processed version
-                    if is_result_ref(processed_response):
-                        logger.info(
-                            f"[RESULT] Step {step}: externalized large result | "
-                            f"store={processed_response.get('_store', 'unknown')} | "
-                            f"size={processed_response.get('_size_bytes', 0)}b"
-                        )
-                        # Keep original response for case evaluation, but mark for external storage
-                        response_for_events = processed_response
-                    else:
-                        response_for_events = response
-                except Exception as result_err:
-                    logger.warning(f"[RESULT] Failed to process result for {step}: {result_err}")
-                    response_for_events = response
+                    response_for_events = processed_response
+                else:
+                    # Keep event payload bounded even if store write fails.
+                    logger.warning(
+                        "[RESULT] Step %s: result persistence did not return ref; using compact fallback",
+                        step,
+                    )
+                    response_for_events = processed_response if isinstance(processed_response, dict) else {"_value": None}
+            except Exception as result_err:
+                logger.warning(f"[RESULT] Failed to process result for {step}: {result_err}")
+                response_for_events = {"_store_failed": True, "_store_error": str(result_err)[:300]}
             t_result_end = time.perf_counter()
             logger.debug(f"[PERF] Result processing for {step} took {(t_result_end - t_result_start)*1000:.1f}ms")
 
@@ -1955,7 +1951,7 @@ class V2Worker:
                         "case.evaluated",
                         {
                             "action": case_action,
-                            "result": eval_response,  # Data reference only (no full payload)
+                            "result": response_for_events,
                             "triggered_by": eval_event_name
                         },
                         actionable=True,  # Server should process this for routing
@@ -2005,7 +2001,7 @@ class V2Worker:
                         "step.exit",
                         {
                             "status": "COMPLETED" if not tool_error else "CASE_HANDLED",
-                            "result": eval_response,
+                            "result": response_for_events,
                             "case_action": case_action,
                             "command_id": command_id,
                         },
@@ -2023,7 +2019,7 @@ class V2Worker:
                             {
                                 "command_id": command_id,
                                 "worker_id": self.worker_id,
-                                "result": eval_response,
+                                "result": response_for_events,
                                 "case_action": case_action
                             },
                             actionable=False,  # Informational - case.evaluated has action

--- a/tests/api/execution/test_executions_status_consistency.py
+++ b/tests/api/execution/test_executions_status_consistency.py
@@ -52,7 +52,7 @@ class _GetExecutionCursor:
             return {"total": len(self._events)}
         if "ORDER BY event_id ASC" in self._query:
             return self._first_event
-        if "AND event_type IN ('execution.cancelled', 'playbook.failed', 'workflow.failed'" in self._query:
+        if "AND event_type IN (" in self._query and "'playbook.completed'" in self._query:
             return self._terminal_event
         if "SELECT event_type, node_name, created_at, status" in self._query:
             return self._latest_event
@@ -109,8 +109,8 @@ def test_derive_status_keeps_non_terminal_completed_running():
 def test_pending_command_count_sql_tracks_command_ids():
     sql = " ".join(execution_api._PENDING_COMMAND_COUNT_SQL.split())
     assert "meta->>'command_id'" in sql
-    assert "result->'data'->>'command_id'" in sql
-    assert "UNION ALL" in sql
+    assert "result->'data'->>'command_id'" not in sql
+    assert "EXCEPT" in sql
     assert "SELECT node_name" not in sql
     assert "'call.done'" not in sql
     assert "'command.completed'" in sql
@@ -175,6 +175,9 @@ async def test_get_executions_keeps_terminal_completed(monkeypatch):
             "result": None,
             "error": None,
             "parent_execution_id": None,
+            "terminal_event_type": "playbook.completed",
+            "terminal_status": "COMPLETED",
+            "terminal_end_time": now,
             "path": "bhs/state_report_generation_prod_v10",
             "version": 1,
         }

--- a/tests/api/test_v2_execution_status_terminal.py
+++ b/tests/api/test_v2_execution_status_terminal.py
@@ -26,6 +26,7 @@ class _FakeCursor:
         pending_count: int = 0,
         latest_event_type: str = "batch.processing",
         latest_status: str = "RUNNING",
+        terminal_event_type: str = "playbook.completed",
     ):
         self._query = ""
         self._start_time = start_time
@@ -34,6 +35,7 @@ class _FakeCursor:
         self._pending_count = pending_count
         self._latest_event_type = latest_event_type
         self._latest_status = latest_status
+        self._terminal_event_type = terminal_event_type
 
     async def execute(self, query, _params):
         self._query = query
@@ -52,7 +54,7 @@ class _FakeCursor:
             if self._terminal_time is None:
                 return None
             return {
-                "event_type": "playbook.completed",
+                "event_type": self._terminal_event_type,
                 "node_name": "bhs/state_report_generation_prod_v10",
                 "status": "COMPLETED",
                 "created_at": self._terminal_time,
@@ -89,8 +91,8 @@ class _ConnCtx:
 def test_v2_pending_command_count_sql_tracks_command_ids():
     sql = " ".join(v2_api._PENDING_COMMAND_COUNT_SQL.split())
     assert "meta->>'command_id'" in sql
-    assert "result->'data'->>'command_id'" in sql
-    assert "UNION ALL" in sql
+    assert "result->'data'->>'command_id'" not in sql
+    assert "EXCEPT" in sql
     assert "SELECT node_name" not in sql
     assert "'call.done'" not in sql
     assert "'command.completed'" in sql
@@ -217,3 +219,34 @@ async def test_status_event_log_fallback_keeps_completion_inferred_false_for_non
     assert result["completion_inferred"] is False
     assert result["end_time"] is None
     assert result["source"] == "event_log_fallback"
+
+
+@pytest.mark.asyncio
+async def test_status_marks_terminal_failure_as_failed_not_completed(monkeypatch):
+    start_time = datetime(2026, 3, 24, 6, 20, 0, tzinfo=timezone.utc)
+    terminal_time = datetime(2026, 3, 24, 6, 26, 29, tzinfo=timezone.utc)
+    latest_time = datetime(2026, 3, 24, 6, 26, 35, tzinfo=timezone.utc)
+
+    fake_state = SimpleNamespace(
+        completed=False,
+        failed=False,
+        current_step="step_a",
+        completed_steps={"start"},
+        variables={},
+    )
+    fake_engine = SimpleNamespace(state_store=SimpleNamespace(get_state=lambda _execution_id: fake_state))
+    fake_cursor = _FakeCursor(
+        start_time,
+        latest_time,
+        terminal_time,
+        terminal_event_type="playbook.failed",
+    )
+
+    monkeypatch.setattr(v2_api, "get_engine", lambda: fake_engine)
+    monkeypatch.setattr(v2_api, "get_pool_connection", lambda: _ConnCtx(_FakeConn(fake_cursor)))
+
+    result = await v2_api.get_execution_status("589375687589363111")
+
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["completion_inferred"] is True

--- a/tests/api/test_v2_reference_only_result_helpers.py
+++ b/tests/api/test_v2_reference_only_result_helpers.py
@@ -82,3 +82,35 @@ def test_validate_reference_only_payload_accepts_compact_context():
             }
         }
     )
+
+
+def test_validate_reference_only_payload_rejects_result_error_and_meta():
+    with pytest.raises(ValueError, match="unsupported keys"):
+        v2_api._validate_reference_only_payload(
+            {
+                "result": {
+                    "status": "failed",
+                    "error": {"message": "boom"},
+                    "meta": {"attempt": 1},
+                }
+            }
+        )
+
+
+def test_build_reference_only_result_keeps_result_shape_without_error_meta():
+    payload = {
+        "result": {
+            "status": "failed",
+            "error": {"message": "boom"},
+            "meta": {"attempt": 1},
+            "context": {"command_id": "cmd-2"},
+        },
+        "error": "boom",
+    }
+
+    result = v2_api._build_reference_only_result(payload=payload, status="FAILED")
+
+    assert result["status"] == "FAILED"
+    assert result["context"]["command_id"] == "cmd-2"
+    assert "error" not in result
+    assert "meta" not in result

--- a/tests/worker/test_v2_worker_playbook_tool.py
+++ b/tests/worker/test_v2_worker_playbook_tool.py
@@ -366,6 +366,73 @@ async def test_execute_command_error_events_use_externalized_response(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_execute_command_forces_reference_persistence_for_event_payloads(monkeypatch):
+    worker = V2Worker(worker_id="test-worker")
+    emitted = []
+    batch_payloads = []
+    seen_output_configs = []
+
+    async def fake_execute_tool(*_args, **_kwargs):
+        # Intentionally small result; worker should still persist it for event transport.
+        return {"status": "ok", "data": {"value": 1}}
+
+    class FakeResultHandler:
+        def __init__(self, execution_id):
+            self.execution_id = execution_id
+
+        async def process_result(self, step_name, result, output_config):
+            seen_output_configs.append(dict(output_config))
+            return {
+                "_ref": {
+                    "kind": "result_ref",
+                    "ref": f"noetl://execution/{self.execution_id}/result/{step_name}/forced-ref",
+                    "store": "kv",
+                    "scope": "execution",
+                    "meta": {"bytes": 64},
+                },
+                "_size_bytes": 64,
+                "_store": "kv",
+            }
+
+    async def fake_emit_event(_server_url, _execution_id, _step, event_name, payload, **_kwargs):
+        emitted.append((event_name, payload))
+
+    async def fake_emit_batch_events(_server_url, _execution_id, events, **_kwargs):
+        batch_payloads.extend(events)
+        return True
+
+    monkeypatch.setattr(worker, "_execute_tool", fake_execute_tool)
+    monkeypatch.setattr(worker, "_emit_event", fake_emit_event)
+    monkeypatch.setattr(worker, "_emit_batch_events", fake_emit_batch_events)
+    monkeypatch.setattr(worker_module, "ResultHandler", FakeResultHandler)
+    monkeypatch.setattr(worker_module, "is_result_ref", lambda value: isinstance(value, dict) and "_ref" in value)
+
+    command = {
+        "execution_id": "exec-5",
+        "step": "step_small_result",
+        "tool_kind": "python",
+        "context": {
+            "tool_config": {},
+            "args": {},
+            "render_context": {},
+        },
+    }
+
+    await worker._execute_command(command, server_url="http://noetl.test", command_id="cmd-5")
+
+    assert seen_output_configs
+    assert seen_output_configs[0]["inline_max_bytes"] == 0
+
+    call_done = next(payload for name, payload in emitted if name == "call.done")
+    assert "_ref" in call_done["response"]
+
+    step_exit = next(item["payload"] for item in batch_payloads if item["name"] == "step.exit")
+    command_completed = next(item["payload"] for item in batch_payloads if item["name"] == "command.completed")
+    assert "_ref" in step_exit["result"]
+    assert "_ref" in command_completed["result"]
+
+
+@pytest.mark.asyncio
 async def test_execute_command_normalizes_stringified_context_sections(monkeypatch):
     worker = V2Worker(worker_id="test-worker")
     emitted = []
@@ -386,9 +453,28 @@ async def test_execute_command_normalizes_stringified_context_sections(monkeypat
     async def fake_emit_batch_events(*_args, **_kwargs):
         return True
 
+    class FakeResultHandler:
+        def __init__(self, execution_id):
+            self.execution_id = execution_id
+
+        async def process_result(self, step_name, result, output_config):
+            return {
+                "_ref": {
+                    "kind": "result_ref",
+                    "ref": f"noetl://execution/{self.execution_id}/result/{step_name}/ctx-normalized",
+                    "store": "kv",
+                    "scope": "execution",
+                    "meta": {"bytes": 48},
+                },
+                "_size_bytes": 48,
+                "_store": "kv",
+            }
+
     monkeypatch.setattr(worker, "_execute_tool", fake_execute_tool)
     monkeypatch.setattr(worker, "_emit_event", fake_emit_event)
     monkeypatch.setattr(worker, "_emit_batch_events", fake_emit_batch_events)
+    monkeypatch.setattr(worker_module, "ResultHandler", FakeResultHandler)
+    monkeypatch.setattr(worker_module, "is_result_ref", lambda value: isinstance(value, dict) and "_ref" in value)
 
     command = {
         "execution_id": "exec-2",


### PR DESCRIPTION
## Summary
- enforce strict reference-only `event.result` contract in API ingest (`status/reference/context` only)
- extract and persist event errors into `noetl.event.error` instead of embedding error/meta under `event.result`
- make worker always persist tool output for event transport (`inline_max_bytes=0`) so emitted events carry references, not inline payload data
- ensure `case.evaluated`, `step.exit`, and `command.completed` use reference-backed result envelopes
- normalize execution status booleans so terminal failed runs return `failed=true` and `completed=false`

## Tests
- `./.venv/bin/pytest tests/api/test_v2_reference_only_result_helpers.py -q`
- `./.venv/bin/pytest tests/api/test_v2_execution_status_terminal.py -q`
- `./.venv/bin/pytest tests/api/execution/test_executions_status_consistency.py -q`
- `./.venv/bin/pytest tests/worker/test_v2_worker_playbook_tool.py -q`
- `./.venv/bin/pytest tests/api/test_v2_batch_async.py tests/api/test_active_claim_cache.py -q`
- `NOETL_HOST=722-2.local NOETL_PORT=8082 ./.venv/bin/pytest tests/test_playbook_regression.py -q -k "should_error_tool_is_required" --maxfail=1`

## Runtime validation
- rebuilt and redeployed local kind image `local/noetl:2026-03-28-23-09`
- verified regression `should_error_tool_is_required` now passes against deployed cluster
