### PR TITLE
fix(engine): guard loop.done dispatch with try_claim_loop_done CAS

### DIFF
--- a/noetl/core/cache/nats_kv.py
+++ b/noetl/core/cache/nats_kv.py
@@ -326,6 +326,13 @@ class NATSKVCache:
                 )
                 return True
 
+            except KeyNotFoundError:
+                logger.debug(
+                    "try_claim_loop_done: key not found for %s (execution=%s) — loop state not initialised yet",
+                    step_name,
+                    execution_id,
+                )
+                return False
             except Exception as e:
                 err = str(e).lower()
                 if "wrong last sequence" in err and attempt < max_retries - 1:

--- a/noetl/core/dsl/v2/engine.py
+++ b/noetl/core/dsl/v2/engine.py
@@ -4375,6 +4375,7 @@ class ControlFlowEngine:
                             # Prevents duplicate loopback dispatches when multiple concurrent
                             # call.done handlers reach this point simultaneously (e.g. via the
                             # NATS-fallback count path where all handlers see the same persisted count).
+                            _skip_loop_done = False
                             try:
                                 if not await nats_cache.try_claim_loop_done(
                                     str(state.execution_id),
@@ -4386,7 +4387,7 @@ class ControlFlowEngine:
                                         parent_step,
                                         state.execution_id,
                                     )
-                                    return commands
+                                    _skip_loop_done = True
                             except Exception as _claim_err:
                                 logger.warning(
                                     "[TASK_SEQ-LOOP] try_claim_loop_done failed for %s: %s — proceeding with aggregation_finalized guard",
@@ -4395,29 +4396,30 @@ class ControlFlowEngine:
                                 )
                                 # Fall through: aggregation_finalized is a second-layer in-process guard.
 
-                            # Loop done - mark completed and create loop.done event
-                            loop_state["completed"] = True
-                            loop_state["aggregation_finalized"] = True
-                            logger.info(f"[TASK_SEQ-LOOP] Loop completed for {parent_step}: {new_count}/{collection_size}")
+                            if not _skip_loop_done:
+                                # Loop done - mark completed and create loop.done event
+                                loop_state["completed"] = True
+                                loop_state["aggregation_finalized"] = True
+                                logger.info(f"[TASK_SEQ-LOOP] Loop completed for {parent_step}: {new_count}/{collection_size}")
 
-                            # Get aggregated result
-                            loop_aggregation = state.get_loop_aggregation(parent_step)
-                            state.mark_step_completed(parent_step, loop_aggregation)
+                                # Get aggregated result
+                                loop_aggregation = state.get_loop_aggregation(parent_step)
+                                state.mark_step_completed(parent_step, loop_aggregation)
 
-                            # Evaluate next transitions with loop.done event
-                            loop_done_event = Event(
-                                execution_id=event.execution_id,
-                                step=parent_step,
-                                name="loop.done",
-                                payload={
-                                    "status": "completed",
-                                    "iterations": new_count,
-                                    "result": loop_aggregation
-                                }
-                            )
-                            loop_done_commands = await self._evaluate_next_transitions(state, parent_step_def, loop_done_event)
-                            commands.extend(loop_done_commands)
-                            logger.info(f"[TASK_SEQ-LOOP] Generated {len(loop_done_commands)} commands from loop.done")
+                                # Evaluate next transitions with loop.done event
+                                loop_done_event = Event(
+                                    execution_id=event.execution_id,
+                                    step=parent_step,
+                                    name="loop.done",
+                                    payload={
+                                        "status": "completed",
+                                        "iterations": new_count,
+                                        "result": loop_aggregation
+                                    }
+                                )
+                                loop_done_commands = await self._evaluate_next_transitions(state, parent_step_def, loop_done_event)
+                                commands.extend(loop_done_commands)
+                                logger.info(f"[TASK_SEQ-LOOP] Generated {len(loop_done_commands)} commands from loop.done")
                         else:
                             # More iterations - create next command
                             if collection_size == 0:
@@ -4659,6 +4661,7 @@ class ControlFlowEngine:
                         # Prevents duplicate loopback dispatches when multiple concurrent
                         # call.done handlers reach this point simultaneously (e.g. via the
                         # NATS-fallback count path where all handlers see the same persisted count).
+                        _skip_loop_done = False
                         try:
                             if not await nats_cache.try_claim_loop_done(
                                 str(state.execution_id),
@@ -4670,7 +4673,7 @@ class ControlFlowEngine:
                                     event.step,
                                     state.execution_id,
                                 )
