### PR TITLE
fix: harden replay idempotency for task-sequence events

### DIFF
--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -219,6 +219,43 @@ def _unwrap_event_payload(payload: Any) -> Any:
     return payload
 
 
+def _extract_command_id_from_event_payload(payload: Any) -> Optional[str]:
+    """Best-effort extraction of command_id from worker event payloads."""
+    if not isinstance(payload, dict):
+        return None
+
+    candidates: list[Any] = [payload.get("command_id")]
+
+    payload_context = payload.get("context")
+    if isinstance(payload_context, dict):
+        candidates.append(payload_context.get("command_id"))
+
+    payload_result = payload.get("result")
+    if isinstance(payload_result, dict):
+        candidates.append(payload_result.get("command_id"))
+        result_context = payload_result.get("context")
+        if isinstance(result_context, dict):
+            candidates.append(result_context.get("command_id"))
+
+    payload_response = payload.get("response")
+    if isinstance(payload_response, dict):
+        candidates.append(payload_response.get("command_id"))
+        response_context = payload_response.get("context")
+        if isinstance(response_context, dict):
+            candidates.append(response_context.get("command_id"))
+        response_result = payload_response.get("result")
+        if isinstance(response_result, dict):
+            candidates.append(response_result.get("command_id"))
+            response_result_context = response_result.get("context")
+            if isinstance(response_result_context, dict):
+                candidates.append(response_result_context.get("command_id"))
+
+    for value in candidates:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
 def _apply_set_mutations(variables: dict, mutations: dict) -> None:
     """Apply DSL v2 `set` mutations to the execution variable store.
 
@@ -1068,6 +1105,7 @@ class StateStore:
                 loop_iteration_state: dict[str, dict[str, Any]] = {}
                 loop_iteration_counts: dict[str, int] = {}
                 loop_event_ids = {}  # {step_name: loop_event_id}
+                replay_loop_command_ids: dict[str, set[str]] = {}
                 replay_render_env = Environment(undefined=StrictUndefined)
                 from noetl.core.dsl.render import render_template as recursive_render
                 
@@ -1133,6 +1171,63 @@ class StateStore:
                                 for key, value in task_ctx.items():
                                     state.variables[key] = value
                                     logger.debug("[STATE-LOAD] Replayed task-sequence ctx: %s", key)
+
+                        # Reconstruct loop iteration progress for task-sequence loop steps.
+                        # step.exit rows use :task_sequence node names and are intentionally
+                        # skipped below, so call.done is the authoritative iteration signal.
+                        loop_step_name = node_name.replace(":task_sequence", "")
+                        if loop_step_name in loop_steps:
+                            command_id = _extract_command_id_from_event_payload(event_payload)
+                            seen_command_ids = replay_loop_command_ids.setdefault(loop_step_name, set())
+                            if command_id and command_id in seen_command_ids:
+                                logger.debug(
+                                    "[STATE-LOAD] Skipping duplicate task-sequence call.done replay "
+                                    "for %s command_id=%s",
+                                    loop_step_name,
+                                    command_id,
+                                )
+                            else:
+                                if command_id:
+                                    seen_command_ids.add(command_id)
+
+                                if loop_step_name not in loop_iteration_state:
+                                    loop_iteration_state[loop_step_name] = {
+                                        "results": [],
+                                        "omitted_results_count": 0,
+                                        "failed_count": 0,
+                                    }
+                                loop_iteration_counts[loop_step_name] = int(
+                                    loop_iteration_counts.get(loop_step_name, 0) or 0
+                                ) + 1
+
+                                step_loop_state = loop_iteration_state[loop_step_name]
+                                iteration_result = (
+                                    response_data.get("results", response_data)
+                                    if isinstance(response_data, dict)
+                                    else response_data
+                                )
+                                step_results = step_loop_state.get("results", [])
+                                if not isinstance(step_results, list):
+                                    step_results = []
+                                step_results.append(_compact_loop_result(iteration_result))
+                                retained_results, omitted_count = _retain_recent_loop_results(
+                                    step_results,
+                                    int(step_loop_state.get("omitted_results_count", 0) or 0),
+                                )
+                                step_loop_state["results"] = retained_results
+                                step_loop_state["omitted_results_count"] = omitted_count
+                                if isinstance(response_data, dict):
+                                    status = str(response_data.get("status", "")).upper()
+                                    if status in {"FAILED", "ERROR"}:
+                                        step_loop_state["failed_count"] = int(
+                                            step_loop_state.get("failed_count", 0) or 0
+                                        ) + 1
+
+                            loop_event_id = event_payload.get("loop_event_id")
+                            if not loop_event_id and isinstance(response_data, dict):
+                                loop_event_id = response_data.get("loop_event_id")
+                            if loop_event_id:
+                                loop_event_ids[loop_step_name] = str(loop_event_id)
 
                     # For loop steps, collect iteration results from step.exit events
                     if event_type == 'step.exit' and event_payload and node_name in loop_steps:
@@ -1809,6 +1904,39 @@ class ControlFlowEngine:
             )
             return -1
 
+    async def _count_persisted_command_events(
+        self,
+        execution_id: str,
+        event_type: str,
+        command_id: str,
+    ) -> int:
+        """Count persisted events by command_id for actionable idempotency guards."""
+        try:
+            async with get_pool_connection() as conn:
+                async with conn.cursor(row_factory=dict_row) as cur:
+                    await cur.execute(
+                        """
+                        SELECT COUNT(*) AS cnt
+                        FROM noetl.event
+                        WHERE execution_id = %s
+                          AND event_type = %s
+                          AND meta ? 'command_id'
+                          AND meta->>'command_id' = %s
+                        """,
+                        (int(execution_id), event_type, str(command_id)),
+                    )
+                    row = await cur.fetchone()
+                    return int((row or {}).get("cnt", 0) or 0)
+        except Exception as exc:
+            logger.warning(
+                "[EVENT-DEDUPE] Failed to count persisted %s events for %s command_id=%s: %s",
+                event_type,
+                execution_id,
+                command_id,
+                exc,
+            )
+            return -1
+
     async def _find_missing_loop_iteration_indices(
         self,
         execution_id: str,
@@ -1818,10 +1946,10 @@ class ControlFlowEngine:
         min_age_seconds: float = _TASKSEQ_LOOP_MISSING_MIN_AGE_SECONDS,
     ) -> list[int]:
         """
