### PR TITLE
fix(dsl): prevent false loop replay from started-event command-id extraction gap

### DIFF
--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -1990,22 +1990,43 @@ class ControlFlowEngine:
                         ),
                         started AS (
                             SELECT
-                                meta->>'command_id' AS command_id,
+                                COALESCE(
+                                    meta->>'command_id',
+                                    result->'context'->>'command_id',
+                                    context->>'command_id'
+                                ) AS command_id,
                                 MAX(created_at) AS started_at
                             FROM noetl.event
                             WHERE execution_id = %s
                               AND node_name = ANY(%s)
                               AND event_type = 'command.started'
-                              AND meta ? 'command_id'
-                            GROUP BY meta->>'command_id'
+                              AND COALESCE(
+                                    meta->>'command_id',
+                                    result->'context'->>'command_id',
+                                    context->>'command_id'
+                                  ) IS NOT NULL
+                            GROUP BY COALESCE(
+                                meta->>'command_id',
+                                result->'context'->>'command_id',
+                                context->>'command_id'
+                            )
                         ),
                         terminal AS (
-                            SELECT DISTINCT meta->>'command_id' AS command_id
+                            SELECT DISTINCT
+                                COALESCE(
+                                    meta->>'command_id',
+                                    result->'context'->>'command_id',
+                                    context->>'command_id'
+                                ) AS command_id
                             FROM noetl.event
                             WHERE execution_id = %s
                               AND node_name = ANY(%s)
-                              AND event_type IN ('command.completed', 'command.failed', 'command.cancelled')
-                              AND meta ? 'command_id'
+                              AND event_type IN ('command.completed', 'command.failed', 'command.cancelled', 'call.done')
+                              AND COALESCE(
+                                    meta->>'command_id',
+                                    result->'context'->>'command_id',
+                                    context->>'command_id'
+                                  ) IS NOT NULL
                         )
                         SELECT i.loop_iteration_index
                         FROM issued i
@@ -2079,20 +2100,38 @@ class ControlFlowEngine:
                               {loop_filter}
                         ),
                         started AS (
-                            SELECT DISTINCT meta->>'command_id' AS command_id
+                            SELECT DISTINCT
+                                COALESCE(
+                                    meta->>'command_id',
+                                    result->'context'->>'command_id',
+                                    context->>'command_id'
+                                ) AS command_id
                             FROM noetl.event
                             WHERE execution_id = %s
                               AND node_name = ANY(%s)
                               AND event_type = 'command.started'
-                              AND meta ? 'command_id'
+                              AND COALESCE(
+                                    meta->>'command_id',
+                                    result->'context'->>'command_id',
+                                    context->>'command_id'
+                                  ) IS NOT NULL
                         ),
                         terminal AS (
-                            SELECT DISTINCT meta->>'command_id' AS command_id
+                            SELECT DISTINCT
+                                COALESCE(
+                                    meta->>'command_id',
+                                    result->'context'->>'command_id',
+                                    context->>'command_id'
+                                ) AS command_id
                             FROM noetl.event
                             WHERE execution_id = %s
                               AND node_name = ANY(%s)
-                              AND event_type IN ('command.completed', 'command.failed', 'command.cancelled')
-                              AND meta ? 'command_id'
+                              AND event_type IN ('command.completed', 'command.failed', 'command.cancelled', 'call.done')
+                              AND COALESCE(
+                                    meta->>'command_id',
+                                    result->'context'->>'command_id',
+                                    context->>'command_id'
+                                  ) IS NOT NULL
                         )
                         SELECT i.loop_iteration_index
                         FROM issued i

--- a/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
+++ b/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
@@ -701,6 +701,8 @@ async def test_find_missing_loop_iteration_indices_applies_age_gating(monkeypatc
 
     assert missing == [1, 4]
     assert "event_type = 'command.started'" in cursor.query
+    assert "result->'context'->>'command_id'" in cursor.query
+    assert "'call.done'" in cursor.query
     assert "meta->>'loop_event_id' = %s" in cursor.query
     assert "s.command_id IS NULL" in cursor.query
     # issued(execution_id,node_name,loop_event_id) + started(execution_id,node_name)
@@ -738,6 +740,8 @@ async def test_find_missing_loop_iteration_indices_clamps_negative_age(monkeypat
     )
 
     assert missing == []
+    assert "result->'context'->>'command_id'" in cursor.query
+    assert "'call.done'" in cursor.query
     # issued(execution_id,node_name) + started(execution_id,node_name)
     # + terminal(execution_id,node_name) + min_age + limit
     assert len(cursor.params) == 8


### PR DESCRIPTION
## Summary
- Fix SQL bind arity in `_find_missing_loop_iteration_indices` (include terminal CTE params).
- Fix loop orphan/missing detection to extract `command_id` from all runtime shapes:
  - `meta.command_id`
  - `result.context.command_id`
  - `context.command_id`
- Treat `call.done` as terminal evidence in missing/orphaned detection.
- Add regression assertions in `test_loop_parallel_dispatch` for bind arity and command-id extraction query shape.

## Why
`command.started` rows persist command IDs in `result.context.command_id` (not always `meta.command_id`).
The prior query only checked `meta`, so started rows were invisible to orphan/missing detection.
That caused false loop-tail replay and over-dispatch (`issued_count` drift) under worker churn.

## Validation
- `uv run pytest -q tests/unit/dsl/v2/test_loop_parallel_dispatch.py` (20 passed)
- Distributed run in kind: `tests/fixtures/playbooks/load_test/tooling_non_blocking`
  - execution: `593562221490209366`
  - status: `COMPLETED`
  - `run_http_probe` issued/terminal: `5/5`
  - `run_postgres_probe` issued/terminal: `5/5`
  - `run_duckdb_probe` issued/terminal: `5/5`
  - duckdb per-index issued counts: indexes `0..4` each exactly `1`

## Notes
- This closes the over-dispatch symptom for duckdb probe (previous failing run had 14 issued for expected 5).
- Worker OOM/restart behavior remains a separate operational tuning track.
