### PR TITLE
feat: execute MCP tools through agent playbooks

### DIFF
--- a/noetl/core/dsl/engine/models/tools.py
+++ b/noetl/core/dsl/engine/models/tools.py
@@ -153,6 +153,7 @@ class ToolSpec(BaseModel):
         "gateway",
         "nats",
         "agent",
+        "mcp",
         "shell",
         "artifact",
         "noop",           # No-operation tool for routing/initialization
@@ -228,4 +229,3 @@ class ToolOutcome(BaseModel):
 # ============================================================================
 # Loop Models - Step-level looping (canonical v10)
 # ============================================================================
-

--- a/noetl/database/ddl/postgres/schema_ddl.sql
+++ b/noetl/database/ddl/postgres/schema_ddl.sql
@@ -6,6 +6,15 @@ CREATE TABLE IF NOT EXISTS noetl.resource (
     meta JSONB
 );
 
+INSERT INTO noetl.resource (name, meta) VALUES
+    ('playbook', '{"description":"Executable NoETL workflow definition","executable":true,"catalog":true}'::jsonb),
+    ('credential', '{"description":"Credential or secret reference metadata","executable":false,"catalog":true}'::jsonb),
+    ('mcp', '{"description":"Model Context Protocol server/tool provider","executable":false,"catalog":true}'::jsonb),
+    ('agent', '{"description":"Agent-as-playbook or agent capability resource","executable":true,"catalog":true}'::jsonb),
+    ('memory', '{"description":"AI memory, knowledge, or coordination artifact","executable":false,"catalog":true}'::jsonb)
+ON CONFLICT (name) DO UPDATE
+SET meta = COALESCE(noetl.resource.meta, '{}'::jsonb) || EXCLUDED.meta;
+
 -- Catalog
 CREATE TABLE IF NOT EXISTS noetl.catalog (
     catalog_id BIGINT PRIMARY KEY,

--- a/noetl/server/api/catalog/endpoint.py
+++ b/noetl/server/api/catalog/endpoint.py
@@ -525,7 +525,7 @@ async def explain_playbook_with_ai(
 
     if not target:
         raise HTTPException(status_code=404, detail="Target playbook not found in catalog")
-    if target.kind != "Playbook":
+    if str(target.kind).lower() != "playbook":
         raise HTTPException(status_code=400, detail=f"Catalog entry kind must be Playbook, got {target.kind}")
 
     payload: dict[str, Any] = {

--- a/noetl/server/api/catalog/schema.py
+++ b/noetl/server/api/catalog/schema.py
@@ -20,8 +20,8 @@ class CatalogEntriesRequest(AppBaseModel):
     """Request schema for listing catalog entries."""
     resource_type: Optional[str] = Field(
         default=None,
-        description="Filter by resource kind (e.g., 'Playbook', 'Tool', 'Model')",
-        example="Playbook"
+        description="Filter by resource kind (e.g., 'playbook', 'agent', 'mcp', 'memory', 'credential')",
+        example="playbook"
     )
     path: Optional[str] = Field(
         default=None,
@@ -211,8 +211,8 @@ class CatalogRegisterRequest(AppBaseModel):
     )
     resource_type: str = Field(
         default="Playbook",
-        description="Type of resource to register (e.g., 'Playbook', 'Tool', 'Model')",
-        example="Playbook"
+        description="Type of resource to register (e.g., 'playbook', 'agent', 'mcp', 'memory', 'credential'). Legacy 'Playbook' is accepted.",
+        example="playbook"
     )
 
     @field_validator('content', mode="before")

--- a/noetl/server/api/catalog/service.py
+++ b/noetl/server/api/catalog/service.py
@@ -306,13 +306,63 @@ class CatalogService:
         }
 
     @staticmethod
+    def _normalize_resource_type(resource_type: Optional[str]) -> str:
+        value = str(resource_type or "playbook").strip()
+        if not value:
+            return "playbook"
+        aliases = {
+            "Playbook": "playbook",
+            "Credential": "credential",
+            "Credentials": "credential",
+            "Secret": "credential",
+            "Secrets": "credential",
+            "MCP": "mcp",
+            "ModelContextProtocol": "mcp",
+            "Agent": "agent",
+            "Memory": "memory",
+        }
+        return aliases.get(value, value).strip().lower()
+
+    @staticmethod
+    def _resource_type_meta(resource_type: str) -> Dict[str, Any]:
+        catalog_types = {
+            "playbook": {
+                "description": "Executable NoETL workflow definition",
+                "executable": True,
+                "catalog": True,
+            },
+            "credential": {
+                "description": "Credential or secret reference metadata",
+                "executable": False,
+                "catalog": True,
+            },
+            "mcp": {
+                "description": "Model Context Protocol server/tool provider",
+                "executable": False,
+                "catalog": True,
+            },
+            "agent": {
+                "description": "Agent-as-playbook or agent capability resource",
+                "executable": True,
+                "catalog": True,
+            },
+            "memory": {
+                "description": "AI memory, knowledge, or coordination artifact",
+                "executable": False,
+                "catalog": True,
+            },
+        }
+        return catalog_types.get(resource_type, {"catalog": True})
+
+    @staticmethod
     async def register_resource(content: str, resource_type: str = "Playbook") -> Dict[str, Any]:
         resource_data = yaml.safe_load(content) or {}
+        resource_type = CatalogService._normalize_resource_type(resource_type)
         path = (resource_data.get("metadata") or {}).get("path") or resource_data.get("path") or (
             resource_data.get("metadata") or {}).get("name") or resource_data.get("name") or "unknown"
 
         # Inject implicit "end" step if playbook doesn't have one
-        if resource_type == "Playbook":
+        if resource_type in {"playbook", "agent"}:
             workflow = resource_data.get("workflow", [])
             if workflow and not any(step.get("step", "").lower() == "end" for step in workflow):
                 logger.info(f"CATALOG: Injecting implicit 'end' step for playbook '{path}'")
@@ -333,8 +383,16 @@ class CatalogService:
         async with get_pool_connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cursor:
                 await cursor.execute(
-                    "INSERT INTO noetl.resource (name) VALUES (%(resource_type)s) ON CONFLICT DO NOTHING",
-                    {"resource_type": resource_type}
+                    """
+                    INSERT INTO noetl.resource (name, meta)
+                    VALUES (%(resource_type)s, %(resource_meta)s)
+                    ON CONFLICT (name) DO UPDATE
+                    SET meta = COALESCE(noetl.resource.meta, '{}'::jsonb) || EXCLUDED.meta
+                    """,
+                    {
+                        "resource_type": resource_type,
+                        "resource_meta": Json(CatalogService._resource_type_meta(resource_type)),
+                    }
                 )
 
                 
@@ -409,7 +467,7 @@ class CatalogService:
     ) -> List[CatalogEntry]:
         """List catalog entries marked as agents, optionally filtered by capability/path."""
         return await CatalogService.fetch_entries(
-            resource_type="Playbook",
+            resource_type=None,
             path=path,
             agent_only=True,
             capabilities=capabilities,
@@ -442,8 +500,8 @@ class CatalogService:
         conditions = []
         
         if resource_type:
-            conditions.append("AND c.kind = %(resource_type)s")
-            params["resource_type"] = resource_type
+            conditions.append("AND lower(c.kind) = %(resource_type)s")
+            params["resource_type"] = CatalogService._normalize_resource_type(resource_type)
         
         if path:
             conditions.append("AND c.path = %(path)s")
@@ -451,7 +509,12 @@ class CatalogService:
 
         if agent_only:
             conditions.append(
-                "AND lower(coalesce(c.payload->'metadata'->>'agent', c.meta->>'agent', 'false')) IN ('1', 'true', 'yes', 'on')"
+                """
+                AND (
+                    lower(c.kind) = 'agent'
+                    OR lower(coalesce(c.payload->'metadata'->>'agent', c.meta->>'agent', 'false')) IN ('1', 'true', 'yes', 'on')
+                )
+                """
             )
 
         normalized_capabilities = [str(c).strip() for c in (capabilities or []) if str(c).strip()]

--- a/noetl/server/api/core/execution.py
+++ b/noetl/server/api/core/execution.py
@@ -24,26 +24,107 @@ _STATUS_TERMINAL_EVENT_TYPES = (
     "execution.cancelled",
     "command.failed",
 )
+_EXECUTABLE_CATALOG_KINDS = {"playbook", "agent"}
+
+
+def _normalize_catalog_kind(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    aliases = {
+        "playbooks": "playbook",
+        "agents": "agent",
+    }
+    return aliases.get(normalized, normalized) if normalized else None
 
 @router.post("/execute", response_model=ExecuteResponse)
 async def execute(req: ExecuteRequest) -> ExecuteResponse:
     from .commands import _build_command_context, _validate_postgres_command_context_or_422, _store_command_context_if_needed
     try:
         engine = get_engine()
+        requested_kind = _normalize_catalog_kind(req.resource_kind)
+        if requested_kind and requested_kind not in _EXECUTABLE_CATALOG_KINDS:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Catalog kind '{req.resource_kind}' is not executable",
+            )
+        allowed_kinds = [requested_kind] if requested_kind else sorted(_EXECUTABLE_CATALOG_KINDS)
+        include_meta_executable = requested_kind is None
         async with get_pool_connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cur:
                 if req.catalog_id:
-                    await cur.execute("SELECT path, catalog_id FROM noetl.catalog WHERE catalog_id = %s", (req.catalog_id,))
+                    await cur.execute(
+                        """
+                        SELECT c.path, c.catalog_id, c.kind
+                        FROM noetl.catalog c
+                        LEFT JOIN noetl.resource r ON r.name = lower(c.kind)
+                        WHERE c.catalog_id = %(catalog_id)s
+                          AND (
+                            lower(c.kind) = ANY(%(allowed_kinds)s)
+                            OR (
+                              %(include_meta_executable)s
+                              AND lower(coalesce(r.meta->>'executable', 'false')) IN ('1', 'true', 'yes', 'on')
+                            )
+                          )
+                        """,
+                        {
+                            "catalog_id": req.catalog_id,
+                            "allowed_kinds": allowed_kinds,
+                            "include_meta_executable": include_meta_executable,
+                        },
+                    )
                     row = await cur.fetchone()
-                    if not row: raise HTTPException(404, f"Playbook not found: catalog_id={req.catalog_id}")
+                    if not row: raise HTTPException(404, f"Executable catalog entry not found: catalog_id={req.catalog_id}")
                     path, catalog_id = row['path'], row['catalog_id']
                 else:
                     if req.version is not None:
-                        await cur.execute("SELECT catalog_id, path FROM noetl.catalog WHERE path = %s AND version = %s", (req.path, req.version))
+                        await cur.execute(
+                            """
+                            SELECT c.catalog_id, c.path
+                            FROM noetl.catalog c
+                            LEFT JOIN noetl.resource r ON r.name = lower(c.kind)
+                            WHERE c.path = %(path)s
+                              AND c.version = %(version)s
+                              AND (
+                                lower(c.kind) = ANY(%(allowed_kinds)s)
+                                OR (
+                                  %(include_meta_executable)s
+                                  AND lower(coalesce(r.meta->>'executable', 'false')) IN ('1', 'true', 'yes', 'on')
+                                )
+                              )
+                            """,
+                            {
+                                "path": req.path,
+                                "version": req.version,
+                                "allowed_kinds": allowed_kinds,
+                                "include_meta_executable": include_meta_executable,
+                            },
+                        )
                     else:
-                        await cur.execute("SELECT catalog_id, path FROM noetl.catalog WHERE path = %s ORDER BY version DESC LIMIT 1", (req.path,))
+                        await cur.execute(
+                            """
+                            SELECT c.catalog_id, c.path
+                            FROM noetl.catalog c
+                            LEFT JOIN noetl.resource r ON r.name = lower(c.kind)
+                            WHERE c.path = %(path)s
+                              AND (
+                                lower(c.kind) = ANY(%(allowed_kinds)s)
+                                OR (
+                                  %(include_meta_executable)s
+                                  AND lower(coalesce(r.meta->>'executable', 'false')) IN ('1', 'true', 'yes', 'on')
+                                )
+                              )
+                            ORDER BY c.version DESC
+                            LIMIT 1
+                            """,
+                            {
+                                "path": req.path,
+                                "allowed_kinds": allowed_kinds,
+                                "include_meta_executable": include_meta_executable,
+                            },
+                        )
                     row = await cur.fetchone()
-                    if not row: raise HTTPException(404, f"Playbook not found: {req.path}")
+                    if not row: raise HTTPException(404, f"Executable catalog entry not found: {req.path}")
                     catalog_id, path = row['catalog_id'], row['path']
         
         execution_id, commands = await engine.start_execution(path, req.payload, catalog_id, req.parent_execution_id)

--- a/noetl/server/api/core/execution.py
+++ b/noetl/server/api/core/execution.py
@@ -49,7 +49,6 @@ async def execute(req: ExecuteRequest) -> ExecuteResponse:
                 detail=f"Catalog kind '{req.resource_kind}' is not executable",
             )
         allowed_kinds = [requested_kind] if requested_kind else sorted(_EXECUTABLE_CATALOG_KINDS)
-        include_meta_executable = requested_kind is None
         async with get_pool_connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cur:
                 if req.catalog_id:
@@ -57,20 +56,12 @@ async def execute(req: ExecuteRequest) -> ExecuteResponse:
                         """
                         SELECT c.path, c.catalog_id, c.kind
                         FROM noetl.catalog c
-                        LEFT JOIN noetl.resource r ON r.name = lower(c.kind)
                         WHERE c.catalog_id = %(catalog_id)s
-                          AND (
-                            lower(c.kind) = ANY(%(allowed_kinds)s)
-                            OR (
-                              %(include_meta_executable)s
-                              AND lower(coalesce(r.meta->>'executable', 'false')) IN ('1', 'true', 'yes', 'on')
-                            )
-                          )
+                          AND lower(c.kind) = ANY(%(allowed_kinds)s)
                         """,
                         {
                             "catalog_id": req.catalog_id,
                             "allowed_kinds": allowed_kinds,
-                            "include_meta_executable": include_meta_executable,
                         },
                     )
                     row = await cur.fetchone()
