### PR TITLE
ci: remove embedded UI build from release workflow

### DIFF
--- a/.github/workflows/build_on_release.yml
+++ b/.github/workflows/build_on_release.yml
@@ -66,26 +66,10 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
       
-      - name: Install Node v23
-        uses: actions/setup-node@v4
-        with:
-          node-version: "23.11.x"
-
       - name: Install UV
         uses: astral-sh/setup-uv@v7
         with:
           version: "0.9.x"
-
-      - name: Install UI dependencies
-        working-directory: ui-src
-        run: npm ci
-
-      - name: Build UI
-        working-directory: ui-src
-        run: npm run build
-
-      - name: Copy built UI artifacts to noetl/core/ui
-        run: cp -R ui-src/dist/* noetl/core/ui/
 
       - name: Install NoETL dependencies
         run: uv sync --locked --all-extras


### PR DESCRIPTION
## Summary

Removes the stale embedded UI build steps from the NoETL release workflow.

The server/worker release job was still trying to run `npm ci` and `npm run build` under `ui-src`, but that directory was removed after the GUI moved to the dedicated `noetl/gui` repository. The GUI now releases its own image separately, so the NoETL package job should only install UV dependencies, build the Python package, and publish it.

## Validation

- Parsed `.github/workflows/build_on_release.yml` with PyYAML
- Confirmed the current `v2.24.1` container image job succeeded; only the PyPI/package job failed on missing `ui-src`