-                                return commands
+                                _skip_loop_done = True
                         except Exception as _claim_err:
                             logger.warning(
                                 "[LOOP-CALL.DONE] try_claim_loop_done failed for %s: %s — proceeding with aggregation_finalized guard",
@@ -4679,30 +4682,31 @@ class ControlFlowEngine:
                             )
                             # Fall through: aggregation_finalized is a second-layer in-process guard.
 
-                        loop_state["completed"] = True
-                        loop_state["aggregation_finalized"] = True
-                        logger.info(f"[LOOP-CALL.DONE] Loop completed for {event.step}: {new_count}/{collection_size}")
+                        if not _skip_loop_done:
+                            loop_state["completed"] = True
+                            loop_state["aggregation_finalized"] = True
+                            logger.info(f"[LOOP-CALL.DONE] Loop completed for {event.step}: {new_count}/{collection_size}")
 
-                        loop_aggregation = state.get_loop_aggregation(event.step)
-                        state.mark_step_completed(event.step, loop_aggregation)
+                            loop_aggregation = state.get_loop_aggregation(event.step)
+                            state.mark_step_completed(event.step, loop_aggregation)
 
-                        loop_done_event = Event(
-                            execution_id=event.execution_id,
-                            step=event.step,
-                            name="loop.done",
-                            payload={
-                                "status": "completed",
-                                "iterations": new_count,
-                                "result": loop_aggregation,
-                            },
-                        )
-                        loop_done_commands = await self._evaluate_next_transitions(
-                            state, step_def, loop_done_event
-                        )
-                        commands.extend(loop_done_commands)
-                        logger.info(
-                            f"[LOOP-CALL.DONE] Generated {len(loop_done_commands)} commands from loop.done"
-                        )
+                            loop_done_event = Event(
+                                execution_id=event.execution_id,
+                                step=event.step,
+                                name="loop.done",
+                                payload={
+                                    "status": "completed",
+                                    "iterations": new_count,
+                                    "result": loop_aggregation,
+                                },
+                            )
+                            loop_done_commands = await self._evaluate_next_transitions(
+                                state, step_def, loop_done_event
+                            )
+                            commands.extend(loop_done_commands)
+                            logger.info(
+                                f"[LOOP-CALL.DONE] Generated {len(loop_done_commands)} commands from loop.done"
+                            )
                     else:
                         # More iterations needed
                         logger.info(

--- a/tests/unit/core/cache/test_nats_kv_loop_claim.py
+++ b/tests/unit/core/cache/test_nats_kv_loop_claim.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from noetl.core.cache.nats_kv import NATSKVCache
+from nats.js.errors import KeyNotFoundError as NatsKeyNotFoundError
 
 
 class _FakeKVEntry:
@@ -131,3 +132,86 @@ async def test_set_loop_state_preserves_existing_collection_size_when_incoming_z
     assert ok is True
     assert lookup_calls == 1
     assert fake_kv.payload["collection_size"] == 8
+
+
+# ── try_claim_loop_done ───────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_try_claim_loop_done_first_caller_wins():
+    """First call sets loop_done_claimed=True and returns True."""
+    cache = NATSKVCache()
+    fake_kv = _FakeKV({"collection_size": 10, "completed_count": 10, "scheduled_count": 10})
+    cache._kv = fake_kv
+
+    result = await cache.try_claim_loop_done("exec1", "fetch_step", event_id="ev1")
+
+    assert result is True
+    assert fake_kv.payload["loop_done_claimed"] is True
+    assert "loop_done_claimed_at" in fake_kv.payload
+
+
+@pytest.mark.asyncio
+async def test_try_claim_loop_done_second_caller_blocked():
+    """Second call sees loop_done_claimed=True and returns False without CAS."""
+    cache = NATSKVCache()
+    fake_kv = _FakeKV({
+        "collection_size": 10,
+        "completed_count": 10,
+        "loop_done_claimed": True,
+        "loop_done_claimed_at": "2026-01-01T00:00:00Z",
+    })
+    cache._kv = fake_kv
+    initial_revision = fake_kv.revision
+
+    result = await cache.try_claim_loop_done("exec1", "fetch_step", event_id="ev1")
+
+    assert result is False
+    assert fake_kv.revision == initial_revision  # no write happened
+
+
+@pytest.mark.asyncio
+async def test_try_claim_loop_done_key_not_found():
+    """Missing NATS key returns False without raising."""
+    cache = NATSKVCache()
+
+    class _MissingKV:
+        async def get(self, _key):
+            raise NatsKeyNotFoundError()
+
+    cache._kv = _MissingKV()
+
+    result = await cache.try_claim_loop_done("exec1", "fetch_step", event_id="ev1")
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_try_claim_loop_done_retries_on_concurrent_write():
+    """CAS conflict on first attempt is retried and succeeds on second."""
+    cache = NATSKVCache()
+    call_count = 0
+
+    class _RacingKV:
+        def __init__(self):
+            self.payload = {"collection_size": 5, "completed_count": 5}
+            self.revision = 1
+
+        async def get(self, _key):
+            return _FakeKVEntry(self.payload, self.revision)
+
+        async def update(self, _key, value, last):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("wrong last sequence")
+            assert last == self.revision
+            self.payload = json.loads(value.decode("utf-8"))
+            self.revision += 1
+            return self.revision
+
+    cache._kv = _RacingKV()
+
+    result = await cache.try_claim_loop_done("exec1", "fetch_step", event_id="ev1")
+
+    assert result is True
+    assert call_count == 2  # first attempt raced, second succeeded

--- a/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
+++ b/tests/unit/dsl/v2/test_task_sequence_loop_completion.py
@@ -31,6 +31,9 @@ class FakeNATSCache:
         self.set_state_calls.append((execution_id, step_name, state, event_id))
         return True
 
+    async def try_claim_loop_done(self, execution_id, step_name, event_id=None):
+        return True  # always grants by default in existing tests
+
 
 class EventAwareNATSCache(FakeNATSCache):
     def __init__(self, execution_id):
@@ -52,6 +55,26 @@ class EventAwareNATSCache(FakeNATSCache):
                 "event_id": event_id,
             }
         return None
