### PR TITLE
fix: guard loop replay over-dispatch and add tooling non-blocking matrix

### DIFF
--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -50,6 +50,10 @@ _TASKSEQ_LOOP_REPAIR_THRESHOLD = max(
     0,
     int(os.getenv("NOETL_TASKSEQ_LOOP_REPAIR_THRESHOLD", "3")),
 )
+_TASKSEQ_LOOP_MISSING_MIN_AGE_SECONDS = max(
+    0.0,
+    float(os.getenv("NOETL_TASKSEQ_LOOP_MISSING_MIN_AGE_SECONDS", "5")),
+)
 _LOOP_STALL_WATCHDOG_SECONDS = max(
     0.0,
     float(os.getenv("NOETL_LOOP_STALL_WATCHDOG_SECONDS", "60")),
@@ -1811,8 +1815,14 @@ class ControlFlowEngine:
         node_name: str,
         loop_event_id: Optional[str] = None,
         limit: int = 10,
+        min_age_seconds: float = _TASKSEQ_LOOP_MISSING_MIN_AGE_SECONDS,
     ) -> list[int]:
-        """Find loop iteration indexes that were issued but have no terminal command event."""
+        """
+        Find loop iteration indexes that appear missing terminal events.
+
+        Guards against false positives from healthy in-flight commands by requiring
+        a minimum age before reissuing an index.
+        """
         if limit <= 0:
             return []
 
@@ -1824,10 +1834,15 @@ class ControlFlowEngine:
                 loop_filter = "AND meta->>'loop_event_id' = %s"
                 issued_params.append(str(loop_event_id))
 
+            min_age = max(0.0, float(min_age_seconds or 0.0))
             params: list[Any] = [
                 *issued_params,
                 int(execution_id),
                 node_names,
+                int(execution_id),
+                node_names,
+                min_age,
+                min_age,
                 int(limit),
             ]
 
@@ -1838,12 +1853,24 @@ class ControlFlowEngine:
                         WITH issued AS (
                             SELECT
                                 meta->>'command_id' AS command_id,
-                                NULLIF(meta->>'loop_iteration_index', '')::int AS loop_iteration_index
+                                NULLIF(meta->>'loop_iteration_index', '')::int AS loop_iteration_index,
+                                created_at AS issued_at
                             FROM noetl.event
                             WHERE execution_id = %s
                               AND node_name = ANY(%s)
                               AND event_type = 'command.issued'
                               {loop_filter}
+                        ),
+                        started AS (
+                            SELECT
+                                meta->>'command_id' AS command_id,
+                                MAX(created_at) AS started_at
+                            FROM noetl.event
+                            WHERE execution_id = %s
+                              AND node_name = ANY(%s)
+                              AND event_type = 'command.started'
+                              AND meta ? 'command_id'
+                            GROUP BY meta->>'command_id'
                         ),
                         terminal AS (
                             SELECT DISTINCT meta->>'command_id' AS command_id
@@ -1855,9 +1882,15 @@ class ControlFlowEngine:
                         )
                         SELECT i.loop_iteration_index
                         FROM issued i
+                        LEFT JOIN started s ON s.command_id = i.command_id
                         LEFT JOIN terminal t ON t.command_id = i.command_id
                         WHERE i.loop_iteration_index IS NOT NULL
                           AND t.command_id IS NULL