-        Find loop iteration indexes that appear missing terminal events.
+        Find loop iteration indexes that were issued but never started and have no terminal event.
 
-        Guards against false positives from healthy in-flight commands by requiring
-        a minimum age before reissuing an index.
+        Guards against false positives from healthy in-flight commands by only
+        considering unstarted commands older than the minimum age threshold.
         """
         if limit <= 0:
             return []
@@ -1839,9 +1967,6 @@ class ControlFlowEngine:
                 *issued_params,
                 int(execution_id),
                 node_names,
-                int(execution_id),
-                node_names,
-                min_age,
                 min_age,
                 int(limit),
             ]
@@ -1887,10 +2012,7 @@ class ControlFlowEngine:
                         WHERE i.loop_iteration_index IS NOT NULL
                           AND t.command_id IS NULL
                           AND i.issued_at <= (NOW() - (%s * INTERVAL '1 second'))
-                          AND (
-                            s.command_id IS NULL
-                            OR s.started_at <= (NOW() - (%s * INTERVAL '1 second'))
-                          )
+                          AND s.command_id IS NULL
                         ORDER BY i.loop_iteration_index
                         LIMIT %s
                         """,
@@ -3797,6 +3919,30 @@ class ControlFlowEngine:
         if not event.step:
             logger.error("Event missing step name")
             return commands
+
+        # Actionable worker completions may be retried by transport/reaper paths.
+        # Since these events are already persisted before handle_event() runs,
+        # duplicates can trigger the same routing side-effects multiple times.
+        # Guard by command_id and only orchestrate the first persisted instance.
+        if already_persisted and event.name in {"call.done", "call.error"}:
+            command_id = _extract_command_id_from_event_payload(normalized_payload)
+            if command_id:
+                persisted_count = await self._count_persisted_command_events(
+                    event.execution_id,
+                    event.name,
+                    command_id,
+                )
+                if persisted_count > 1:
+                    logger.warning(
+                        "[EVENT-DEDUPE] Ignoring duplicate persisted %s for execution=%s "
+                        "step=%s command_id=%s count=%s",
+                        event.name,
+                        event.execution_id,
+                        event.step,
+                        command_id,
+                        persisted_count,
+                    )
+                    return commands
         
         # Handle inline tasks (dynamically created from pipeline task execution)
         # These have format "parent_step:task_name" (e.g., "success:send_callback")

--- a/noetl/server/api/v2.py
+++ b/noetl/server/api/v2.py
@@ -574,6 +574,14 @@ _EVENT_TYPE_CLAIMED_PREDICATE = "event_type = 'command.claimed'"
 _EVENT_TYPE_SAME_WORKER_LATEST_PREDICATE = (
     "event_type IN ('command.started', 'command.completed', 'command.failed')"
 )