+
+
+class ClaimAwareNATSCache(FakeNATSCache):
+    """Simulates two concurrent handlers: first claim wins, second loses."""
+
+    def __init__(self, terminal_count: int):
+        super().__init__()
+        self._terminal_count = terminal_count
+        self._claim_count = 0
+        self.loop_done_dispatch_count = 0
+
+    async def increment_loop_completed(self, execution_id, step_name, event_id=None):
+        return self._terminal_count  # both handlers see terminal count
+
+    async def get_loop_state(self, execution_id, step_name, event_id=None):
+        return {"collection_size": self._terminal_count, "completed_count": self._terminal_count}
+
+    async def try_claim_loop_done(self, execution_id, step_name, event_id=None):
+        self._claim_count += 1
+        return self._claim_count == 1  # first caller wins, rest lose
 
 
 @pytest.mark.asyncio
@@ -1535,3 +1558,111 @@ workflow:
     assert invalidate_calls == [
         (execution_id, "stale_cache_newer_persisted_events")
     ]
+
+
+@pytest.mark.asyncio
+async def test_task_sequence_loop_concurrent_call_done_dispatches_loop_done_only_once(monkeypatch):
+    """Two concurrent call.done handlers at the terminal count must produce loop.done commands only once.
+
+    The ClaimAwareNATSCache grants the claim to exactly one caller (first wins, second loses).
+    We use asyncio.gather to run two handle_event calls simultaneously and verify that
+    loop.done-related transitions are evaluated exactly once across both handlers.
+    """
+    import asyncio as _asyncio
+
+    fixture = Path(
+        "tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step/"
+        "traveler_batch_enrichment_in_step.yaml"
+    )
+    playbook = Playbook(**yaml.safe_load(fixture.read_text(encoding="utf-8")))
+
+    playbook_repo = PlaybookRepo()
+    state_store = StateStore(playbook_repo)
+    engine = ControlFlowEngine(playbook_repo, state_store)
+
+    execution_id = "9050"
+    parent_step = "run_batch_workers"
+    terminal_count = 4  # matches collection_size returned by ClaimAwareNATSCache
+
+    state = ExecutionState(execution_id, playbook, payload={})
+    state.loop_state[parent_step] = {
+        "collection": [],
+        "iterator": "batch",
+        "index": 0,
+        "mode": "sequential",
+        "completed": False,
+        "results": [],
+        "failed_count": 0,
+        "aggregation_finalized": False,
+        "event_id": None,
+    }
+    await state_store.save_state(state)
+
+    claim_cache = ClaimAwareNATSCache(terminal_count)
+
+    async def fake_get_nats_cache():
+        return claim_cache
+
+    loop_done_eval_count = {"count": 0}
+
+    async def counting_evaluate_next_transitions(_state, _step_def, event_obj):
+        if event_obj.name == "loop.done":
+            loop_done_eval_count["count"] += 1
+        return []
+
+    async def fake_create_command_for_step(_state, step_def, _args):
+        return Command(
+            execution_id=execution_id,
+            step=step_def.step,
+            tool=ToolCall(kind="playbook", config={}),
+            input={},
+            render_context={},
+        )
+
+    monkeypatch.setattr(engine_module, "get_nats_cache", fake_get_nats_cache)
+    monkeypatch.setattr(engine, "_create_command_for_step", fake_create_command_for_step)
+    monkeypatch.setattr(engine, "_evaluate_next_transitions", counting_evaluate_next_transitions)
+
+    event_a = Event(
+        execution_id=execution_id,
+        step=f"{parent_step}:task_sequence",
+        name="call.done",
+        payload={
+            "response": {
+                "status": "completed",
+                "results": {
+                    "worker_result": {
+                        "status": "completed",
+                    }
+                },
+            }
+        },
+    )
+    event_b = Event(
+        execution_id=execution_id,
+        step=f"{parent_step}:task_sequence",
+        name="call.done",
+        payload={
+            "response": {
+                "status": "completed",
+                "results": {
+                    "worker_result": {
+                        "status": "completed",
+                    }
+                },
+            }
+        },
+    )
+
+    await _asyncio.gather(
+        engine.handle_event(event_a, already_persisted=True),
+        engine.handle_event(event_b, already_persisted=True),
+    )
+
+    assert loop_done_eval_count["count"] == 1, (
+        f"loop.done transitions evaluated {loop_done_eval_count['count']} times; expected exactly 1"
+    )
+    # At least one handler must have attempted the claim. In practice the second handler
+    # may be blocked earlier by the aggregation_finalized in-process guard (the second layer
+    # of defence), so _claim_count may be 1 or 2 depending on asyncio interleaving.
+    assert claim_cache._claim_count >= 1