@@ -82,22 +73,14 @@ async def execute(req: ExecuteRequest) -> ExecuteResponse:
                             """
                             SELECT c.catalog_id, c.path
                             FROM noetl.catalog c
-                            LEFT JOIN noetl.resource r ON r.name = lower(c.kind)
                             WHERE c.path = %(path)s
                               AND c.version = %(version)s
-                              AND (
-                                lower(c.kind) = ANY(%(allowed_kinds)s)
-                                OR (
-                                  %(include_meta_executable)s
-                                  AND lower(coalesce(r.meta->>'executable', 'false')) IN ('1', 'true', 'yes', 'on')
-                                )
-                              )
+                              AND lower(c.kind) = ANY(%(allowed_kinds)s)
                             """,
                             {
                                 "path": req.path,
                                 "version": req.version,
                                 "allowed_kinds": allowed_kinds,
-                                "include_meta_executable": include_meta_executable,
                             },
                         )
                     else:
@@ -105,22 +88,14 @@ async def execute(req: ExecuteRequest) -> ExecuteResponse:
                             """
                             SELECT c.catalog_id, c.path
                             FROM noetl.catalog c
-                            LEFT JOIN noetl.resource r ON r.name = lower(c.kind)
                             WHERE c.path = %(path)s
-                              AND (
-                                lower(c.kind) = ANY(%(allowed_kinds)s)
-                                OR (
-                                  %(include_meta_executable)s
-                                  AND lower(coalesce(r.meta->>'executable', 'false')) IN ('1', 'true', 'yes', 'on')
-                                )
-                              )
+                              AND lower(c.kind) = ANY(%(allowed_kinds)s)
                             ORDER BY c.version DESC
                             LIMIT 1
                             """,
                             {
                                 "path": req.path,
                                 "allowed_kinds": allowed_kinds,
-                                "include_meta_executable": include_meta_executable,
                             },
                         )
                     row = await cur.fetchone()

