### PR TITLE
test(playwright): add regression e2e tests for master regression playbooks

### DIFF
--- a/gui/src/components/Catalog.tsx
+++ b/gui/src/components/Catalog.tsx
@@ -540,7 +540,7 @@ const Catalog: React.FC = () => {
                       icon={<PlayCircleOutlined />}
                       onClick={() => handleExecutePlaybook(playbook.catalog_id)}
                       disabled={playbook.status !== "active"}
-                      data-pw={`catalog.execute`}
+                      data-testid={`catalog-execute-${playbook.path.split("/").pop()}`}
                     >
                       Execute
                     </Button>

--- a/gui/src/components/Execution.tsx
+++ b/gui/src/components/Execution.tsx
@@ -636,7 +636,7 @@ const Execution: React.FC = () => {
     return (
       <Content className="execution-loading-content">
         <Spin size="large" />
-        <div className="execution-loading-text">Loading executions...</div>
+        <div className="execution-loading-text" data-testid="execution-loading">Loading executions...</div>
       </Content>
     );
   }

--- a/gui/src/components/ExecutionDetail.tsx
+++ b/gui/src/components/ExecutionDetail.tsx
@@ -917,6 +917,7 @@ const ExecutionDetail: React.FC = () => {
         </Space>
       </Card>
 
+      <div data-testid="events-table">
       <Table
         dataSource={filteredEvents}
         columns={columns}
@@ -1013,6 +1014,7 @@ const ExecutionDetail: React.FC = () => {
         }}
         size="small"
       />
+      </div>
 
       {filteredEvents.length === 0 && events.length > 0 && (
         <Alert

--- a/tests/playwright/e2e/regression/test_master_regression.spec.ts
+++ b/tests/playwright/e2e/regression/test_master_regression.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect, type Page } from '@playwright/test';
 import { execSync } from 'child_process';
 
-const NOETL_HOST = process.env.NOETL_HOST;
-const NOETL_PORT = process.env.NOETL_PORT;
-const BASE_URL = process.env.NOETL_BASE_URL;
+const NOETL_HOST = process.env.NOETL_HOST ?? 'localhost';
+const NOETL_PORT = process.env.NOETL_PORT ?? '8082';
+const BASE_URL = process.env.NOETL_BASE_URL ?? `http://${NOETL_HOST}:${NOETL_PORT}`;
 
 const CATALOG_URL = `${BASE_URL}/catalog`;
 
@@ -11,13 +11,12 @@ const PLAYBOOK_NAME = 'master_regression_test';
 const PLAYBOOK_PATH = `tests/fixtures/playbooks/regression_test/${PLAYBOOK_NAME}.yaml`;
 const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/regression_test/${PLAYBOOK_NAME}`;
 
-const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
 
 type TableRow = Record<typeof viewHeaders[number], string>;
 
-async function readEventsTable(page: Page): Promise<TableRow[]> {
-    const rows = page.locator('[data-testid="events-table-row"]');
+async function readEventsTablePage(page: Page): Promise<TableRow[]> {
+    const rows = page.locator('[data-testid="events-table"] .ant-table-row');
     const rowCount = await rows.count();
     const tableData: TableRow[] = [];
     for (let i = 0; i < rowCount; i++) {
@@ -28,49 +27,65 @@ async function readEventsTable(page: Page): Promise<TableRow[]> {
     return tableData;
 }
 
+async function readEventsTable(page: Page): Promise<TableRow[]> {
+    await page.waitForLoadState('networkidle').catch(() => {});
+    const allData: TableRow[] = [];
+    while (true) {
+        const pageData = await readEventsTablePage(page);
+        allData.push(...pageData);
+        const nextBtn = page.locator('[data-testid="events-table"] .ant-pagination-next:not(.ant-pagination-disabled)');
+        if (await nextBtn.count() === 0) break;
+        await nextBtn.click();
+        await page.waitForTimeout(300);
+    }
+    return allData;
+}
+
 function hasEvent(tableData: TableRow[], eventType: string, nodeName: string, status?: string): boolean {
-    return tableData.some(
-        r =>
-            r['Event Type'] === eventType &&
-            r['Node Name'] === nodeName &&
-            (status ? r['Status'] === status : true)
+    return tableData.some(r =>
+        r['Event Type'] === eventType &&
+        r['Node Name'] === nodeName &&
+        (status ? r['Status'] === status : true)
     );
 }
 
-test.describe('Master Regression Test (Sequential)', () => {
-    // 53 playbooks run sequentially — allow up to 15 minutes
-    test.setTimeout(900_000);
+test.describe('Master Regression Test', () => {
+    test.setTimeout(15 * 60 * 1000);
 
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
         execSync(`noetl --host ${NOETL_HOST} --port ${NOETL_PORT} register playbook --file "${PLAYBOOK_PATH}"`, { stdio: 'inherit' });
     });
 
-    test('should complete all regression playbooks successfully', async ({ page }) => {
+    test('should complete and emit playbook lifecycle events', async ({ page }) => {
         await test.step('Navigate: open Catalog', async () => {
             await page.goto(CATALOG_URL);
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
         await test.step(`Execute "${PLAYBOOK_NAME}" from Catalog`, async () => {
-            const executeButton = page.locator(
-                `(//*[text()='${PLAYBOOK_NAME}']/following::button[normalize-space()='Execute'])[1]`
-            );
+            const executeButton = page.locator(`[data-testid="catalog-execute-${PLAYBOOK_NAME}"]`).first();
             await executeButton.click();
             await expect(page).toHaveURL(/\/execution/);
         });
 
+        await test.step('Wait for completion, then reload', async () => {
+            await page.waitForTimeout(5000);
+            await page.reload();
+            await expect(page).toHaveTitle('NoETL Dashboard');
+        });
+
         await test.step('Wait: executions loader finishes (if present)', async () => {
-            const loader = page.locator(`//*[text()='${LOADING_EXECUTIONS_TEXT}']`);
+            const loader = page.locator('[data-testid="execution-loading"]');
             try {
                 await loader.waitFor({ state: 'visible', timeout: 5000 });
             } catch {
-                // loader may not appear if execution starts very quickly
+                // loader may not appear
             }
-            await loader.waitFor({ state: 'detached', timeout: 30_000 });
+            await loader.waitFor({ state: 'detached', timeout: 30000 });
         });
 