### PR DESCRIPTION
## Problem

Closes #358.

When `increment_loop_completed` fails (NATS under pressure) and the engine falls back to counting persisted `call.done` events, multiple concurrent `handle_event` coroutines can all observe `new_count >= collection_size` simultaneously and each dispatch a `loop.done` event + loopback command.

The normal NATS path is already safe — the CAS increment ensures only one caller gets the terminal count value. The fallback path had no such protection, causing duplicate `load_patients_for_*` dispatches in production. With PostgreSQL MVCC, the racing concurrent queries all see the same unclaimed patient batch; only one `INSERT ... RETURNING` wins, the rest get 0 rows and arc prematurely to the next data type — so only ~100 patients are processed per data type instead of all of them.

## Fix

**`noetl/core/cache/nats_kv.py`** — adds `try_claim_loop_done()`:
- Same optimistic CAS pattern as `increment_loop_completed` (up to 10 retries with jittered backoff on `"wrong last sequence"`)
- Reads the loop state key, checks `loop_done_claimed`; if unset atomically sets it to `True`
- Returns `True` only to the winner; all other callers get `False`

**`noetl/core/dsl/v2/engine.py`** — identical guard added to both loop completion paths:
- **Pathway B** (`[TASK_SEQ-LOOP]`) — task_sequence loops, before `loop_state["completed"] = True`
- **Pathway A** (`[LOOP-CALL.DONE]`) — non-task_sequence loops, before same

If the claim returns `False` the handler returns early (no `loop.done` dispatched). If NATS itself is down and `try_claim_loop_done` throws, logs a warning and falls through to the existing in-process `aggregation_finalized` guard as a second layer.

## Test plan

- [ ] Run `test_reference_chain_loop_stress.py` (issue #278 repro) under `kind-noetl` — loop should advance monotonically with no duplicate dispatches in logs
- [ ] Grep server logs for `loop.done already claimed` — should appear for all but one concurrent handler on last-batch completions
- [ ] Deploy to `kind-noetl`, run a BHS facility with >100 patients; verify all 5 data types process full patient count (not just first 100)
- [ ] Confirm no regression on single-worker sequential loops (only one handler, `try_claim_loop_done` wins immediately)

## Related

- Fixes #358
- Related to #278 (intermittent loop dispatch pauses — overlapping symptom)
- BHS context: cybrnx/bhs-state-program-analytics#72 (documents both failed workaround attempts)