--- a/noetl/server/api/core/models.py
+++ b/noetl/server/api/core/models.py
@@ -8,6 +8,10 @@ class ExecuteRequest(BaseModel):
     path: Optional[str] = Field(None, description="Playbook catalog path")
     catalog_id: Optional[int] = Field(None, description="Catalog ID (alternative to path)")
     version: Optional[int] = Field(None, description="Specific version to execute (used with path)")
+    resource_kind: Optional[str] = Field(
+        None,
+        description="Executable catalog kind to run. Defaults to playbook or agent.",
+    )
     payload: dict[str, Any] = Field(default_factory=dict, alias="workload", description="Input payload/workload")
     parent_execution_id: Optional[int] = Field(None, description="Parent execution ID")
 

--- a/noetl/tools/__init__.py
+++ b/noetl/tools/__init__.py
@@ -50,6 +50,8 @@ _EXECUTORS = {
     "execute_nats_task": ("noetl.tools.nats", "execute_nats_task"),
     "execute_agent_task": ("noetl.tools.agent", "execute_agent_task"),
     "execute_mcp_task": ("noetl.tools.mcp", "execute_mcp_task"),
+    "execute_task": ("noetl.core.runtime.execution", "execute_task"),
+    "execute_task_resolved": ("noetl.core.runtime.execution", "execute_task_resolved"),
 }
 
 REGISTRY = {name: name for name in _MODULES}

--- a/noetl/tools/__init__.py
+++ b/noetl/tools/__init__.py
@@ -1,103 +1,71 @@
-"""
-NoETL tool implementations for workflow execution.
+"""NoETL tool implementations for workflow execution.
 