+                          AND i.issued_at <= (NOW() - (%s * INTERVAL '1 second'))
+                          AND (
+                            s.command_id IS NULL
+                            OR s.started_at <= (NOW() - (%s * INTERVAL '1 second'))
+                          )
                         ORDER BY i.loop_iteration_index
                         LIMIT %s
                         """,

--- a/tests/fixtures/playbook_test_config.yaml
+++ b/tests/fixtures/playbook_test_config.yaml
@@ -302,6 +302,17 @@ playbooks:
     validation:
       execution_status: completed
 
+  # === Load / Non-Blocking Tooling ===
+  - name: tooling_non_blocking
+    path: tests/fixtures/playbooks/load_test/tooling_non_blocking/tooling_non_blocking
+    category: advanced
+    enabled: true
+    requires_credentials: [pg_k8s]
+    expected_result_file: tooling_non_blocking.json
+    validation:
+      execution_status: completed
+      min_steps: 8
+
   # === Playbook Composition ===
   - name: playbook_composition
     path: tests/fixtures/playbooks/playbook_composition/playbook_composition

--- a/tests/fixtures/playbooks/load_test/tooling_non_blocking/tooling_non_blocking.yaml
+++ b/tests/fixtures/playbooks/load_test/tooling_non_blocking/tooling_non_blocking.yaml
@@ -1,0 +1,479 @@
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: tooling_non_blocking
+  path: tests/fixtures/playbooks/load_test/tooling_non_blocking
+  description: |
+    Validate that representative tools do not serialize execution under parallel loop load.
+    Core probes (HTTP/Postgres/DuckDB) run by default.
+    Optional probes (Snowflake, NATS KV, NATS Object Store) can be enabled via workload flags.
+
+workload:
+  api_url: "http://paginated-api.test-server.svc.cluster.local:5555"
+  noetl_api_url: "http://noetl.noetl.svc.cluster.local:8082"
+  expected_total: 5
+  expected_min_parallel: 2
+  mandatory_steps:
+    - run_http_probe
+    - run_postgres_probe
+    - run_duckdb_probe
+  optional_steps:
+    - run_snowflake_probe
+    - run_nats_kv_probe
+    - run_nats_object_probe
+  probe_items:
+    - label: "slow"
+      delay_seconds: 4.0
+      duckdb_work_units: 4000000
+    - label: "fast_a"
+      delay_seconds: 0.0
+      duckdb_work_units: 200000
+    - label: "fast_b"
+      delay_seconds: 0.0
+      duckdb_work_units: 200000
+    - label: "fast_c"
+      delay_seconds: 0.0
+      duckdb_work_units: 200000
+    - label: "fast_d"
+      delay_seconds: 0.0
+      duckdb_work_units: 200000
+
+  # Optional probes are disabled by default so the fixture stays runnable in local kind.
+  enable_snowflake_probe: false
+  enable_nats_kv_probe: false
+  enable_nats_object_probe: false
+
+  snowflake_auth: "sf_test"
+  nats_auth: "nats_credential"
+  nats_kv_bucket: "sessions"
+  nats_object_bucket: "test-objects"
+
+workflow:
+  - step: start
+    desc: Initialize non-blocking tooling matrix context
+    tool:
+      kind: python
+      input: {}
+      code: |
+        result = {"status": "initialized"}
+    set:
+      ctx.probe_items: "{{ workload.probe_items }}"
+      ctx.expected_total: "{{ workload.expected_total }}"
+      ctx.expected_min_parallel: "{{ workload.expected_min_parallel }}"
+      ctx.noetl_api_url: "{{ workload.noetl_api_url }}"
+      ctx.mandatory_steps: "{{ workload.mandatory_steps }}"
+      ctx.optional_steps: "{{ workload.optional_steps }}"
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: reset_http_probe_stats
+
+  - step: reset_http_probe_stats
+    desc: Reset HTTP probe counters before matrix run
+    tool:
+      kind: http
+      method: POST
+      url: "{{ api_url }}/api/v1/concurrency/reset"
+      spec:
+        policy:
+          rules:
+            - when: "{{ output.status == 'error' and output.error.retryable }}"
+              then: { do: retry, attempts: 3, backoff: fixed, delay: 1.0 }
+            - when: "{{ output.status == 'error' }}"
+              then: { do: fail }
+            - else:
+                then: { do: continue }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: run_http_probe
+
+  - step: run_http_probe
+    desc: Execute HTTP slow/fast probes in parallel
+    loop:
+      in: "{{ ctx.probe_items }}"
+      iterator: item
+      spec:
+        mode: parallel
+        max_in_flight: 5
+    tool:
+      kind: http
+      method: GET
+      url: "{{ api_url }}/api/v1/concurrency/probe"
+      params:
+        label: "{{ iter.item.label }}"
+        delay_seconds: "{{ iter.item.delay_seconds }}"
+      spec:
+        policy:
+          rules:
+            - when: "{{ output.status == 'error' and output.error.retryable }}"
+              then: { do: retry, attempts: 3, backoff: fixed, delay: 0.5 }
+            - when: "{{ output.status == 'error' }}"
+              then: { do: fail }
+            - else:
+                then: { do: continue }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: run_postgres_probe
+          when: '{{ event.name == "loop.done" }}'
+
+  - step: run_postgres_probe
+    desc: Execute Postgres slow/fast probes in parallel
+    loop:
+      in: "{{ ctx.probe_items }}"
+      iterator: item
+      spec:
+        mode: parallel
+        max_in_flight: 5
+    tool:
+      kind: postgres
+      auth: pg_k8s
+      query: |
+        SELECT
+          '{{ iter.item.label }}' AS label,
+          {{ iter.item.delay_seconds }}::double precision AS delay_seconds,
+          NOW() AS observed_at
+        FROM (SELECT pg_sleep({{ iter.item.delay_seconds }}::double precision)) AS sleep_call;
+      spec:
+        policy:
+          rules:
+            - when: "{{ output.status == 'error' and output.error.retryable }}"
+              then: { do: retry, attempts: 3, backoff: fixed, delay: 0.5 }
+            - when: "{{ output.status == 'error' }}"
+              then: { do: fail }
+            - else:
+                then: { do: continue }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: run_duckdb_probe
+          when: '{{ event.name == "loop.done" }}'
+
+  - step: run_duckdb_probe
+    desc: Execute DuckDB mixed-work probes in parallel
+    loop:
+      in: "{{ ctx.probe_items }}"
+      iterator: item
+      spec:
+        mode: parallel
+        max_in_flight: 5
+    tool:
+      kind: duckdb
+      database: "/tmp/noetl_tooling_non_blocking_{{ execution_id }}_{{ loop_index }}.duckdb"
+      query: |
+        SELECT
+          '{{ iter.item.label }}' AS label,
+          {{ iter.item.duckdb_work_units }}::BIGINT AS work_units,
+          SUM(LENGTH(md5(CAST(i AS VARCHAR)))) AS checksum
+        FROM range({{ iter.item.duckdb_work_units }}::BIGINT) t(i);
+      spec:
+        policy:
+          rules:
+            - when: "{{ output.status == 'error' and output.error.retryable }}"
+              then: { do: retry, attempts: 3, backoff: fixed, delay: 0.5 }
+            - when: "{{ output.status == 'error' }}"
+              then: { do: fail }
+            - else:
+                then: { do: continue }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: gate_snowflake_probe
+          when: '{{ event.name == "loop.done" }}'
+
+  - step: gate_snowflake_probe
+    desc: Determine if Snowflake probe should run
+    tool:
+      kind: python
+      input:
+        enabled: "{{ workload.enable_snowflake_probe }}"
+      code: |
+        value = str(enabled).strip().lower() if enabled is not None else "false"
+        run = value in {"1", "true", "yes", "on"}
+        result = {"run": run}
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: run_snowflake_probe
+          when: "{{ gate_snowflake_probe.run }}"
+        - step: gate_nats_kv_probe
+
+  - step: run_snowflake_probe
+    desc: Execute Snowflake probes in parallel (optional)
+    loop:
+      in: "{{ ctx.probe_items }}"
+      iterator: item
+      spec:
+        mode: parallel
+        max_in_flight: 5
+    tool:
+      kind: snowflake
+      auth: "{{ workload.snowflake_auth }}"
+      query: |
+        SELECT
+          '{{ iter.item.label }}' AS label,
+          {{ iter.item.delay_seconds }}::FLOAT AS delay_seconds,
+          CURRENT_TIMESTAMP() AS observed_at;
+      spec:
+        policy:
+          rules:
+            - when: "{{ output.status == 'error' and output.error.retryable }}"
+              then: { do: retry, attempts: 2, backoff: fixed, delay: 1.0 }
+            - when: "{{ output.status == 'error' }}"
+              then: { do: fail }
+            - else:
+                then: { do: continue }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: gate_nats_kv_probe
+          when: '{{ event.name == "loop.done" }}'
+
+  - step: gate_nats_kv_probe
+    desc: Determine if NATS KV probe should run
+    tool:
+      kind: python
+      input:
+        enabled: "{{ workload.enable_nats_kv_probe }}"
+      code: |
+        value = str(enabled).strip().lower() if enabled is not None else "false"
+        run = value in {"1", "true", "yes", "on"}
+        result = {"run": run}
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: run_nats_kv_probe
+          when: "{{ gate_nats_kv_probe.run }}"
+        - step: gate_nats_object_probe
+
+  - step: run_nats_kv_probe
+    desc: Execute NATS KV probes in parallel (optional)
+    loop:
+      in: "{{ ctx.probe_items }}"
+      iterator: item
+      spec:
+        mode: parallel
+        max_in_flight: 5
+    tool:
+      kind: nats
+      auth: "{{ workload.nats_auth }}"
+      operation: kv_put
+      bucket: "{{ workload.nats_kv_bucket }}"
+      key: "tooling-non-blocking/{{ execution_id }}/{{ loop_index }}/{{ iter.item.label }}"
+      value:
+        label: "{{ iter.item.label }}"
+        execution_id: "{{ execution_id }}"
+        loop_index: "{{ loop_index }}"
+      spec:
+        policy:
+          rules:
+            - when: "{{ output.status == 'error' and output.error.retryable }}"
+              then: { do: retry, attempts: 2, backoff: fixed, delay: 0.5 }
+            - when: "{{ output.status == 'error' }}"
+              then: { do: fail }
+            - else:
+                then: { do: continue }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: gate_nats_object_probe
+          when: '{{ event.name == "loop.done" }}'
+
+  - step: gate_nats_object_probe
+    desc: Determine if NATS Object Store probe should run
+    tool:
+      kind: python
+      input:
+        enabled: "{{ workload.enable_nats_object_probe }}"
+      code: |
+        value = str(enabled).strip().lower() if enabled is not None else "false"
+        run = value in {"1", "true", "yes", "on"}
+        result = {"run": run}
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: run_nats_object_probe
+          when: "{{ gate_nats_object_probe.run }}"
+        - step: analyze_matrix
+
+  - step: run_nats_object_probe
+    desc: Execute NATS Object Store probes in parallel (optional)
+    loop:
+      in: "{{ ctx.probe_items }}"
+      iterator: item
+      spec:
+        mode: parallel
+        max_in_flight: 5
+    tool:
+      kind: nats
+      auth: "{{ workload.nats_auth }}"
+      operation: object_put
+      bucket: "{{ workload.nats_object_bucket }}"
+      name: "tooling-non-blocking-{{ execution_id }}-{{ loop_index }}-{{ iter.item.label }}.json"
+      data: |
+        {"label":"{{ iter.item.label }}","execution_id":"{{ execution_id }}","loop_index":"{{ loop_index }}"}
+      encoding: utf-8
+      spec:
+        policy:
+          rules:
+            - when: "{{ output.status == 'error' and output.error.retryable }}"
+              then: { do: retry, attempts: 2, backoff: fixed, delay: 0.5 }
+            - when: "{{ output.status == 'error' }}"
+              then: { do: fail }
+            - else:
+                then: { do: continue }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: analyze_matrix
+          when: '{{ event.name == "loop.done" }}'
+
+  - step: analyze_matrix
+    desc: Validate non-blocking behavior from execution events for each enabled tool step
+    tool:
+      kind: python
+      input:
+        noetl_api_url: "{{ ctx.noetl_api_url }}"
+        execution_id: "{{ execution_id }}"
+        expected_total: "{{ ctx.expected_total }}"
+        expected_min_parallel: "{{ ctx.expected_min_parallel }}"
+        mandatory_steps: "{{ ctx.mandatory_steps }}"
+        optional_steps: "{{ ctx.optional_steps }}"
+      code: |
+        urllib_parse = __import__("urllib.parse", fromlist=["urlencode"])
+        urllib_request = __import__("urllib.request", fromlist=["urlopen"])
+        datetime_cls = __import__("datetime").datetime
+
+        page = 1
+        events = []
+        while True:
+            params = urllib_parse.urlencode({"page": page, "page_size": 500})
+            with urllib_request.urlopen(f"{noetl_api_url}/api/executions/{execution_id}?{params}", timeout=30) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+
+            page_events = payload.get("events", [])
+            if isinstance(page_events, list):
+                events.extend(page_events)
+
+            pagination = payload.get("pagination", {})
+            if not isinstance(pagination, dict) or not pagination.get("has_next"):
+                break
+            page += 1
+
+        expected_total_int = int(expected_total)
+        expected_parallel_int = int(expected_min_parallel)
+        tool_metrics = {}
+        tool_status = {}
+
+        all_steps = list(mandatory_steps or []) + list(optional_steps or [])
+        for step_name in all_steps:
+            candidates = {step_name, f"{step_name}:task_sequence"}
+            scoped = [evt for evt in events if str(evt.get("node_id") or evt.get("node_name") or "") in candidates]
+
+            issued = [evt for evt in scoped if evt.get("event_type") == "command.issued"]
+            started = [evt for evt in scoped if evt.get("event_type") == "command.started"]
+            terminal = [
+                evt for evt in scoped
+                if evt.get("event_type") in {"command.completed", "command.failed", "command.cancelled"}
+            ]
+
+            timeline = []
+            for evt in started:
+                value = evt.get("created_at")
+                if value:
+                    text = str(value)
+                    if text.endswith("Z"):
+                        text = text[:-1] + "+00:00"
+                    try:
+                        ts = datetime_cls.fromisoformat(text)
+                        timeline.append((ts, 1))
+                    except Exception:
+                        pass
+            for evt in terminal:
+                value = evt.get("created_at")
+                if value:
+                    text = str(value)
+                    if text.endswith("Z"):
+                        text = text[:-1] + "+00:00"
+                    try:
+                        ts = datetime_cls.fromisoformat(text)
+                        timeline.append((ts, -1))
+                    except Exception:
+                        pass
+
+            timeline.sort(key=lambda item: (item[0], -item[1]))
+            in_flight = 0
+            max_parallel = 0
+            for _ts, delta in timeline:
+                in_flight += delta
+                if in_flight > max_parallel:
+                    max_parallel = in_flight
+
+            window_seconds = 0.0
+            if timeline:
+                window_seconds = (timeline[-1][0] - timeline[0][0]).total_seconds()
+
+            metrics = {
+                "issued_count": len(issued),
+                "started_count": len(started),
+                "terminal_count": len(terminal),
+                "max_parallel": int(max_parallel),
+                "window_seconds": round(window_seconds, 3),
+            }
+            tool_metrics[step_name] = metrics
+
+            if metrics["issued_count"] == 0:
+                tool_status[step_name] = "skipped"
+                continue
+
+            assert metrics["issued_count"] == expected_total_int, (
+                f"{step_name}: expected issued_count={expected_total_int}, got {metrics['issued_count']}"
+            )
+            assert metrics["terminal_count"] == expected_total_int, (
+                f"{step_name}: expected terminal_count={expected_total_int}, got {metrics['terminal_count']}"
+            )
+            assert metrics["max_parallel"] >= expected_parallel_int, (
+                f"{step_name}: expected max_parallel>={expected_parallel_int}, got {metrics['max_parallel']}"
+            )
+            tool_status[step_name] = "validated"
+
+        for step_name in list(mandatory_steps or []):
+            assert tool_status.get(step_name) == "validated", (
+                f"Mandatory probe step '{step_name}' was not validated. status={tool_status.get(step_name)}"
+            )
+
+        result = {
+            "status": "success",
+            "expected_total": expected_total_int,
+            "expected_min_parallel": expected_parallel_int,
+            "tool_status": tool_status,
+            "tool_metrics": tool_metrics,
+        }
+    set:
+      ctx.tooling_metrics: "{{ analyze_matrix.tool_metrics }}"
+      ctx.tooling_status: "{{ analyze_matrix.tool_status }}"
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: end
+
+  - step: end
+    desc: Matrix test complete
+    tool:
+      kind: python
+      input: {}
+      code: |
+        result = {"status": "complete"}

--- a/tests/fixtures/playbooks/pagination/basic/test_pagination_basic.yaml
+++ b/tests/fixtures/playbooks/pagination/basic/test_pagination_basic.yaml
@@ -3,52 +3,125 @@ kind: Playbook
 metadata:
   name: test_pagination_basic
   path: tests/pagination/basic/basic
-  description: Basic page-number pagination test using canonical format
+  description: Async non-blocking HTTP probe using canonical DSL fields
 
 workload:
   api_url: "http://paginated-api.test-server.svc.cluster.local:5555"
-  current_page: 1
-  page_size: 10
-  collected_items: 0
-  has_more: true
+  slow_delay_seconds: 4.0
+  fast_probe_count: 4
+  expected_min_overlap: 2
 
 workflow:
   - step: start
-    desc: Initialize pagination
+    desc: Initialize async-overlap probe
     tool:
       kind: python
       input: {}
       code: |
         result = {"status": "initialized"}
     set:
-      ctx.current_page: "{{ workload.current_page }}"
-      ctx.page_size: "{{ workload.page_size }}"
-      ctx.collected_items: "{{ workload.collected_items }}"
-      ctx.has_more: "{{ workload.has_more }}"
+      ctx.slow_delay_seconds: "{{ workload.slow_delay_seconds }}"
+      ctx.fast_probe_count: "{{ workload.fast_probe_count }}"
+      ctx.expected_min_overlap: "{{ workload.expected_min_overlap }}"
     next:
       spec:
         mode: exclusive
       arcs:
-        - step: fetch_page
+        - step: reset_probe_stats
 
-  - step: fetch_page
-    desc: Fetch a single page of assessments
+  - step: reset_probe_stats
+    desc: Reset server-side async probe counters and verify baseline
+    tool:
+      kind: python
+      input:
+        api_url: "{{ api_url }}"
+      code: |
+        import json
+        import urllib.request
+
+        reset_url = f"{api_url}/api/v1/concurrency/reset"
+        stats_url = f"{api_url}/api/v1/concurrency/stats"
+
+        reset_request = urllib.request.Request(reset_url, method="POST")
+        with urllib.request.urlopen(reset_request, timeout=20) as response:
+            reset_payload = json.loads(response.read().decode("utf-8"))
+
+        with urllib.request.urlopen(stats_url, timeout=20) as response:
+            stats_payload = json.loads(response.read().decode("utf-8"))
+
+        assert reset_payload.get("status") == "reset", "Failed to reset probe counters"
+        assert int(stats_payload.get("started", 0) or 0) == 0, "Probe started counter not reset"
+        assert int(stats_payload.get("completed", 0) or 0) == 0, "Probe completed counter not reset"
+
+        result = {
+            "status": "reset",
+            "started": int(stats_payload.get("started", 0) or 0),
+            "completed": int(stats_payload.get("completed", 0) or 0),
+            "max_active": int(stats_payload.get("max_active", 0) or 0),
+        }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: build_probe_plan
+
+  - step: build_probe_plan
+    desc: Build one slow probe plus N fast probes
+    tool:
+      kind: python
+      input:
+        slow_delay_seconds: "{{ ctx.slow_delay_seconds }}"
+        fast_probe_count: "{{ ctx.fast_probe_count }}"
+      code: |
+        try:
+            slow_delay = float(slow_delay_seconds)
+        except (TypeError, ValueError):
+            slow_delay = 4.0
+
+        try:
+            fast_count = int(fast_probe_count)
+        except (TypeError, ValueError):
+            fast_count = 4
+
+        fast_count = max(1, fast_count)
+        probe_delays = [slow_delay] + [0.0] * fast_count
+        result = {
+            "probe_delays": probe_delays,
+            "expected_total": len(probe_delays),
+        }
+    set:
+      ctx.probe_delays: "{{ build_probe_plan.probe_delays }}"
+      ctx.expected_total: "{{ build_probe_plan.expected_total }}"
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: run_probes
+
+  - step: run_probes
+    desc: Run probes in parallel to verify requests overlap while one is delayed
+    loop:
+      in: "{{ ctx.probe_delays }}"
+      iterator: item
+      spec:
+        mode: parallel
+        max_in_flight: 5
     tool:
       kind: http
-      url: "{{ api_url }}/api/v1/assessments"
       method: GET
+      url: "{{ api_url }}/api/v1/concurrency/probe"
       params:
-        page: "{{ ctx.current_page }}"
-        pageSize: "{{ ctx.page_size }}"
+        delay_seconds: "{{ iter.item }}"
+        label: "pagination-basic"
       spec:
         policy:
           rules:
             - when: "{{ output.status == 'error' and output.error.retryable }}"
               then:
                 do: retry
-                attempts: 5
-                backoff: exponential
-                delay: 1.0
+                attempts: 3
+                backoff: fixed
+                delay: 0.5
             - when: "{{ output.status == 'error' }}"
               then:
                 do: fail
@@ -59,84 +132,78 @@ workflow:
       spec:
         mode: exclusive
       arcs:
-        - step: check_pagination
-
-  - step: check_pagination
-    desc: Check if more pages exist and collect results
-    tool:
-      kind: python
-      input:
-        collected: "{{ ctx.collected_items }}"
-        current_page: "{{ ctx.current_page }}"
-        page_size: "{{ ctx.page_size }}"
-      code: |
-        if isinstance(collected, str):
-            try:
-                collected = int(collected)
-            except ValueError:
-                collected = 0
-        if isinstance(current_page, str):
-            try:
-                current_page = int(current_page)
-            except ValueError:
-                current_page = 1
-        if isinstance(page_size, str):
-            try:
-                page_size = int(page_size)
-            except ValueError:
-                page_size = 10
-
-        if current_page < 4:
-            page_count = page_size
-            has_more_flag = True
-        elif current_page == 4:
-            page_count = 5
-            has_more_flag = False
-        else:
-            page_count = 0
-            has_more_flag = False
-
-        collected_so_far = collected if isinstance(collected, int) else 0
-        total_collected = collected_so_far + page_count
-        next_page = current_page + 1
-
-        result = {
-            'collected_items': total_collected,
-            'has_more': has_more_flag,
-            'next_page': next_page,
-            'total_collected': total_collected
-        }
-    set:
-      ctx.collected_items: "{{ check_pagination.collected_items }}"
-      ctx.current_page: "{{ check_pagination.next_page }}"
-      ctx.has_more: "{{ check_pagination.has_more }}"
-    next:
-      spec:
-        mode: exclusive
-      arcs:
-        - step: fetch_page
-          when: "{{ ctx.has_more == true }}"
         - step: validate_results
-          when: "{{ ctx.has_more != true }}"
+          when: '{{ event.name == "loop.done" }}'
 
   - step: validate_results
-    desc: Validate merged results
+    desc: Assert overlap metrics from server-side probe stats
     tool:
       kind: python
       input:
-        total_items: "{{ ctx.collected_items }}"
+        api_url: "{{ api_url }}"
+        expected_total: "{{ ctx.expected_total }}"
+        expected_min_overlap: "{{ ctx.expected_min_overlap }}"
       code: |
-        total = total_items if isinstance(total_items, int) else 0
-        print(f"Total items fetched: {total}")
-        expected_count = 35
-        success = total == expected_count
+        import json
+        import time
+        import urllib.request
+
+        try:
+            total_expected = int(expected_total)
+        except (TypeError, ValueError):
+            total_expected = 0
+
+        try:
+            min_overlap = int(expected_min_overlap)
+        except (TypeError, ValueError):
+            min_overlap = 2
+
+        stats_url = f"{api_url}/api/v1/concurrency/stats"
+        deadline = time.time() + 20.0
+        stats = {}
+        started = 0
+        completed = 0
+        active = 0
+        max_active = 0
+
+        while True:
+            with urllib.request.urlopen(stats_url, timeout=20) as response:
+                stats = json.loads(response.read().decode("utf-8"))
+
+            started = int(stats.get("started", 0) or 0)
+            completed = int(stats.get("completed", 0) or 0)
+            active = int(stats.get("active", 0) or 0)
+            max_active = int(stats.get("max_active", 0) or 0)
+
+            if active == 0 and completed >= total_expected:
+                break
+            if time.time() >= deadline:
+                break
+            time.sleep(0.25)
+
+        assert started >= total_expected, (
+            f"Expected at least {total_expected} started probes, got {started}"
+        )
+        assert completed >= total_expected, (
+            f"Expected at least {total_expected} completed probes, got {completed}"
+        )
+        assert active == 0, (
+            "Timed out waiting for probe requests to drain; "
+            f"active={active}, started={started}, completed={completed}"
+        )
+        assert max_active >= min_overlap, (
+            "Detected serialized or blocking behavior: "
+            f"expected max_active >= {min_overlap}, got {max_active}"
+        )
 
         result = {
-            'status': 'success' if success else 'failed',
-            'total_items': total,
-            'first_id': 1 if success else 0,
-            'last_id': expected_count if success else 0,
-            'expected': expected_count
+            "status": "success",
+            "started": started,
+            "completed": completed,
+            "active": active,
+            "max_active": max_active,
+            "expected_total": total_expected,
+            "expected_min_overlap": min_overlap,
         }
     next:
       spec:

--- a/tests/fixtures/servers/paginated_api.py
+++ b/tests/fixtures/servers/paginated_api.py
@@ -15,7 +15,7 @@ import sys
 import time
 import random
 import string
-from collections import defaultdict
+from collections import defaultdict, deque
 import logging
 
 logger = logging.getLogger(__name__)
@@ -36,11 +36,127 @@ PATIENT_RECORDS_RATE_LIMIT = int(os.getenv("PATIENT_RECORDS_RATE_LIMIT", "50"))
 PATIENT_RECORDS_MIN_PAGES = int(os.getenv("PATIENT_RECORDS_MIN_PAGES", "2"))
 PATIENT_RECORDS_MAX_PAGES = int(os.getenv("PATIENT_RECORDS_MAX_PAGES", "5"))
 PATIENT_RECORDS_PAYLOAD_KB = int(os.getenv("PATIENT_RECORDS_PAYLOAD_KB", "100"))
+CONCURRENCY_PROBE_MAX_EVENTS = int(os.getenv("CONCURRENCY_PROBE_MAX_EVENTS", "200"))
 
 # Track request attempts per page for flaky endpoint
 flaky_attempts = defaultdict(int)
 rate_limit_tracker = defaultdict(list)  # Track requests per second
 patient_records_rate_tracker: list = []  # Global rate tracker for /patient-records
+
+# Track async overlap behavior for concurrency probes
+concurrency_probe_lock = asyncio.Lock()
+concurrency_probe_state = {
+    "started": 0,
+    "completed": 0,
+    "active": 0,
+    "max_active": 0,
+}
+concurrency_probe_events = deque(maxlen=CONCURRENCY_PROBE_MAX_EVENTS)
+
+
+async def _record_probe_start(delay_seconds: float, label: str) -> tuple[int, int]:
+    """Record probe start and return request id + active count at start."""
+    async with concurrency_probe_lock:
+        concurrency_probe_state["started"] += 1
+        request_id = concurrency_probe_state["started"]
+        concurrency_probe_state["active"] += 1
+        concurrency_probe_state["max_active"] = max(
+            concurrency_probe_state["max_active"],
+            concurrency_probe_state["active"],
+        )
+        active_at_start = concurrency_probe_state["active"]
+        concurrency_probe_events.append(
+            {
+                "phase": "start",
+                "request_id": request_id,
+                "label": label,
+                "delay_seconds": delay_seconds,
+                "ts": time.time(),
+                "active": active_at_start,
+            }
+        )
+    return request_id, active_at_start
+
+
+async def _record_probe_end(request_id: int, label: str, duration_seconds: float) -> dict:
+    """Record probe completion and return updated snapshot."""
+    async with concurrency_probe_lock:
+        concurrency_probe_state["active"] = max(0, concurrency_probe_state["active"] - 1)
+        concurrency_probe_state["completed"] += 1
+        snapshot = {
+            "started": concurrency_probe_state["started"],
+            "completed": concurrency_probe_state["completed"],
+            "active": concurrency_probe_state["active"],
+            "max_active": concurrency_probe_state["max_active"],
+        }
+        concurrency_probe_events.append(
+            {
+                "phase": "end",
+                "request_id": request_id,
+                "label": label,
+                "duration_seconds": round(duration_seconds, 4),
+                "ts": time.time(),
+                "active": concurrency_probe_state["active"],
+            }
+        )
+    return snapshot
+
+
+@app.post('/api/v1/concurrency/reset')
+async def reset_concurrency_probe():
+    """Reset async overlap counters for probe-based blocking tests."""
+    async with concurrency_probe_lock:
+        concurrency_probe_state["started"] = 0
+        concurrency_probe_state["completed"] = 0
+        concurrency_probe_state["active"] = 0
+        concurrency_probe_state["max_active"] = 0
+        concurrency_probe_events.clear()
+    return {"status": "reset"}
+
+
+@app.get('/api/v1/concurrency/stats')
+async def get_concurrency_stats():
+    """Return current overlap stats for async concurrency probes."""
+    async with concurrency_probe_lock:
+        snapshot = {
+            "started": concurrency_probe_state["started"],
+            "completed": concurrency_probe_state["completed"],
+            "active": concurrency_probe_state["active"],
+            "max_active": concurrency_probe_state["max_active"],
+            "recent_events": list(concurrency_probe_events),
+        }
+    return snapshot
+
+
+@app.get('/api/v1/concurrency/probe')
+async def run_concurrency_probe(
+    delay_seconds: float = Query(default=0.0, ge=0.0, le=60.0),
+    label: str = Query(default="probe"),
+):
+    """
+    Async probe endpoint used to detect blocking behavior in callers.
+
+    It intentionally sleeps using asyncio (non-blocking) so other requests can
+    progress while this request is in-flight.
+    """
+    started_at = time.time()
+    request_id, active_at_start = await _record_probe_start(delay_seconds, label)
+    if delay_seconds > 0:
+        await asyncio.sleep(delay_seconds)
+    duration_seconds = time.time() - started_at
+    snapshot = await _record_probe_end(request_id, label, duration_seconds)
+
+    return {
+        "request_id": request_id,
+        "label": label,
+        "delay_seconds": delay_seconds,
+        "duration_seconds": round(duration_seconds, 4),
+        "active_at_start": active_at_start,
+        "started": snapshot["started"],
+        "completed": snapshot["completed"],
+        "active": snapshot["active"],
+        "max_active": snapshot["max_active"],
+    }
 
 
 @app.get('/api/v1/assessments')
@@ -477,7 +593,7 @@ def get_reference_chain_detail(
 # ============================================================================
 
 @app.get('/api/v1/errors')
-def get_with_errors(
+async def get_with_errors(
     page: int = Query(default=1),
     error_type: str = Query(default=None, description="Error to simulate: 429, 500, 503, timeout, auth"),
     retry_after: int = Query(default=5, description="Retry-After header value for 429"),
@@ -510,8 +626,8 @@ def get_with_errors(
         )
 
     elif error_type == 'timeout':
-        # Simulate a slow response (30 seconds)
-        time.sleep(30)
+        # Simulate a slow response with non-blocking async sleep.
+        await asyncio.sleep(30)
         return {'data': [], 'simulated': 'timeout'}
 
     elif error_type == 'auth':
@@ -781,6 +897,9 @@ if __name__ == '__main__':
     print(f"      defaults: delay={PATIENT_RECORDS_MIN_DELAY}-{PATIENT_RECORDS_MAX_DELAY}s, "
           f"pages={PATIENT_RECORDS_MIN_PAGES}-{PATIENT_RECORDS_MAX_PAGES}, "
           f"payload={PATIENT_RECORDS_PAYLOAD_KB}KB, rate_limit={PATIENT_RECORDS_RATE_LIMIT}/s")
+    print("    POST /api/v1/concurrency/reset                - Reset async-overlap probe counters")
+    print("    GET /api/v1/concurrency/probe?delay_seconds=N - Async probe request")
+    print("    GET /api/v1/concurrency/stats                 - Async overlap metrics")
     print("  Error Simulation:")
     print("    GET /api/v1/flaky?page=N&fail_on=2,3          - Flaky endpoint (fails first attempt)")
     print("    GET /api/v1/errors?error_type=429|500|503     - Simulate specific errors")

--- a/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
+++ b/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
@@ -103,6 +103,51 @@ class RepairingNATSCache:
         return claim_index
 
 
+class RecordingCursor:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.query = ""
+        self.params = tuple()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, query, params):
+        self.query = query
+        self.params = tuple(params)
+
+    async def fetchall(self):
+        return list(self.rows)
+
+
+class RecordingConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self, row_factory=None):
+        return self._cursor
+
+
+class RecordingPoolContext:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
 @pytest.mark.asyncio
 async def test_parallel_loop_issues_up_to_max_in_flight(monkeypatch):
     fixture = Path(
@@ -628,6 +673,70 @@ async def test_loop_counter_reconcile_recovers_no_slot_without_watchdog(monkeypa
     assert int(fake_cache.state.get("completed_count", 0)) == 4
     assert int(fake_cache.state.get("scheduled_count", 0)) == 6
     assert fake_cache.state.get("last_counter_reconcile_at")
+
+
+@pytest.mark.asyncio
+async def test_find_missing_loop_iteration_indices_applies_age_gating(monkeypatch):
+    fixture = Path(
+        "tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel/"
+        "heavy_payload_pipeline_in_step_parallel.yaml"
+    )
+    playbook = yaml.safe_load(fixture.read_text(encoding="utf-8"))
+    parsed_playbook = engine_module.Playbook(**playbook)
+    playbook_repo = PlaybookRepo()
+    state_store = StateStore(playbook_repo)
+    engine = ControlFlowEngine(playbook_repo, state_store)
+
+    cursor = RecordingCursor(rows=[{"loop_iteration_index": 1}, {"loop_iteration_index": 4}])
+    conn = RecordingConn(cursor)
+    monkeypatch.setattr(engine_module, "get_pool_connection", lambda: RecordingPoolContext(conn))
+
+    missing = await engine._find_missing_loop_iteration_indices(
+        execution_id="9701",
+        node_name="run_batch_workers",
+        loop_event_id="loop_9701",
+        limit=3,
+        min_age_seconds=7.25,
+    )
+
+    assert missing == [1, 4]
+    assert "event_type = 'command.started'" in cursor.query
+    assert "meta->>'loop_event_id' = %s" in cursor.query
+    assert "s.started_at <= (NOW() - (%s * INTERVAL '1 second'))" in cursor.query
+    assert cursor.params[2] == "loop_9701"
+    assert cursor.params[-3] == 7.25
+    assert cursor.params[-2] == 7.25
+    assert cursor.params[-1] == 3
+
+
+@pytest.mark.asyncio
+async def test_find_missing_loop_iteration_indices_clamps_negative_age(monkeypatch):
+    fixture = Path(
+        "tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel/"
+        "heavy_payload_pipeline_in_step_parallel.yaml"
+    )
+    playbook = yaml.safe_load(fixture.read_text(encoding="utf-8"))
+    parsed_playbook = engine_module.Playbook(**playbook)
+    playbook_repo = PlaybookRepo()
+    state_store = StateStore(playbook_repo)
+    engine = ControlFlowEngine(playbook_repo, state_store)
+
+    cursor = RecordingCursor(rows=[])
+    conn = RecordingConn(cursor)
+    monkeypatch.setattr(engine_module, "get_pool_connection", lambda: RecordingPoolContext(conn))
+
+    missing = await engine._find_missing_loop_iteration_indices(
+        execution_id="9702",
+        node_name="run_batch_workers",
+        loop_event_id=None,
+        limit=5,
+        min_age_seconds=-10.0,
+    )
+
+    assert missing == []
+    assert cursor.params[-3] == 0.0
+    assert cursor.params[-2] == 0.0
+    assert cursor.params[-1] == 5
 
 
 def test_restore_loop_collection_snapshot_when_replay_shrinks_collection():


### PR DESCRIPTION
## Summary
- add loop missing-index age gating in server engine to avoid premature replay reissue of healthy in-flight iterations
  - new env: `NOETL_TASKSEQ_LOOP_MISSING_MIN_AGE_SECONDS` (default `5`)
  - `_find_missing_loop_iteration_indices(...)` now joins `command.started` and applies min-age checks on issued/started rows
- add targeted unit tests for missing-index age gating and negative-age clamping
- restore/expand async probe fixture surface in `paginated_api.py` for blocking detection
  - `/api/v1/concurrency/reset`
  - `/api/v1/concurrency/probe`
  - `/api/v1/concurrency/stats`
  - non-blocking timeout simulation (`await asyncio.sleep`)
- update `test_pagination_basic` to canonical DSL async-overlap validation (`input/output/set`)
- add new load-test fixture `tooling_non_blocking` and wire it into `playbook_test_config.yaml`
  - core probes (default): `http`, `postgres`, `duckdb`
  - optional probes (workload flags): `snowflake`, `nats kv`, `nats object store`
  - single analyzer step validates issued/terminal counts and max parallel overlap from execution events

## Why
Recent distributed runtime executions showed loop over-dispatch/replay under long in-flight tool work (issued count exceeding expected loop cardinality). This patch separates and hardens replay behavior and adds a matrix fixture to continuously detect blocking/serialization and over-dispatch regressions.

## Validation
- `./.venv/bin/pytest -q tests/unit/dsl/v2/test_loop_parallel_dispatch.py -k "find_missing_loop_iteration_indices_applies_age_gating or find_missing_loop_iteration_indices_clamps_negative_age"`
- `python3 -m py_compile noetl/core/dsl/v2/engine.py tests/fixtures/servers/paginated_api.py tests/unit/dsl/v2/test_loop_parallel_dispatch.py`
- playbook parse validation:
  - `tests/fixtures/playbooks/load_test/tooling_non_blocking/tooling_non_blocking.yaml`
  - `tests/fixtures/playbooks/pagination/basic/test_pagination_basic.yaml`
- local runtime repro captured pre-redeploy on `722-2.local:8082` with `tooling_non_blocking`:
  - execution `593446259529089845`
  - `run_http_probe`: issued=5, terminal=5
  - `run_postgres_probe`: issued=5, terminal=5
  - `run_duckdb_probe`: issued=12, terminal=8 (expected 5/5)

## Tracking
- Issue updated with repro + fix split notes: https://github.com/noetl/noetl/issues/345