### PR TITLE
fix(runtime): stabilize command claims under long-running tools

### DIFF
--- a/noetl/claim_policy.py
+++ b/noetl/claim_policy.py
@@ -38,14 +38,14 @@ def decide_reclaim_for_existing_claim(
         and worker_heartbeat_age_seconds >= heartbeat_stale_seconds
     )
 
+    if claim_age_seconds < lease_seconds:
+        return ClaimReclaimDecision(reclaim=False, retry_reason="lease_active")
+
     if worker_inactive:
         return ClaimReclaimDecision(reclaim=True, reason="worker_inactive")
 
     if heartbeat_stale:
         return ClaimReclaimDecision(reclaim=True, reason="worker_heartbeat_stale")
-
-    if claim_age_seconds < lease_seconds:
-        return ClaimReclaimDecision(reclaim=False, retry_reason="lease_active")
 
     worker_healthy = (
         status_norm == "ready"

--- a/noetl/server/api/v2.py
+++ b/noetl/server/api/v2.py
@@ -435,18 +435,21 @@ def _active_claim_cache_invalidate(
             _active_claim_cache_by_command.pop(cached.command_id, None)
 
 
-def _extract_event_command_id(req: "EventRequest") -> Optional[str]:
-    payload = req.payload or {}
-    meta = req.meta or {}
+def _extract_command_id_from_payload(
+    payload: Optional[dict[str, Any]],
+    meta: Optional[dict[str, Any]] = None,
+) -> Optional[str]:
+    payload_obj = payload if isinstance(payload, dict) else {}
+    meta_obj = meta if isinstance(meta, dict) else {}
 
-    candidates = [
-        payload.get("command_id"),
-        meta.get("command_id"),
+    candidates: list[Any] = [
+        payload_obj.get("command_id"),
+        meta_obj.get("command_id"),
     ]
-    payload_context = payload.get("context")
+    payload_context = payload_obj.get("context")
     if isinstance(payload_context, dict):
         candidates.append(payload_context.get("command_id"))
-    payload_result = payload.get("result")
+    payload_result = payload_obj.get("result")
     if isinstance(payload_result, dict):
         candidates.append(payload_result.get("command_id"))
         result_context = payload_result.get("context")
@@ -457,6 +460,10 @@ def _extract_event_command_id(req: "EventRequest") -> Optional[str]:
         if isinstance(value, str) and value.strip():
             return value.strip()
     return None
+
+
+def _extract_event_command_id(req: "EventRequest") -> Optional[str]:
+    return _extract_command_id_from_payload(req.payload, req.meta)
 
 
 # Reference-only result envelope persisted in noetl.event.result.
@@ -570,9 +577,10 @@ _EVENT_TYPE_TERMINAL_PREDICATE = (
     + ", ".join(f"'{e}'" for e in _COMMAND_TERMINAL_EVENT_TYPES)
     + ")"
 )
+_EVENT_TYPE_ACTIVE_CLAIM_PREDICATE = "event_type IN ('command.claimed', 'command.heartbeat')"
 _EVENT_TYPE_CLAIMED_PREDICATE = "event_type = 'command.claimed'"
 _EVENT_TYPE_SAME_WORKER_LATEST_PREDICATE = (
-    "event_type IN ('command.started', 'command.completed', 'command.failed')"
+    "event_type IN ('command.started', 'command.heartbeat', 'command.completed', 'command.failed')"
 )
 _COMMAND_EVENT_DEDUPE_TYPES = {
     "call.done",
@@ -621,7 +629,7 @@ _CLAIM_TERMINAL_LOOKUP_SQL = _build_command_id_latest_lookup_sql(
 _CLAIM_EXISTING_LOOKUP_SQL = _build_command_id_latest_lookup_sql(
     inner_select_columns="event_id, worker_id, meta, created_at",
     outer_select_columns="event_id, worker_id, meta, created_at",
-    event_type_predicate=_EVENT_TYPE_CLAIMED_PREDICATE,
+    event_type_predicate=_EVENT_TYPE_ACTIVE_CLAIM_PREDICATE,
     alias="claimed_match",
 )
 _CLAIM_SAME_WORKER_LATEST_LOOKUP_SQL = _build_command_id_latest_lookup_sql(
@@ -1971,6 +1979,7 @@ async def handle_event(req: EventRequest) -> EventResponse:
     
     Skip engine for administrative events:
     - command.claimed: Just persist, don't process
+    - command.heartbeat: lease/liveness refresh, don't process
     - command.started: Just persist, don't process
     - command.completed: Already processed by worker
     - step.enter: Just marks step started
@@ -1984,8 +1993,11 @@ async def handle_event(req: EventRequest) -> EventResponse:
         # Events that should NOT trigger engine processing
         # These are administrative events that just need to be persisted
         skip_engine_events = {
-            "command.claimed", "command.started", "command.completed",
-            "step.enter"
+            "command.claimed",
+            "command.heartbeat",
+            "command.started",
+            "command.completed",
+            "step.enter",
         }
         
         # For command.claimed, use fully atomic claiming with advisory lock + insert in same transaction
@@ -2498,6 +2510,7 @@ async def _persist_batch_acceptance(
 ) -> _BatchAcceptanceResult:
     skip_engine_events = {
         "command.claimed",
+        "command.heartbeat",
         "command.started",
         "command.completed",
         "step.enter",
@@ -2558,6 +2571,7 @@ async def _persist_batch_acceptance(
             event_ids: list[int] = []
             last_actionable_event: Optional[Event] = None
             last_actionable_evt_id: Optional[int] = None
+            terminal_command_ids: set[str] = set()
             for item in req.events:
                 try:
                     _validate_reference_only_payload(item.payload)
@@ -2580,6 +2594,9 @@ async def _persist_batch_acceptance(
                     meta_obj["worker_id"] = req.worker_id
                 if idempotency_key:
                     meta_obj["idempotency_key"] = idempotency_key
+                item_command_id = _extract_command_id_from_payload(item.payload)
+                if item_command_id:
+                    meta_obj["command_id"] = item_command_id
 
                 await cur.execute(
                     """
@@ -2608,6 +2625,8 @@ async def _persist_batch_acceptance(
                         datetime.now(timezone.utc),
                     ),
                 )
+                if item_command_id and item.name in _COMMAND_TERMINAL_EVENT_TYPES:
+                    terminal_command_ids.add(item_command_id)
 
                 if item.actionable and item.name not in skip_engine_events:
                     last_actionable_event = Event(
@@ -2665,6 +2684,8 @@ async def _persist_batch_acceptance(
                 ),
             )
             await conn.commit()
+            for terminal_command_id in terminal_command_ids:
+                _active_claim_cache_invalidate(command_id=terminal_command_id)
 
     job = _BatchAcceptJob(
         request_id=request_id,

--- a/noetl/server/command_reaper.py
+++ b/noetl/server/command_reaper.py
@@ -53,6 +53,13 @@ _TERMINAL_COMMAND_EVENT_TYPES = [
     "command.failed",
     "command.cancelled",
 ]
+_TERMINAL_EXECUTION_EVENT_TYPES = [
+    "playbook.completed",
+    "playbook.failed",
+    "workflow.completed",
+    "workflow.failed",
+    "execution.cancelled",
+]
 
 _REAPER_ENABLED = os.getenv("NOETL_COMMAND_REAPER_ENABLED", "true").strip().lower() in {
     "1", "true", "yes", "on"
@@ -156,6 +163,12 @@ async def _find_orphaned_commands(
                         WHERE x.execution_id = issued_candidates.execution_id
                           AND x.event_type = 'execution.cancelled'
                     )
+                    -- Execution has already reached terminal lifecycle state
+                    AND NOT EXISTS (
+                        SELECT 1 FROM noetl.event et
+                        WHERE et.execution_id = issued_candidates.execution_id
+                          AND et.event_type = ANY(%s)
+                    )
                 ORDER BY issued_candidates.event_id DESC
                 LIMIT %s
                 """,
@@ -164,6 +177,7 @@ async def _find_orphaned_commands(
                     lookback_hours,
                     stale_seconds,
                     _TERMINAL_COMMAND_EVENT_TYPES,
+                    _TERMINAL_EXECUTION_EVENT_TYPES,
                     max_commands,
                 ),
             )
@@ -223,6 +237,12 @@ async def _find_unclaimed_pending_commands(
                       WHERE x.execution_id = issued_candidates.execution_id
                         AND x.event_type = 'execution.cancelled'
                   )
+                  -- Execution has already reached terminal lifecycle state
+                  AND NOT EXISTS (
+                      SELECT 1 FROM noetl.event et
+                      WHERE et.execution_id = issued_candidates.execution_id
+                        AND et.event_type = ANY(%s)
+                  )
                 ORDER BY issued_candidates.event_id DESC
                 LIMIT %s
                 """,
@@ -230,6 +250,7 @@ async def _find_unclaimed_pending_commands(
                     lookback_hours,
                     pending_retry_seconds,
                     _TERMINAL_COMMAND_EVENT_TYPES,
+                    _TERMINAL_EXECUTION_EVENT_TYPES,
                     max_commands,
                 ),
             )

--- a/noetl/worker/v2_worker_nats.py
+++ b/noetl/worker/v2_worker_nats.py
@@ -179,6 +179,18 @@ class V2Worker:
         )
         self._recent_command_activity: dict[str, float] = {}
         self._recent_command_activity_last_prune_monotonic = 0.0
+        self._command_heartbeat_interval_seconds = max(
+            2.0,
+            float(os.getenv("NOETL_COMMAND_HEARTBEAT_INTERVAL_SECONDS", "15")),
+        )
+        self._command_heartbeat_timeout_seconds = max(
+            1.0,
+            float(os.getenv("NOETL_COMMAND_HEARTBEAT_TIMEOUT_SECONDS", "3")),
+        )
+        self._command_heartbeat_max_retries = max(
+            1,
+            int(os.getenv("NOETL_COMMAND_HEARTBEAT_MAX_RETRIES", "1")),
+        )
         # Adaptive AIMD concurrency controller: limits simultaneous claim/event
         # requests from this worker process, backing off when the server pool
         # is saturated (503) and recovering as it clears.
@@ -256,6 +268,58 @@ class V2Worker:
             self._recent_command_activity.pop(str(command_id), None)
             return False
         return True
+
+    async def _command_heartbeat_loop(
+        self,
+        *,
+        server_url: str,
+        execution_id: int,
+        step: str,
+        command_id: str,
+        stop_event: asyncio.Event,
+    ) -> None:
+        """Emit periodic command.heartbeat events while a command is executing."""
+        interval_seconds = self._command_heartbeat_interval_seconds
+        while self._running and not stop_event.is_set():
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
+                break
+            except asyncio.TimeoutError:
+                pass
+
+            if stop_event.is_set():
+                break
+
+            try:
+                emitted = await self._emit_event(
+                    server_url=server_url,
+                    execution_id=execution_id,
+                    step=step,
+                    name="command.heartbeat",
+                    payload={"command_id": command_id, "worker_id": self.worker_id},
+                    actionable=False,
+                    informative=True,
+                    timeout_seconds=self._command_heartbeat_timeout_seconds,
+                    max_retries=self._command_heartbeat_max_retries,
+                    raise_on_failure=False,
+                )
+                if not emitted:
+                    logger.debug(
+                        "[HEARTBEAT] command.heartbeat emission failed | execution=%s step=%s command=%s",
+                        execution_id,
+                        step,
+                        command_id,
+                    )
+            except asyncio.CancelledError:
+                break
+            except Exception as heartbeat_error:
+                logger.debug(
+                    "[HEARTBEAT] command.heartbeat error | execution=%s step=%s command=%s error=%s",
+                    execution_id,
+                    step,
+                    command_id,
+                    heartbeat_error,
+                )
 
     async def _wait_for_postgres_capacity(self, step: str, command_id: str) -> None:
         """Pause db-heavy command execution while plugin pools are saturated."""
@@ -1776,15 +1840,47 @@ class V2Worker:
                     )
 
             # Execute tool
+            heartbeat_stop_event: Optional[asyncio.Event] = None
+            heartbeat_task: Optional[asyncio.Task] = None
+            if command_id:
+                heartbeat_stop_event = asyncio.Event()
+                heartbeat_task = asyncio.create_task(
+                    self._command_heartbeat_loop(
+                        server_url=server_url,
+                        execution_id=execution_id,
+                        step=step,
+                        command_id=command_id,
+                        stop_event=heartbeat_stop_event,
+                    ),
+                    name=f"command-heartbeat:{command_id}",
+                )
+
             t_tool_start = time.perf_counter()
-            response = await self._execute_tool(
-                tool_kind,
-                tool_config,
-                command_input,
-                step,
-                render_context,
-                case_blocks=case_blocks,
-            )
+            try:
+                response = await self._execute_tool(
+                    tool_kind,
+                    tool_config,
+                    command_input,
+                    step,
+                    render_context,
+                    case_blocks=case_blocks,
+                )
+            finally:
+                if heartbeat_stop_event:
+                    heartbeat_stop_event.set()
+                if heartbeat_task:
+                    try:
+                        await asyncio.wait_for(
+                            heartbeat_task,
+                            timeout=self._command_heartbeat_timeout_seconds + 0.5,
+                        )
+                    except asyncio.TimeoutError:
+                        heartbeat_task.cancel()
+                        try:
+                            await heartbeat_task
+                        except asyncio.CancelledError:
+                            pass
+
             t_tool_end = time.perf_counter()
             logger.info(f"[PERF] Tool execution for {step} took {(t_tool_end - t_tool_start)*1000:.1f}ms")
 

--- a/tests/api/test_claim_policy.py
+++ b/tests/api/test_claim_policy.py
@@ -1,11 +1,27 @@
 from noetl.claim_policy import decide_reclaim_for_existing_claim
 
 
-def test_reclaim_when_worker_inactive_even_if_lease_not_expired():
+def test_keep_claim_when_worker_inactive_but_lease_not_expired():
     decision = decide_reclaim_for_existing_claim(
         existing_worker="worker-a",
         requesting_worker="worker-b",
         claim_age_seconds=10.0,
+        lease_seconds=120.0,
+        worker_runtime_status="error",
+        worker_heartbeat_age_seconds=1.0,
+        heartbeat_stale_seconds=30.0,
+        healthy_worker_hard_timeout_seconds=1800.0,
+    )
+
+    assert decision.reclaim is False
+    assert decision.retry_reason == "lease_active"
+
+
+def test_reclaim_when_worker_inactive_after_lease_expiry():
+    decision = decide_reclaim_for_existing_claim(
+        existing_worker="worker-a",
+        requesting_worker="worker-b",
+        claim_age_seconds=130.0,
         lease_seconds=120.0,
         worker_runtime_status="error",
         worker_heartbeat_age_seconds=1.0,
@@ -63,3 +79,35 @@ def test_reclaim_on_lease_expiry_when_worker_health_unknown():
 
     assert decision.reclaim is True
     assert decision.reason == "lease_expired"
+
+
+def test_keep_claim_when_heartbeat_stale_but_lease_active():
+    decision = decide_reclaim_for_existing_claim(
+        existing_worker="worker-a",
+        requesting_worker="worker-b",
+        claim_age_seconds=67.0,
+        lease_seconds=120.0,
+        worker_runtime_status="ready",
+        worker_heartbeat_age_seconds=65.0,
+        heartbeat_stale_seconds=30.0,
+        healthy_worker_hard_timeout_seconds=1800.0,
+    )
+
+    assert decision.reclaim is False
+    assert decision.retry_reason == "lease_active"
+
+
+def test_reclaim_when_heartbeat_stale_after_lease_expiry():
+    decision = decide_reclaim_for_existing_claim(
+        existing_worker="worker-a",
+        requesting_worker="worker-b",
+        claim_age_seconds=130.0,
+        lease_seconds=120.0,
+        worker_runtime_status="ready",
+        worker_heartbeat_age_seconds=65.0,
+        heartbeat_stale_seconds=30.0,
+        healthy_worker_hard_timeout_seconds=1800.0,
+    )
+
+    assert decision.reclaim is True
+    assert decision.reason == "worker_heartbeat_stale"

--- a/tests/api/test_v2_batch_async.py
+++ b/tests/api/test_v2_batch_async.py
@@ -42,6 +42,17 @@ def _build_acceptance_result(
     return v2_api._BatchAcceptanceResult(job=job, event_ids=event_ids or [1, 2], duplicate=duplicate)
 
 
+def test_extract_command_id_from_payload_supports_nested_result_context():
+    payload = {
+        "result": {
+            "context": {
+                "command_id": "cmd-nested",
+            }
+        }
+    }
+    assert v2_api._extract_command_id_from_payload(payload, None) == "cmd-nested"
+
+
 @pytest.mark.asyncio
 async def test_batch_enqueue_ack_timeout_under_queue_pressure(monkeypatch):
     queue = asyncio.Queue(maxsize=1)
@@ -114,6 +125,96 @@ async def test_batch_worker_unavailable_error_code(monkeypatch):
 
     assert exc.value.status_code == 503
     assert exc.value.detail["code"] == v2_api._BATCH_FAILURE_WORKER_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_persist_batch_acceptance_stores_command_id_in_meta(monkeypatch):
+    class _CursorCtx:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        async def __aenter__(self):
+            return self._cursor
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _PersistCursor:
+        def __init__(self):
+            self.insert_params = []
+            self._fetch_calls = 0
+
+        async def execute(self, query, params=None):
+            if "INSERT INTO noetl.event" in query:
+                self.insert_params.append(params)
+
+        async def fetchone(self):
+            self._fetch_calls += 1
+            if self._fetch_calls == 1:
+                return {"catalog_id": 10}
+            return None
+
+    class _PersistConn:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def cursor(self, row_factory=None):
+            return _CursorCtx(self._cursor)
+
+        async def commit(self):
+            return None
+
+    class _ConnCtx:
+        def __init__(self, conn):
+            self._conn = conn
+
+        async def __aenter__(self):
+            return self._conn
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    fake_cursor = _PersistCursor()
+    fake_conn = _PersistConn(fake_cursor)
+
+    def _fake_get_pool_connection(*_args, **_kwargs):
+        return _ConnCtx(fake_conn)
+
+    next_ids = iter(range(1000, 1200))
+
+    async def _fake_next_snowflake_id(_cur):
+        return next(next_ids)
+
+    monkeypatch.setattr(v2_api, "get_pool_connection", _fake_get_pool_connection)
+    monkeypatch.setattr(v2_api, "_next_snowflake_id", _fake_next_snowflake_id)
+
+    req = v2_api.BatchEventRequest(
+        execution_id="42",
+        worker_id="worker-1",
+        events=[
+            v2_api.BatchEventItem(
+                step="tool_step",
+                name="command.completed",
+                payload={
+                    "result": {"status": "COMPLETED"},
+                    "command_id": "cmd-42",
+                },
+                actionable=False,
+                informative=True,
+            )
+        ],
+    )
+
+    acceptance = await v2_api._persist_batch_acceptance(req, idempotency_key=None)
+    assert acceptance.duplicate is False
+    inserted_command_completed = [
+        params
+        for params in fake_cursor.insert_params
+        if isinstance(params, tuple) and len(params) > 8 and params[3] == "command.completed"
+    ]
+    assert inserted_command_completed
+    meta_obj = inserted_command_completed[0][8].obj
+    assert meta_obj["command_id"] == "cmd-42"
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_v2_command_id_lookup_sql.py
+++ b/tests/api/test_v2_command_id_lookup_sql.py
@@ -19,6 +19,7 @@ def test_claim_command_lookup_sql_remains_index_friendly():
     _assert_index_friendly_lookup(v2_api._CLAIM_TERMINAL_LOOKUP_SQL)
     _assert_index_friendly_lookup(v2_api._CLAIM_EXISTING_LOOKUP_SQL)
     _assert_index_friendly_lookup(v2_api._CLAIM_SAME_WORKER_LATEST_LOOKUP_SQL)
+    assert "command.heartbeat" in v2_api._CLAIM_EXISTING_LOOKUP_SQL
 
 
 def test_handle_event_claim_lookup_sql_remains_index_friendly():

--- a/tests/worker/test_v2_worker_command_heartbeat.py
+++ b/tests/worker/test_v2_worker_command_heartbeat.py
@@ -1,0 +1,64 @@
+import asyncio
+
+import pytest
+
+from noetl.worker.v2_worker_nats import V2Worker
+
+
+@pytest.mark.asyncio
+async def test_command_heartbeat_loop_emits_periodic_events(monkeypatch):
+    worker = V2Worker(worker_id="test-worker")
+    worker._running = True
+    worker._command_heartbeat_interval_seconds = 0.01
+    worker._command_heartbeat_timeout_seconds = 0.01
+    worker._command_heartbeat_max_retries = 1
+
+    emitted: list[dict] = []
+
+    async def _fake_emit_event(**kwargs):
+        emitted.append(kwargs)
+        return True
+
+    monkeypatch.setattr(worker, "_emit_event", _fake_emit_event)
+
+    stop_event = asyncio.Event()
+    task = asyncio.create_task(
+        worker._command_heartbeat_loop(
+            server_url="http://server",
+            execution_id=101,
+            step="run_step",
+            command_id="cmd-101",
+            stop_event=stop_event,
+        )
+    )
+
+    await asyncio.sleep(0.035)
+    stop_event.set()
+    await task
+
+    assert len(emitted) >= 2
+    assert all(evt["name"] == "command.heartbeat" for evt in emitted)
+    assert all(evt["payload"]["command_id"] == "cmd-101" for evt in emitted)
+
+
+@pytest.mark.asyncio
+async def test_command_heartbeat_loop_stops_without_emitting_when_already_stopped(monkeypatch):
+    worker = V2Worker(worker_id="test-worker")
+    worker._running = True
+    worker._command_heartbeat_interval_seconds = 0.01
+
+    async def _fail_if_called(**_kwargs):
+        raise AssertionError("heartbeat event should not be emitted")
+
+    monkeypatch.setattr(worker, "_emit_event", _fail_if_called)
+
+    stop_event = asyncio.Event()
+    stop_event.set()
+
+    await worker._command_heartbeat_loop(
+        server_url="http://server",
+        execution_id=102,
+        step="run_step",
+        command_id="cmd-102",
+        stop_event=stop_event,
+    )


### PR DESCRIPTION
## Summary
- add worker-side periodic `command.heartbeat` emission during active command execution
- treat `command.heartbeat` as active-claim activity in claim lookups to prevent stale lease reclaim while long tools are still running
- keep `command.heartbeat` administrative-only (skip engine processing in single and batch event paths)
- keep command-id extraction/persistence consistent in batch ingest and invalidate active claim cache on terminal command events
- harden command reaper to skip executions already in terminal lifecycle states
- add/extend tests for claim policy, batch command-id persistence, SQL predicates, and worker heartbeat loop

## Validation
- `uv run pytest -q tests/api/test_claim_policy.py tests/api/test_v2_command_id_lookup_sql.py tests/api/test_v2_batch_async.py tests/worker/test_v2_worker_command_heartbeat.py tests/worker/test_v2_worker_claim.py`
- distributed smoke: `tests/pagination/basic/basic` execution `593734644470645113` completed successfully
- distributed non-blocking matrix: `tests/fixtures/playbooks/load_test/tooling_non_blocking` execution `593734777371361822` completed with validated HTTP/Postgres/DuckDB parallelism

## Notes
- command payload data remains reference-first; events carry reference/context metadata only