-This package contains all action executors moved from plugin/tools/:
-
-- python: Python code execution
-- http: HTTP request execution
-- postgres: PostgreSQL task execution
-- duckdb: DuckDB query execution
-- ducklake: DuckLake distributed DuckDB with Postgres metastore
-- snowflake: Snowflake task execution
-- transfer: Data transfer operations
-- container: Container execution
-- artifact: Result artifact storage (get/put from S3, GCS, filesystem)
-- nats: NATS JetStream, K/V Store, and Object Store operations
-- agent: External AI agent framework bridge (ADK/LangChain/custom)
+This package intentionally keeps imports lazy. Tool modules may import worker
+helpers, and workers import tool executors; eager imports here create circular
+initialization paths.
 """
 
-# Import tool modules
-from noetl.tools import (
-    python,
-    http,
-    postgres,
-    duckdb,
-    ducklake,
-    snowflake,
-    transfer,
-    container,
-    gcs,
-    artifact,
-    nats,
-    agent,
-)
-from noetl.tools.transfer import snowflake_transfer
+from __future__ import annotations
 
-# Import executors
-from noetl.tools.python import execute_python_task, execute_python_task_async
-from noetl.tools.http import execute_http_task
-from noetl.tools.postgres import execute_postgres_task
-from noetl.tools.duckdb import execute_duckdb_task
-from noetl.tools.ducklake import execute_ducklake_task
-from noetl.tools.snowflake import execute_snowflake_task, execute_snowflake_transfer_task
-from noetl.tools.transfer import execute_transfer_action
-from noetl.tools.transfer.snowflake_transfer import execute_snowflake_transfer_action
-from noetl.tools.container import execute_container_task
-from noetl.tools.gcs import execute_gcs_task
-from noetl.tools.artifact import execute_artifact_task, execute_artifact_get, execute_artifact_put
-from noetl.tools.nats import execute_nats_task
-from noetl.tools.agent import execute_agent_task
+from importlib import import_module
+from typing import Any
 
-# Tool registry for dynamic lookup
-REGISTRY = {
-    "python": python,
-    "http": http,
-    "postgres": postgres,
-    "duckdb": duckdb,
-    "ducklake": ducklake,
-    "snowflake": snowflake,
-    "transfer": transfer,
-    "snowflake_transfer": snowflake_transfer,
-    "container": container,
-    "gcs": gcs,
-    "artifact": artifact,
-    "nats": nats,
-    "agent": agent,
+_MODULES = {
+    "python": "noetl.tools.python",
+    "http": "noetl.tools.http",
+    "postgres": "noetl.tools.postgres",
+    "duckdb": "noetl.tools.duckdb",
+    "ducklake": "noetl.tools.ducklake",
+    "snowflake": "noetl.tools.snowflake",
+    "transfer": "noetl.tools.transfer",
+    "snowflake_transfer": "noetl.tools.transfer.snowflake_transfer",
+    "container": "noetl.tools.container",
+    "gcs": "noetl.tools.gcs",
+    "artifact": "noetl.tools.artifact",
+    "nats": "noetl.tools.nats",
+    "agent": "noetl.tools.agent",
+    "mcp": "noetl.tools.mcp",
 }
 
-__all__ = [
-    # Modules
-    "python",
-    "http",
-    "postgres",
-    "duckdb",
-    "ducklake",
-    "snowflake",
-    "transfer",
-    "snowflake_transfer",
-    "container",
-    "gcs",
-    "artifact",
-    "nats",
-    "agent",
-    # Executors
-    "execute_python_task",
-    "execute_python_task_async",
-    "execute_http_task",
-    "execute_postgres_task",
-    "execute_duckdb_task",
-    "execute_ducklake_task",
-    "execute_snowflake_task",
-    "execute_snowflake_transfer_task",
-    "execute_transfer_action",
-    "execute_snowflake_transfer_action",
-    "execute_container_task",
-    "execute_gcs_task",
-    "execute_artifact_task",
-    "execute_artifact_get",
-    "execute_artifact_put",
-    "execute_nats_task",
-    "execute_agent_task",
-    # Registry
-    "REGISTRY",
-]
+_EXECUTORS = {
+    "execute_python_task": ("noetl.tools.python", "execute_python_task"),
+    "execute_python_task_async": ("noetl.tools.python", "execute_python_task_async"),
+    "execute_http_task": ("noetl.tools.http", "execute_http_task"),
+    "execute_postgres_task": ("noetl.tools.postgres", "execute_postgres_task"),
+    "execute_postgres_task_async": ("noetl.tools.postgres", "execute_postgres_task_async"),
+    "execute_duckdb_task": ("noetl.tools.duckdb", "execute_duckdb_task"),
+    "execute_ducklake_task": ("noetl.tools.ducklake", "execute_ducklake_task"),
+    "execute_snowflake_task": ("noetl.tools.snowflake", "execute_snowflake_task"),
+    "execute_snowflake_transfer_task": ("noetl.tools.snowflake", "execute_snowflake_transfer_task"),
+    "execute_transfer_action": ("noetl.tools.transfer", "execute_transfer_action"),
+    "execute_snowflake_transfer_action": (
+        "noetl.tools.transfer.snowflake_transfer",
+        "execute_snowflake_transfer_action",
+    ),
+    "execute_container_task": ("noetl.tools.container", "execute_container_task"),
+    "execute_gcs_task": ("noetl.tools.gcs", "execute_gcs_task"),
+    "execute_artifact_task": ("noetl.tools.artifact", "execute_artifact_task"),
+    "execute_artifact_get": ("noetl.tools.artifact", "execute_artifact_get"),
+    "execute_artifact_put": ("noetl.tools.artifact", "execute_artifact_put"),
+    "execute_nats_task": ("noetl.tools.nats", "execute_nats_task"),
+    "execute_agent_task": ("noetl.tools.agent", "execute_agent_task"),
+    "execute_mcp_task": ("noetl.tools.mcp", "execute_mcp_task"),
+}
+
+REGISTRY = {name: name for name in _MODULES}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _MODULES:
+        module = import_module(_MODULES[name])
+        globals()[name] = module
+        return module
+    if name in _EXECUTORS:
+        module_name, attr = _EXECUTORS[name]
+        value = getattr(import_module(module_name), attr)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module 'noetl.tools' has no attribute {name!r}")
+
+
+__all__ = [*_MODULES.keys(), *_EXECUTORS.keys(), "REGISTRY"]

--- a/noetl/tools/mcp/__init__.py
+++ b/noetl/tools/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""MCP tool executor."""
+
+from .executor import execute_mcp_task
+
+__all__ = ["execute_mcp_task"]

--- a/noetl/tools/mcp/executor.py
+++ b/noetl/tools/mcp/executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 from typing import Any, Dict, Optional
 from urllib.parse import urlsplit, urlunsplit
@@ -14,6 +15,37 @@ from noetl.core.dsl.render import render_template
 from noetl.core.logger import setup_logger
 
 logger = setup_logger(__name__, include_location=True)
+
+
+def _read_float_env(name: str, default: float, min_value: float = 0.1) -> float:
+    raw = os.getenv(name)
+    if raw is None or not str(raw).strip():
+        return default
+    try:
+        parsed = float(raw)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(parsed):
+        return default
+    return max(min_value, parsed)
+
+
+def _resolve_timeout_seconds(timeout_value: Any) -> float:
+    default_timeout = _read_float_env("NOETL_MCP_REQUEST_TIMEOUT_SECONDS", 60.0)
+    command_timeout_budget = _read_float_env("NOETL_WORKER_COMMAND_TIMEOUT_SECONDS", 180.0, min_value=1.0)
+    max_timeout = max(1.0, command_timeout_budget)
+
+    if timeout_value is None or (isinstance(timeout_value, str) and not timeout_value.strip()):
+        return min(default_timeout, max_timeout)
+
+    try:
+        parsed = float(timeout_value)
+    except (TypeError, ValueError):
+        return min(default_timeout, max_timeout)
+    if not math.isfinite(parsed):
+        return min(default_timeout, max_timeout)
+
+    return min(max(0.1, parsed), max_timeout)
 
 
 def _trim_slash(value: str) -> str:
