### PR TITLE
refactor: enforce canonical input/output/set and drop legacy DSL aliases

### DIFF
--- a/noetl/core/dsl/render.py
+++ b/noetl/core/dsl/render.py
@@ -26,8 +26,6 @@ class TaskResultProxy:
         data = object.__getattribute__(self, "_data")
         if name == "data" and name not in data:
             return self
-        if name == "result" and name not in data:
-            return self
         if name == "is_defined":
             return True
         def _wrap(val: Any):

--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -223,8 +223,7 @@ def _apply_set_mutations(variables: dict, mutations: dict) -> None:
     """Apply DSL v2 `set` mutations to the execution variable store.
 
     Handles scoped keys (ctx.x, iter.x, step.x) by stripping the scope prefix
-    and writing the bare key.  Bare keys (no dot prefix) are written as-is for
-    backward compatibility with legacy set_ctx usage.
+    and writing the bare key. Bare keys (no dot prefix) are written as-is.
     """
     for key, value in mutations.items():
         if "." in key:
@@ -258,15 +257,17 @@ def _merge_hydrated_step_result(
     compact_result: dict[str, Any],
     ref_wrapper: dict[str, Any],
 ) -> Any:
-    """Merge resolved result data with compact PRD metadata for runtime templating."""
+    """Merge resolved output data with compact PRD metadata for runtime templating."""
     reference = compact_result.get("reference")
     compact_context = compact_result.get("context")
     compact_status = compact_result.get("status")
 
     if isinstance(resolved, dict):
         hydrated = dict(resolved)
+        hydrated.setdefault("data", resolved)
         hydrated.setdefault("_ref", ref_wrapper)
         if isinstance(reference, dict):
+            hydrated.setdefault("ref", reference)
             hydrated.setdefault("reference", reference)
         if compact_status is not None:
             hydrated.setdefault("status", compact_status)
@@ -275,18 +276,20 @@ def _merge_hydrated_step_result(
         return hydrated
 
     wrapped: dict[str, Any] = {
+        "data": resolved,
         "_ref": ref_wrapper,
-        "reference": reference,
         "status": compact_status,
-        "result": resolved,
     }
+    if isinstance(reference, dict):
+        wrapped["ref"] = reference
+        wrapped["reference"] = reference
     if isinstance(compact_context, dict):
         wrapped["context"] = compact_context
     return wrapped
 
 
 async def _hydrate_reference_only_step_result(result: Any) -> Any:
-    """Resolve compact `result.reference` envelopes back into runtime step data."""
+    """Resolve compact `result.reference` envelopes back into runtime step output."""
     if not isinstance(result, dict):
         return result
 
@@ -306,6 +309,61 @@ async def _hydrate_reference_only_step_result(result: Any) -> Any:
         return result
 
     return _merge_hydrated_step_result(resolved, result, ref_wrapper)
+
+
+def _normalize_output_status(value: Any) -> str:
+    raw = str(value or "").strip().lower()
+    if raw in {"ok", "success", "completed", "done", "noop"}:
+        return "ok"
+    if raw in {"error", "failed", "failure"}:
+        return "error"
+    return "ok"
+
+
+def _build_output_view(
+    *,
+    event_payload: dict[str, Any],
+    step_result: Any,
+) -> dict[str, Any]:
+    """Build canonical author-facing output envelope from control-plane payload and step state."""
+    payload_result = event_payload.get("result")
+    output: dict[str, Any] = {
+        "status": "error" if event_payload.get("error") else "ok",
+        "data": None,
+        "ref": None,
+        "error": event_payload.get("error"),
+    }
+
+    if isinstance(payload_result, dict):
+        output["status"] = _normalize_output_status(payload_result.get("status", output["status"]))
+        if isinstance(payload_result.get("reference"), dict):
+            output["ref"] = payload_result.get("reference")
+        if isinstance(payload_result.get("error"), dict):
+            output["error"] = payload_result.get("error")
+        if isinstance(payload_result.get("context"), dict):
+            output["context"] = payload_result.get("context")
+            output["data"] = payload_result.get("context")
+
+    if isinstance(step_result, dict):
+        if "status" in step_result:
+            output["status"] = _normalize_output_status(step_result.get("status"))
+        if "error" in step_result and step_result.get("error") is not None:
+            output["error"] = step_result.get("error")
+        if isinstance(step_result.get("ref"), dict):
+            output["ref"] = step_result.get("ref")
+        elif isinstance(step_result.get("reference"), dict):
+            output["ref"] = step_result.get("reference")
+        output["data"] = step_result.get("data", step_result)
+        for key in ("http", "pg", "py", "meta", "context"):
+            if key in step_result:
+                output[key] = step_result.get(key)
+    elif step_result is not None:
+        output["data"] = step_result
+
+    if output.get("data") is None and output.get("context") is not None:
+        output["data"] = output["context"]
+
+    return output
 
 
 def _pending_step_key(step_name: Optional[str]) -> str:
@@ -760,20 +818,17 @@ class ExecutionState:
         
         # Add event-specific data (strict reference-only contract).
         if isinstance(event_payload, dict):
-            if "error" in event_payload:
-                context["error"] = event_payload["error"]
-            if "result" in event_payload:
-                context["result"] = event_payload["result"]
-                # Keep response alias for existing condition expressions, but only
-                # from strict result envelope (never raw tool response payload).
-                context["response"] = event_payload["result"]
-            # Canonical DSL v2: expose result payload as 'output.data'
-            context["output"] = {
-                "data": event_payload.get("result"),
-                "ref": event_payload.get("result_ref") or event_payload.get("ref"),
-                "error": event_payload.get("error"),
-                "status": "error" if event_payload.get("error") else "ok",
-            }
+            step_result = self.step_results.get(event.step) if event.step else None
+            if step_result is None and isinstance(event.step, str) and event.step.endswith(":task_sequence"):
+                step_result = self.step_results.get(event.step.rsplit(":", 1)[0])
+
+            output_view = _build_output_view(
+                event_payload=event_payload,
+                step_result=step_result,
+            )
+            context["output"] = output_view
+            if output_view.get("error") is not None:
+                context["error"] = output_view.get("error")
 
         return context
 
@@ -990,7 +1045,7 @@ class StateStore:
                     return None
                 
                 # Extract workload from playbook.initialized event payload.
-                # This contains the merged workload (playbook defaults + parent args)
+                # This contains the merged workload (playbook defaults + parent input)
                 workload = {}
                 logger.debug(
                     "[STATE-LOAD] event_result type=%s truthy=%s is_dict=%s",
@@ -2141,8 +2196,7 @@ class ControlFlowEngine:
             target_step = next_target.get("step")
             when_condition = next_target.get("when")
             # Canonical DSL v2: arc.set contains transition-scoped mutations.
-            # Legacy arc.args treated as backward-compat alias for arc.set.
-            arc_set = next_target.get("set") or next_target.get("args") or {}
+            arc_set = next_target.get("set") or {}
 
             if not target_step:
                 logger.warning(f"[NEXT-EVAL] Skipping next entry {idx} with no step")
@@ -2281,7 +2335,7 @@ class ControlFlowEngine:
 
         Supports:
         - Task sequences: labeled tasks with tool.eval: for flow control
-        - Reserved action types: next, set, result, fail, collect, retry
+        - Reserved action types: next, set, fail, collect, retry, call
         - Inline tasks with tool: { task_name: { tool: { kind: ... } } }
 
         IMPORTANT: Actions are processed sequentially. If inline tasks are present,
@@ -2295,7 +2349,7 @@ class ControlFlowEngine:
         # Reserved action keys that are not named tasks
         # Any key not in this set that contains a tool: is treated as an inline task
         # NOTE: 'vars' REMOVED in strict v10
-        reserved_actions = {"next", "set", "result", "fail", "collect", "retry"}
+        reserved_actions = {"next", "set", "fail", "collect", "retry", "call"}
 
         # Normalize to list
         actions = then_block if isinstance(then_block, list) else [then_block]
@@ -2325,7 +2379,7 @@ class ControlFlowEngine:
                         continue
                     # Skip labeled tasks (they're in the task sequence)
                     is_task = any(
-                        key not in {"next", "set", "result", "fail", "collect", "retry"}
+                        key not in {"next", "set", "fail", "collect", "retry", "call"}
                         and isinstance(val, dict) and "tool" in val
                         for key, val in action.items()
                     )
@@ -2387,11 +2441,11 @@ class ControlFlowEngine:
             # Return only inline task commands (next actions are deferred)
             commands.extend(inline_task_commands)
 
-            # Still process non-next reserved actions (set, result, fail, collect)
+            # Still process non-next reserved actions (set, fail, collect, retry, call)
             for action in actions:
                 if not isinstance(action, dict):
                     continue
-                # Process set, result, fail, collect immediately (they don't depend on inline tasks)
+                # Process immediate actions that don't depend on inline task completion.
                 await self._process_immediate_actions(action, state, context, event, commands)
 
             return commands
@@ -2427,9 +2481,9 @@ class ControlFlowEngine:
                         target_step = next_item
                         arc_set_legacy = {}
                     elif isinstance(next_item, dict):
-                        # {step: name, set: {...}} (canonical) or {step: name, args: {...}} (legacy)
+                        # {step: name, set: {...}} (canonical)
                         target_step = next_item.get("step")
-                        arc_set_legacy = next_item.get("set") or next_item.get("args") or {}
+                        arc_set_legacy = next_item.get("set") or {}
 
                         # Render and apply arc-level set mutations
                         if arc_set_legacy:
@@ -2464,16 +2518,6 @@ class ControlFlowEngine:
                         state.variables[key] = self._render_template(value, context)
                     else:
                         state.variables[key] = value
-            
-            elif "result" in action:
-                # Set step result
-                result_spec = action["result"]
-                if isinstance(result_spec, dict) and "from" in result_spec:
-                    from_key = result_spec["from"]
-                    if from_key in state.variables:
-                        state.mark_step_completed(event.step, state.variables[from_key])
-                else:
-                    state.mark_step_completed(event.step, result_spec)
             
             elif "fail" in action:
                 # Mark execution as failed
@@ -2572,7 +2616,7 @@ class ControlFlowEngine:
                         else:
                             rendered_params[key] = value
 
-                    # HTTP tool expects runtime pagination overrides under args['params']
+                    # HTTP tool expects runtime pagination overrides under input['params']
                     updated_args["params"] = rendered_params
 
                 # Process other updatable fields
@@ -2595,7 +2639,7 @@ class ControlFlowEngine:
                         f"(index now {loop_state['index']})"
                     )
 
-                # Create retry command with updated args (same step)
+                # Create retry command with updated input (same step)
                 retry_args_with_control = dict(updated_args)
                 if loop_state is not None:
                     retry_args_with_control["__loop_retry"] = True
@@ -2620,15 +2664,15 @@ class ControlFlowEngine:
                 # Call/invoke a step with new arguments
                 call_spec = action["call"]
                 target_step = call_spec.get("step")
-                args = call_spec.get("input") or call_spec.get("args") or {}
+                call_input = call_spec.get("input") or {}
                 
                 if not target_step:
                     logger.warning("Call action missing 'step' attribute")
                     continue
                 
-                # Render args
+                # Render input payload.
                 rendered_args = {}
-                for key, value in args.items():
+                for key, value in call_input.items():
                     if isinstance(value, str) and "{{" in value:
                         rendered_args[key] = self._render_template(value, context)
                     else:
@@ -2652,7 +2696,7 @@ class ControlFlowEngine:
                 delay = retry_spec.get("delay", 0)
                 max_attempts = retry_spec.get("max_attempts", 3)
                 backoff = retry_spec.get("backoff", "linear")  # linear, exponential
-                retry_args = retry_spec.get("args", {})  # Get rendered args from worker
+                retry_args = retry_spec.get("input", {})  # Rendered retry input from worker
                 
                 # Get current attempt from event.attempt (Event model field)
                 current_attempt = event.attempt if event.attempt else 1
@@ -2677,7 +2721,7 @@ class ControlFlowEngine:
                     _sample_keys(retry_args),
                 )
                 