-        await test.step('Poll: wait for playbook.completed (up to 10 minutes)', async () => {
+        await test.step('Poll: wait for playbook.completed', async () => {
             await expect
                 .poll(
                     async () => {
@@ -79,12 +94,12 @@ test.describe('Master Regression Test (Sequential)', () => {
                         const tableData = await readEventsTable(page);
                         return hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED');
                     },
-                    { timeout: 600_000, intervals: [10_000, 30_000] }
+                    { timeout: 10 * 60 * 1000, intervals: [5000, 10000, 15000] }
                 )
                 .toBeTruthy();
         });
 
-        await test.step('Validate: playbook lifecycle events completed', async () => {
+        await test.step('Validate: lifecycle events', async () => {
             const tableData = await readEventsTable(page);
 
             expect(hasEvent(tableData, 'playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();

--- a/tests/playwright/e2e/regression/test_master_regression.spec.ts
+++ b/tests/playwright/e2e/regression/test_master_regression.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect, type Page } from '@playwright/test';
+import { execSync } from 'child_process';
+
+const NOETL_HOST = process.env.NOETL_HOST;
+const NOETL_PORT = process.env.NOETL_PORT;
+const BASE_URL = process.env.NOETL_BASE_URL;
+
+const CATALOG_URL = `${BASE_URL}/catalog`;
+
+const PLAYBOOK_NAME = 'master_regression_test';
+const PLAYBOOK_PATH = `tests/fixtures/playbooks/regression_test/${PLAYBOOK_NAME}.yaml`;
+const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/regression_test/${PLAYBOOK_NAME}`;
+
+const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
+const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
+
+type TableRow = Record<typeof viewHeaders[number], string>;
+
+async function readEventsTable(page: Page): Promise<TableRow[]> {
+    const rows = page.locator('.ant-table-wrapper .ant-table-row');
+    const rowCount = await rows.count();
+    const tableData: TableRow[] = [];
+    for (let i = 0; i < rowCount; i++) {
+        const cells = rows.nth(i).locator('td');
+        const values = await cells.allTextContents();
+        tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])) as TableRow);
+    }
+    return tableData;
+}
+
+function hasEvent(tableData: TableRow[], eventType: string, nodeName: string, status?: string): boolean {
+    return tableData.some(
+        r =>
+            r['Event Type'] === eventType &&
+            r['Node Name'] === nodeName &&
+            (status ? r['Status'] === status : true)
+    );
+}
+
+test.describe('Master Regression Test (Sequential)', () => {
+    // 53 playbooks run sequentially — allow up to 15 minutes
+    test.setTimeout(900_000);
+
+    test.beforeAll(() => {
+        console.log(`Registering ${PLAYBOOK_NAME}...`);
+        execSync(`noetl register "${PLAYBOOK_PATH}" --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+    });
+
+    test('should complete all regression playbooks successfully', async ({ page }) => {
+        await test.step('Navigate: open Catalog', async () => {
+            await page.goto(CATALOG_URL);
+            await expect(page).toHaveTitle('NoETL Dashboard');
+        });
+
+        await test.step(`Execute "${PLAYBOOK_NAME}" from Catalog`, async () => {
+            const executeButton = page.locator(
+                `(//*[text()='${PLAYBOOK_NAME}']/following::button[normalize-space()='Execute'])[1]`
+            );
+            await executeButton.click();
+            await expect(page).toHaveURL(/\/execution/);
+        });
+
+        await test.step('Wait: executions loader finishes (if present)', async () => {
+            const loader = page.locator(`//*[text()='${LOADING_EXECUTIONS_TEXT}']`);
+            try {
+                await loader.waitFor({ state: 'visible', timeout: 5000 });
+            } catch {
+                // loader may not appear if execution starts very quickly
+            }
+            await loader.waitFor({ state: 'detached', timeout: 30_000 });
+        });
+
+        await test.step('Poll: wait for playbook.completed (up to 10 minutes)', async () => {
+            await expect
+                .poll(
+                    async () => {
+                        await page.reload();
+                        await expect(page).toHaveTitle('NoETL Dashboard');
+                        const tableData = await readEventsTable(page);
+                        return hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED');
+                    },
+                    { timeout: 600_000, intervals: [10_000, 30_000] }
+                )
+                .toBeTruthy();
+        });
+
+        await test.step('Validate: playbook lifecycle events completed', async () => {
+            const tableData = await readEventsTable(page);
+
+            expect(hasEvent(tableData, 'playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED')).toBeTruthy();
+        });
+    });
+});

--- a/tests/playwright/e2e/regression/test_master_regression.spec.ts
+++ b/tests/playwright/e2e/regression/test_master_regression.spec.ts
@@ -43,7 +43,7 @@ test.describe('Master Regression Test (Sequential)', () => {
 
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register "${PLAYBOOK_PATH}" --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        execSync(`noetl --host ${NOETL_HOST} --port ${NOETL_PORT} register playbook --file "${PLAYBOOK_PATH}"`, { stdio: 'inherit' });
     });
 
     test('should complete all regression playbooks successfully', async ({ page }) => {

--- a/tests/playwright/e2e/regression/test_master_regression.spec.ts
+++ b/tests/playwright/e2e/regression/test_master_regression.spec.ts
@@ -17,7 +17,7 @@ const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration
 type TableRow = Record<typeof viewHeaders[number], string>;
 
 async function readEventsTable(page: Page): Promise<TableRow[]> {
-    const rows = page.locator('.ant-table-wrapper .ant-table-row');
+    const rows = page.locator('[data-testid="events-table-row"]');
     const rowCount = await rows.count();
     const tableData: TableRow[] = [];
     for (let i = 0; i < rowCount; i++) {

--- a/tests/playwright/e2e/regression/test_master_regression_parallel.spec.ts
+++ b/tests/playwright/e2e/regression/test_master_regression_parallel.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect, type Page } from '@playwright/test';
+import { execSync } from 'child_process';
+
+const NOETL_HOST = process.env.NOETL_HOST;
+const NOETL_PORT = process.env.NOETL_PORT;
+const BASE_URL = process.env.NOETL_BASE_URL;
+
+const CATALOG_URL = `${BASE_URL}/catalog`;
+
+const PLAYBOOK_NAME = 'master_regression_test_parallel';
+const PLAYBOOK_PATH = `tests/fixtures/playbooks/regression_test/${PLAYBOOK_NAME}.yaml`;
+const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/regression_test/${PLAYBOOK_NAME}`;
+
+const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
+const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
+
+type TableRow = Record<typeof viewHeaders[number], string>;
+
+async function readEventsTable(page: Page): Promise<TableRow[]> {
+    const rows = page.locator('.ant-table-wrapper .ant-table-row');
+    const rowCount = await rows.count();
+    const tableData: TableRow[] = [];
+    for (let i = 0; i < rowCount; i++) {
+        const cells = rows.nth(i).locator('td');
+        const values = await cells.allTextContents();
+        tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])) as TableRow);
+    }
+    return tableData;
+}
+
+function hasEvent(tableData: TableRow[], eventType: string, nodeName: string, status?: string): boolean {
+    return tableData.some(
+        r =>
+            r['Event Type'] === eventType &&
+            r['Node Name'] === nodeName &&
+            (status ? r['Status'] === status : true)
+    );
+}
+
+test.describe('Master Regression Test (Parallel)', () => {
+    // 51 playbooks run in parallel with max_in_flight=10 — allow up to 10 minutes
+    test.setTimeout(600_000);
+
+    test.beforeAll(() => {
+        console.log(`Registering ${PLAYBOOK_NAME}...`);
+        execSync(`noetl register "${PLAYBOOK_PATH}" --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+    });
+
+    test('should complete all regression playbooks successfully', async ({ page }) => {
+        await test.step('Navigate: open Catalog', async () => {
+            await page.goto(CATALOG_URL);
+            await expect(page).toHaveTitle('NoETL Dashboard');
+        });
+
+        await test.step(`Execute "${PLAYBOOK_NAME}" from Catalog`, async () => {
+            const executeButton = page.locator(
+                `(//*[text()='${PLAYBOOK_NAME}']/following::button[normalize-space()='Execute'])[1]`
+            );
+            await executeButton.click();
+            await expect(page).toHaveURL(/\/execution/);
+        });
+
+        await test.step('Wait: executions loader finishes (if present)', async () => {
+            const loader = page.locator(`//*[text()='${LOADING_EXECUTIONS_TEXT}']`);
+            try {
+                await loader.waitFor({ state: 'visible', timeout: 5000 });
+            } catch {
+                // loader may not appear if execution starts very quickly
+            }
+            await loader.waitFor({ state: 'detached', timeout: 30_000 });
+        });
+
+        await test.step('Poll: wait for playbook.completed (up to 7 minutes)', async () => {
+            await expect
+                .poll(
+                    async () => {
+                        await page.reload();
+                        await expect(page).toHaveTitle('NoETL Dashboard');
+                        const tableData = await readEventsTable(page);
+                        return hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED');
+                    },
+                    { timeout: 420_000, intervals: [10_000, 30_000] }
+                )
+                .toBeTruthy();
+        });
+
+        await test.step('Validate: playbook lifecycle events completed', async () => {
+            const tableData = await readEventsTable(page);
+
+            expect(hasEvent(tableData, 'playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED')).toBeTruthy();
+        });
+    });
+});

--- a/tests/playwright/e2e/regression/test_master_regression_parallel.spec.ts
+++ b/tests/playwright/e2e/regression/test_master_regression_parallel.spec.ts
@@ -43,7 +43,7 @@ test.describe('Master Regression Test (Parallel)', () => {
 
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register "${PLAYBOOK_PATH}" --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        execSync(`noetl --host ${NOETL_HOST} --port ${NOETL_PORT} register playbook --file "${PLAYBOOK_PATH}"`, { stdio: 'inherit' });
     });
 
     test('should complete all regression playbooks successfully', async ({ page }) => {

--- a/tests/playwright/e2e/regression/test_master_regression_parallel.spec.ts
+++ b/tests/playwright/e2e/regression/test_master_regression_parallel.spec.ts
@@ -17,7 +17,7 @@ const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration
 type TableRow = Record<typeof viewHeaders[number], string>;
 
 async function readEventsTable(page: Page): Promise<TableRow[]> {
-    const rows = page.locator('.ant-table-wrapper .ant-table-row');
+    const rows = page.locator('[data-testid="events-table-row"]');
     const rowCount = await rows.count();
     const tableData: TableRow[] = [];
     for (let i = 0; i < rowCount; i++) {

--- a/tests/playwright/e2e/regression/test_master_regression_parallel.spec.ts
+++ b/tests/playwright/e2e/regression/test_master_regression_parallel.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect, type Page } from '@playwright/test';
 import { execSync } from 'child_process';
 
-const NOETL_HOST = process.env.NOETL_HOST;
-const NOETL_PORT = process.env.NOETL_PORT;
-const BASE_URL = process.env.NOETL_BASE_URL;
+const NOETL_HOST = process.env.NOETL_HOST ?? 'localhost';
+const NOETL_PORT = process.env.NOETL_PORT ?? '8082';
+const BASE_URL = process.env.NOETL_BASE_URL ?? `http://${NOETL_HOST}:${NOETL_PORT}`;
 
 const CATALOG_URL = `${BASE_URL}/catalog`;
 
@@ -11,13 +11,12 @@ const PLAYBOOK_NAME = 'master_regression_test_parallel';
 const PLAYBOOK_PATH = `tests/fixtures/playbooks/regression_test/${PLAYBOOK_NAME}.yaml`;
 const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/regression_test/${PLAYBOOK_NAME}`;
 
-const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
 
 type TableRow = Record<typeof viewHeaders[number], string>;
 
-async function readEventsTable(page: Page): Promise<TableRow[]> {
-    const rows = page.locator('[data-testid="events-table-row"]');
+async function readEventsTablePage(page: Page): Promise<TableRow[]> {
+    const rows = page.locator('[data-testid="events-table"] .ant-table-row');
     const rowCount = await rows.count();
     const tableData: TableRow[] = [];
     for (let i = 0; i < rowCount; i++) {
@@ -28,49 +27,65 @@ async function readEventsTable(page: Page): Promise<TableRow[]> {
     return tableData;
 }
 
+async function readEventsTable(page: Page): Promise<TableRow[]> {
+    await page.waitForLoadState('networkidle').catch(() => {});
+    const allData: TableRow[] = [];
+    while (true) {
+        const pageData = await readEventsTablePage(page);
+        allData.push(...pageData);
+        const nextBtn = page.locator('[data-testid="events-table"] .ant-pagination-next:not(.ant-pagination-disabled)');
+        if (await nextBtn.count() === 0) break;
+        await nextBtn.click();
+        await page.waitForTimeout(300);
+    }
+    return allData;
+}
+
 function hasEvent(tableData: TableRow[], eventType: string, nodeName: string, status?: string): boolean {
-    return tableData.some(
-        r =>
-            r['Event Type'] === eventType &&
-            r['Node Name'] === nodeName &&
-            (status ? r['Status'] === status : true)
+    return tableData.some(r =>
+        r['Event Type'] === eventType &&
+        r['Node Name'] === nodeName &&
+        (status ? r['Status'] === status : true)
     );
 }
 
-test.describe('Master Regression Test (Parallel)', () => {
-    // 51 playbooks run in parallel with max_in_flight=10 — allow up to 10 minutes
-    test.setTimeout(600_000);
+test.describe('Master Regression Test Parallel', () => {
+    test.setTimeout(10 * 60 * 1000);
 
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
         execSync(`noetl --host ${NOETL_HOST} --port ${NOETL_PORT} register playbook --file "${PLAYBOOK_PATH}"`, { stdio: 'inherit' });
     });
 
-    test('should complete all regression playbooks successfully', async ({ page }) => {
+    test('should complete and emit playbook lifecycle events', async ({ page }) => {
         await test.step('Navigate: open Catalog', async () => {
             await page.goto(CATALOG_URL);
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
         await test.step(`Execute "${PLAYBOOK_NAME}" from Catalog`, async () => {
-            const executeButton = page.locator(
-                `(//*[text()='${PLAYBOOK_NAME}']/following::button[normalize-space()='Execute'])[1]`
-            );
+            const executeButton = page.locator(`[data-testid="catalog-execute-${PLAYBOOK_NAME}"]`).first();
             await executeButton.click();
             await expect(page).toHaveURL(/\/execution/);
         });
 
+        await test.step('Wait for completion, then reload', async () => {
+            await page.waitForTimeout(5000);
+            await page.reload();
+            await expect(page).toHaveTitle('NoETL Dashboard');
+        });
+
         await test.step('Wait: executions loader finishes (if present)', async () => {
-            const loader = page.locator(`//*[text()='${LOADING_EXECUTIONS_TEXT}']`);
+            const loader = page.locator('[data-testid="execution-loading"]');
             try {
                 await loader.waitFor({ state: 'visible', timeout: 5000 });
             } catch {
-                // loader may not appear if execution starts very quickly
+                // loader may not appear
             }
-            await loader.waitFor({ state: 'detached', timeout: 30_000 });
+            await loader.waitFor({ state: 'detached', timeout: 30000 });
         });
 
-        await test.step('Poll: wait for playbook.completed (up to 7 minutes)', async () => {
+        await test.step('Poll: wait for playbook.completed', async () => {
             await expect
                 .poll(
                     async () => {
@@ -79,12 +94,12 @@ test.describe('Master Regression Test (Parallel)', () => {
                         const tableData = await readEventsTable(page);
                         return hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED');
                     },
-                    { timeout: 420_000, intervals: [10_000, 30_000] }
+                    { timeout: 7 * 60 * 1000, intervals: [5000, 10000, 15000] }
                 )
                 .toBeTruthy();
         });
 
-        await test.step('Validate: playbook lifecycle events completed', async () => {
+        await test.step('Validate: lifecycle events', async () => {
             const tableData = await readEventsTable(page);
 
             expect(hasEvent(tableData, 'playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();

--- a/tests/playwright/e2e/test_control_flow_workbook.spec.ts
+++ b/tests/playwright/e2e/test_control_flow_workbook.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { execSync } from 'child_process';
 
 const NOETL_HOST = process.env.NOETL_HOST;
@@ -9,85 +9,114 @@ const CATALOG_URL = `${BASE_URL}/catalog`;
 
 const PLAYBOOK_NAME = 'control_flow_workbook';
 const PLAYBOOK_PATH = `tests/fixtures/playbooks/${PLAYBOOK_NAME}/${PLAYBOOK_NAME}.yaml`;
-
-const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
+const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/${PLAYBOOK_NAME}`;
 
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
+
+type TableRow = Record<typeof viewHeaders[number], string>;
+
+async function readEventsTablePage(page: Page): Promise<TableRow[]> {
+    const rows = page.locator('[data-testid="events-table"] .ant-table-row');
+    const rowCount = await rows.count();
+    const tableData: TableRow[] = [];
+    for (let i = 0; i < rowCount; i++) {
+        const cells = rows.nth(i).locator('td');
+        const values = await cells.allTextContents();
+        tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])) as TableRow);
+    }
+    return tableData;
+}
+
+async function readEventsTable(page: Page): Promise<TableRow[]> {
+    await page.waitForLoadState('networkidle').catch(() => {});
+    const allData: TableRow[] = [];
+    while (true) {
+        const pageData = await readEventsTablePage(page);
+        allData.push(...pageData);
+        const nextBtn = page.locator('[data-testid="events-table"] .ant-pagination-next:not(.ant-pagination-disabled)');
+        if (await nextBtn.count() === 0) break;
+        await nextBtn.click();
+        await page.waitForTimeout(300);
+    }
+    return allData;
+}
+
+function hasEvent(tableData: TableRow[], eventType: string, nodeName: string, status?: string): boolean {
+    return tableData.some(r =>
+        r['Event Type'] === eventType &&
+        r['Node Name'] === nodeName &&
+        (status ? r['Status'] === status : true)
+    );
+}
 
 test.describe('Control flow workbook', () => {
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register ${PLAYBOOK_PATH} --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        execSync(`noetl --host ${NOETL_HOST} --port ${NOETL_PORT} register playbook --file ${PLAYBOOK_PATH}`, { stdio: 'inherit' });
     });
 
-    test('should open catalog page', async ({ page }) => {
-        await test.step('Open Catalog', async () => {
+    test('should execute and emit expected control flow events', async ({ page }) => {
+        await test.step('Navigate: open Catalog', async () => {
             await page.goto(CATALOG_URL);
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step(`Execute ${PLAYBOOK_NAME} from Catalog`, async () => {
-            const executeButton = page.locator(
-                `(//*[text()='${PLAYBOOK_NAME}']/following::button[normalize-space()='Execute'])[1]`
-            );
+        await test.step(`Execute "${PLAYBOOK_NAME}" from Catalog`, async () => {
+            const executeButton = page.locator(`[data-testid="catalog-execute-${PLAYBOOK_NAME}"]`).first();
             await executeButton.click();
             await expect(page).toHaveURL(/\/execution/);
         });
 
-        await test.step('Wait for executions loader to finish (if present)', async () => {
-            const loader = page.locator(`//*[text()='${LOADING_EXECUTIONS_TEXT}']`);
-            await loader.waitFor({ state: 'visible', timeout: 5000 }).catch(() => { });
-            await loader.waitFor({ state: 'detached' });
-            // (visible is optional, but detached is required)
+        await test.step('Wait: executions loader finishes (if present)', async () => {
+            const loader = page.locator('[data-testid="execution-loading"]');
+            await loader.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
+            await loader.waitFor({ state: 'detached', timeout: 30000 });
         });
 
-        await test.step('Wait for execution to complete and reload', async () => {
+        await test.step('Wait for execution to complete, then reload', async () => {
             await page.waitForTimeout(10000);
             await page.reload();
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step('Parse events table and validate key events', async () => {
-            const rows = page.locator('.ant-table-wrapper .ant-table-row');
-            const rowCount = await rows.count();
 
-            const tableData: Record<string, string>[] = [];
+        await test.step('Poll: wait for playbook.completed', async () => {
+            await expect
+                .poll(
+                    async () => {
+                        await page.reload();
+                        await expect(page).toHaveTitle('NoETL Dashboard');
+                        const tableData = await readEventsTable(page);
+                        return hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED');
+                    },
+                    { timeout: 60000, intervals: [1000, 2000, 5000] }
+                )
+                .toBeTruthy();
+        });
 
-            for (let i = 0; i < rowCount; i++) {
-                const cells = rows.nth(i).locator('td');
-                const values = await cells.allTextContents();
-                const rowData = Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]]));
-                tableData.push(rowData);
-            }
-
+        await test.step('Validate: control flow events present', async () => {
+            const tableData = await readEventsTable(page);
             console.log(tableData);
 
-            const hasEvent = (eventType: string, nodeName: string, status?: string) =>
-                tableData.some(r =>
-                    r['Event Type'] === eventType &&
-                    r['Node Name'] === nodeName &&
-                    (status ? r['Status'] === status : true)
-                );
+            expect(hasEvent(tableData, 'playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
 
-            expect(hasEvent('playbook.initialized', `tests/fixtures/playbooks/${PLAYBOOK_NAME}`, 'INITIALIZED')).toBeTruthy();
-            expect(hasEvent('workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'start', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'start', 'COMPLETED')).toBeTruthy();
 
-            expect(hasEvent('step.enter', 'start', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'start', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'eval_flag', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'eval_flag', 'COMPLETED')).toBeTruthy();
 
-            expect(hasEvent('step.enter', 'eval_flag', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'eval_flag', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'hot_path', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'hot_path', 'COMPLETED')).toBeTruthy();
 
-            expect(hasEvent('step.enter', 'hot_path', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'hot_path', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'hot_task_a', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'hot_task_b', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'hot_task_a', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'hot_task_b', 'COMPLETED')).toBeTruthy();
 
-            expect(hasEvent('command.issued', 'hot_task_a', 'PENDING')).toBeTruthy();
-            expect(hasEvent('command.issued', 'hot_task_b', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.exit', 'hot_task_a', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'hot_task_b', 'COMPLETED')).toBeTruthy();
-
-            expect(hasEvent('workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('playbook.completed', `tests/fixtures/playbooks/${PLAYBOOK_NAME}`, 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED')).toBeTruthy();
         });
     });
 });

--- a/tests/playwright/e2e/test_create_tables.spec.ts
+++ b/tests/playwright/e2e/test_create_tables.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { execSync } from 'child_process';
 
 const NOETL_HOST = process.env.NOETL_HOST;
@@ -9,37 +9,62 @@ const CATALOG_URL = `${BASE_URL}/catalog`;
 
 const PLAYBOOK_NAME = 'create_tables';
 const PLAYBOOK_PATH = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
-
 const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
 
-const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
-
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
+
+type TableRow = Record<typeof viewHeaders[number], string>;
+
+async function readEventsTablePage(page: Page): Promise<TableRow[]> {
+    const rows = page.locator('[data-testid="events-table"] .ant-table-row');
+    const rowCount = await rows.count();
+    const tableData: TableRow[] = [];
+    for (let i = 0; i < rowCount; i++) {
+        const cells = rows.nth(i).locator('td');
+        const values = await cells.allTextContents();
+        tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])) as TableRow);
+    }
+    return tableData;
+}
+
+async function readEventsTable(page: Page): Promise<TableRow[]> {
+    await page.waitForLoadState('networkidle').catch(() => {});
+    const allData: TableRow[] = [];
+    while (true) {
+        const pageData = await readEventsTablePage(page);
+        allData.push(...pageData);
+        const nextBtn = page.locator('[data-testid="events-table"] .ant-pagination-next:not(.ant-pagination-disabled)');
+        if (await nextBtn.count() === 0) break;
+        await nextBtn.click();
+        await page.waitForTimeout(300);
+    }
+    return allData;
+}
+
+function hasEvent(tableData: TableRow[], eventType: string, nodeName: string, status?: string): boolean {
+    return tableData.some(r =>
+        r['Event Type'] === eventType &&
+        r['Node Name'] === nodeName &&
+        (status ? r['Status'] === status : true)
+    );
+}
 
 test.describe('Create Tables', () => {
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register ${PLAYBOOK_PATH} --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        execSync(`noetl --host ${NOETL_HOST} --port ${NOETL_PORT} register playbook --file ${PLAYBOOK_PATH}`, { stdio: 'inherit' });
     });
 
-    test('should open catalog page', async ({ page }) => {
-        await test.step('Open Catalog', async () => {
+    test('should execute and emit expected step events', async ({ page }) => {
+        await test.step('Navigate: open Catalog', async () => {
             await page.goto(CATALOG_URL);
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step(`Execute ${PLAYBOOK_NAME} from Catalog`, async () => {
-            const executeButton = page.locator(
-                `(//*[text()='${PLAYBOOK_NAME}']/following::button[normalize-space()='Execute'])[1]`
-            );
+        await test.step(`Execute "${PLAYBOOK_NAME}" from Catalog`, async () => {
+            const executeButton = page.locator(`[data-testid="catalog-execute-${PLAYBOOK_NAME}"]`).first();
             await executeButton.click();
             await expect(page).toHaveURL(/\/execution/);
-        });
-
-        await test.step('Wait for executions loader to finish (if present)', async () => {
-            const loader = page.locator(`//*[text()='${LOADING_EXECUTIONS_TEXT}']`);
-            await loader.waitFor({ state: 'visible', timeout: 5000 }).catch(() => { });
-            await loader.waitFor({ state: 'detached' });
         });
 
         await test.step('Wait for completion, then reload', async () => {
@@ -48,63 +73,62 @@ test.describe('Create Tables', () => {
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step('Parse events table and validate key events', async () => {
-            const rows = page.locator('.ant-table-wrapper .ant-table-row');
-            const rowCount = await rows.count();
-
-            const tableData: Record<string, string>[] = [];
-
-            for (let i = 0; i < rowCount; i++) {
-                const cells = rows.nth(i).locator('td');
-                const values = await cells.allTextContents();
-                const rowData = Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]]));
-                tableData.push(rowData);
+        await test.step('Wait: executions loader finishes (if present)', async () => {
+            const loader = page.locator('[data-testid="execution-loading"]');
+            try {
+                await loader.waitFor({ state: 'visible', timeout: 5000 });
+            } catch {
+                // loader may not appear
             }
+            await loader.waitFor({ state: 'detached', timeout: 30000 });
+        });
 
-            console.log(tableData);
+        await test.step('Poll: wait for playbook.completed', async () => {
+            await expect
+                .poll(
+                    async () => {
+                        await page.reload();
+                        await expect(page).toHaveTitle('NoETL Dashboard');
+                        const tableData = await readEventsTable(page);
+                        return hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED');
+                    },
+                    { timeout: 60000, intervals: [1000, 2000, 5000] }
+                )
+                .toBeTruthy();
+        });
 
-            const hasEvent = (eventType: string, nodeName: string, status?: string) =>
-                tableData.some(r =>
-                    r['Event Type'] === eventType &&
-                    r['Node Name'] === nodeName &&
-                    (status ? r['Status'] === status : true)
-                );
+        await test.step('Validate: lifecycle and step events', async () => {
+            const tableData = await readEventsTable(page);
 
-            // playbook/workflow lifecycle
-            expect(hasEvent('playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
-            expect(hasEvent('workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
 
-            // start step
-            expect(hasEvent('command.issued', 'start', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'start', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'start', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'start', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'start', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'start', 'COMPLETED')).toBeTruthy();
 
-            // create_flat_table step
-            expect(hasEvent('command.issued', 'create_flat_table', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'create_flat_table', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'create_flat_table', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'create_flat_table', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'create_flat_table', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'create_flat_table', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'create_flat_table', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'create_flat_table', 'COMPLETED')).toBeTruthy();
 
-            // create_nested_table step
-            expect(hasEvent('command.issued', 'create_nested_table', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'create_nested_table', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'create_nested_table', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'create_nested_table', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'create_nested_table', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'create_nested_table', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'create_nested_table', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'create_nested_table', 'COMPLETED')).toBeTruthy();
 
-            // create_summary_table step
-            expect(hasEvent('command.issued', 'create_summary_table', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'create_summary_table', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'create_summary_table', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'create_summary_table', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'create_summary_table', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'create_summary_table', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'create_summary_table', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'create_summary_table', 'COMPLETED')).toBeTruthy();
 
-            // end + completion
-            expect(hasEvent('command.issued', 'end', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'end', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'end', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'end', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'end', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'end', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'end', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'end', 'COMPLETED')).toBeTruthy();
 
-            expect(hasEvent('workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED')).toBeTruthy();
         });
     });
 });

--- a/tests/playwright/e2e/test_hello_world.spec.ts
+++ b/tests/playwright/e2e/test_hello_world.spec.ts
@@ -11,34 +11,60 @@ const PLAYBOOK_NAME = 'hello_world';
 const PLAYBOOK_PATH = `tests/fixtures/playbooks/${PLAYBOOK_NAME}/${PLAYBOOK_NAME}.yaml`;
 const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/${PLAYBOOK_NAME}`;
 
-const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
-
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
+
+type TableRow = Record<typeof viewHeaders[number], string>;
+
+async function readEventsTablePage(page: Page): Promise<TableRow[]> {
+    const rows = page.locator('[data-testid="events-table"] .ant-table-row');
+    const rowCount = await rows.count();
+    const tableData: TableRow[] = [];
+    for (let i = 0; i < rowCount; i++) {
+        const cells = rows.nth(i).locator('td');
+        const values = await cells.allTextContents();
+        tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])) as TableRow);
+    }
+    return tableData;
+}
+
+async function readEventsTable(page: Page): Promise<TableRow[]> {
+    await page.waitForLoadState('networkidle').catch(() => {});
+    const allData: TableRow[] = [];
+    while (true) {
+        const pageData = await readEventsTablePage(page);
+        allData.push(...pageData);
+        const nextBtn = page.locator('[data-testid="events-table"] .ant-pagination-next:not(.ant-pagination-disabled)');
+        if (await nextBtn.count() === 0) break;
+        await nextBtn.click();
+        await page.waitForTimeout(300);
+    }
+    return allData;
+}
+
+function hasEvent(tableData: TableRow[], eventType: string, nodeName: string, status?: string): boolean {
+    return tableData.some(r =>
+        r['Event Type'] === eventType &&
+        r['Node Name'] === nodeName &&
+        (status ? r['Status'] === status : true)
+    );
+}
 
 test.describe('Hello World', () => {
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register ${PLAYBOOK_PATH} --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        execSync(`noetl --host ${NOETL_HOST} --port ${NOETL_PORT} register playbook --file ${PLAYBOOK_PATH}`, { stdio: 'inherit' });
     });
 
-    test('should open catalog page', async ({ page }) => {
+    test('should execute and emit expected lifecycle events', async ({ page }) => {
         await test.step('Navigate: open Catalog', async () => {
             await page.goto(CATALOG_URL);
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step(`Execute ${PLAYBOOK_NAME} from Catalog`, async () => {
-            const executeButton = page.locator(
-                `(//*[text()='${PLAYBOOK_NAME}']/following::button[normalize-space()='Execute'])[1]`
-            );
+        await test.step(`Execute "${PLAYBOOK_NAME}" from Catalog`, async () => {
+            const executeButton = page.locator(`[data-testid="catalog-execute-${PLAYBOOK_NAME}"]`).first();
             await executeButton.click();
             await expect(page).toHaveURL(/\/execution/);
-        });
-
-        await test.step('Wait: loader finishes (if present)', async () => {
-            const loader = page.locator(`//*[text()='${LOADING_EXECUTIONS_TEXT}']`);
-            await loader.waitFor({ state: 'visible', timeout: 5000 }).catch(() => { });
-            await loader.waitFor({ state: 'detached' });
         });
 
         await test.step('Wait for completion, then reload', async () => {
@@ -47,56 +73,55 @@ test.describe('Hello World', () => {
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step('Parse events table and validate key events', async () => {
-            const rows = page.locator('.ant-table-wrapper .ant-table-row');
-            const rowCount = await rows.count();
-
-            const tableData: Record<string, string>[] = [];
-
-            for (let i = 0; i < rowCount; i++) {
-                const cells = rows.nth(i).locator('td');
-                const values = await cells.allTextContents();
-                const rowData = Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]]));
-                tableData.push(rowData);
+        await test.step('Wait: executions loader finishes (if present)', async () => {
+            const loader = page.locator('[data-testid="execution-loading"]');
+            try {
+                await loader.waitFor({ state: 'visible', timeout: 5000 });
+            } catch {
+                // loader may not appear
             }
-
-            console.log(tableData);
-
-            const hasEvent = (eventType: string, nodeName: string, status?: string) =>
-                tableData.some(r =>
-                    r['Event Type'] === eventType &&
-                    r['Node Name'] === nodeName &&
-                    (status ? r['Status'] === status : true)
-                );
-
-            // playbook/workflow lifecycle
-            expect(hasEvent('playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
-            expect(hasEvent('workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
-
-            // start step
-            expect(hasEvent('command.issued', 'start', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'start', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'start', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'start', 'COMPLETED')).toBeTruthy();
-
-            // test_step
-            expect(hasEvent('command.issued', 'test_step', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_step', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_step', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_step', 'COMPLETED')).toBeTruthy();
-
-            // end
-            expect(hasEvent('command.issued', 'end', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'end', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'end', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'end', 'COMPLETED')).toBeTruthy();
-
-            // end_sink
-            expect(hasEvent('command.issued', 'end_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'end_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'end_sink', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'end_sink', 'COMPLETED')).toBeTruthy();
+            await loader.waitFor({ state: 'detached', timeout: 30000 });
         });
 
+        await test.step('Poll: wait for playbook.completed', async () => {
+            await expect
+                .poll(
+                    async () => {
+                        await page.reload();
+                        await expect(page).toHaveTitle('NoETL Dashboard');
+                        const tableData = await readEventsTable(page);
+                        return hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED');
+                    },
+                    { timeout: 60000, intervals: [1000, 2000, 5000] }
+                )
+                .toBeTruthy();
+        });
+
+        await test.step('Validate: lifecycle and step events', async () => {
+            const tableData = await readEventsTable(page);
+
+            expect(hasEvent(tableData, 'playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
+
+            expect(hasEvent(tableData, 'command.issued', 'start', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'start', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'start', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'start', 'COMPLETED')).toBeTruthy();
+
+            expect(hasEvent(tableData, 'command.issued', 'test_step', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_step', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_step', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_step', 'COMPLETED')).toBeTruthy();
+
+            expect(hasEvent(tableData, 'command.issued', 'end', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'end', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'end', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'end', 'COMPLETED')).toBeTruthy();
+
+            expect(hasEvent(tableData, 'command.issued', 'end_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'end_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'end_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'end_sink', 'COMPLETED')).toBeTruthy();
+        });
     });
 });

--- a/tests/playwright/e2e/test_http_duckdb_postgres.spec.ts
+++ b/tests/playwright/e2e/test_http_duckdb_postgres.spec.ts
@@ -6,36 +6,65 @@ const NOETL_PORT = process.env.NOETL_PORT;
 const BASE_URL = `http://${NOETL_HOST}:${NOETL_PORT}`;
 
 const CATALOG_URL = `${BASE_URL}/catalog`;
+
 const PLAYBOOK_NAME = 'duckdb_query';
 const PLAYBOOK_PATH = `tests/retry/${PLAYBOOK_NAME}.yaml`;
 const PLAYBOOK_CATALOG_NODE = `tests/retry/${PLAYBOOK_NAME}`;
-const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
+
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
+
+type TableRow = Record<typeof viewHeaders[number], string>;
+
+async function readEventsTablePage(page: Page): Promise<TableRow[]> {
+    const rows = page.locator('[data-testid="events-table"] .ant-table-row');
+    const rowCount = await rows.count();
+    const tableData: TableRow[] = [];
+    for (let i = 0; i < rowCount; i++) {
+        const cells = rows.nth(i).locator('td');
+        const values = await cells.allTextContents();
+        tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])) as TableRow);
+    }
+    return tableData;
+}
+
+async function readEventsTable(page: Page): Promise<TableRow[]> {
+    await page.waitForLoadState('networkidle').catch(() => {});
+    const allData: TableRow[] = [];
+    while (true) {
+        const pageData = await readEventsTablePage(page);
+        allData.push(...pageData);
+        const nextBtn = page.locator('[data-testid="events-table"] .ant-pagination-next:not(.ant-pagination-disabled)');
+        if (await nextBtn.count() === 0) break;
+        await nextBtn.click();
+        await page.waitForTimeout(300);
+    }
+    return allData;
+}
+
+function hasEvent(tableData: TableRow[], eventType: string, nodeName: string, status?: string): boolean {
+    return tableData.some(r =>
+        r['Event Type'] === eventType &&
+        r['Node Name'] === nodeName &&
+        (status ? r['Status'] === status : true)
+    );
+}
 
 test.describe('HTTP DuckDB to Postgres', () => {
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register ${PLAYBOOK_PATH} --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        execSync(`noetl --host ${NOETL_HOST} --port ${NOETL_PORT} register playbook --file ${PLAYBOOK_PATH}`, { stdio: 'inherit' });
     });
 
-    test('should open catalog page', async ({ page }) => {
+    test('should execute and emit expected step events', async ({ page }) => {
         await test.step('Navigate: open Catalog', async () => {
             await page.goto(CATALOG_URL);
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step(`Execute ${PLAYBOOK_NAME} from Catalog`, async () => {
-            const executeButton = page.locator(
-                `(//*[text()='${PLAYBOOK_NAME}']/following::button[normalize-space()='Execute'])[1]`
-            );
+        await test.step(`Execute "${PLAYBOOK_NAME}" from Catalog`, async () => {
+            const executeButton = page.locator(`[data-testid="catalog-execute-${PLAYBOOK_NAME}"]`).first();
             await executeButton.click();
             await expect(page).toHaveURL(/\/execution/);
-        });
-
-        await test.step('Wait: executions loader finishes (if present)', async () => {
-            const loader = page.locator(`//*[text()='${LOADING_EXECUTIONS_TEXT}']`);
-            await loader.waitFor({ state: 'visible', timeout: 5000 }).catch(() => { });
-            await loader.waitFor({ state: 'detached' });
         });
 
         await test.step('Wait for completion, then reload', async () => {
@@ -44,56 +73,55 @@ test.describe('HTTP DuckDB to Postgres', () => {
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step('Parse events table and validate key events', async () => {
-            const rows = page.locator('.ant-table-wrapper .ant-table-row');
-            const rowCount = await rows.count();
-
-            const tableData: Record<string, string>[] = [];
-
-            for (let i = 0; i < rowCount; i++) {
-                const cells = rows.nth(i).locator('td');
-                const values = await cells.allTextContents();
-                const rowData = Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]]));
-                tableData.push(rowData);
+        await test.step('Wait: executions loader finishes (if present)', async () => {
+            const loader = page.locator('[data-testid="execution-loading"]');
+            try {
+                await loader.waitFor({ state: 'visible', timeout: 5000 });
+            } catch {
+                // loader may not appear
             }
-
-            console.log(tableData);
-
-            const hasEvent = (eventType: string, nodeName: string, status?: string) =>
-                tableData.some(r =>
-                    r['Event Type'] === eventType &&
-                    r['Node Name'] === nodeName &&
-                    (status ? r['Status'] === status : true)
-                );
-
-            // playbook/workflow lifecycle
-            expect(hasEvent('playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
-            expect(hasEvent('workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
-
-            // start step
-            expect(hasEvent('command.issued', 'start', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'start', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'start', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'start', 'COMPLETED')).toBeTruthy();
-
-            // test_step
-            expect(hasEvent('command.issued', 'test_step', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_step', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_step', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_step', 'COMPLETED')).toBeTruthy();
-
-            // end
-            expect(hasEvent('command.issued', 'end', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'end', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'end', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'end', 'COMPLETED')).toBeTruthy();
-
-            // end_sink
-            expect(hasEvent('command.issued', 'end_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'end_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'end_sink', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'end_sink', 'COMPLETED')).toBeTruthy();
+            await loader.waitFor({ state: 'detached', timeout: 30000 });
         });
 
+        await test.step('Poll: wait for playbook.completed', async () => {
+            await expect
+                .poll(
+                    async () => {
+                        await page.reload();
+                        await expect(page).toHaveTitle('NoETL Dashboard');
+                        const tableData = await readEventsTable(page);
+                        return hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED');
+                    },
+                    { timeout: 60000, intervals: [1000, 2000, 5000] }
+                )
+                .toBeTruthy();
+        });
+
+        await test.step('Validate: lifecycle and step events', async () => {
+            const tableData = await readEventsTable(page);
+
+            expect(hasEvent(tableData, 'playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
+
+            expect(hasEvent(tableData, 'command.issued', 'start', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'start', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'start', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'start', 'COMPLETED')).toBeTruthy();
+
+            expect(hasEvent(tableData, 'command.issued', 'test_step', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_step', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_step', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_step', 'COMPLETED')).toBeTruthy();
+
+            expect(hasEvent(tableData, 'command.issued', 'end', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'end', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'end', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'end', 'COMPLETED')).toBeTruthy();
+
+            expect(hasEvent(tableData, 'command.issued', 'end_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'end_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'end_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'end_sink', 'COMPLETED')).toBeTruthy();
+        });
     });
 });

--- a/tests/playwright/e2e/test_playbook_composition.spec.ts
+++ b/tests/playwright/e2e/test_playbook_composition.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
 import { execSync } from 'child_process';
-import path from 'path';
 
 const NOETL_HOST = process.env.NOETL_HOST;
 const NOETL_PORT = process.env.NOETL_PORT;
@@ -9,112 +8,131 @@ const BASE_URL = `http://${NOETL_HOST}:${NOETL_PORT}`;
 const CATALOG_URL = `${BASE_URL}/catalog`;
 
 const PLAYBOOK_NAME = 'playbook_composition';
-const PLAYBOOK_PATH = path.resolve(
-    process.cwd(),
-    'tests/fixtures/playbooks',
-    PLAYBOOK_NAME,
-    `${PLAYBOOK_NAME}.yaml`
-);
+const PLAYBOOK_PATH = `tests/fixtures/playbooks/${PLAYBOOK_NAME}/${PLAYBOOK_NAME}.yaml`;
 const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/${PLAYBOOK_NAME}/${PLAYBOOK_NAME}`;
-const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
+
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
 
+type TableRow = Record<typeof viewHeaders[number], string>;
+
+async function readEventsTablePage(page: Page): Promise<TableRow[]> {
+    const rows = page.locator('[data-testid="events-table"] .ant-table-row');
+    const rowCount = await rows.count();
+    const tableData: TableRow[] = [];
+    for (let i = 0; i < rowCount; i++) {
+        const cells = rows.nth(i).locator('td');
+        const values = await cells.allTextContents();
+        tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])) as TableRow);
+    }
+    return tableData;
+}
+
+async function readEventsTable(page: Page): Promise<TableRow[]> {
+    await page.waitForLoadState('networkidle').catch(() => {});
+    const allData: TableRow[] = [];
+    while (true) {
+        const pageData = await readEventsTablePage(page);
+        allData.push(...pageData);
+        const nextBtn = page.locator('[data-testid="events-table"] .ant-pagination-next:not(.ant-pagination-disabled)');
+        if (await nextBtn.count() === 0) break;
+        await nextBtn.click();
+        await page.waitForTimeout(300);
+    }
+    return allData;
+}
+
+function hasEvent(tableData: TableRow[], eventType: string, nodeName: string, status?: string): boolean {
+    return tableData.some(r =>
+        r['Event Type'] === eventType &&
+        r['Node Name'] === nodeName &&
+        (status ? r['Status'] === status : true)
+    );
+}
 
 test.describe('Playbook Composition', () => {
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register ${PLAYBOOK_PATH} --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        execSync(`noetl --host ${NOETL_HOST} --port ${NOETL_PORT} register playbook --file ${PLAYBOOK_PATH}`, { stdio: 'inherit' });
     });
 
-    test('should open catalog page', async ({ page }) => {
+    test('should execute and emit expected step events', async ({ page }) => {
         await test.step('Navigate: open Catalog', async () => {
             await page.goto(CATALOG_URL);
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step(`Execute ${PLAYBOOK_NAME} from Catalog`, async () => {
-            const executeButton = page.locator(
-                `(//*[text()='${PLAYBOOK_NAME}']/following::button[normalize-space()='Execute'])[1]`
-            );
+        await test.step(`Execute "${PLAYBOOK_NAME}" from Catalog`, async () => {
+            const executeButton = page.locator(`[data-testid="catalog-execute-${PLAYBOOK_NAME}"]`).first();
             await executeButton.click();
             await expect(page).toHaveURL(/\/execution/);
         });
+
         await test.step('Wait for completion, then reload', async () => {
             await page.waitForTimeout(5000);
             await page.reload();
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
+
         await test.step('Wait: executions loader finishes (if present)', async () => {
-            const loader = page.locator(`//*[text()='${LOADING_EXECUTIONS_TEXT}']`);
-            await loader.waitFor({ state: 'visible', timeout: 5000 }).catch(() => { });
-            await loader.waitFor({ state: 'detached' });
+            const loader = page.locator('[data-testid="execution-loading"]');
+            await loader.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
+            await loader.waitFor({ state: 'detached', timeout: 30000 });
         });
-        await test.step('Parse events table and validate key events', async () => {
-            const rows = page.locator('.ant-table-wrapper .ant-table-row');
-            const rowCount = await rows.count();
 
-            const tableData: Record<string, string>[] = [];
 
-            for (let i = 0; i < rowCount; i++) {
-                const cells = rows.nth(i).locator('td');
-                const values = await cells.allTextContents();
-                const rowData = Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]]));
-                tableData.push(rowData);
-            }
+        await test.step('Poll: wait for playbook.completed', async () => {
+            await expect
+                .poll(
+                    async () => {
+                        await page.reload();
+                        await expect(page).toHaveTitle('NoETL Dashboard');
+                        const tableData = await readEventsTable(page);
+                        return hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED');
+                    },
+                    { timeout: 60000, intervals: [1000, 2000, 5000] }
+                )
+                .toBeTruthy();
+        });
 
+        await test.step('Validate: lifecycle and step events', async () => {
+            const tableData = await readEventsTable(page);
             console.log(tableData);
 
-            const hasEvent = (eventType: string, nodeName: string, status?: string) =>
-                tableData.some(r =>
-                    r['Event Type'] === eventType &&
-                    r['Node Name'] === nodeName &&
-                    (status ? r['Status'] === status : true)
-                );
+            expect(hasEvent(tableData, 'playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
 
-            // playbook/workflow lifecycle
-            expect(hasEvent('playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
-            expect(hasEvent('workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'start', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'start', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'start', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'start', 'COMPLETED')).toBeTruthy();
 
-            // start step
-            expect(hasEvent('command.issued', 'start', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'start', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'start', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'start', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'setup_storage', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'setup_storage', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'setup_storage', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'setup_storage', 'COMPLETED')).toBeTruthy();
 
-            // setup_storage step
-            expect(hasEvent('command.issued', 'setup_storage', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'setup_storage', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'setup_storage', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'setup_storage', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'process_users', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'process_users', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'process_users', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'process_users', 'COMPLETED')).toBeTruthy();
 
-            // process_users step 
-            expect(hasEvent('command.issued', 'process_users', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'process_users', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'process_users', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'process_users', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'validate_results', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'validate_results', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'validate_results', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'validate_results', 'COMPLETED')).toBeTruthy();
 
-            // validate_results step 
-            expect(hasEvent('command.issued', 'validate_results', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'validate_results', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'validate_results', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'validate_results', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'process_users_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'process_users_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'process_users_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'process_users_sink', 'COMPLETED')).toBeTruthy();
 
-            // process_users_sink step 
-            expect(hasEvent('command.issued', 'process_users_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'process_users_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'process_users_sink', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'process_users_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'end', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'end', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'end', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'end', 'COMPLETED')).toBeTruthy();
 
-            // end
-            expect(hasEvent('command.issued', 'end', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'end', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'end', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'end', 'COMPLETED')).toBeTruthy();
-
-            // completion
-            expect(hasEvent('workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED')).toBeTruthy();
         });
-
     });
 });

--- a/tests/playwright/e2e/test_save_all_storage_types.spec.ts
+++ b/tests/playwright/e2e/test_save_all_storage_types.spec.ts
@@ -10,142 +10,161 @@ const CATALOG_URL = `${BASE_URL}/catalog`;
 const PLAYBOOK_NAME = 'save_all_storage_types';
 const PLAYBOOK_PATH = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
 const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
-const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
+
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
+
+type TableRow = Record<typeof viewHeaders[number], string>;
+
+async function readEventsTablePage(page: Page): Promise<TableRow[]> {
+    const rows = page.locator('[data-testid="events-table"] .ant-table-row');
+    const rowCount = await rows.count();
+    const tableData: TableRow[] = [];
+    for (let i = 0; i < rowCount; i++) {
+        const cells = rows.nth(i).locator('td');
+        const values = await cells.allTextContents();
+        tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])) as TableRow);
+    }
+    return tableData;
+}
+
+async function readEventsTable(page: Page): Promise<TableRow[]> {
+    await page.waitForLoadState('networkidle').catch(() => {});
+    const allData: TableRow[] = [];
+    while (true) {
+        const pageData = await readEventsTablePage(page);
+        allData.push(...pageData);
+        const nextBtn = page.locator('[data-testid="events-table"] .ant-pagination-next:not(.ant-pagination-disabled)');
+        if (await nextBtn.count() === 0) break;
+        await nextBtn.click();
+        await page.waitForTimeout(300);
+    }
+    return allData;
+}
+
+function hasEvent(tableData: TableRow[], eventType: string, nodeName: string, status?: string): boolean {
+    return tableData.some(r =>
+        r['Event Type'] === eventType &&
+        r['Node Name'] === nodeName &&
+        (status ? r['Status'] === status : true)
+    );
+}
 
 test.describe('Save all storage types', () => {
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register ${PLAYBOOK_PATH} --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        execSync(`noetl --host ${NOETL_HOST} --port ${NOETL_PORT} register playbook --file ${PLAYBOOK_PATH}`, { stdio: 'inherit' });
     });
 
-    test('should open catalog page', async ({ page }) => {
+    test('should execute and emit expected step events', async ({ page }) => {
         await test.step('Navigate: open Catalog', async () => {
             await page.goto(CATALOG_URL);
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step(`Execute ${PLAYBOOK_NAME} from Catalog`, async () => {
-            const executeButton = page.locator(
-                `(//*[text()='${PLAYBOOK_NAME}']/following::button[normalize-space()='Execute'])[1]`
-            );
+        await test.step(`Execute "${PLAYBOOK_NAME}" from Catalog`, async () => {
+            const executeButton = page.locator(`[data-testid="catalog-execute-${PLAYBOOK_NAME}"]`).first();
             await executeButton.click();
             await expect(page).toHaveURL(/\/execution/);
         });
+
         await test.step('Wait for completion, then reload', async () => {
             await page.waitForTimeout(5000);
             await page.reload();
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
+
         await test.step('Wait: executions loader finishes (if present)', async () => {
-            const loader = page.locator(`//*[text()='${LOADING_EXECUTIONS_TEXT}']`);
-            await loader.waitFor({ state: 'visible', timeout: 5000 }).catch(() => { });
-            await loader.waitFor({ state: 'detached' });
+            const loader = page.locator('[data-testid="execution-loading"]');
+            await loader.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
+            await loader.waitFor({ state: 'detached', timeout: 30000 });
         });
-        await test.step('Parse events table and validate key events', async () => {
-            const rows = page.locator('.ant-table-wrapper .ant-table-row');
-            const rowCount = await rows.count();
 
-            const tableData: Record<string, string>[] = [];
 
-            for (let i = 0; i < rowCount; i++) {
-                const cells = rows.nth(i).locator('td');
-                const values = await cells.allTextContents();
-                const rowData = Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]]));
-                tableData.push(rowData);
-            }
+        await test.step('Poll: wait for playbook.completed', async () => {
+            await expect
+                .poll(
+                    async () => {
+                        await page.reload();
+                        await expect(page).toHaveTitle('NoETL Dashboard');
+                        const tableData = await readEventsTable(page);
+                        return hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED');
+                    },
+                    { timeout: 60000, intervals: [1000, 2000, 5000] }
+                )
+                .toBeTruthy();
+        });
 
+        await test.step('Validate: lifecycle and step events', async () => {
+            const tableData = await readEventsTable(page);
             console.log(tableData);
 
-            const hasEvent = (eventType: string, nodeName: string, status?: string) =>
-                tableData.some(r =>
-                    r['Event Type'] === eventType &&
-                    r['Node Name'] === nodeName &&
-                    (status ? r['Status'] === status : true)
-                );
+            expect(hasEvent(tableData, 'playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
 
-            // lifecycle
-            expect(hasEvent('playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
-            expect(hasEvent('workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'start', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'start', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'start', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'start', 'COMPLETED')).toBeTruthy();
 
-            // start
-            expect(hasEvent('command.issued', 'start', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'start', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'start', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'start', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'initialize_test_data', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'initialize_test_data', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'initialize_test_data', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'initialize_test_data', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'initialize_test_data_sink', 'PENDING')).toBeTruthy();
 
-            // initialize_test_data (+ sink issued)
-            expect(hasEvent('command.issued', 'initialize_test_data', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'initialize_test_data', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'initialize_test_data', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'initialize_test_data', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.issued', 'initialize_test_data_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_flat_postgres_save', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_flat_postgres_save', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_flat_postgres_save', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_flat_postgres_save', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_flat_postgres_save_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_flat_postgres_save_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_flat_postgres_save_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_flat_postgres_save_sink', 'COMPLETED')).toBeTruthy();
 
-            // test_flat_postgres_save (+ sink)
-            expect(hasEvent('command.issued', 'test_flat_postgres_save', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_flat_postgres_save', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_flat_postgres_save', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_flat_postgres_save', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_nested_postgres_save', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_nested_postgres_save', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_nested_postgres_save', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_nested_postgres_save', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_nested_postgres_save_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_nested_postgres_save_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_nested_postgres_save_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_nested_postgres_save_sink', 'COMPLETED')).toBeTruthy();
 
-            expect(hasEvent('command.issued', 'test_flat_postgres_save_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_flat_postgres_save_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_flat_postgres_save_sink', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_flat_postgres_save_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_postgres_statement_save', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_postgres_statement_save', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_postgres_statement_save', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_postgres_statement_save', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_postgres_statement_save_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_postgres_statement_save_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_postgres_statement_save_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_postgres_statement_save_sink', 'COMPLETED')).toBeTruthy();
 
-            // test_nested_postgres_save (+ sink)
-            expect(hasEvent('command.issued', 'test_nested_postgres_save', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_nested_postgres_save', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_nested_postgres_save', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_nested_postgres_save', 'COMPLETED')).toBeTruthy();
+            // python_save sink is expected to FAIL
+            expect(hasEvent(tableData, 'command.issued', 'test_python_save', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_python_save', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_python_save', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_python_save', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_python_save_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_python_save_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_python_save_sink', 'FAILED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.failed', 'test_python_save_sink', 'FAILED')).toBeTruthy();
 
-            expect(hasEvent('command.issued', 'test_nested_postgres_save_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_nested_postgres_save_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_nested_postgres_save_sink', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_nested_postgres_save_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_duckdb_save', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_duckdb_save', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_duckdb_save', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_duckdb_save', 'COMPLETED')).toBeTruthy();
 
-            // test_postgres_statement_save (+ sink)
-            expect(hasEvent('command.issued', 'test_postgres_statement_save', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_postgres_statement_save', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_postgres_statement_save', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_postgres_statement_save', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_http_save', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_http_save', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_http_save', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_http_save', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_http_save_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_http_save_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_http_save_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_http_save_sink', 'COMPLETED')).toBeTruthy();
 
-            expect(hasEvent('command.issued', 'test_postgres_statement_save_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_postgres_statement_save_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_postgres_statement_save_sink', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_postgres_statement_save_sink', 'COMPLETED')).toBeTruthy();
-
-            // test_python_save (+ sink FAIL in provided log)
-            expect(hasEvent('command.issued', 'test_python_save', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_python_save', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_python_save', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_python_save', 'COMPLETED')).toBeTruthy();
-
-            expect(hasEvent('command.issued', 'test_python_save_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_python_save_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_python_save_sink', 'FAILED')).toBeTruthy();
-            expect(hasEvent('command.failed', 'test_python_save_sink', 'FAILED')).toBeTruthy();
-
-            // test_duckdb_save
-            expect(hasEvent('command.issued', 'test_duckdb_save', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_duckdb_save', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_duckdb_save', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_duckdb_save', 'COMPLETED')).toBeTruthy();
-
-            // test_http_save (+ sink)
-            expect(hasEvent('command.issued', 'test_http_save', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_http_save', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_http_save', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_http_save', 'COMPLETED')).toBeTruthy();
-
-            expect(hasEvent('command.issued', 'test_http_save_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_http_save_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_http_save_sink', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_http_save_sink', 'COMPLETED')).toBeTruthy();
-
-            // test_completion (в предоставленном логе есть issued + enter; exit/completed не показаны)
-            expect(hasEvent('command.issued', 'test_completion', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_completion', 'STARTED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_completion', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_completion', 'RUNNING')).toBeTruthy();
         });
-
     });
 });

--- a/tests/playwright/e2e/test_save_delegation_test.spec.ts
+++ b/tests/playwright/e2e/test_save_delegation_test.spec.ts
@@ -6,125 +6,146 @@ const NOETL_PORT = process.env.NOETL_PORT;
 const BASE_URL = `http://${NOETL_HOST}:${NOETL_PORT}`;
 
 const CATALOG_URL = `${BASE_URL}/catalog`;
-const EXECUTION_URL_PATTERN = '**/execution*';
 
 const PLAYBOOK_NAME = 'save_delegation_test';
 const PLAYBOOK_PATH = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
 const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
-const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
+
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
 
+type TableRow = Record<typeof viewHeaders[number], string>;
+
+async function readEventsTablePage(page: Page): Promise<TableRow[]> {
+    const rows = page.locator('[data-testid="events-table"] .ant-table-row');
+    const rowCount = await rows.count();
+    const tableData: TableRow[] = [];
+    for (let i = 0; i < rowCount; i++) {
+        const cells = rows.nth(i).locator('td');
+        const values = await cells.allTextContents();
+        tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])) as TableRow);
+    }
+    return tableData;
+}
+
+async function readEventsTable(page: Page): Promise<TableRow[]> {
+    await page.waitForLoadState('networkidle').catch(() => {});
+    const allData: TableRow[] = [];
+    while (true) {
+        const pageData = await readEventsTablePage(page);
+        allData.push(...pageData);
+        const nextBtn = page.locator('[data-testid="events-table"] .ant-pagination-next:not(.ant-pagination-disabled)');
+        if (await nextBtn.count() === 0) break;
+        await nextBtn.click();
+        await page.waitForTimeout(300);
+    }
+    return allData;
+}
+
+function hasEvent(tableData: TableRow[], eventType: string, nodeName: string, status?: string): boolean {
+    return tableData.some(r =>
+        r['Event Type'] === eventType &&
+        r['Node Name'] === nodeName &&
+        (status ? r['Status'] === status : true)
+    );
+}
 
 test.describe('Save delegation test', () => {
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register "${PLAYBOOK_PATH}" --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        execSync(`noetl --host ${NOETL_HOST} --port ${NOETL_PORT} register playbook --file "${PLAYBOOK_PATH}"`, { stdio: 'inherit' });
     });
 
-    test('should open catalog page', async ({ page }) => {
+    test('should execute and emit expected step events', async ({ page }) => {
         await test.step('Navigate: open Catalog', async () => {
             await page.goto(CATALOG_URL);
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step(`Execute ${PLAYBOOK_NAME} from Catalog`, async () => {
-            const executeButton = page.locator(
-                `(//*[text()='${PLAYBOOK_NAME}']/following::button[normalize-space()='Execute'])[1]`
-            );
+        await test.step(`Execute "${PLAYBOOK_NAME}" from Catalog`, async () => {
+            const executeButton = page.locator(`[data-testid="catalog-execute-${PLAYBOOK_NAME}"]`).first();
             await executeButton.click();
             await expect(page).toHaveURL(/\/execution/);
         });
+
         await test.step('Wait for completion, then reload', async () => {
             await page.waitForTimeout(5000);
             await page.reload();
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
+
         await test.step('Wait: executions loader finishes (if present)', async () => {
-            const loader = page.locator(`//*[text()='${LOADING_EXECUTIONS_TEXT}']`);
-            await loader.waitFor({ state: 'visible', timeout: 5000 }).catch(() => { });
-            await loader.waitFor({ state: 'detached' });
+            const loader = page.locator('[data-testid="execution-loading"]');
+            await loader.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
+            await loader.waitFor({ state: 'detached', timeout: 30000 });
         });
-        await test.step('Parse events table and validate key events', async () => {
-            const rows = page.locator('.ant-table-wrapper .ant-table-row');
-            const rowCount = await rows.count();
 
-            const tableData: Record<string, string>[] = [];
 
-            for (let i = 0; i < rowCount; i++) {
-                const cells = rows.nth(i).locator('td');
-                const values = await cells.allTextContents();
-                const rowData = Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]]));
-                tableData.push(rowData);
-            }
+        await test.step('Poll: wait for playbook.completed', async () => {
+            await expect
+                .poll(
+                    async () => {
+                        await page.reload();
+                        await expect(page).toHaveTitle('NoETL Dashboard');
+                        const tableData = await readEventsTable(page);
+                        return hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED');
+                    },
+                    { timeout: 60000, intervals: [1000, 2000, 5000] }
+                )
+                .toBeTruthy();
+        });
 
+        await test.step('Validate: lifecycle and step events', async () => {
+            const tableData = await readEventsTable(page);
             console.log(tableData);
 
-            const hasEvent = (eventType: string, nodeName: string, status?: string) =>
-                tableData.some(r =>
-                    r['Event Type'] === eventType &&
-                    r['Node Name'] === nodeName &&
-                    (status ? r['Status'] === status : true)
-                );
+            expect(hasEvent(tableData, 'playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
 
-            // lifecycle
-            expect(hasEvent('playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
-            expect(hasEvent('workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'start', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'start', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'start', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'start', 'COMPLETED')).toBeTruthy();
 
-            // start
-            expect(hasEvent('command.issued', 'start', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'start', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'start', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'start', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'create_tables', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'create_tables', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'create_tables', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'create_tables', 'COMPLETED')).toBeTruthy();
 
-            // create_tables
-            expect(hasEvent('command.issued', 'create_tables', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'create_tables', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'create_tables', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'create_tables', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'truncate_tables', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'truncate_tables', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'truncate_tables', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'truncate_tables', 'COMPLETED')).toBeTruthy();
 
-            // truncate_tables
-            expect(hasEvent('command.issued', 'truncate_tables', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'truncate_tables', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'truncate_tables', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'truncate_tables', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'event_test', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'event_test', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'event_test', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'event_test', 'COMPLETED')).toBeTruthy();
+            // event_test_sink is async (delegated)
+            expect(hasEvent(tableData, 'command.issued', 'event_test_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.claimed', 'event_test_sink', 'RUNNING')).toBeTruthy();
 
-            // event_test (+ sink issued/claimed)
-            expect(hasEvent('command.issued', 'event_test', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'event_test', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'event_test', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'event_test', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'postgres_test', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'postgres_test', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'postgres_test', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'postgres_test', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'postgres_test_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'postgres_test_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'postgres_test_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'postgres_test_sink', 'COMPLETED')).toBeTruthy();
 
-            expect(hasEvent('command.issued', 'event_test_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('command.claimed', 'event_test_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'duckdb_test', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'duckdb_test', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'duckdb_test', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'duckdb_test', 'COMPLETED')).toBeTruthy();
 
-            // postgres_test (+ sink)
-            expect(hasEvent('command.issued', 'postgres_test', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'postgres_test', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'postgres_test', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'postgres_test', 'COMPLETED')).toBeTruthy();
-
-            expect(hasEvent('command.issued', 'postgres_test_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'postgres_test_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'postgres_test_sink', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'postgres_test_sink', 'COMPLETED')).toBeTruthy();
-
-            // duckdb_test
-            expect(hasEvent('command.issued', 'duckdb_test', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'duckdb_test', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'duckdb_test', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'duckdb_test', 'COMPLETED')).toBeTruthy();
-
-            // http_test (+ sink)
-            expect(hasEvent('command.issued', 'http_test', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'http_test', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'http_test', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'http_test', 'COMPLETED')).toBeTruthy();
-
-            expect(hasEvent('command.issued', 'http_test_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'http_test_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'http_test_sink', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'http_test_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'http_test', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'http_test', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'http_test', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'http_test', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'http_test_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'http_test_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'http_test_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'http_test_sink', 'COMPLETED')).toBeTruthy();
         });
-
     });
 });

--- a/tests/playwright/e2e/test_save_edge_cases.spec.ts
+++ b/tests/playwright/e2e/test_save_edge_cases.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { execSync } from 'child_process';
 
 const NOETL_HOST = process.env.NOETL_HOST;
@@ -11,140 +11,159 @@ const PLAYBOOK_NAME = 'save_edge_cases';
 const PLAYBOOK_PATH = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
 const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
 
-const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
-
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
+
+type TableRow = Record<typeof viewHeaders[number], string>;
+
+async function readEventsTablePage(page: Page): Promise<TableRow[]> {
+    const rows = page.locator('[data-testid="events-table"] .ant-table-row');
+    const rowCount = await rows.count();
+    const tableData: TableRow[] = [];
+    for (let i = 0; i < rowCount; i++) {
+        const cells = rows.nth(i).locator('td');
+        const values = await cells.allTextContents();
+        tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])) as TableRow);
+    }
+    return tableData;
+}
+
+async function readEventsTable(page: Page): Promise<TableRow[]> {
+    await page.waitForLoadState('networkidle').catch(() => {});
+    const allData: TableRow[] = [];
+    while (true) {
+        const pageData = await readEventsTablePage(page);
+        allData.push(...pageData);
+        const nextBtn = page.locator('[data-testid="events-table"] .ant-pagination-next:not(.ant-pagination-disabled)');
+        if (await nextBtn.count() === 0) break;
+        await nextBtn.click();
+        await page.waitForTimeout(300);
+    }
+    return allData;
+}
+
+function hasEvent(tableData: TableRow[], eventType: string, nodeName: string, status?: string): boolean {
+    return tableData.some(r =>
+        r['Event Type'] === eventType &&
+        r['Node Name'] === nodeName &&
+        (status ? r['Status'] === status : true)
+    );
+}
 
 test.describe('Save edge cases', () => {
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register "${PLAYBOOK_PATH}" --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        execSync(`noetl --host ${NOETL_HOST} --port ${NOETL_PORT} register playbook --file "${PLAYBOOK_PATH}"`, { stdio: 'inherit' });
     });
 
-    test('should execute playbook and show expected events', async ({ page }) => {
+    test('should execute and emit expected step events', async ({ page }) => {
         await test.step('Navigate: open Catalog', async () => {
             await page.goto(CATALOG_URL);
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step(`Execute ${PLAYBOOK_NAME} from Catalog`, async () => {
-            const executeButton = page.locator(
-                `(//*[text()='${PLAYBOOK_NAME}']/following::button[normalize-space()='Execute'])[1]`
-            );
+        await test.step(`Execute "${PLAYBOOK_NAME}" from Catalog`, async () => {
+            const executeButton = page.locator(`[data-testid="catalog-execute-${PLAYBOOK_NAME}"]`).first();
             await executeButton.click();
             await expect(page).toHaveURL(/\/execution/);
         });
+
         await test.step('Wait for completion, then reload', async () => {
             await page.waitForTimeout(5000);
             await page.reload();
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
+
         await test.step('Wait: executions loader finishes (if present)', async () => {
-            const loader = page.locator(`//*[text()='${LOADING_EXECUTIONS_TEXT}']`);
-            await loader.waitFor({ state: 'visible', timeout: 5000 }).catch(() => { });
-            await loader.waitFor({ state: 'detached' });
+            const loader = page.locator('[data-testid="execution-loading"]');
+            await loader.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
+            await loader.waitFor({ state: 'detached', timeout: 30000 });
         });
 
-        await test.step('Validate: events table contains expected lifecycle and step events', async () => {
-            const rows = page.locator('.ant-table-wrapper .ant-table-row');
-            const rowCount = await rows.count();
 
-            const tableData: Record<string, string>[] = [];
-            for (let i = 0; i < rowCount; i++) {
-                const cells = rows.nth(i).locator('td');
-                const values = await cells.allTextContents();
-                tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])));
-            }
+        await test.step('Poll: wait for playbook.completed', async () => {
+            await expect
+                .poll(
+                    async () => {
+                        await page.reload();
+                        await expect(page).toHaveTitle('NoETL Dashboard');
+                        const tableData = await readEventsTable(page);
+                        return hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED');
+                    },
+                    { timeout: 60000, intervals: [1000, 2000, 5000] }
+                )
+                .toBeTruthy();
+        });
 
+        await test.step('Validate: lifecycle and step events', async () => {
+            const tableData = await readEventsTable(page);
             console.log(tableData);
 
-            const hasEvent = (eventType: string, nodeName: string, status?: string) =>
-                tableData.some(
-                    r =>
-                        r['Event Type'] === eventType &&
-                        r['Node Name'] === nodeName &&
-                        (status ? r['Status'] === status : true)
-                );
+            expect(hasEvent(tableData, 'playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
 
-            // lifecycle
-            expect(hasEvent('playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
-            expect(hasEvent('workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'start', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'start', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'start', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'start', 'COMPLETED')).toBeTruthy();
 
-            // start
-            expect(hasEvent('command.issued', 'start', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'start', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'start', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'start', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_mixed_types', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_mixed_types', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_mixed_types', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_mixed_types', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_mixed_types_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_mixed_types_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_mixed_types_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_mixed_types_sink', 'COMPLETED')).toBeTruthy();
 
-            // test_mixed_types (+ sink)
-            expect(hasEvent('command.issued', 'test_mixed_types', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_mixed_types', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_mixed_types', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_mixed_types', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_special_characters', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_special_characters', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_special_characters', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_special_characters', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_special_characters_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_special_characters_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_special_characters_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_special_characters_sink', 'COMPLETED')).toBeTruthy();
 
-            expect(hasEvent('command.issued', 'test_mixed_types_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_mixed_types_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_mixed_types_sink', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_mixed_types_sink', 'COMPLETED')).toBeTruthy();
+            // test_empty_data sink is expected to FAIL
+            expect(hasEvent(tableData, 'command.issued', 'test_empty_data', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_empty_data', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_empty_data', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_empty_data', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_empty_data_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_empty_data_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_empty_data_sink', 'FAILED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.failed', 'test_empty_data_sink', 'FAILED')).toBeTruthy();
 
-            // test_special_characters (+ sink)
-            expect(hasEvent('command.issued', 'test_special_characters', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_special_characters', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_special_characters', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_special_characters', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_large_payload', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_large_payload', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_large_payload', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_large_payload', 'COMPLETED')).toBeTruthy();
 
-            expect(hasEvent('command.issued', 'test_special_characters_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_special_characters_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_special_characters_sink', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_special_characters_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_error_recovery', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_error_recovery', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_error_recovery', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_error_recovery', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_error_recovery_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_error_recovery_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_error_recovery_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_error_recovery_sink', 'COMPLETED')).toBeTruthy();
 
-            // test_empty_data (+ sink FAILED)
-            expect(hasEvent('command.issued', 'test_empty_data', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_empty_data', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_empty_data', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_empty_data', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_completion_summary', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_completion_summary', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_completion_summary', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_completion_summary', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'test_completion_summary_sink', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'test_completion_summary_sink', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'test_completion_summary_sink', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'test_completion_summary_sink', 'COMPLETED')).toBeTruthy();
 
-            expect(hasEvent('command.issued', 'test_empty_data_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_empty_data_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_empty_data_sink', 'FAILED')).toBeTruthy();
-            expect(hasEvent('command.failed', 'test_empty_data_sink', 'FAILED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.issued', 'end', 'PENDING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.enter', 'end', 'RUNNING')).toBeTruthy();
+            expect(hasEvent(tableData, 'step.exit', 'end', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'command.completed', 'end', 'COMPLETED')).toBeTruthy();
 
-            // test_large_payload
-            expect(hasEvent('command.issued', 'test_large_payload', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_large_payload', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_large_payload', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_large_payload', 'COMPLETED')).toBeTruthy();
-
-            // test_error_recovery (+ sink)
-            expect(hasEvent('command.issued', 'test_error_recovery', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_error_recovery', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_error_recovery', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_error_recovery', 'COMPLETED')).toBeTruthy();
-
-            expect(hasEvent('command.issued', 'test_error_recovery_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_error_recovery_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_error_recovery_sink', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_error_recovery_sink', 'COMPLETED')).toBeTruthy();
-
-            // test_completion_summary (+ sink)
-            expect(hasEvent('command.issued', 'test_completion_summary', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_completion_summary', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_completion_summary', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_completion_summary', 'COMPLETED')).toBeTruthy();
-
-            expect(hasEvent('command.issued', 'test_completion_summary_sink', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'test_completion_summary_sink', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'test_completion_summary_sink', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'test_completion_summary_sink', 'COMPLETED')).toBeTruthy();
-
-            // end + completion
-            expect(hasEvent('command.issued', 'end', 'PENDING')).toBeTruthy();
-            expect(hasEvent('step.enter', 'end', 'STARTED')).toBeTruthy();
-            expect(hasEvent('step.exit', 'end', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('command.completed', 'end', 'COMPLETED')).toBeTruthy();
-
-            expect(hasEvent('workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED')).toBeTruthy();
         });
     });
 });

--- a/tests/playwright/e2e/test_save_simple_test.spec.ts
+++ b/tests/playwright/e2e/test_save_simple_test.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { execSync } from 'child_process';
 
 const NOETL_HOST = process.env.NOETL_HOST;
@@ -11,14 +11,48 @@ const PLAYBOOK_NAME = 'save_simple_test';
 const PLAYBOOK_PATH = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
 const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
 
-const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
-
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
+
+type TableRow = Record<typeof viewHeaders[number], string>;
+
+async function readEventsTablePage(page: Page): Promise<TableRow[]> {
+    const rows = page.locator('[data-testid="events-table"] .ant-table-row');
+    const rowCount = await rows.count();
+    const tableData: TableRow[] = [];
+    for (let i = 0; i < rowCount; i++) {
+        const cells = rows.nth(i).locator('td');
+        const values = await cells.allTextContents();
+        tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])) as TableRow);
+    }
+    return tableData;
+}
+
+async function readEventsTable(page: Page): Promise<TableRow[]> {
+    await page.waitForLoadState('networkidle').catch(() => {});
+    const allData: TableRow[] = [];
+    while (true) {
+        const pageData = await readEventsTablePage(page);
+        allData.push(...pageData);
+        const nextBtn = page.locator('[data-testid="events-table"] .ant-pagination-next:not(.ant-pagination-disabled)');
+        if (await nextBtn.count() === 0) break;
+        await nextBtn.click();
+        await page.waitForTimeout(300);
+    }
+    return allData;
+}
+
+function hasEvent(tableData: TableRow[], eventType: string, nodeName: string, status?: string): boolean {
+    return tableData.some(r =>
+        r['Event Type'] === eventType &&
+        r['Node Name'] === nodeName &&
+        (status ? r['Status'] === status : true)
+    );
+}
 
 test.describe('Save Simple Test', () => {
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register "${PLAYBOOK_PATH}" --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        execSync(`noetl --host ${NOETL_HOST} --port ${NOETL_PORT} register playbook --file "${PLAYBOOK_PATH}"`, { stdio: 'inherit' });
     });
 
     test('should execute playbook and show expected events', async ({ page }) => {
@@ -27,129 +61,77 @@ test.describe('Save Simple Test', () => {
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step(`Click: Execute "${PLAYBOOK_NAME}" and wait for navigation`, async () => {
-            const executeButton = page.locator(
-                `(//*[text()='${PLAYBOOK_NAME}']/following::button[normalize-space()='Execute'])[1]`
-            );
+        await test.step(`Execute "${PLAYBOOK_NAME}" from Catalog`, async () => {
+            const executeButton = page.locator(`[data-testid="catalog-execute-${PLAYBOOK_NAME}"]`).first();
             await executeButton.click();
             await expect(page).toHaveURL(/\/execution/);
         });
+
         await test.step('Wait for completion, then reload', async () => {
             await page.waitForTimeout(5000);
             await page.reload();
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
-        await test.step('Wait: executions loader finishes (if present)', async () => {
-            const loader = page.locator(`//*[text()='${LOADING_EXECUTIONS_TEXT}']`);
 
-            // "visible" is optional: loader might flash too fast or not appear at all.
+        await test.step('Wait: executions loader finishes (if present)', async () => {
+            const loader = page.locator('[data-testid="execution-loading"]');
             try {
                 await loader.waitFor({ state: 'visible', timeout: 5000 });
             } catch {
-                // ignore
+                // loader may not appear
             }
-
-            // If loader appears and gets stuck, fail here (do not swallow).
             await loader.waitFor({ state: 'detached', timeout: 30000 });
         });
 
-        await test.step('Wait: execution emits playbook.completed (reload)', async () => {
+        await test.step('Poll: wait for playbook.completed', async () => {
             await expect
                 .poll(
                     async () => {
                         await page.reload();
                         await expect(page).toHaveTitle('NoETL Dashboard');
-
-                        const rows = page.locator('.ant-table-wrapper .ant-table-row');
-                        const rowCount = await rows.count();
-
-                        const tableData: Record<string, string>[] = [];
-                        for (let i = 0; i < rowCount; i++) {
-                            const cells = rows.nth(i).locator('td');
-                            const values = await cells.allTextContents();
-                            tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])));
-                        }
-
-                        return tableData.some(
-                            r =>
-                                r['Event Type'] === 'playbook.completed' &&
-                                r['Node Name'] === PLAYBOOK_CATALOG_NODE &&
-                                r['Status'] === 'COMPLETED'
-                        );
+                        const tableData = await readEventsTable(page);
+                        return hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED');
                     },
                     { timeout: 60000, intervals: [1000, 2000, 5000] }
                 )
                 .toBeTruthy();
         });
 
-        await test.step('Validate: events table contains expected lifecycle and step events', async () => {
-            const rows = page.locator('.ant-table-wrapper .ant-table-row');
-            await expect(rows.first()).toBeVisible();
-
-            const rowCount = await rows.count();
-
-            const tableData: Record<string, string>[] = [];
-            for (let i = 0; i < rowCount; i++) {
-                const cells = rows.nth(i).locator('td');
-                const values = await cells.allTextContents();
-                tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])));
-            }
-
+        await test.step('Validate: lifecycle and step events', async () => {
+            const tableData = await readEventsTable(page);
+            await expect(page.locator('[data-testid="events-table"] .ant-table-row').first()).toBeVisible();
             console.log(tableData);
 
-            const hasEvent = (eventType: string, nodeName: string, status?: string) =>
-                tableData.some(
-                    r =>
-                        r['Event Type'] === eventType &&
-                        r['Node Name'] === nodeName &&
-                        (status ? r['Status'] === status : true)
-                );
-
-            const validateCommandStep = async (stepName: string) => {
-                await test.step(`Validate: ${stepName} step`, async () => {
-                    expect(hasEvent('command.issued', stepName, 'PENDING')).toBeTruthy();
-                    expect(hasEvent('step.enter', stepName, 'STARTED')).toBeTruthy();
-                    expect(hasEvent('step.exit', stepName, 'COMPLETED')).toBeTruthy();
-                    expect(hasEvent('command.completed', stepName, 'COMPLETED')).toBeTruthy();
+            const validateStep = async (stepName: string) => {
+                await test.step(`Validate: ${stepName}`, async () => {
+                    expect(hasEvent(tableData, 'command.issued', stepName, 'PENDING')).toBeTruthy();
+                    expect(hasEvent(tableData, 'step.enter', stepName, 'RUNNING')).toBeTruthy();
+                    expect(hasEvent(tableData, 'step.exit', stepName, 'COMPLETED')).toBeTruthy();
+                    expect(hasEvent(tableData, 'command.completed', stepName, 'COMPLETED')).toBeTruthy();
                 });
             };
 
-            const validateIssuedClaimedOnly = async (stepName: string) => {
-                await test.step(`Validate: ${stepName} command issued + claimed`, async () => {
-                    expect(hasEvent('command.issued', stepName, 'PENDING')).toBeTruthy();
-                    expect(hasEvent('command.claimed', stepName, 'RUNNING')).toBeTruthy();
-                });
-            };
+            expect(hasEvent(tableData, 'playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
 
-            await test.step('Validate: playbook/workflow lifecycle', async () => {
-                expect(hasEvent('playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
-                expect(hasEvent('workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
+            await validateStep('start');
+            await validateStep('create_tables');
+            await validateStep('truncate_tables');
+
+            await test.step('Validate: event_test + async sink', async () => {
+                await validateStep('event_test');
+                expect(hasEvent(tableData, 'command.issued', 'event_test_sink', 'PENDING')).toBeTruthy();
+                expect(hasEvent(tableData, 'command.claimed', 'event_test_sink', 'RUNNING')).toBeTruthy();
             });
 
-            await validateCommandStep('start');
-            await validateCommandStep('create_tables');
-            await validateCommandStep('truncate_tables');
+            await validateStep('postgres_flat_test');
+            await validateStep('postgres_flat_test_sink');
+            await validateStep('postgres_nested_test');
+            await validateStep('postgres_nested_test_sink');
+            await validateStep('end');
 
-            await test.step('Validate: event_test step (+ sink claimed)', async () => {
-                await validateCommandStep('event_test');
-                await validateIssuedClaimedOnly('event_test_sink');
-            });
-
-            await test.step('Validate: postgres_flat_test step (+ sink)', async () => {
-                await validateCommandStep('postgres_flat_test');
-                await validateCommandStep('postgres_flat_test_sink');
-            });
-
-            await test.step('Validate: postgres_nested_test step (+ sink)', async () => {
-                await validateCommandStep('postgres_nested_test');
-                await validateCommandStep('postgres_nested_test_sink');
-            });
-
-            await test.step('Validate: end + workflow/playbook completion', async () => {
-                await validateCommandStep('end');
-                expect(hasEvent('workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
-                expect(hasEvent('playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED')).toBeTruthy();
-            });
+            expect(hasEvent(tableData, 'workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED')).toBeTruthy();
         });
     });
 });

--- a/tests/playwright/e2e/test_user_profile_scorer.spec.ts
+++ b/tests/playwright/e2e/test_user_profile_scorer.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { execSync } from 'child_process';
 
 const NOETL_HOST = process.env.NOETL_HOST ?? 'localhost';
@@ -11,90 +11,119 @@ const PLAYBOOK_NAME = 'user_profile_scorer';
 const PLAYBOOK_PATH = `tests/fixtures/playbooks/playbook_composition/${PLAYBOOK_NAME}.yaml`;
 const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/playbook_composition/${PLAYBOOK_NAME}`;
 
-const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
-
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
+
+type TableRow = Record<typeof viewHeaders[number], string>;
+
+async function readEventsTablePage(page: Page): Promise<TableRow[]> {
+    const rows = page.locator('[data-testid="events-table"] .ant-table-row');
+    const rowCount = await rows.count();
+    const tableData: TableRow[] = [];
+    for (let i = 0; i < rowCount; i++) {
+        const cells = rows.nth(i).locator('td');
+        const values = await cells.allTextContents();
+        tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])) as TableRow);
+    }
+    return tableData;
+}
+
+async function readEventsTable(page: Page): Promise<TableRow[]> {
+    await page.waitForLoadState('networkidle').catch(() => {});
+    const allData: TableRow[] = [];
+    while (true) {
+        const pageData = await readEventsTablePage(page);
+        allData.push(...pageData);
+        const nextBtn = page.locator('[data-testid="events-table"] .ant-pagination-next:not(.ant-pagination-disabled)');
+        if (await nextBtn.count() === 0) break;
+        await nextBtn.click();
+        await page.waitForTimeout(300);
+    }
+    return allData;
+}
+
+function hasEvent(tableData: TableRow[], eventType: string, nodeName: string, status?: string): boolean {
+    return tableData.some(r =>
+        r['Event Type'] === eventType &&
+        r['Node Name'] === nodeName &&
+        (status ? r['Status'] === status : true)
+    );
+}
 
 test.describe('User Profile Scorer', () => {
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register "${PLAYBOOK_PATH}" --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        execSync(`noetl --host ${NOETL_HOST} --port ${NOETL_PORT} register playbook --file "${PLAYBOOK_PATH}"`, { stdio: 'inherit' });
     });
 
-    test('should execute playbook and show expected events', async ({ page }) => {
+    test('should execute and emit expected step events', async ({ page }) => {
         await test.step('Navigate: open Catalog', async () => {
             await page.goto(CATALOG_URL);
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step(`Click: Execute "${PLAYBOOK_NAME}" and wait for navigation`, async () => {
-            const executeButton = page.locator(
-                `(//*[text()='${PLAYBOOK_NAME}']/following::button[normalize-space()='Execute'])[1]`
-            );
+        await test.step(`Execute "${PLAYBOOK_NAME}" from Catalog`, async () => {
+            const executeButton = page.locator(`[data-testid="catalog-execute-${PLAYBOOK_NAME}"]`).first();
             await executeButton.click();
             await expect(page).toHaveURL(/\/execution/);
         });
 
-        await test.step('Wait: executions loader finishes (if present)', async () => {
-            const loader = page.locator(`//*[text()='${LOADING_EXECUTIONS_TEXT}']`);
-            await loader.waitFor({ state: 'visible', timeout: 5000 }).catch(() => { });
-            await loader.waitFor({ state: 'detached', timeout: 30000 }).catch(() => { });
-        });
         await test.step('Wait for completion, then reload', async () => {
             await page.waitForTimeout(5000);
             await page.reload();
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
-        await test.step('Validate: events table contains expected lifecycle and step events', async () => {
-            const rows = page.locator('.ant-table-wrapper .ant-table-row');
-            const rowCount = await rows.count();
-
-            const tableData: Record<string, string>[] = [];
-            for (let i = 0; i < rowCount; i++) {
-                const cells = rows.nth(i).locator('td');
-                const values = await cells.allTextContents();
-                tableData.push(Object.fromEntries(viewHeaders.map((key, idx) => [key, values[idx]])));
+        await test.step('Wait: executions loader finishes (if present)', async () => {
+            const loader = page.locator('[data-testid="execution-loading"]');
+            try {
+                await loader.waitFor({ state: 'visible', timeout: 5000 });
+            } catch {
+                // loader may not appear
             }
+            await loader.waitFor({ state: 'detached', timeout: 30000 });
+        });
 
-            console.log(tableData);
+        await test.step('Poll: wait for playbook.completed', async () => {
+            await expect
+                .poll(
+                    async () => {
+                        await page.reload();
+                        await expect(page).toHaveTitle('NoETL Dashboard');
+                        const tableData = await readEventsTable(page);
+                        return hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED');
+                    },
+                    { timeout: 60000, intervals: [1000, 2000, 5000] }
+                )
+                .toBeTruthy();
+        });
 
-            const hasEvent = (eventType: string, nodeName: string, status?: string) =>
-                tableData.some(
-                    r =>
-                        r['Event Type'] === eventType &&
-                        r['Node Name'] === nodeName &&
-                        (status ? r['Status'] === status : true)
-                );
+        await test.step('Validate: lifecycle and step events', async () => {
+            const tableData = await readEventsTable(page);
 
-            const validateCommandStep = async (stepName: string) => {
-                await test.step(`Validate: ${stepName} step`, async () => {
-                    expect(hasEvent('command.issued', stepName, 'PENDING')).toBeTruthy();
-                    expect(hasEvent('step.enter', stepName, 'STARTED')).toBeTruthy();
-                    expect(hasEvent('step.exit', stepName, 'COMPLETED')).toBeTruthy();
-                    expect(hasEvent('command.completed', stepName, 'COMPLETED')).toBeTruthy();
+            const validateStep = async (stepName: string) => {
+                await test.step(`Validate: ${stepName}`, async () => {
+                    expect(hasEvent(tableData, 'command.issued', stepName, 'PENDING')).toBeTruthy();
+                    expect(hasEvent(tableData, 'step.enter', stepName, 'RUNNING')).toBeTruthy();
+                    expect(hasEvent(tableData, 'step.exit', stepName, 'COMPLETED')).toBeTruthy();
+                    expect(hasEvent(tableData, 'command.completed', stepName, 'COMPLETED')).toBeTruthy();
                 });
             };
 
-            await test.step('Validate: playbook/workflow lifecycle', async () => {
-                expect(hasEvent('playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
-                expect(hasEvent('workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
-            });
+            expect(hasEvent(tableData, 'playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent(tableData, 'workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
 
-            await validateCommandStep('start');
-            await validateCommandStep('extract_user_data');
-            await validateCommandStep('score_experience');
-            await validateCommandStep('score_performance');
-            await validateCommandStep('score_department');
-            await validateCommandStep('score_age');
-            await validateCommandStep('compute_total_score');
-            await validateCommandStep('determine_score_category');
-            await validateCommandStep('finalize_result');
+            await validateStep('start');
+            await validateStep('extract_user_data');
+            await validateStep('score_experience');
+            await validateStep('score_performance');
+            await validateStep('score_department');
+            await validateStep('score_age');
+            await validateStep('compute_total_score');
+            await validateStep('determine_score_category');
+            await validateStep('finalize_result');
 
-            await test.step('Validate: workflow/playbook completion', async () => {
-                expect(hasEvent('workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
-                expect(hasEvent('playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED')).toBeTruthy();
-            });
+            expect(hasEvent(tableData, 'workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
+            expect(hasEvent(tableData, 'playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED')).toBeTruthy();
         });
     });
 });

--- a/ui-src/src/components/Catalog.tsx
+++ b/ui-src/src/components/Catalog.tsx
@@ -444,7 +444,7 @@ const Catalog: React.FC = () => {
                       icon={<PlayCircleOutlined />}
                       onClick={() => handleExecutePlaybook(playbook.catalog_id)}
                       disabled={playbook.status !== "active"}
-                      data-pw={`catalog.execute`}
+                      data-testid={`catalog-execute-${playbook.path.split("/").pop()}`}
                     >
                       Execute
                     </Button>

--- a/ui-src/src/components/Execution.tsx
+++ b/ui-src/src/components/Execution.tsx
@@ -640,7 +640,7 @@ const Execution: React.FC = () => {
     return (
       <Content className="execution-loading-content">
         <Spin size="large" />
-        <div className="execution-loading-text">Loading executions...</div>
+        <div className="execution-loading-text" data-testid="execution-loading">Loading executions...</div>
       </Content>
     );
   }

--- a/ui-src/src/components/ExecutionDetail.tsx
+++ b/ui-src/src/components/ExecutionDetail.tsx
@@ -688,6 +688,7 @@ const ExecutionDetail: React.FC = () => {
         </Space>
       </Card>
 
+      <div data-testid="events-table">
       <Table
         dataSource={filteredEvents}
         columns={columns}
@@ -784,6 +785,7 @@ const ExecutionDetail: React.FC = () => {
         }}
         size="small"
       />
+      </div>
 
       {filteredEvents.length === 0 && events.length > 0 && (
         <Alert


### PR DESCRIPTION
Closes #382

## Summary
- Add `data-testid` attributes to events table wrapper, catalog execute buttons, and execution loading indicator in both `ui-src/` and `gui/` React components
- Replace all CSS/XPath locators with `data-testid` selectors across all 10 e2e test files and 2 regression test files
- Add poll step to wait for `playbook.completed` before validating events (fixes race condition)
- Add pagination loop in `readEventsTable` to read all table pages (executions emit 100+ events)
- Fix `step.enter` status check: `STARTED` → `RUNNING` (actual emitted value)
- Add `networkidle` wait before reading table rows

## Test plan
- [x] `test_user_profile_scorer.spec.ts` passes locally against Kind cluster
- [ ] Run full e2e suite
- [ ] Regression tests (require long-running playbooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)