### PR TITLE
fix: discover terminal agents across catalog resource kinds

### DIFF
--- a/noetl/server/api/catalog/service.py
+++ b/noetl/server/api/catalog/service.py
@@ -300,9 +300,22 @@ class CatalogService:
         else:
             normalized_capabilities = []
 
+        terminal = metadata.get("terminal")
+        terminal = terminal if isinstance(terminal, dict) else {}
+        terminal_scopes = terminal.get("scopes") or terminal.get("scope") or []
+        if isinstance(terminal_scopes, str):
+            normalized_terminal_scopes = [scope.strip() for scope in terminal_scopes.split(",") if scope.strip()]
+        elif isinstance(terminal_scopes, list):
+            normalized_terminal_scopes = [str(scope).strip() for scope in terminal_scopes if str(scope).strip()]
+        else:
+            normalized_terminal_scopes = []
+
         return {
             "agent": CatalogService._is_truthy(metadata.get("agent", False)),
             "capabilities": normalized_capabilities,
+            "terminal": terminal,
+            "terminal_visible": CatalogService._is_truthy(terminal.get("visible", False)),
+            "terminal_scopes": normalized_terminal_scopes,
         }
 
     @staticmethod
@@ -409,7 +422,7 @@ class CatalogService:
     ) -> List[CatalogEntry]:
         """List catalog entries marked as agents, optionally filtered by capability/path."""
         return await CatalogService.fetch_entries(
-            resource_type="Playbook",
+            resource_type=None,
             path=path,
             agent_only=True,
             capabilities=capabilities,

--- a/tests/api/test_catalog_agent_filters.py
+++ b/tests/api/test_catalog_agent_filters.py
@@ -37,6 +37,18 @@ def test_catalog_query_builder_includes_agent_filters():
     assert params["capabilities"] == ["release-management", "deployment"]
 
 
+def test_catalog_query_builder_can_discover_agents_across_resource_kinds():
+    query, params = CatalogService._build_query_filter(
+        resource_type=None,
+        agent_only=True,
+        capabilities=["mcp:kubernetes"],
+    )
+
+    assert "c.kind = %(resource_type)s" not in query
+    assert "payload->'metadata'->>'agent'" in query
+    assert params["capabilities"] == ["mcp:kubernetes"]
+
+
 def test_catalog_agents_request_normalizes_capabilities():
     req = CatalogAgentsRequest(capability="code-review", capabilities=["security-audit"])
     assert req.capabilities == ["security-audit", "code-review"]
@@ -48,3 +60,22 @@ def test_extract_agent_metadata_normalizes_string_capability():
     )
     assert metadata["agent"] is True
     assert metadata["capabilities"] == ["release-management"]
+
+
+def test_extract_agent_metadata_preserves_terminal_scopes():
+    metadata = CatalogService._extract_agent_metadata(
+        {
+            "metadata": {
+                "agent": True,
+                "terminal": {
+                    "visible": True,
+                    "workspace": "kubernetes",
+                    "scopes": ["/mcp/kubernetes"],
+                },
+            }
+        }
+    )
+
+    assert metadata["terminal_visible"] is True
+    assert metadata["terminal"]["workspace"] == "kubernetes"
+    assert metadata["terminal_scopes"] == ["/mcp/kubernetes"]


### PR DESCRIPTION
## Summary

Allows the catalog API to discover terminal-visible agent resources across catalog kinds, not only `Playbook` rows. Agent metadata now preserves terminal visibility, scopes, commands, and capabilities so the GUI terminal can build MCP workspaces from registered catalog resources.

## Why

MCP integrations should be exposed through registered NoETL resources and executed as tracked playbook/agent runs. This lets the GUI discover `/mcp/<service>` scopes from catalog state without requiring direct MCP calls.

## Validation

- `.venv/bin/python -m pytest tests/api/test_catalog_agent_filters.py tests/api/test_catalog_agents_endpoint.py -q`