-                # Create retry command with rendered args from worker
+                # Create retry command with rendered input from worker
                 command = await self._create_command_for_step(state, step_def, retry_args)
                 if command:
                     # Increment attempt counter
@@ -2704,7 +2748,7 @@ class ControlFlowEngine:
         commands: list[Command]
     ) -> None:
         """
-        Process immediate (non-deferred) actions like set, result, fail, collect.
+        Process immediate (non-deferred) actions like set and fail.
         These actions don't depend on inline task completion and can run immediately.
         """
         if "set" in action:
@@ -2716,19 +2760,9 @@ class ControlFlowEngine:
                 else:
                     state.variables[key] = value
 
-        # NOTE: 'vars' action is REMOVED in strict v10 - use 'set' or task.spec.policy.rules set_ctx
+        # NOTE: 'vars' action is REMOVED in strict v10 - use scoped 'set' assignments.
 
-        if "result" in action:
-            # Set step result
-            result_spec = action["result"]
-            if isinstance(result_spec, dict) and "from" in result_spec:
-                from_key = result_spec["from"]
-                if from_key in state.variables:
-                    state.mark_step_completed(event.step, state.variables[from_key])
-            else:
-                state.mark_step_completed(event.step, result_spec)
-
-        elif "fail" in action:
+        if "fail" in action:
             # Mark execution as failed
             state.failed = True
             logger.info(f"Execution {state.execution_id} marked as failed")
@@ -2809,7 +2843,7 @@ class ControlFlowEngine:
                     deferred_arc_set: dict = {}
                 elif isinstance(next_item, dict):
                     target_step = next_item.get("step")
-                    deferred_arc_set = next_item.get("set") or next_item.get("args") or {}
+                    deferred_arc_set = next_item.get("set") or {}
 
                     # Render and apply arc-level set mutations
                     if deferred_arc_set:
@@ -2862,7 +2896,7 @@ class ControlFlowEngine:
                 kind: gateway
                 action: callback
                 data:
-                  status: "{{ result.status }}"
+                  status: "{{ output.status }}"
 
         Args:
             state: Current execution state
@@ -3594,9 +3628,6 @@ class ControlFlowEngine:
         step_args = {}
         if step.input:
             step_args.update(step.input)