+_COMMAND_EVENT_DEDUPE_TYPES = {
+    "call.done",
+    "call.error",
+    "step.exit",
+    "command.started",
+    "command.completed",
+    "command.failed",
+}
 
 
 def _build_command_id_latest_lookup_sql(
@@ -2092,16 +2100,49 @@ async def handle_event(req: EventRequest) -> EventResponse:
         # Persist worker event
         async with get_pool_connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cur:
-                evt_id = await _next_snowflake_id(cur)
                 await cur.execute(
                     "SELECT catalog_id FROM noetl.event WHERE execution_id = %s LIMIT 1",
                     (int(req.execution_id),)
                 )
                 row = await cur.fetchone()
                 catalog_id = row['catalog_id'] if row else None
-                
-                # Determine status based on event name
-                status = _status_from_event_name(req.name)
+
+                if command_id and req.name in _COMMAND_EVENT_DEDUPE_TYPES:
+                    await cur.execute(
+                        """
+                        SELECT event_id
+                        FROM noetl.event
+                        WHERE execution_id = %s
+                          AND event_type = %s
+                          AND node_name = %s
+                          AND meta ? 'command_id'
+                          AND meta->>'command_id' = %s
+                        ORDER BY event_id DESC
+                        LIMIT 1
+                        """,
+                        (int(req.execution_id), req.name, req.step, command_id),
+                    )
+                    duplicate_row = await cur.fetchone()
+                    if duplicate_row:
+                        duplicate_event_id = int(duplicate_row.get("event_id"))
+                        logger.warning(
+                            "[EVENT-DEDUPE] Ignoring duplicate event %s for execution=%s step=%s "
+                            "command_id=%s existing_event_id=%s",
+                            req.name,
+                            req.execution_id,
+                            req.step,
+                            command_id,
+                            duplicate_event_id,
+                        )
+                        if req.name in {"command.completed", "command.failed"}:
+                            _active_claim_cache_invalidate(command_id=command_id)
+                        return EventResponse(
+                            status="ok",
+                            event_id=duplicate_event_id,
+                            commands_generated=0,
+                        )
+
+                evt_id = await _next_snowflake_id(cur)
 
                 await cur.execute("""
                     INSERT INTO noetl.event (

--- a/tests/fixtures/playbooks/load_test/tooling_non_blocking/tooling_non_blocking.yaml
+++ b/tests/fixtures/playbooks/load_test/tooling_non_blocking/tooling_non_blocking.yaml
@@ -377,6 +377,26 @@ workflow:
         tool_metrics = {}
         tool_status = {}
 
+        def extract_command_id(evt):
+            if not isinstance(evt, dict):
+                return None
+            context = evt.get("context")
+            if isinstance(context, dict):
+                value = context.get("command_id")
+                if isinstance(value, str) and value:
+                    return value
+            result_obj = evt.get("result")
+            if isinstance(result_obj, dict):
+                value = result_obj.get("command_id")
+                if isinstance(value, str) and value:
+                    return value
+                result_context = result_obj.get("context")
+                if isinstance(result_context, dict):
+                    value = result_context.get("command_id")
+                    if isinstance(value, str) and value:
+                        return value
+            return None
+
         all_steps = list(mandatory_steps or []) + list(optional_steps or [])
         for step_name in all_steps:
             candidates = {step_name, f"{step_name}:task_sequence"}
@@ -384,10 +404,16 @@ workflow:
 
             issued = [evt for evt in scoped if evt.get("event_type") == "command.issued"]
             started = [evt for evt in scoped if evt.get("event_type") == "command.started"]
-            terminal = [
-                evt for evt in scoped
-                if evt.get("event_type") in {"command.completed", "command.failed", "command.cancelled"}
-            ]
+            done_events = [evt for evt in scoped if evt.get("event_type") == "call.done"]
+            done_by_command = {}
+            done_without_command = []
+            for evt in done_events:
+                command_id = extract_command_id(evt)
+                if command_id:
+                    done_by_command[command_id] = evt
+                else:
+                    done_without_command.append(evt)
+            terminal = list(done_by_command.values()) + done_without_command
 
             timeline = []
             for evt in started:

--- a/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
+++ b/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
@@ -702,9 +702,8 @@ async def test_find_missing_loop_iteration_indices_applies_age_gating(monkeypatc
     assert missing == [1, 4]
     assert "event_type = 'command.started'" in cursor.query
     assert "meta->>'loop_event_id' = %s" in cursor.query
-    assert "s.started_at <= (NOW() - (%s * INTERVAL '1 second'))" in cursor.query
+    assert "s.command_id IS NULL" in cursor.query
     assert cursor.params[2] == "loop_9701"
-    assert cursor.params[-3] == 7.25
     assert cursor.params[-2] == 7.25
     assert cursor.params[-1] == 3
 
@@ -734,9 +733,90 @@ async def test_find_missing_loop_iteration_indices_clamps_negative_age(monkeypat
     )
 
     assert missing == []
-    assert cursor.params[-3] == 0.0
     assert cursor.params[-2] == 0.0
     assert cursor.params[-1] == 5
+
+
+def test_extract_command_id_from_event_payload_supports_reference_only_shapes():
+    assert (
+        engine_module._extract_command_id_from_event_payload(
+            {"command_id": "cmd-top-level"}
+        )
+        == "cmd-top-level"
+    )
+    assert (
+        engine_module._extract_command_id_from_event_payload(
+            {"response": {"context": {"command_id": "cmd-response-context"}}}
+        )
+        == "cmd-response-context"
+    )
+    assert (
+        engine_module._extract_command_id_from_event_payload(
+            {"result": {"context": {"command_id": "cmd-result-context"}}}
+        )
+        == "cmd-result-context"
+    )
+    assert engine_module._extract_command_id_from_event_payload({"response": {"status": "ok"}}) is None
+
+
+@pytest.mark.asyncio
+async def test_handle_event_skips_duplicate_persisted_call_done(monkeypatch):
+    playbook = {
+        "apiVersion": "noetl.io/v2",
+        "kind": "Playbook",
+        "metadata": {"name": "duplicate_call_done_guard"},
+        "workflow": [
+            {
+                "step": "reset_http_probe_stats",
+                "tool": {"kind": "python", "code": "def main(**kwargs): return {'ok': True}"},
+                "next": [{"step": "end"}],
+            },
+            {
+                "step": "end",
+                "tool": {"kind": "python", "code": "def main(**kwargs): return {'ok': True}"},
+            },
+        ],
+    }
+
+    parsed_playbook = engine_module.Playbook(**playbook)
+    playbook_repo = PlaybookRepo()
+    state_store = StateStore(playbook_repo)
+    engine = ControlFlowEngine(playbook_repo, state_store)
+
+    state = ExecutionState("9703", parsed_playbook, payload={})
+    state.last_event_id = 1
+
+    async def fake_load_state(_execution_id):
+        return state
+
+    async def fake_should_refresh(*_args, **_kwargs):
+        return False
+
+    async def fake_duplicate_count(*_args, **_kwargs):
+        return 2
+
+    async def should_not_route(*_args, **_kwargs):
+        raise AssertionError("duplicate call.done should not trigger routing")
+
+    monkeypatch.setattr(state_store, "load_state", fake_load_state)
+    monkeypatch.setattr(state_store, "get_state", lambda _execution_id: state)
+    monkeypatch.setattr(state_store, "should_refresh_cached_state", fake_should_refresh)
+    monkeypatch.setattr(engine, "_count_persisted_command_events", fake_duplicate_count)
+    monkeypatch.setattr(engine, "_evaluate_next_transitions", should_not_route)
+
+    event = Event(
+        execution_id="9703",
+        step="reset_http_probe_stats:task_sequence",
+        name="call.done",
+        payload={
+            "command_id": "9703:reset_http_probe_stats:task_sequence:cmd-1",
+            "response": {"status": "COMPLETED"},
+        },
+    )
+
+    commands = await engine.handle_event(event, already_persisted=True)
+
+    assert commands == []
 
 
 def test_restore_loop_collection_snapshot_when_replay_shrinks_collection():


### PR DESCRIPTION
## Summary
- harden engine replay/state rebuild for task-sequence loop progress by replaying loop counters from `call.done` with per-command dedupe
- add actionable-event dedupe guard in engine for persisted `call.done`/`call.error` by `command_id` count
- suppress duplicate command-scoped worker events in API ingestion for `(execution_id, step, event_type, command_id)`
- normalize tooling matrix analyzer to use actionable `call.done` command IDs for terminal counting
- add unit coverage for command-id extraction and duplicate persisted `call.done` handling

## Validation
- `.venv/bin/pytest -q tests/unit/dsl/v2/test_loop_parallel_dispatch.py`
  - `20 passed`
- local kind redeploy + live fixture rerun
  - execution: `593473735189856942` (`COMPLETED`)
  - mandatory probe event metrics (DB)
    - `run_http_probe:task_sequence`: `issued=5`, `started=5`, `call.done=5`, `max_parallel=5`
    - `run_postgres_probe:task_sequence`: `issued=5`, `started=5`, `call.done=5`, `max_parallel=5`
    - `run_duckdb_probe:task_sequence`: `issued=5`, `started=5`, `call.done=5`, `max_parallel=5`

## Tracking
- issue update posted on `noetl/noetl#345` with full post-fix evidence