@@ -141,7 +173,7 @@ async def execute_mcp_task(
         server = str(config.get("server") or "kubernetes")
         endpoint = _resolve_endpoint(config, context or {})
         method = str(config.get("method") or config.get("action") or "tools/call")
-        timeout = float(config.get("timeout_seconds") or 60)
+        timeout = _resolve_timeout_seconds(config.get("timeout_seconds"))
         request_id = int(config.get("request_id") or 1)
 
         async with httpx.AsyncClient(timeout=timeout) as client:

--- a/noetl/tools/mcp/executor.py
+++ b/noetl/tools/mcp/executor.py
@@ -128,95 +128,122 @@ async def execute_mcp_task(
     - `tools/list`: initialize, then list tools
     - `tools/call`: initialize, then call one tool with `arguments`
     """
-    rendered = render_template(jinja_env, dict(task_config or {}), context or {})
-    rendered_input = render_template(jinja_env, dict(task_with or {}), context or {})
-    config = {**rendered, **rendered_input}
+    server = "kubernetes"
+    endpoint: Optional[str] = None
+    method = "tools/call"
+    params: Dict[str, Any] = {}
 
-    server = str(config.get("server") or "kubernetes")
-    endpoint = _resolve_endpoint(config, context or {})
-    method = str(config.get("method") or config.get("action") or "tools/call")
-    timeout = float(config.get("timeout_seconds") or 60)
-    request_id = int(config.get("request_id") or 1)
+    try:
+        rendered = render_template(jinja_env, dict(task_config or {}), context or {})
+        rendered_input = render_template(jinja_env, dict(task_with or {}), context or {})
+        config = {**rendered, **rendered_input}
 
-    async with httpx.AsyncClient(timeout=timeout) as client:
-        if method == "health":
-            response = await client.get(_resolve_health_endpoint(endpoint))
-            response.raise_for_status()
-            return {
-                "status": "ok",
-                "server": server,
-                "endpoint": endpoint,
-                "method": method,
-                "healthy": True,
-                "text": response.text,
-            }
+        server = str(config.get("server") or "kubernetes")
+        endpoint = _resolve_endpoint(config, context or {})
+        method = str(config.get("method") or config.get("action") or "tools/call")
+        timeout = float(config.get("timeout_seconds") or 60)
+        request_id = int(config.get("request_id") or 1)
 
-        init_envelope, init_headers = await _post_jsonrpc(
-            client,
-            endpoint,
-            {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "method": "initialize",
-                "params": {
-                    "protocolVersion": str(config.get("protocol_version") or "2025-03-26"),
-                    "capabilities": config.get("capabilities") or {},
-                    "clientInfo": {
-                        "name": str(config.get("client_name") or "noetl-worker"),
-                        "version": str(config.get("client_version") or "0"),
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            if method == "health":
+                response = await client.get(_resolve_health_endpoint(endpoint))
+                response.raise_for_status()
+                return {
+                    "status": "ok",
+                    "server": server,
+                    "endpoint": endpoint,
+                    "method": method,
+                    "healthy": True,
+                    "text": response.text,
+                }
+
+            init_envelope, init_headers = await _post_jsonrpc(
+                client,
+                endpoint,
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": str(config.get("protocol_version") or "2025-03-26"),
+                        "capabilities": config.get("capabilities") or {},
+                        "clientInfo": {
+                            "name": str(config.get("client_name") or "noetl-worker"),
+                            "version": str(config.get("client_version") or "0"),
+                        },
                     },
                 },
-            },
-        )
-        session_id = init_headers.get("mcp-session-id") or init_headers.get("Mcp-Session-Id")
-        if not session_id:
-            raise RuntimeError("MCP server did not return a session id")
+            )
+            session_id = init_headers.get("mcp-session-id") or init_headers.get("Mcp-Session-Id")
+            if not session_id:
+                raise RuntimeError("MCP server did not return a session id")
 
-        params: Dict[str, Any]
-        if method == "tools/call":
-            tool_name = config.get("tool") or config.get("tool_name")
-            if not tool_name:
-                raise ValueError("mcp tool name is required for tools/call")
-            arguments = config.get("arguments")
-            if arguments is None:
-                arguments = config.get("args")
-            if arguments is None:
-                arguments = {}
-            if not isinstance(arguments, dict):
-                raise ValueError("mcp arguments must be an object")
-            params = {"name": str(tool_name), "arguments": arguments}
-        elif method == "tools/list":
-            params = {}
-        else:
-            params = config.get("params") or {}
-            if not isinstance(params, dict):
-                raise ValueError("mcp params must be an object")
+            if method == "tools/call":
+                tool_name = config.get("tool") or config.get("tool_name")
+                if not tool_name:
+                    raise ValueError("mcp tool name is required for tools/call")
+                arguments = config.get("arguments")
+                if arguments is None:
+                    arguments = config.get("args")
+                if arguments is None:
+                    arguments = {}
+                if isinstance(arguments, str):
+                    arguments = json.loads(arguments)
+                if not isinstance(arguments, dict):
+                    raise ValueError("mcp arguments must be an object")
+                params = {"name": str(tool_name), "arguments": arguments}
+            elif method == "tools/list":
+                params = {}
+            else:
+                params = config.get("params") or {}
+                if isinstance(params, str):
+                    params = json.loads(params)
+                if not isinstance(params, dict):
+                    raise ValueError("mcp params must be an object")
 
-        envelope, _headers = await _post_jsonrpc(
-            client,
+            envelope, _headers = await _post_jsonrpc(
+                client,
+                endpoint,
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id + 1,
+                    "method": method,
+                    "params": params,
+                },
+                session_id=session_id,
+            )
+
+        result = envelope.get("result") or {}
+        if not isinstance(result, dict):
+            result = {"value": result}
+        text = _extract_text(result)
+        logger.debug("MCP request completed: server=%s method=%s endpoint=%s", server, method, endpoint)
+        return {
+            "status": "ok",
+            "server": server,
+            "endpoint": endpoint,
+            "method": method,
+            "tool": params.get("name") if isinstance(params, dict) else None,
+            "arguments": params.get("arguments") if isinstance(params, dict) else None,
+            "text": text,
+            "result": result,
+            "initialize": init_envelope.get("result"),
+        }
+    except (ValueError, RuntimeError, json.JSONDecodeError, httpx.HTTPError) as exc:
+        logger.warning(
+            "MCP request failed: server=%s method=%s endpoint=%s error=%s",
+            server,
+            method,
             endpoint,
-            {
-                "jsonrpc": "2.0",
-                "id": request_id + 1,
-                "method": method,
-                "params": params,
-            },
-            session_id=session_id,
+            exc,
         )
-
-    result = envelope.get("result") or {}
-    if not isinstance(result, dict):
-        result = {"value": result}
-    text = _extract_text(result)
-    logger.debug("MCP request completed: server=%s method=%s endpoint=%s", server, method, endpoint)
-    return {
-        "status": "ok",
-        "server": server,
-        "endpoint": endpoint,
-        "method": method,
-        "tool": params.get("name") if isinstance(params, dict) else None,
-        "arguments": params.get("arguments") if isinstance(params, dict) else None,
-        "text": text,
-        "result": result,
-        "initialize": init_envelope.get("result"),
-    }
+        return {
+            "status": "error",
+            "server": server,
+            "endpoint": endpoint,
+            "method": method,
+            "tool": params.get("name") if isinstance(params, dict) else None,
+            "arguments": params.get("arguments") if isinstance(params, dict) else None,
+            "error": str(exc),
+            "text": str(exc),
+        }

--- a/noetl/tools/mcp/executor.py
+++ b/noetl/tools/mcp/executor.py
@@ -1,0 +1,222 @@
+"""Model Context Protocol tool executor for NoETL workers."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Optional
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+from jinja2 import Environment
+
+from noetl.core.dsl.render import render_template
+from noetl.core.logger import setup_logger
+
+logger = setup_logger(__name__, include_location=True)
+
+
+def _trim_slash(value: str) -> str:
+    return str(value or "").rstrip("/")
+
+
+def _parse_mcp_envelope(raw: Any, context: str) -> Dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if not isinstance(raw, str):
+        raise ValueError(f"Invalid MCP response for {context}: {type(raw).__name__}")
+
+    data_lines = [
+        line.replace("data:", "", 1).strip()
+        for line in raw.splitlines()
+        if line.startswith("data:")
+    ]
+    payload = "\n".join(data_lines) if data_lines else raw
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:
+        preview = " ".join(payload.split())[:360]
+        raise ValueError(f"Invalid MCP response for {context}: {preview}") from exc
+
+
+def _extract_text(result: Dict[str, Any]) -> str:
+    content = result.get("content")
+    if isinstance(content, list):
+        parts = [
+            str(item.get("text", ""))
+            for item in content
+            if isinstance(item, dict) and item.get("type") == "text" and item.get("text") is not None
+        ]
+        if parts:
+            return "\n".join(parts)
+    return json.dumps(result, default=str, separators=(",", ":"))
+
+
+def _server_env_name(server: str) -> str:
+    safe = "".join(ch if ch.isalnum() else "_" for ch in server.upper())
+    return f"NOETL_MCP_{safe}_URL"
+
+
+def _resolve_endpoint(config: Dict[str, Any], context: Dict[str, Any]) -> str:
+    endpoint = (
+        config.get("endpoint")
+        or config.get("url")
+        or config.get("server_url")
+        or config.get("base_url")
+    )
+    server = str(config.get("server") or config.get("name") or "kubernetes")
+    if not endpoint:
+        mcp_servers = context.get("mcp_servers")
+        if isinstance(mcp_servers, dict):
+            server_config = mcp_servers.get(server)
+            if isinstance(server_config, dict):
+                endpoint = server_config.get("endpoint") or server_config.get("url")
+            elif isinstance(server_config, str):
+                endpoint = server_config
+    if not endpoint:
+        endpoint = os.getenv(_server_env_name(server)) or os.getenv("NOETL_MCP_URL")
+    if not endpoint:
+        raise ValueError(f"mcp endpoint is required for server '{server}'")
+    return _trim_slash(str(endpoint))
+
+
+def _resolve_health_endpoint(endpoint: str) -> str:
+    parts = urlsplit(endpoint)
+    path = parts.path.rstrip("/")
+    if path in {"/mcp", "/sse", "/message"}:
+        path = "/healthz"
+    else:
+        path = f"{path}/healthz" if path else "/healthz"
+    return urlunsplit((parts.scheme, parts.netloc, path, "", ""))
+
+
+async def _post_jsonrpc(
+    client: httpx.AsyncClient,
+    endpoint: str,
+    payload: Dict[str, Any],
+    *,
+    session_id: Optional[str] = None,
+) -> tuple[Dict[str, Any], httpx.Headers]:
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+
+    response = await client.post(endpoint, json=payload, headers=headers)
+    response.raise_for_status()
+    envelope = _parse_mcp_envelope(response.text, str(payload.get("method") or "request"))
+    if envelope.get("error"):
+        error = envelope["error"]
+        if isinstance(error, dict):
+            raise RuntimeError(error.get("message") or json.dumps(error, default=str))
+        raise RuntimeError(str(error))
+    return envelope, response.headers
+
+
+async def execute_mcp_task(
+    task_config: Dict[str, Any],
+    context: Dict[str, Any],
+    jinja_env: Environment,
+    task_with: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Execute a JSON-RPC request against an MCP server.
+
+    Supported actions:
+    - `health`: GET `<endpoint>/healthz`
+    - `tools/list`: initialize, then list tools
+    - `tools/call`: initialize, then call one tool with `arguments`
+    """
+    rendered = render_template(jinja_env, dict(task_config or {}), context or {})
+    rendered_input = render_template(jinja_env, dict(task_with or {}), context or {})
+    config = {**rendered, **rendered_input}
+
+    server = str(config.get("server") or "kubernetes")
+    endpoint = _resolve_endpoint(config, context or {})
+    method = str(config.get("method") or config.get("action") or "tools/call")
+    timeout = float(config.get("timeout_seconds") or 60)
+    request_id = int(config.get("request_id") or 1)
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        if method == "health":
+            response = await client.get(_resolve_health_endpoint(endpoint))
+            response.raise_for_status()
+            return {
+                "status": "ok",
+                "server": server,
+                "endpoint": endpoint,
+                "method": method,
+                "healthy": True,
+                "text": response.text,
+            }
+
+        init_envelope, init_headers = await _post_jsonrpc(
+            client,
+            endpoint,
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": str(config.get("protocol_version") or "2025-03-26"),
+                    "capabilities": config.get("capabilities") or {},
+                    "clientInfo": {
+                        "name": str(config.get("client_name") or "noetl-worker"),
+                        "version": str(config.get("client_version") or "0"),
+                    },
+                },
+            },
+        )
+        session_id = init_headers.get("mcp-session-id") or init_headers.get("Mcp-Session-Id")
+        if not session_id:
+            raise RuntimeError("MCP server did not return a session id")
+
+        params: Dict[str, Any]
+        if method == "tools/call":
+            tool_name = config.get("tool") or config.get("tool_name")
+            if not tool_name:
+                raise ValueError("mcp tool name is required for tools/call")
+            arguments = config.get("arguments")
+            if arguments is None:
+                arguments = config.get("args")
+            if arguments is None:
+                arguments = {}
+            if not isinstance(arguments, dict):
+                raise ValueError("mcp arguments must be an object")
+            params = {"name": str(tool_name), "arguments": arguments}
+        elif method == "tools/list":
+            params = {}
+        else:
+            params = config.get("params") or {}
+            if not isinstance(params, dict):
+                raise ValueError("mcp params must be an object")
+
+        envelope, _headers = await _post_jsonrpc(
+            client,
+            endpoint,
+            {
+                "jsonrpc": "2.0",
+                "id": request_id + 1,
+                "method": method,
+                "params": params,
+            },
+            session_id=session_id,
+        )
+
+    result = envelope.get("result") or {}
+    if not isinstance(result, dict):
+        result = {"value": result}
+    text = _extract_text(result)
+    logger.debug("MCP request completed: server=%s method=%s endpoint=%s", server, method, endpoint)
+    return {
+        "status": "ok",
+        "server": server,
+        "endpoint": endpoint,
+        "method": method,
+        "tool": params.get("name") if isinstance(params, dict) else None,
+        "arguments": params.get("arguments") if isinstance(params, dict) else None,
+        "text": text,
+        "result": result,
+        "initialize": init_envelope.get("result"),
+    }

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -68,6 +68,7 @@ from noetl.tools.transfer import execute_transfer_action
 from noetl.tools.transfer.snowflake_transfer import execute_snowflake_transfer_action
 from noetl.tools.script import execute_script_task
 from noetl.tools.agent import execute_agent_task
+from noetl.tools.mcp import execute_mcp_task
 from noetl.core.secrets import execute_secrets_task
 from noetl.core.workflow.workbook import execute_workbook_task
 from noetl.core.workflow.playbook import execute_playbook_task
@@ -2601,6 +2602,15 @@ class Worker:
             # Agent runtime bridge (ADK/LangChain/custom callable adapters)
             task_with = {**config, **args}
             result = await execute_agent_task(task_config, context, jinja_env, task_with)
+            if isinstance(result, dict) and result.get("status") == "error":
+                return result
+            return result.get("data", result) if isinstance(result, dict) else result
+
+        elif tool_kind == "mcp":
+            # Model Context Protocol server bridge. Operations stay inside
+            # playbook execution so MCP activity is visible in command/event state.
+            task_with = {**config, **args}
+            result = await execute_mcp_task(task_config, context, jinja_env, task_with)
             if isinstance(result, dict) and result.get("status") == "error":
                 return result
             return result.get("data", result) if isinstance(result, dict) else result

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -2369,9 +2369,12 @@ class Worker:
         # For workbook tool, preserve 'name' field from config (it's the workbook action name)
         # For other tools, add 'name' as step name for logging
         task_config = {**config}
-        # Merge canonical tool.input with command input overrides.
+        # Merge canonical tool args/input with command input overrides.
+        # `args` is still used by Python playbooks, while newer tools prefer
+        # `input`; keep both forms flowing through the worker adapter.
+        config_args = config.get("args") if isinstance(config.get("args"), dict) else {}
         config_input = config.get("input") if isinstance(config.get("input"), dict) else {}
-        merged_input = {**config_input, **args} if config_input or args else {}
+        merged_input = {**config_args, **config_input, **args} if config_args or config_input or args else {}
         task_config["input"] = merged_input
         task_config["args"] = merged_input  # plugin compatibility until all tools read `input`
         if "name" not in config:

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -2612,7 +2612,9 @@ class Worker:
         elif tool_kind == "mcp":
             # Model Context Protocol server bridge. Operations stay inside
             # playbook execution so MCP activity is visible in command/event state.
-            task_with = {**config, **args}
+            # Pass only runtime overrides. task_config already contains merged
+            # input/args, and stale config values must not override it again.
+            task_with = dict(args or {})
             result = await execute_mcp_task(task_config, context, jinja_env, task_with)
             if isinstance(result, dict) and result.get("status") == "error":
                 return result

--- a/tests/api/test_catalog_agent_filters.py
+++ b/tests/api/test_catalog_agent_filters.py
@@ -25,14 +25,14 @@ def test_catalog_query_builder_includes_agent_filters():
         capabilities=["release-management", "deployment"],
     )
 
-    assert "c.kind = %(resource_type)s" in query
+    assert "lower(c.kind) = %(resource_type)s" in query
     assert "c.path = %(path)s" in query
     assert "payload->'metadata'->>'agent'" in query
     assert "c.meta->>'agent'" in query
     assert "jsonb_array_elements_text" in query
     assert "jsonb_typeof" in query
     assert "capabilities" in params
-    assert params["resource_type"] == "Playbook"
+    assert params["resource_type"] == "playbook"
     assert params["path"] == "agents/release-coordinator"
     assert params["capabilities"] == ["release-management", "deployment"]
 

--- a/tests/tool/test_mcp_tool.py
+++ b/tests/tool/test_mcp_tool.py
@@ -1,0 +1,86 @@
+import pytest
+from jinja2 import Environment
+
+from noetl.tools.mcp import execute_mcp_task
+
+
+class _FakeResponse:
+    def __init__(self, text, headers=None, status_code=200):
+        self.text = text
+        self.headers = headers or {}
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"status={self.status_code}")
+
+
+class _FakeAsyncClient:
+    def __init__(self, *args, **kwargs):
+        self.posts = []
+        self.gets = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url):
+        self.gets.append(url)
+        return _FakeResponse("ok")
+
+    async def post(self, endpoint, json, headers):
+        self.posts.append((endpoint, json, headers))
+        if json["method"] == "initialize":
+            return _FakeResponse(
+                'data: {"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"fake"}}}',
+                headers={"mcp-session-id": "session-1"},
+            )
+        assert headers["Mcp-Session-Id"] == "session-1"
+        return _FakeResponse(
+            'data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"pod-a Running"}]}}'
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_tool_call(monkeypatch):
+    monkeypatch.setattr("noetl.tools.mcp.executor.httpx.AsyncClient", _FakeAsyncClient)
+
+    result = await execute_mcp_task(
+        {
+            "server": "kubernetes",
+            "endpoint": "http://mcp.example/mcp",
+            "method": "tools/call",
+            "tool": "pods_list_in_namespace",
+            "arguments": {"namespace": "{{ namespace }}"},
+        },
+        {"namespace": "noetl"},
+        Environment(),
+        {},
+    )
+
+    assert result["status"] == "ok"
+    assert result["server"] == "kubernetes"
+    assert result["method"] == "tools/call"
+    assert result["tool"] == "pods_list_in_namespace"
+    assert result["arguments"] == {"namespace": "noetl"}
+    assert result["text"] == "pod-a Running"
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_health(monkeypatch):
+    monkeypatch.setattr("noetl.tools.mcp.executor.httpx.AsyncClient", _FakeAsyncClient)
+
+    result = await execute_mcp_task(
+        {
+            "endpoint": "http://mcp.example/mcp",
+            "method": "health",
+        },
+        {},
+        Environment(),
+        {},
+    )
+
+    assert result["status"] == "ok"
+    assert result["healthy"] is True

--- a/tests/tool/test_mcp_tool.py
+++ b/tests/tool/test_mcp_tool.py
@@ -1,6 +1,7 @@
 import pytest
 from jinja2 import Environment
 
+from noetl.tools import execute_task
 from noetl.tools.mcp import execute_mcp_task
 
 
@@ -16,7 +17,10 @@ class _FakeResponse:
 
 
 class _FakeAsyncClient:
+    timeouts = []
+
     def __init__(self, *args, **kwargs):
+        self.__class__.timeouts.append(kwargs.get("timeout"))
         self.posts = []
         self.gets = []
 
@@ -54,8 +58,13 @@ class _FakeErrorAsyncClient(_FakeAsyncClient):
         return _FakeResponse('data: {"jsonrpc":"2.0","id":2,"error":{"message":"tool failed"}}')
 
 
+def test_tools_package_preserves_execute_task_export():
+    assert callable(execute_task)
+
+
 @pytest.mark.asyncio
 async def test_execute_mcp_tool_call(monkeypatch):
+    _FakeAsyncClient.timeouts = []
     monkeypatch.setattr("noetl.tools.mcp.executor.httpx.AsyncClient", _FakeAsyncClient)
 
     result = await execute_mcp_task(
@@ -77,10 +86,12 @@ async def test_execute_mcp_tool_call(monkeypatch):
     assert result["tool"] == "pods_list_in_namespace"
     assert result["arguments"] == {"namespace": "noetl"}
     assert result["text"] == "pod-a Running"
+    assert _FakeAsyncClient.timeouts == [60.0]
 
 
 @pytest.mark.asyncio
 async def test_execute_mcp_health(monkeypatch):
+    _FakeAsyncClient.timeouts = []
     monkeypatch.setattr("noetl.tools.mcp.executor.httpx.AsyncClient", _FakeAsyncClient)
 
     result = await execute_mcp_task(
@@ -95,10 +106,54 @@ async def test_execute_mcp_health(monkeypatch):
 
     assert result["status"] == "ok"
     assert result["healthy"] is True
+    assert _FakeAsyncClient.timeouts == [60.0]
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_timeout_is_bounded(monkeypatch):
+    _FakeAsyncClient.timeouts = []
+    monkeypatch.setenv("NOETL_MCP_REQUEST_TIMEOUT_SECONDS", "999")
+    monkeypatch.setenv("NOETL_WORKER_COMMAND_TIMEOUT_SECONDS", "2")
+    monkeypatch.setattr("noetl.tools.mcp.executor.httpx.AsyncClient", _FakeAsyncClient)
+
+    result = await execute_mcp_task(
+        {
+            "endpoint": "http://mcp.example/mcp",
+            "method": "health",
+            "timeout_seconds": "inf",
+        },
+        {},
+        Environment(),
+        {},
+    )
+
+    assert result["status"] == "ok"
+    assert _FakeAsyncClient.timeouts == [2.0]
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_timeout_zero_keeps_safe_floor(monkeypatch):
+    _FakeAsyncClient.timeouts = []
+    monkeypatch.setattr("noetl.tools.mcp.executor.httpx.AsyncClient", _FakeAsyncClient)
+
+    result = await execute_mcp_task(
+        {
+            "endpoint": "http://mcp.example/mcp",
+            "method": "health",
+            "timeout_seconds": 0,
+        },
+        {},
+        Environment(),
+        {},
+    )
+
+    assert result["status"] == "ok"
+    assert _FakeAsyncClient.timeouts == [0.1]
 
 
 @pytest.mark.asyncio
 async def test_execute_mcp_returns_structured_error(monkeypatch):
+    _FakeErrorAsyncClient.timeouts = []
     monkeypatch.setattr("noetl.tools.mcp.executor.httpx.AsyncClient", _FakeErrorAsyncClient)
 
     result = await execute_mcp_task(

--- a/tests/tool/test_mcp_tool.py
+++ b/tests/tool/test_mcp_tool.py
@@ -43,6 +43,17 @@ class _FakeAsyncClient:
         )
 
 
+class _FakeErrorAsyncClient(_FakeAsyncClient):
+    async def post(self, endpoint, json, headers):
+        self.posts.append((endpoint, json, headers))
+        if json["method"] == "initialize":
+            return _FakeResponse(
+                'data: {"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"fake"}}}',
+                headers={"mcp-session-id": "session-1"},
+            )
+        return _FakeResponse('data: {"jsonrpc":"2.0","id":2,"error":{"message":"tool failed"}}')
+
+
 @pytest.mark.asyncio
 async def test_execute_mcp_tool_call(monkeypatch):
     monkeypatch.setattr("noetl.tools.mcp.executor.httpx.AsyncClient", _FakeAsyncClient)
@@ -84,3 +95,22 @@ async def test_execute_mcp_health(monkeypatch):
 
     assert result["status"] == "ok"
     assert result["healthy"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_returns_structured_error(monkeypatch):
+    monkeypatch.setattr("noetl.tools.mcp.executor.httpx.AsyncClient", _FakeErrorAsyncClient)
+
+    result = await execute_mcp_task(
+        {
+            "endpoint": "http://mcp.example/mcp",
+            "method": "tools/call",
+            "tool": "pods_list",
+        },
+        {},
+        Environment(),
+        {},
+    )
+
+    assert result["status"] == "error"
+    assert result["error"] == "tool failed"


### PR DESCRIPTION
## Summary
- add a first-class `mcp` worker tool that calls MCP servers from inside NoETL executions
- add executable catalog resource-kind support for `agent` alongside `playbook`, and seed `mcp`/`memory`/`credential` resource metadata
- allow `/api/execute` to run catalog entries registered as `agent`

## Validation
- `uv run pytest tests/tool/test_mcp_tool.py tests/api/test_catalog_agent_filters.py -q`
- local kind redeploy through `repos/ops/automation/development/noetl.yaml`
- registered `automation/agents/kubernetes/runtime` as `agent` and executed Kubernetes MCP `tools/list` plus `pods_list_in_namespace`