-        elif getattr(step, "args", None):
-            # Backward compat: accept legacy step.args if step.input not set
-            step_args.update(step.args)
 
         # Merge transition-scoped input published by prior routing/actions.
         filtered_args = {
@@ -3619,10 +3650,10 @@ class ControlFlowEngine:
         pipeline = None
         if isinstance(step.tool, list):
             # Pipeline: list of labeled tasks
-            # Each item is {label: {kind: ..., args: ..., eval: ...}}
+            # Each item is {name: ..., kind: ..., input/spec/output...}
             # IMPORTANT: Do NOT pre-render pipeline templates here!
             # Task sequences may have templates that depend on variables set by earlier tasks
-            # (e.g., set_ctx from policy rules). The worker's task_sequence_executor
+            # (e.g., via `set` in policy rules). The worker's task_sequence_executor
             # will render templates at execution time with the proper context.
             pipeline = step.tool  # Pass raw list, worker renders at execution time
             logger.info(f"[PIPELINE] Step '{step.step}' has pipeline with {len(pipeline)} tasks (deferred rendering)")
@@ -3735,7 +3766,7 @@ class ControlFlowEngine:
 
         return command
 
-    # NOTE: _process_vars_block REMOVED in strict v10 - use task.spec.policy.rules set_ctx
+    # NOTE: _process_vars_block REMOVED in strict v10 - use scoped `set` mutations.
 
     async def handle_event(self, event: Event, already_persisted: bool = False) -> list[Command]:
         """
@@ -3894,8 +3925,8 @@ class ControlFlowEngine:
             if not payload_loop_event_id and isinstance(response_data, dict):
                 payload_loop_event_id = response_data.get("loop_event_id")
 
-            # Extract ctx variables from task sequence result and merge into execution state
-            # This syncs set_ctx mutations from task policy rules back to the server
+            # Extract ctx variables from task sequence result and merge into execution state.
+            # This syncs scoped set mutations from task policy rules back to the server.
             task_ctx = response_data.get("ctx", {})
             if task_ctx and isinstance(task_ctx, dict):
                 for key, value in task_ctx.items():
@@ -4197,7 +4228,7 @@ class ControlFlowEngine:
                     except Exception as e:
                         logger.error(f"[TASK_SEQ-LOOP] Error handling loop: {e}", exc_info=True)
             else:
-                # Not in loop - parent step was already marked completed above (before set_ctx)
+                # Not in loop - parent step was already marked completed above (before set processing)
                 # with the last tool's result promoted to the top level for flat template access.
                 logger.info(f"[TASK_SEQ] Parent step '{parent_step}' already marked completed with promoted result")
 
@@ -4610,7 +4641,7 @@ class ControlFlowEngine:
 
             elif action_type == "next":
                 # Worker sends steps as a list: [{"step": "upsert_user"}]
-                # _process_then_actions expects next items to be step names or {step: name, args: {...}}
+                # _process_then_actions expects next items to be step names or {step: name, set: {...}}
                 worker_commands = await self._process_then_actions(
                     [{"next": action_config}],
                     state,
@@ -4764,7 +4795,7 @@ class ControlFlowEngine:
                         loop_done_commands = await self._evaluate_next_transitions(state, step_def, loop_done_event)
                         commands.extend(loop_done_commands)
 
-        # NOTE: step.vars is REMOVED in strict v10 - use task.spec.policy.rules set_ctx
+        # NOTE: step.vars is REMOVED in strict v10 - use scoped `set` mutations.
 
         # If step.exit event and no next/loop matched, use structural next as fallback
         # NOTE: This code path should rarely be hit because next transitions are evaluated

--- a/noetl/core/dsl/v2/models.py
+++ b/noetl/core/dsl/v2/models.py
@@ -28,11 +28,10 @@ class StepEnterPayload(BaseModel):
 
     @model_validator(mode='before')
     @classmethod
-    def _rename_legacy_fields(cls, obj):
-        """Accept legacy 'args' as alias for 'input'."""
-        if isinstance(obj, dict) and "args" in obj and "input" not in obj:
-            obj = dict(obj)
-            obj["input"] = obj.pop("args")
+    def _reject_legacy_fields(cls, obj):
+        """Reject legacy payload aliases to keep event contracts unambiguous."""
+        if isinstance(obj, dict) and "args" in obj:
+            raise ValueError("step.enter payload must use 'input' (legacy 'args' is not allowed)")
         return obj
 
 
@@ -84,11 +83,10 @@ class CommandIssuedPayload(BaseModel):
 
     @model_validator(mode='before')
     @classmethod
-    def _rename_legacy_fields(cls, obj):
-        """Accept legacy 'args' as alias for 'input'."""
-        if isinstance(obj, dict) and "args" in obj and "input" not in obj:
-            obj = dict(obj)
-            obj["input"] = obj.pop("args")
+    def _reject_legacy_fields(cls, obj):
+        """Reject legacy payload aliases to keep command contracts strict."""
+        if isinstance(obj, dict) and "args" in obj:
+            raise ValueError("command.issued payload must use 'input' (legacy 'args' is not allowed)")
         return obj
 
 
@@ -206,19 +204,10 @@ class PolicyRuleThen(BaseModel):
 
     @model_validator(mode='before')
     @classmethod
-    def _rename_legacy_fields(cls, obj):
-        """Accept legacy set_ctx/set_iter as aliases for set."""
-        if isinstance(obj, dict) and "set" not in obj:
-            obj = dict(obj)
-            legacy: dict[str, Any] = {}
-            if "set_ctx" in obj:
-                for k, v in obj.pop("set_ctx").items():
-                    legacy[f"ctx.{k}" if "." not in k else k] = v
-            if "set_iter" in obj:
-                for k, v in obj.pop("set_iter").items():
-                    legacy[f"iter.{k}" if "." not in k else k] = v
-            if legacy:
-                obj["set"] = legacy
+    def _reject_legacy_fields(cls, obj):
+        """Reject legacy assignment aliases; use canonical `set` only."""
+        if isinstance(obj, dict) and ("set_ctx" in obj or "set_iter" in obj):
+            raise ValueError("policy.then must use 'set' (legacy set_ctx/set_iter are not allowed)")
         return obj
 
 
@@ -646,11 +635,10 @@ class Arc(BaseModel):
 
     @model_validator(mode='before')
     @classmethod
-    def _rename_legacy_fields(cls, obj):
-        """Accept legacy 'args' as alias for 'set' on arcs."""
-        if isinstance(obj, dict) and "args" in obj and "set" not in obj:
-            obj = dict(obj)
-            obj["set"] = obj.pop("args")
+    def _reject_legacy_fields(cls, obj):
+        """Reject legacy arc aliases; use canonical `set` only."""
+        if isinstance(obj, dict) and "args" in obj:
+            raise ValueError("next.arcs[] must use 'set' (legacy 'args' is not allowed)")
         return obj
 
 
@@ -886,14 +874,18 @@ class Step(BaseModel):
 
     @model_validator(mode='before')
     @classmethod
-    def _rename_legacy_fields(cls, obj):
-        """Accept legacy field names as aliases for canonical ones."""
-        if isinstance(obj, dict):
-            obj = dict(obj)
-            if "args" in obj and "input" not in obj:
-                obj["input"] = obj.pop("args")
-            if "set_ctx" in obj and "set" not in obj:
-                obj["set"] = obj.pop("set_ctx")
+    def _reject_legacy_fields(cls, obj):
+        """Reject legacy step-level aliases; canonical fields are input/output/set only."""
+        if isinstance(obj, dict) and (
+            "args" in obj
+            or "set_ctx" in obj
+            or "set_iter" in obj
+            or "result" in obj
+            or "outcome" in obj
+        ):
+            raise ValueError(
+                "step must use canonical fields only (legacy args/set_ctx/set_iter/result/outcome are not allowed; use input/set and tool.output)"
+            )
         return obj
 
 
@@ -1084,11 +1076,10 @@ class Command(BaseModel):
 
     @model_validator(mode='before')
     @classmethod
-    def _rename_legacy_fields(cls, obj):
-        """Accept legacy 'args' as alias for 'input'."""
-        if isinstance(obj, dict) and "args" in obj and "input" not in obj:
-            obj = dict(obj)
-            obj["input"] = obj.pop("args")
+    def _reject_legacy_fields(cls, obj):
+        """Reject legacy command aliases; canonical commands carry `input`."""
+        if isinstance(obj, dict) and "args" in obj:
+            raise ValueError("command must use 'input' (legacy 'args' is not allowed)")
         return obj
 
     def to_queue_record(self) -> dict[str, Any]:
@@ -1112,11 +1103,8 @@ class Command(BaseModel):
         }
 
 
-# NOTE: Legacy aliases accepted via model_validate for backward compat:
-# - 'args' -> 'input'  (Step, Arc, Command, StepEnterPayload)
-# - 'set_ctx'/'set_iter' -> 'set'  (Step, PolicyRuleThen)
-# - 'outcome' -> 'output'  (template context key, see engine.py)
-# - 'result' -> 'data'  (ToolOutcome payload field)
+# NOTE: Canonical-only parsing:
+# - Reject legacy aliases such as args/set_ctx/set_iter/outcome/result on author-facing DSL models.
 # Canonical v10 patterns:
 # - step.input / arc.set / output.data / output.ref
 # - set: { ctx.*, iter.*, step.* }

--- a/noetl/server/api/v2.py
+++ b/noetl/server/api/v2.py
@@ -1012,26 +1012,20 @@ def _estimate_json_size(value: Any) -> int:
 
 
 def _command_input_from_context(context: Any) -> dict[str, Any]:
-    """Return canonical command input map from context, accepting legacy args alias."""
+    """Return canonical command input map from context."""
     if not isinstance(context, dict):
         return {}
     input_map = context.get("input")
     if isinstance(input_map, dict):
         return input_map
-    legacy_args = context.get("args")
-    if isinstance(legacy_args, dict):
-        return legacy_args
     return {}
 
 
 def _command_input_from_model(cmd: Any) -> dict[str, Any]:
-    """Read command input from canonical field first, then legacy args."""
+    """Read command input from canonical field."""
     cmd_input = getattr(cmd, "input", None)
     if isinstance(cmd_input, dict):
         return cmd_input
-    legacy_args = getattr(cmd, "args", None)
-    if isinstance(legacy_args, dict):
-        return legacy_args
     return {}
 
 

--- a/noetl/worker/case_evaluator.py
+++ b/noetl/worker/case_evaluator.py
@@ -343,16 +343,49 @@ def build_eval_context(
 
     This context includes:
     - All render_context variables (workload, step results, etc.)
-    - response/result/this: tool response data
+    - output: canonical tool output envelope
     - event: event context (name, type, step)
     - error: error message if call.error
     - status_code: HTTP status code if available
     """
+    output_status = "error" if event_name == "call.error" else "ok"
+    output_error: Any = error
+    output_ref = None
+    output_data: Any = response
+    output_http: dict[str, Any] = {}
+
+    if isinstance(response, dict):
+        raw_status = str(response.get("status", "")).strip().lower()
+        if raw_status in {"error", "failed"}:
+            output_status = "error"
+        elif raw_status in {"ok", "success", "completed", "noop"}:
+            output_status = "ok"
+
+        if response.get("error") is not None:
+            output_error = response.get("error")
+        output_ref = response.get("ref") or response.get("reference")
+        output_data = response.get("data", response)
+        http_status = response.get("status_code")
+        if isinstance(output_data, dict) and http_status is None:
+            http_status = output_data.get("status_code")
+        if http_status is not None:
+            output_http["status"] = http_status
+
+    if output_error is not None and not isinstance(output_error, dict):
+        output_error = {"message": str(output_error)}
+
+    output = {
+        "status": output_status,
+        "data": output_data,
+        "ref": output_ref,
+        "error": output_error,
+    }
+    if output_http:
+        output["http"] = output_http
+
     eval_context = {
         **render_context,
-        'response': response,
-        'result': response,
-        'this': response,
+        'output': output,
         'event': {
             'name': event_name,
             'type': 'tool.completed' if event_name == 'call.done' else 'tool.error',

--- a/noetl/worker/task_sequence_executor.py
+++ b/noetl/worker/task_sequence_executor.py
@@ -8,10 +8,10 @@ Features:
 - Data threading via _prev (like Clojure's ->)
 - Per-task flow control via task.spec.policy.rules (canonical v10 ONLY)
 - Control actions: continue, retry, break, jump, fail
-- Tracks _task, _prev, _attempt, outcome for template access
+- Tracks _task, _prev, _attempt, output for template access
 - Uses `when` as the ONLY conditional keyword (rejects `expr`)
 - Outcome status uses "ok" | "error" (rejects "success")
-- Variable mutations via set_ctx/set_iter (rejects set_vars)
+- Variable mutations via set (ctx.*, iter.*, step.*) (rejects set_vars)
 
 NO BACKWARD COMPATIBILITY - v10 patterns only.
 
@@ -31,15 +31,15 @@ Canonical v10 usage in playbooks:
           spec:
             policy:
               rules:
-                - when: "{{ outcome.status == 'error' and outcome.error.retryable }}"
+                - when: "{{ output.status == 'error' and output.error.retryable }}"
                   then: { do: retry, attempts: 5, backoff: exponential, delay: 1.0 }
-                - when: "{{ outcome.status == 'error' }}"
+                - when: "{{ output.status == 'error' }}"
                   then: { do: fail }
                 - else:
                     then: { do: continue }
         - name: transform
           kind: python
-          args: { data: "{{ _prev }}" }
+          input: { data: "{{ _prev }}" }
           code: "..."
       next:
         arcs:
@@ -67,7 +67,7 @@ class TaskSequenceContext:
     - _prev: pipeline-local, only valid during tool pipeline execution
     - _task: current task name (pipeline-local)
     - _attempt: retry attempt for current task (pipeline-local)
-    - outcome: current task execution result (pipeline-local)
+    - output: current task execution envelope (pipeline-local)
     - results: all task results by name (pipeline-local)
     - ctx: execution-scoped mutable state (canonical v10)
     - iter: iteration-scoped vars (canonical v10, isolated per parallel loop iteration)
@@ -75,55 +75,52 @@ class TaskSequenceContext:
     _task: str = ""
     _prev: Any = None
     _attempt: int = 1
-    outcome: Optional[dict[str, Any]] = None
+    output: Optional[dict[str, Any]] = None
     results: dict[str, Any] = field(default_factory=dict)
     ctx: dict[str, Any] = field(default_factory=dict)
     iter: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dict for template rendering."""
-        # Canonical DSL v2: expose result as 'output.data'/'output.ref'.
-        # Keep 'outcome' for backward compat with existing playbooks.
         output_view: dict[str, Any] = {}
-        if isinstance(self.outcome, dict):
+        if isinstance(self.output, dict):
             output_view = {
-                "status": self.outcome.get("status", "ok"),
-                "data": self.outcome.get("data") or self.outcome.get("result"),
-                "ref": self.outcome.get("ref"),
-                "error": self.outcome.get("error"),
+                "status": self.output.get("status", "ok"),
+                "data": self.output.get("data"),
+                "ref": self.output.get("ref"),
+                "error": self.output.get("error"),
             }
             for k in ("http", "pg", "py", "meta"):
-                if k in self.outcome:
-                    output_view[k] = self.outcome[k]
+                if k in self.output:
+                    output_view[k] = self.output[k]
         return {
             "_task": self._task,
             "_prev": self._prev,
             "_attempt": self._attempt,
-            "outcome": self.outcome,   # backward compat
-            "output": output_view,     # canonical DSL v2
+            "output": output_view,
             "results": self.results,
             "ctx": self.ctx,
             "iter": self.iter,
         }
 
-    def update_success(self, task_name: str, result: Any, outcome: dict[str, Any]):
+    def update_success(self, task_name: str, result: Any, output: dict[str, Any]):
         """Update context after successful task."""
         self._prev = result
         self._task = task_name
-        self.outcome = outcome
+        self.output = output
         self.results[task_name] = result
 
-    def update_error(self, task_name: str, outcome: dict[str, Any]):
+    def update_error(self, task_name: str, output: dict[str, Any]):
         """Update context after failed task."""
         self._task = task_name
-        self.outcome = outcome
+        self.output = output
 
-    def set_ctx_vars(self, vars_dict: dict[str, Any]):
-        """Update execution-scoped context (canonical v10: set_ctx)."""
+    def apply_ctx_set(self, vars_dict: dict[str, Any]):
+        """Update execution-scoped context."""
         self.ctx.update(vars_dict)
 
-    def set_iter_vars(self, vars_dict: dict[str, Any]):
-        """Update iteration-scoped variables (canonical v10: set_iter)."""
+    def apply_iter_set(self, vars_dict: dict[str, Any]):
+        """Update iteration-scoped variables."""
         self.iter.update(vars_dict)
 
 
@@ -148,7 +145,7 @@ def build_outcome(
     attempt: int = 1,
 ) -> dict[str, Any]:
     """
-    Build a structured outcome object for policy rule expressions.
+    Build a structured output envelope for policy rule expressions.
 
     Args:
         status: "ok" or "error" (canonical v10 - "success" is REJECTED)
@@ -160,7 +157,7 @@ def build_outcome(
         attempt: Current attempt number
 
     Returns:
-        Outcome dict with status, result/error, meta, and tool-specific helpers
+        Output dict with status, data/error, meta, and tool-specific helpers
 
     Raises:
         ValueError: If status is "success" (must use "ok" in v10)
@@ -170,9 +167,9 @@ def build_outcome(
         raise ValueError("Canonical v10 requires status='ok', not 'success'")
 
     if status not in ("ok", "error"):
-        raise ValueError(f"Invalid outcome status: {status}. Must be 'ok' or 'error'")
+        raise ValueError(f"Invalid output status: {status}. Must be 'ok' or 'error'")
 
-    outcome = {
+    output = {
         "status": status,
         "meta": {
             "attempt": attempt,
@@ -182,10 +179,9 @@ def build_outcome(
     }
 
     if status == "ok":
-        outcome["result"] = result   # backward compat
-        outcome["data"] = result     # canonical DSL v2: output.data
+        output["data"] = result
     else:
-        outcome["error"] = error or {"kind": "unknown", "retryable": False, "message": "Unknown error"}
+        output["error"] = error or {"kind": "unknown", "retryable": False, "message": "Unknown error"}
 
     # Add tool-specific helpers
     if tool_kind == "http":
@@ -208,22 +204,22 @@ def build_outcome(
             http_headers = result.get("headers", {})
         if error:
             http_status = error.get("status_code") or error.get("code") or http_status
-        outcome["http"] = {
+        output["http"] = {
             "status": _normalize_http_status(http_status),
             "headers": http_headers,
         }
     elif tool_kind == "postgres":
-        outcome["pg"] = {}
+        output["pg"] = {}
         if error:
-            outcome["pg"]["code"] = error.get("code")
-            outcome["pg"]["sqlstate"] = error.get("sqlstate")
+            output["pg"]["code"] = error.get("code")
+            output["pg"]["sqlstate"] = error.get("sqlstate")
     elif tool_kind == "python":
-        outcome["py"] = {}
+        output["py"] = {}
         if error:
-            outcome["py"]["exception"] = error.get("exception")
-            outcome["py"]["traceback"] = error.get("traceback")
+            output["py"]["exception"] = error.get("exception")
+            output["py"]["traceback"] = error.get("traceback")
 
-    return outcome
+    return output
 
 
 class TaskSequenceExecutor:
@@ -433,7 +429,7 @@ class TaskSequenceExecutor:
             # Spread task results at top level so {{ task_name }} works (not just {{ results.task_name }})
             # IMPORTANT: Merge ctx dicts properly instead of overriding
             # base_context["ctx"] contains execution variables (current_endpoint, etc.)
-            # ctx.ctx contains task sequence mutations (from set_ctx in policy rules)
+            # ctx.ctx contains task-sequence scoped mutations from policy rules.
             # We need both available for template rendering
             task_seq_dict = ctx.to_dict()
             merged_ctx = {**base_context.get("ctx", {}), **task_seq_dict.get("ctx", {})}
@@ -442,7 +438,7 @@ class TaskSequenceExecutor:
             render_ctx = {
                 **base_context,
                 **ctx.results,  # Task results at root level: {{ amadeus_search }}
-                **task_seq_dict,  # Pipeline-local vars: _prev, _task, _attempt, outcome, results
+                **task_seq_dict,  # Pipeline-local vars: _prev, _task, _attempt, output, results
                 "ctx": merged_ctx,  # Merged execution ctx + task sequence ctx
                 "iter": merged_iter,  # Merged iteration vars
             }
@@ -459,7 +455,7 @@ class TaskSequenceExecutor:
                 len(merged_iter),
             )
 
-            # Execute tool and build outcome
+            # Execute tool and build output envelope
             start_time = time.monotonic()
             try:
                 tool_kind = tool_config.get("kind")
@@ -479,7 +475,7 @@ class TaskSequenceExecutor:
                 # Check for error in result
                 if isinstance(result, dict) and result.get("status") == "error":
                     # Preserve HTTP metadata from tool/plugin error payloads so policy rules
-                    # can match outcome.http.status and outcome.error.retryable reliably.
+                    # can match output.http.status and output.error.retryable reliably.
                     raw_status_code = result.get("status_code")
                     if raw_status_code is None and isinstance(result.get("data"), dict):
                         raw_status_code = (
@@ -518,23 +514,23 @@ class TaskSequenceExecutor:
                         if previous_task_name:
                             error_info["recovery"] = {"do": "jump", "to": previous_task_name}
 
-                    outcome = build_outcome(
+                    output = build_outcome(
                         status="error",
                         error=error_info,
                         tool_kind=tool_kind,
                         duration_ms=duration_ms,
                         attempt=ctx._attempt,
                     )
-                    ctx.update_error(task_name, outcome)
+                    ctx.update_error(task_name, output)
                 else:
-                    outcome = build_outcome(
+                    output = build_outcome(
                         status="ok",
                         result=result,
                         tool_kind=tool_kind,
                         duration_ms=duration_ms,
                         attempt=ctx._attempt,
                     )
-                    ctx.update_success(task_name, result, outcome)
+                    ctx.update_success(task_name, result, output)
                     logger.debug(f"[TASK_SEQ] Task '{task_name}' completed successfully")
 
             except Exception as e:
@@ -545,18 +541,18 @@ class TaskSequenceExecutor:
                     tool_config.get("kind", "unknown"),
                     previous_task_name=previous_task_name,
                 )
-                outcome = build_outcome(
+                output = build_outcome(
                     status="error",
                     error=error_info.to_dict(),
                     tool_kind=tool_config.get("kind", "unknown"),
                     duration_ms=duration_ms,
                     attempt=ctx._attempt,
                 )
-                ctx.update_error(task_name, outcome)
+                ctx.update_error(task_name, output)
                 logger.warning(f"[TASK_SEQ] Task '{task_name}' failed: {error_info.message}")
 
             # Evaluate policy rules (strict v10)
-            # Update render_ctx with latest task sequence state (outcome, _prev, etc.)
+            # Update render_ctx with latest task sequence state (_prev, output, etc.)
             # but preserve the merged ctx/iter from render_ctx
             latest_task_dict = ctx.to_dict()
             eval_ctx = {
@@ -564,12 +560,11 @@ class TaskSequenceExecutor:
                 "_task": latest_task_dict["_task"],
                 "_prev": latest_task_dict["_prev"],
                 "_attempt": latest_task_dict["_attempt"],
-                "outcome": latest_task_dict["outcome"],   # backward compat
-                "output": latest_task_dict["output"],     # canonical DSL v2
+                "output": latest_task_dict["output"],
                 "results": latest_task_dict["results"],
                 # Keep merged ctx and iter from render_ctx (don't override with empty task seq ctx)
             }
-            action = self._evaluate_policy_rules(policy_rules, eval_ctx, ctx.outcome)
+            action = self._evaluate_policy_rules(policy_rules, eval_ctx, ctx.output)
 
             # Apply unified 'set' mutations (canonical DSL v2: ctx.*, iter.*, step.*)
             if action.set:
@@ -581,14 +576,14 @@ class TaskSequenceExecutor:
                             logger.warning(f"[TASK_SEQ] Error rendering set.{key}: {e}")
                     # Route to ctx or iter based on scope prefix
                     if key.startswith("ctx."):
-                        ctx.set_ctx_vars({key[4:]: value})
+                        ctx.apply_ctx_set({key[4:]: value})
                     elif key.startswith("iter."):
-                        ctx.set_iter_vars({key[5:]: value})
+                        ctx.apply_iter_set({key[5:]: value})
                     elif key.startswith("step."):
-                        ctx.set_ctx_vars({key[5:]: value})  # step scope → ctx for now
+                        ctx.apply_ctx_set({key[5:]: value})  # step scope → ctx for now
                     else:
-                        # Bare key: backward compat — write to ctx
-                        ctx.set_ctx_vars({key: value})
+                        # Bare key writes into execution context.
+                        ctx.apply_ctx_set({key: value})
                 logger.debug(f"[TASK_SEQ] Applied set keys={list(action.set.keys())}")
 
             # Apply control action
@@ -605,7 +600,7 @@ class TaskSequenceExecutor:
                         "_prev": ctx._prev,
                         "results": ctx.results,
                         "ctx": ctx.ctx,
-                        "error": ctx.outcome.get("error") if ctx.outcome else None,
+                        "error": ctx.output.get("error") if ctx.output else None,
                         "failed_task": task_name,
                     }
 
@@ -697,7 +692,7 @@ class TaskSequenceExecutor:
                     "_prev": ctx._prev,
                     "results": ctx.results,
                     "ctx": ctx.ctx,
-                    "error": ctx.outcome.get("error") if ctx.outcome else None,
+                    "error": ctx.output.get("error") if ctx.output else None,
                     "failed_task": task_name,
                 }
 
@@ -736,7 +731,7 @@ class TaskSequenceExecutor:
                 if "eval" in config:
                     raise ValueError(
                         f"Task '{name}': 'eval' is not allowed in v10. "
-                        "Use 'spec.policy.rules' for outcome handling."
+                        "Use 'spec.policy.rules' for output handling."
                     )
 
                 # Get policy rules from spec.policy.rules
@@ -763,7 +758,7 @@ class TaskSequenceExecutor:
                 if "eval" in config:
                     raise ValueError(
                         f"Task '{name}': 'eval' is not allowed in v10. "
-                        "Use 'spec.policy.rules' for outcome handling."
+                        "Use 'spec.policy.rules' for output handling."
                     )
 
                 # Get policy rules from spec.policy.rules
@@ -853,20 +848,20 @@ class TaskSequenceExecutor:
         self,
         policy_rules: list[dict],
         render_ctx: dict,
-        outcome: dict[str, Any],
+        output: dict[str, Any],
     ) -> ControlAction:
         """
         Evaluate task.spec.policy.rules (strict v10 - no legacy support).
 
         REJECTS: expr (must use when)
-        REJECTS: set_vars (must use set_ctx)
+        REJECTS: set_vars (must use set)
 
         Default behavior (if no rules):
         - ok → continue
         - error → fail
         """
         if not policy_rules:
-            if outcome and outcome.get("status") == "error":
+            if output and output.get("status") == "error":
                 return ControlAction(action="fail")
             return ControlAction(action="continue")
 
@@ -921,7 +916,7 @@ class TaskSequenceExecutor:
                 continue
 
         # No rule matched
-        if outcome and outcome.get("status") == "error":
+        if output and output.get("status") == "error":
             logger.debug("[TASK_SEQ] No policy rule matched for error, defaulting to fail")
             return ControlAction(action="fail")
 
@@ -955,15 +950,7 @@ class TaskSequenceExecutor:
                 delay = 1.0
 
         # Canonical DSL v2: unified 'set' with scoped keys (ctx.*, iter.*, step.*).
-        # Accept legacy set_ctx / set_iter as backward-compat aliases.
         merged_set: Optional[dict[str, Any]] = then_data.get("set")
-        if merged_set is None:
-            legacy: dict[str, Any] = {}
-            for key, val in (then_data.get("set_ctx") or {}).items():
-                legacy[f"ctx.{key}" if "." not in key else key] = val
-            for key, val in (then_data.get("set_iter") or {}).items():
-                legacy[f"iter.{key}" if "." not in key else key] = val
-            merged_set = legacy or None
 
         return ControlAction(
             action=then_data["do"],

--- a/noetl/worker/v2_worker_nats.py
+++ b/noetl/worker/v2_worker_nats.py
@@ -589,8 +589,6 @@ class V2Worker:
 
         raw_output = tool_config.get("output")
         if not isinstance(raw_output, dict):
-            raw_output = tool_config.get("result")
-        if not isinstance(raw_output, dict):
             return {}
 
         normalized = dict(raw_output)
@@ -1393,7 +1391,7 @@ class V2Worker:
 
         Evaluates case conditions against:
         - Event context (event.name == 'call.done' or 'call.error')
-        - Data context (response.status_code, result.field, error, etc.)
+        - Data context (output.status, output.data.*, output.http.status, error, etc.)
 
         This allows case blocks to handle both success and error scenarios:
 
@@ -1409,7 +1407,7 @@ class V2Worker:
 
         Args:
             case_blocks: List of case conditions
-            response: Tool response/result
+            response: Tool output payload
             render_context: Full render context
             server_url: Server API URL
             execution_id: Execution ID
@@ -1420,38 +1418,19 @@ class V2Worker:
         Returns:
             Action dict {type: 'next'|'retry', details: {...}} or None
         """
-        from jinja2 import Environment
-        
         if not case_blocks or not isinstance(case_blocks, list):
             return None
         
         logger.info(f"[CASE-EVAL] Evaluating {len(case_blocks)} case blocks | event={event_name} | has_error={error is not None}")
-        
-        # Create Jinja environment for condition evaluation
-        jinja_env = Environment()
-        
-        # Build hybrid evaluation context with both event and data
-        eval_context = {
-            **render_context,
-            'response': response,
-            'result': response,
-            'this': response,
-            'event': {
-                'name': event_name,  # 'call.done' or 'call.error'
-                'type': 'tool.completed' if event_name == 'call.done' else 'tool.error',
-                'step': step
-            },
-            'error': error
-        }
-        
-        # Add HTTP-specific context if available
-        if isinstance(response, dict):
-            # Add status_code to top level for convenience
-            if 'status_code' in response:
-                eval_context['status_code'] = response['status_code']
-            # Add data.status_code for nested HTTP responses
-            if isinstance(response.get('data'), dict) and 'status_code' in response['data']:
-                eval_context['status_code'] = response['data']['status_code']
+
+        # Canonical DSL context: output + event + error.
+        eval_context = build_eval_context(
+            render_context=render_context,
+            response=response,
+            step=step,
+            event_name=event_name,
+            error=error,
+        )
         
         # Track if we need to fetch variables from server
         variables_fetched = False
@@ -1524,13 +1503,13 @@ class V2Worker:
                             # Get raw retry config (may contain Jinja2 templates)
                             raw_retry_config = action['retry']
                             
-                            # Render retry args templates with current context
+                            # Render retry input templates with current context
                             # This ensures page numbers and other dynamic values are computed NOW
                             retry_config = {}
                             for key, value in raw_retry_config.items():
-                                if key == 'args' and isinstance(value, dict):
-                                    # Recursively render args
-                                    rendered_args = {}
+                                if key == 'input' and isinstance(value, dict):
+                                    # Recursively render input
+                                    rendered_input = {}
                                     for arg_key, arg_value in value.items():
                                         if isinstance(arg_value, dict):
                                             # Recursively render nested dicts (e.g., params)
@@ -1541,13 +1520,13 @@ class V2Worker:
                                                     rendered_nested[nested_key] = template.render(eval_context)
                                                 else:
                                                     rendered_nested[nested_key] = nested_value
-                                            rendered_args[arg_key] = rendered_nested
+                                            rendered_input[arg_key] = rendered_nested
                                         elif isinstance(arg_value, str) and '{{' in arg_value:
                                             template = _template_cache.get_or_compile(arg_value)
-                                            rendered_args[arg_key] = template.render(eval_context)
+                                            rendered_input[arg_key] = template.render(eval_context)
                                         else:
-                                            rendered_args[arg_key] = arg_value
-                                    retry_config[key] = rendered_args
+                                            rendered_input[arg_key] = arg_value
+                                    retry_config[key] = rendered_input
                                 else:
                                     retry_config[key] = value
                             
@@ -1639,7 +1618,7 @@ class V2Worker:
 
         Evaluates case conditions against:
         - Event context (event.name, event.type, etc.)
-        - Data context (response.status_code, result.field, error, etc.)
+        - Data context (output.status, output.data.*, output.http.status, error, etc.)
 
         Returns action to take: {type: 'next'|'retry', details: {...}}
         If no case matches, returns None.
@@ -1675,9 +1654,8 @@ class V2Worker:
             step=step,
             execution_id=execution_id,
         )
-        # Canonical DSL v2: command carries 'input'. Accept 'args' as backward-compat alias.
         command_input = self._normalize_command_context_mapping(
-            context.get("input") or context.get("args"),
+            context.get("input"),
             field_name="input",
             step=step,
             execution_id=execution_id,
@@ -1709,11 +1687,9 @@ class V2Worker:
             eval_mode = spec.get("eval_mode", "on_entry")
             logger.debug(f"[SPEC] Step '{step}' spec: case_mode={case_mode}, eval_mode={eval_mode}")
         
-        # CRITICAL: Merge tool_config input/args with top-level command input.
-        # Canonical DSL v2: tool.input replaces tool.args; accept both for backward compat.
-        tool_input = tool_config.get("input") or tool_config.get("args")
+        # Merge tool.input with top-level command input (top-level values take precedence).
+        tool_input = tool_config.get("input")
         if tool_input and isinstance(tool_input, dict):
-            # Merge with top-level command input taking precedence.
             merged_input = {**tool_input, **command_input}
             command_input = merged_input
             logger.debug("Input config: merged_from_tool_config | keys=%s", _safe_keys(command_input))
@@ -1942,7 +1918,7 @@ class V2Worker:
                     
                     # ARCHITECTURE PRINCIPLE #3:
                     # Report case action to server via ACTIONABLE event
-                    # Server will issue new command with rendered args from case_action.config
+                    # Server will issue new command with rendered input from case_action.config
                     # This follows server-worker-server control loop pattern
                     await self._emit_event(
                         server_url,
@@ -2322,11 +2298,11 @@ class V2Worker:
         # For workbook tool, preserve 'name' field from config (it's the workbook action name)
         # For other tools, add 'name' as step name for logging
         task_config = {**config}
-        # Merge input: config["input"] (canonical DSL v2) or config["args"] (legacy) + args parameter
-        # This preserves tool input from pipeline while allowing parameter override
-        config_args = config.get("input") or config.get("args") or {}
-        task_config["args"] = {**config_args, **args} if config_args or args else {}
-        task_config["input"] = task_config["args"]  # canonical alias
+        # Merge canonical tool.input with command input overrides.
+        config_input = config.get("input") if isinstance(config.get("input"), dict) else {}
+        merged_input = {**config_input, **args} if config_input or args else {}
+        task_config["input"] = merged_input
+        task_config["args"] = merged_input  # plugin compatibility until all tools read `input`
         if "name" not in config:
             task_config["name"] = step
         
@@ -2504,9 +2480,9 @@ class V2Worker:
             return result.get('data', result) if isinstance(result, dict) else result
             
         elif tool_kind == "playbook":
-            # Playbook tasks need merged task args from config["args"] (task_sequence path passes args={}).
+            # Playbook tasks need merged task input from config["input"] (task_sequence path passes args={}).
             # If return_step is configured, use native async executor with polling support.
-            playbook_args = task_config.get("args") if isinstance(task_config.get("args"), dict) else args
+            playbook_args = task_config.get("input") if isinstance(task_config.get("input"), dict) else args
             if task_config.get("return_step"):
                 return await self._execute_playbook(task_config, playbook_args or {})
 

--- a/tests/unit/dsl/test_render_reference_only.py
+++ b/tests/unit/dsl/test_render_reference_only.py
@@ -3,11 +3,13 @@ import pytest
 from noetl.core.dsl.render import TaskResultProxy
 
 
-def test_task_result_proxy_result_alias_returns_self_for_dict_payload():
+def test_task_result_proxy_exposes_canonical_data_and_rejects_result_alias():
     proxy = TaskResultProxy({"rows": [{"id": 1}], "status": "success"})
 
-    assert proxy.result.rows[0]["id"] == 1
-    assert proxy.result.status == "success"
+    assert proxy.data.rows[0]["id"] == 1
+    assert proxy.data.status == "success"
+    with pytest.raises(AttributeError):
+        _ = proxy.result
 
 
 def test_task_result_proxy_does_not_flatten_context_keys_to_top_level():

--- a/tests/unit/dsl/v2/test_engine.py
+++ b/tests/unit/dsl/v2/test_engine.py
@@ -385,8 +385,8 @@ workflow:
     assert len(state.context["all_items"]) == 3
 
 
-def test_conditional_transition_with_args(engine_setup):
-    """Test conditional transition passing args to next step."""
+def test_conditional_transition_with_set_and_input(engine_setup):
+    """Test conditional transition using arc set + step input."""
     engine, playbook_repo, state_store = engine_setup
     
     yaml_content = """
@@ -402,16 +402,20 @@ workflow:
       method: GET
       endpoint: "https://api.example.com/data"
     
-    case:
-      - when: "{{ event.name == 'call.done' and response.status == 200 }}"
-        then:
-          next:
-            - step: process
-              args:
-                data: "{{ response.data }}"
-                count: "{{ response.data | length }}"
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: process
+          when: "{{ event.name == 'call.done' and output.data.status == 200 }}"
+          set:
+            ctx.process_data: "{{ output.data.data }}"
+            ctx.process_count: "{{ output.data.data | length }}"
 
   - step: process
+    input:
+      data: "{{ ctx.process_data }}"
+      count: "{{ ctx.process_count }}"
     tool:
       kind: python
       code: "def main(data, count): return {'processed': count}"
@@ -436,10 +440,10 @@ workflow:
     
     commands = engine.handle_event(event)
 
-    # Should generate command for process step with args
+    # Should generate command for process step with canonical input.
     assert len(commands) == 1
     assert commands[0].step == "process"
-    assert commands[0].args is not None
+    assert commands[0].input is not None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
+++ b/tests/unit/dsl/v2/test_loop_parallel_dispatch.py
@@ -160,7 +160,7 @@ async def test_parallel_loop_issues_up_to_max_in_flight(monkeypatch):
     run_batch_workers = next(
         step for step in playbook["workflow"] if step.get("step") == "run_batch_workers"
     )
-    run_batch_workers["args"] = {
+    run_batch_workers["input"] = {
         "claimed_batch": "{{ iter.batch.batch_number }}",
         "claimed_index": "{{ loop_index }}",
     }
@@ -276,7 +276,7 @@ async def test_loop_continue_reuses_cached_collection_when_ctx_key_missing(monke
         step for step in playbook["workflow"] if step.get("step") == "run_batch_workers"
     )
     run_batch_workers["loop"]["in"] = "{{ ctx.patients_needing_demographics }}"
-    run_batch_workers["args"] = {
+    run_batch_workers["input"] = {
         "claimed_patient_id": "{{ iter.batch.patient_id }}",
         "claimed_index": "{{ loop_index }}",
     }
@@ -343,7 +343,7 @@ async def test_loop_claim_repairs_zero_collection_size_metadata(monkeypatch):
     run_batch_workers = next(
         step for step in playbook["workflow"] if step.get("step") == "run_batch_workers"
     )
-    run_batch_workers["args"] = {
+    run_batch_workers["input"] = {
         "claimed_batch": "{{ iter.batch.batch_number }}",
         "claimed_index": "{{ loop_index }}",
     }
@@ -398,7 +398,7 @@ async def test_loop_continue_rerenders_when_replayed_cached_collection_is_empty(
     run_batch_workers = next(
         step for step in playbook["workflow"] if step.get("step") == "run_batch_workers"
     )
-    run_batch_workers["args"] = {
+    run_batch_workers["input"] = {
         "claimed_batch": "{{ iter.batch.batch_number }}",
         "claimed_index": "{{ loop_index }}",
     }
@@ -479,7 +479,7 @@ async def test_loop_watchdog_recovers_stalled_scheduled_counts(monkeypatch):
     run_batch_workers = next(
         step for step in playbook["workflow"] if step.get("step") == "run_batch_workers"
     )
-    run_batch_workers["args"] = {
+    run_batch_workers["input"] = {
         "claimed_batch": "{{ iter.batch.batch_number }}",
         "claimed_index": "{{ loop_index }}",
     }
@@ -544,7 +544,7 @@ async def test_loop_watchdog_recovers_stale_inflight_saturation(monkeypatch):
     run_batch_workers = next(
         step for step in playbook["workflow"] if step.get("step") == "run_batch_workers"
     )
-    run_batch_workers["args"] = {
+    run_batch_workers["input"] = {
         "claimed_batch": "{{ iter.batch.batch_number }}",
         "claimed_index": "{{ loop_index }}",
     }
@@ -612,7 +612,7 @@ async def test_loop_counter_reconcile_recovers_no_slot_without_watchdog(monkeypa
     run_batch_workers = next(
         step for step in playbook["workflow"] if step.get("step") == "run_batch_workers"
     )
-    run_batch_workers["args"] = {
+    run_batch_workers["input"] = {
         "claimed_batch": "{{ iter.batch.batch_number }}",
         "claimed_index": "{{ loop_index }}",
     }

--- a/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
+++ b/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
@@ -94,7 +94,7 @@ async def test_task_sequence_loop_uses_nats_collection_size_when_local_collectio
             execution_id=execution_id,
             step=step_def.step,
             tool=ToolCall(kind="playbook", config={}),
-            args={},
+            input={},
             render_context={},
         )
 
@@ -182,7 +182,7 @@ async def test_task_sequence_loop_prefers_execution_loop_key_when_step_event_id_
             execution_id=execution_id,
             step=step_def.step,
             tool=ToolCall(kind="playbook", config={}),
-            args={},
+            input={},
             render_context={},
         )
 
@@ -268,7 +268,7 @@ async def test_task_sequence_loop_persists_issued_steps_before_return(monkeypatc
             execution_id=execution_id,
             step=step_def.step,
             tool=ToolCall(kind="playbook", config={}),
-            args={},
+            input={},
             render_context={},
         )
 
@@ -354,7 +354,7 @@ async def test_task_sequence_loop_persists_event_before_early_return_when_needed
             execution_id=execution_id,
             step=step_def.step,
             tool=ToolCall(kind="playbook", config={}),
-            args={},
+            input={},
             render_context={},
         )
 
@@ -546,17 +546,17 @@ workflow:
       kind: postgres
       auth: pg_k8s
       query: SELECT 1;
-    set_ctx:
-      facility_mapping_id: "{{ load_next_facility.command_0.rows[0].facility_mapping_id }}"
-      facility_id: "{{ load_next_facility.command_0.rows[0].facility_id }}"
+    set:
+      ctx.facility_mapping_id: "{{ load_next_facility.command_0.rows[0].facility_mapping_id }}"
+      ctx.facility_id: "{{ load_next_facility.command_0.rows[0].facility_id }}"
   - step: load_patient_ids_context
     tool:
       kind: postgres
       auth: pg_k8s
       query: SELECT 1;
-    set_ctx:
-      patient_count: "{{ load_patient_ids_context.command_0.rows[0].patient_count | int }}"
-      facility_mapping_id: "{{ load_next_facility.command_0.rows[0].facility_mapping_id }}"
+    set:
+      ctx.patient_count: "{{ load_patient_ids_context.command_0.rows[0].patient_count | int }}"
+      ctx.facility_mapping_id: "{{ load_next_facility.command_0.rows[0].facility_mapping_id }}"
   - step: load_patients_for_assessments
     tool:
       kind: postgres
@@ -678,17 +678,17 @@ workflow:
       kind: postgres
       auth: pg_k8s
       query: SELECT 1;
-    set_ctx:
-      facility_mapping_id: "{{ load_next_facility.command_0.rows[0].facility_mapping_id }}"
-      facility_id: "{{ load_next_facility.command_0.rows[0].facility_id }}"
+    set:
+      ctx.facility_mapping_id: "{{ load_next_facility.command_0.rows[0].facility_mapping_id }}"
+      ctx.facility_id: "{{ load_next_facility.command_0.rows[0].facility_id }}"
   - step: load_patient_ids_context
     tool:
       kind: postgres
       auth: pg_k8s
       query: SELECT 1;
-    set_ctx:
-      patient_count: "{{ load_patient_ids_context.command_0.rows[0].patient_count | int }}"
-      facility_mapping_id: "{{ load_next_facility.command_0.rows[0].facility_mapping_id }}"
+    set:
+      ctx.patient_count: "{{ load_patient_ids_context.command_0.rows[0].patient_count | int }}"
+      ctx.facility_mapping_id: "{{ load_next_facility.command_0.rows[0].facility_mapping_id }}"
   - step: load_patients_for_assessments
     tool:
       kind: postgres
@@ -805,9 +805,9 @@ workflow:
       kind: postgres
       auth: pg_k8s
       query: SELECT 1;
-    set_ctx:
-      facility_mapping_id: "{{ load_next_facility.data.result.command_0.rows[0].facility_mapping_id }}"
-      facility_id: "{{ load_next_facility.data.result.command_0.rows[0].facility_id }}"
+    set:
+      ctx.facility_mapping_id: "{{ load_next_facility.data.result.command_0.rows[0].facility_mapping_id }}"
+      ctx.facility_id: "{{ load_next_facility.data.result.command_0.rows[0].facility_id }}"
   - step: load_patients_for_assessments
     tool:
       kind: postgres

--- a/tests/unit/dsl/v2/test_wrapped_event_payloads.py
+++ b/tests/unit/dsl/v2/test_wrapped_event_payloads.py
@@ -29,7 +29,7 @@ workflow:
   - step: extract
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"performance_rating": 4.0}
     next:
@@ -41,7 +41,7 @@ workflow:
   - step: score
     tool:
       kind: python
-      args:
+      input:
         performance_rating: "{{ extract.performance_rating }}"
       code: |
         result = {"seen": performance_rating}
@@ -69,7 +69,7 @@ workflow:
 
     assert len(commands) == 1
     assert commands[0].step == "score"
-    assert commands[0].tool.config["args"]["performance_rating"] == 4.0
+    assert commands[0].tool.config["input"]["performance_rating"] == 4.0
 
 
 @pytest.mark.asyncio
@@ -85,7 +85,7 @@ workflow:
   - step: create
     tool:
       kind: python
-      args: {}
+      input: {}
       code: |
         result = {"user_id": 999}
       spec:
@@ -94,8 +94,8 @@ workflow:
             - else:
                 then:
                   do: continue
-                  set_ctx:
-                    test_user_id: "{{ outcome.result.user_id }}"
+                  set:
+                    ctx.test_user_id: "{{ output.data.user_id }}"
     next:
       spec:
         mode: exclusive
@@ -105,7 +105,7 @@ workflow:
   - step: verify
     tool:
       kind: python
-      args:
+      input:
         user_id: "{{ ctx.test_user_id }}"
       code: |
         result = {"user_id": user_id}
@@ -144,7 +144,7 @@ workflow:
 
     assert len(commands) == 1
     assert commands[0].step == "verify"
-    assert commands[0].tool.config["args"]["user_id"] == "999"
+    assert commands[0].tool.config["input"]["user_id"] == "999"
 
 
 @pytest.mark.asyncio
@@ -170,8 +170,8 @@ workflow:
   - step: check_results
     tool:
       kind: python
-      args:
-        stats: "{{ validate_results.data.result.command_0.rows }}"
+      input:
+        stats: "{{ validate_results.data.command_0.rows }}"
       code: |
         result = {"stats": stats}
 """,
@@ -182,12 +182,8 @@ workflow:
     async def fake_resolve(ref):
         assert ref["ref"] == "noetl://execution/123/result/validate_results/abcd1234"
         return {
-            "data": {
-                "result": {
-                    "command_0": {
-                        "rows": [{"total_patients": 500}],
-                    }
-                }
+            "command_0": {
+                "rows": [{"total_patients": 500}],
             }
         }
 
@@ -214,4 +210,4 @@ workflow:
 
     assert len(commands) == 1
     assert commands[0].step == "check_results"
-    assert commands[0].tool.config["args"]["stats"] == [{"total_patients": 500}]
+    assert commands[0].tool.config["input"]["stats"] == [{"total_patients": 500}]

--- a/tests/worker/test_task_sequence_executor.py
+++ b/tests/worker/test_task_sequence_executor.py
@@ -64,11 +64,11 @@ async def test_http_error_status_code_drives_retry_rule():
                 "policy": {
                     "rules": [
                         {
-                            "when": "{{ outcome.status == 'error' and outcome.http.status in [500] }}",
+                            "when": "{{ output.status == 'error' and output.http.status in [500] }}",
                             "then": {"do": "retry", "attempts": 2, "backoff": "none", "delay": 0},
                         },
                         {
-                            "when": "{{ outcome.status == 'error' }}",
+                            "when": "{{ output.status == 'error' }}",
                             "then": {"do": "fail"},
                         },
                         {"else": {"then": {"do": "continue"}}},
@@ -114,11 +114,11 @@ async def test_http_error_infers_retryable_for_429():
                 "policy": {
                     "rules": [
                         {
-                            "when": "{{ outcome.status == 'error' and outcome.error.retryable }}",
+                            "when": "{{ output.status == 'error' and output.error.retryable }}",
                             "then": {"do": "retry", "attempts": 2, "backoff": "none", "delay": 0},
                         },
                         {
-                            "when": "{{ outcome.status == 'error' }}",
+                            "when": "{{ output.status == 'error' }}",
                             "then": {"do": "fail"},
                         },
                         {"else": {"then": {"do": "continue"}}},
@@ -169,7 +169,7 @@ async def test_task_sequence_jump_overwrites_latest_result_for_same_task_name():
                 "policy": {
                     "rules": [
                         {
-                            "when": "{{ outcome.status == 'ok' and outcome.result.jump }}",
+                            "when": "{{ output.status == 'ok' and output.data.jump }}",
                             "then": {"do": "jump", "to": "fetch"},
                         },
                         {"else": {"then": {"do": "continue"}}},
@@ -254,7 +254,7 @@ async def test_task_sequence_jump_previous_alias_targets_prior_task():
                 "policy": {
                     "rules": [
                         {
-                            "when": "{{ outcome.status == 'ok' and outcome.result.repeat }}",
+                            "when": "{{ output.status == 'ok' and output.data.repeat }}",
                             "then": {"do": "jump", "to": "previous"},
                         },
                         {"else": {"then": {"do": "continue"}}},
@@ -310,11 +310,11 @@ async def test_task_sequence_missing_reference_error_supports_jump_replay():
                 "policy": {
                     "rules": [
                         {
-                            "when": "{{ outcome.status == 'error' and outcome.error.code == 'REFERENCE_NOT_AVAILABLE' }}",
+                            "when": "{{ output.status == 'error' and output.error.code == 'REFERENCE_NOT_AVAILABLE' }}",
                             "then": {"do": "jump", "to": "previous"},
                         },
                         {
-                            "when": "{{ outcome.status == 'error' }}",
+                            "when": "{{ output.status == 'error' }}",
                             "then": {"do": "fail"},
                         },
                         {"else": {"then": {"do": "continue"}}},
@@ -353,7 +353,7 @@ async def test_task_sequence_missing_reference_error_reports_reference_code():
                 "policy": {
                     "rules": [
                         {
-                            "when": "{{ outcome.status == 'error' }}",
+                            "when": "{{ output.status == 'error' }}",
                             "then": {"do": "fail"},
                         }
                     ]


### PR DESCRIPTION
## Summary
- enforce canonical DSL semantics across engine/worker/server by removing legacy args/set_ctx/set_iter compatibility fallbacks
- keep PRD control-plane contract intact: events still persist `result` envelope, but author-facing render context is now canonical `output` only
- remove legacy `result` proxy fallback in template access (`TaskResultProxy`)
- tighten model validation to reject legacy aliases on author-facing DSL models
- update affected DSL/unit tests and fixtures to canonical `input`, `output`, `set` usage

## Key runtime changes
- `ExecutionState.get_render_context()` now builds `output` from control-plane payload + hydrated step state and no longer publishes `result`/`response` aliases
- task-sequence policy evaluation now uses `output.*` only and no longer emits/reads `outcome.result`
- case evaluation context now provides canonical `output` envelope
- command/input extraction paths now require `input` (legacy `args` alias removed)

## Validation
- `python -m py_compile` run for all edited Python modules and updated tests
- `pytest` could not be executed in this environment because `psycopg` is missing during import collection
