### PR TITLE
Fix indexed execution observability pagination

### DIFF
--- a/noetl/database/ddl/postgres/schema_ddl.sql
+++ b/noetl/database/ddl/postgres/schema_ddl.sql
@@ -57,22 +57,22 @@ COMMENT ON COLUMN noetl.transient.accessed_at IS 'Last time this variable was re
 -- Event (range-partitioned by execution_id for instant per-execution cleanup)
 --
 -- Partition key: execution_id (snowflake bigint, epoch = 2024-01-01 UTC)
---   id = (elapsed_ms << 22) | (node_id << 12) | seq
---   IDs per quarter ≈ 33 trillion; quarterly boundaries below.
+--   id = (elapsed_ms << 23) | (node_id << 12) | seq
+--   IDs per quarter ≈ 66 trillion; quarterly boundaries below.
 --
 -- Cleanup: DROP TABLE noetl.event_<quarter> — instant, no VACUUM needed.
 -- Add new partitions before each quarter starts:
 --   CREATE TABLE noetl.event_2028_q1 PARTITION OF noetl.event
---     FOR VALUES FROM (595000000000000000) TO (628000000000000000);
+--     FOR VALUES FROM (1058897343283200000) TO (1124137159091200000);
 --
 -- Boundary reference (id_for_date, epoch=2024-01-01):
---   2026-01-01:  264_905_529_753_600_000
---   2026-04-01:  297_520_437_657_600_000
---   2026-07-01:  330_497_733_427_200_000
---   2026-10-01:  363_837_417_062_400_000
---   2027-01-01:  397_177_100_697_600_000
---   2027-07-01:  462_769_304_371_200_000
---   2028-01-01:  529_448_671_641_600_000
+--   2026-01-01:  529_811_059_507_200_000
+--   2026-04-01:  595_040_875_315_200_000
+--   2026-07-01:  660_995_466_854_400_000
+--   2026-10-01:  727_674_834_124_800_000
+--   2027-01-01:  794_354_201_395_200_000
+--   2027-07-01:  925_538_608_742_400_000
+--   2028-01-01:  1_058_897_343_283_200_000
 CREATE TABLE IF NOT EXISTS noetl.event (
     execution_id        BIGINT,
     catalog_id          BIGINT NOT NULL REFERENCES noetl.catalog(catalog_id),
@@ -160,6 +160,68 @@ CREATE TABLE IF NOT EXISTS noetl.event_2027_h2
 -- GKE deployment uses a non-standard snowflake epoch producing IDs in the 569T–600T range
 CREATE TABLE IF NOT EXISTS noetl.event_2026_gke
     PARTITION OF noetl.event FOR VALUES FROM (569000000000000000) TO (600000000000000000);
+-- Current/future ranges for the standard noetl.snowflake_id() layout. These are
+-- skipped per-range when event_default already contains overlapping rows so
+-- schema re-apply never fails on clusters that already caught rows in default.
+-- The 569T-600T interval is already covered by event_2026_gke, so the standard
+-- 2026 ranges are split around it to avoid overlapping partition bounds.
+DO $$
+DECLARE
+    partition_names text[] := ARRAY[
+        'event_2026_q1_standard',
+        'event_2026_q2_standard',
+        'event_2026_q3_standard',
+        'event_2026_q4_standard',
+        'event_2027_h1_standard',
+        'event_2027_h2_standard',
+        'event_2028_q1_standard'
+    ];
+    start_ids bigint[] := ARRAY[
+        529811059507200000,
+        600000000000000000,
+        660995466854400000,
+        727674834124800000,
+        794354201395200000,
+        925538608742400000,
+        1058897343283200000
+    ];
+    end_ids bigint[] := ARRAY[
+        569000000000000000,
+        660995466854400000,
+        727674834124800000,
+        794354201395200000,
+        925538608742400000,
+        1058897343283200000,
+        1124137159091200000
+    ];
+    idx int;
+    default_has_overlap boolean;
+BEGIN
+    FOR idx IN 1..array_length(partition_names, 1) LOOP
+        default_has_overlap := false;
+        IF to_regclass('noetl.event_default') IS NOT NULL THEN
+            EXECUTE format(
+                'SELECT EXISTS (SELECT 1 FROM noetl.event_default WHERE execution_id >= %s AND execution_id < %s LIMIT 1)',
+                start_ids[idx],
+                end_ids[idx]
+            ) INTO default_has_overlap;
+        END IF;
+
+        IF default_has_overlap THEN
+            RAISE NOTICE
+                'Skipping %. Move/split overlapping rows from noetl.event_default before attaching this partition.',
+                partition_names[idx];
+        ELSE
+            EXECUTE format(
+                'CREATE TABLE IF NOT EXISTS noetl.%I PARTITION OF noetl.event FOR VALUES FROM (%s) TO (%s)',
+                partition_names[idx],
+                start_ids[idx],
+                end_ids[idx]
+            );
+        END IF;
+    END LOOP;
+END;
+$$;
 -- Default catches any IDs not covered by named partitions above
 CREATE TABLE IF NOT EXISTS noetl.event_default
     PARTITION OF noetl.event DEFAULT;
@@ -563,6 +625,9 @@ ALTER TABLE noetl.execution
 CREATE INDEX IF NOT EXISTS idx_execution_status ON noetl.execution (status);
 CREATE INDEX IF NOT EXISTS idx_execution_catalog_id ON noetl.execution (catalog_id);
 CREATE INDEX IF NOT EXISTS idx_execution_start_time ON noetl.execution (start_time DESC);
+CREATE INDEX IF NOT EXISTS idx_execution_list_page
+    ON noetl.execution ((COALESCE(start_time, created_at)) DESC NULLS LAST, execution_id DESC)
+    INCLUDE (catalog_id, parent_execution_id, status, last_event_type, last_node_name, last_event_id, end_time, error);
 -- Execution projection is maintained by the projection worker and state store.
 -- Explicitly remove the old row-level trigger so schema re-application after
 -- Postgres recovery cannot recreate the high-contention hot path.
@@ -667,6 +732,9 @@ CREATE INDEX IF NOT EXISTS idx_command_execution_step
     ON noetl.command (execution_id, step_name);
 CREATE INDEX IF NOT EXISTS idx_command_status
     ON noetl.command (status) WHERE status IN ('PENDING', 'CLAIMED');
+CREATE INDEX IF NOT EXISTS idx_command_execution_status
+    ON noetl.command (execution_id, status)
+    WHERE status IN ('PENDING', 'CLAIMED', 'RUNNING');
 CREATE INDEX IF NOT EXISTS idx_command_worker
     ON noetl.command (worker_id, updated_at) WHERE status = 'CLAIMED';
 CREATE INDEX IF NOT EXISTS idx_command_loop

--- a/noetl/server/api/execution/endpoint.py
+++ b/noetl/server/api/execution/endpoint.py
@@ -12,7 +12,7 @@ from psycopg.rows import dict_row
 from psycopg.types.json import Json
 from noetl.core.db.pool import get_pool_connection, get_snowflake_id
 from noetl.core.logger import setup_logger
-from noetl.core.common import convert_snowflake_ids_for_api
+from noetl.core.common import convert_snowflake_ids_for_api, normalize_execution_id_for_db
 from noetl.server.api.event_queries import PENDING_COMMAND_COUNT_SQL
 from .schema import (
     ExecutionEntryResponse,
@@ -195,38 +195,26 @@ async def _fetch_execution_events_page(
 
 async def _fetch_pending_command_counts_for_executions(
     cursor,
-    execution_ids: list[str],
+    execution_ids: list[Any],
 ) -> dict[str, int]:
     if not execution_ids:
         return {}
 
+    numeric_execution_ids = [normalize_execution_id_for_db(execution_id) for execution_id in execution_ids]
+    if any(execution_id <= 0 for execution_id in numeric_execution_ids):
+        raise ValueError(f"Invalid execution_id values for pending command lookup: {execution_ids!r}")
+    if not numeric_execution_ids:
+        return {}
+
     await cursor.execute(
         """
-        WITH filtered_events AS (
-            SELECT
-                execution_id,
-                event_type,
-                meta->>'command_id' AS command_id
-            FROM noetl.event
-            WHERE execution_id::text IN (SELECT unnest(%s::text[]))
-              AND meta ? 'command_id'
-              AND event_type IN ('command.issued', 'command.completed', 'command.failed', 'command.cancelled')
-        ),
-        command_status AS (
-            SELECT
-                execution_id,
-                command_id,
-                MAX(CASE WHEN event_type = 'command.issued' THEN 1 ELSE 0 END) AS is_issued,
-                MAX(CASE WHEN event_type IN ('command.completed', 'command.failed', 'command.cancelled') THEN 1 ELSE 0 END) AS is_terminal
-            FROM filtered_events
-            GROUP BY execution_id, command_id
-        )
         SELECT execution_id, COUNT(*) AS pending_count
-        FROM command_status
-        WHERE is_issued = 1 AND is_terminal = 0
+        FROM noetl.command
+        WHERE execution_id = ANY(%s::bigint[])
+          AND status IN ('PENDING', 'CLAIMED', 'RUNNING')
         GROUP BY execution_id
         """,
-        (execution_ids,),
+        (numeric_execution_ids,),
     )
     rows = await cursor.fetchall()
     return {str(row["execution_id"]): int(row["pending_count"] or 0) for row in rows}
@@ -851,67 +839,78 @@ async def get_executions(
                 # Keep this endpoint lightweight for UI polling. Avoid scanning giant payload columns.
                 await cursor.execute("SET LOCAL statement_timeout = '8s'")
                 await cursor.execute("""
-                    WITH latest AS (
-                        SELECT DISTINCT ON (execution_id)
-                            execution_id, event_type, node_name, status AS event_status,
-                            created_at, catalog_id, parent_execution_id, error
-                        FROM noetl.event
-                        WHERE execution_id IS NOT NULL
-                        ORDER BY execution_id, event_id DESC
-                    ),
-                    first_event AS (
-                        SELECT DISTINCT ON (execution_id)
-                            execution_id, created_at AS first_created_at, catalog_id AS first_catalog_id,
-                            parent_execution_id AS first_parent_execution_id
-                        FROM noetl.event
-                        WHERE execution_id IS NOT NULL
-                        ORDER BY execution_id, event_id ASC
-                    ),
-                    terminal AS (
-                        SELECT DISTINCT ON (execution_id)
-                            execution_id, event_type, status, created_at, error
-                        FROM noetl.event
-                        WHERE execution_id IS NOT NULL
-                          AND event_type IN (
-                            'execution.cancelled',
-                            'playbook.failed',
-                            'workflow.failed',
-                            'command.failed',
-                            'playbook.completed',
-                            'workflow.completed'
-                          )
-                        ORDER BY execution_id, event_id DESC
-                    )
                     SELECT
-                        l.execution_id,
-                        COALESCE(e.catalog_id, l.catalog_id, f.first_catalog_id) AS catalog_id,
-                        l.event_type,
-                        l.node_name,
-                        COALESCE(e.status, l.event_status) AS status,
-                        l.event_status,
-                        l.event_type AS derived_event_type,
-                        COALESCE(e.start_time, f.first_created_at) AS start_time,
-                        COALESCE(e.end_time, l.created_at) AS end_time,
+                        e.execution_id,
+                        e.catalog_id,
+                        COALESCE(
+                            e.last_event_type,
+                            CASE
+                                WHEN e.status IN ('COMPLETED', 'FAILED', 'CANCELLED')
+                                THEN 'execution.' || lower(e.status)
+                                ELSE 'execution.projected'
+                            END
+                        ) AS event_type,
+                        e.last_node_name AS node_name,
+                        e.status,
+                        e.status AS event_status,
+                        COALESCE(e.last_event_type, 'execution.projected') AS derived_event_type,
+                        COALESCE(e.start_time, e.created_at) AS start_time,
+                        e.end_time,
                         NULL::jsonb AS result,
-                        COALESCE(e.error, t.error, l.error) AS error,
-                        COALESCE(e.parent_execution_id, l.parent_execution_id, f.first_parent_execution_id) AS parent_execution_id,
-                        t.event_type AS terminal_event_type,
-                        t.status AS terminal_status,
-                        t.created_at AS terminal_end_time,
+                        e.error,
+                        e.parent_execution_id,
+                        CASE
+                            WHEN e.last_event_type IN (
+                                'execution.cancelled',
+                                'playbook.failed',
+                                'workflow.failed',
+                                'command.failed',
+                                'playbook.completed',
+                                'workflow.completed'
+                            )
+                            THEN e.last_event_type
+                            WHEN e.last_event_type IS NULL
+                             AND e.status IN ('COMPLETED', 'FAILED', 'CANCELLED')
+                            THEN 'execution.' || lower(e.status)
+                            ELSE NULL
+                        END AS terminal_event_type,
+                        CASE
+                            WHEN e.last_event_type IN (
+                                'execution.cancelled',
+                                'playbook.failed',
+                                'workflow.failed',
+                                'command.failed',
+                                'playbook.completed',
+                                'workflow.completed'
+                            )
+                             OR (e.last_event_type IS NULL AND e.status IN ('COMPLETED', 'FAILED', 'CANCELLED'))
+                            THEN e.status
+                            ELSE NULL
+                        END AS terminal_status,
+                        CASE
+                            WHEN e.last_event_type IN (
+                                'execution.cancelled',
+                                'playbook.failed',
+                                'workflow.failed',
+                                'command.failed',
+                                'playbook.completed',
+                                'workflow.completed'
+                            )
+                             OR (e.last_event_type IS NULL AND e.status IN ('COMPLETED', 'FAILED', 'CANCELLED'))
+                            THEN COALESCE(e.end_time, e.updated_at)
+                            ELSE NULL
+                        END AS terminal_end_time,
                         COALESCE(c.path, 'unknown') AS path,
                         COALESCE(c.version, 0) AS version
-                    FROM latest l
-                    JOIN first_event f ON f.execution_id = l.execution_id
-                    LEFT JOIN terminal t ON t.execution_id = l.execution_id
-                    LEFT JOIN noetl.execution e ON e.execution_id = l.execution_id
-                    LEFT JOIN noetl.catalog c ON c.catalog_id = COALESCE(e.catalog_id, l.catalog_id, f.first_catalog_id)
-                    ORDER BY COALESCE(e.start_time, f.first_created_at) DESC NULLS LAST, l.execution_id DESC
+                    FROM noetl.execution e
+                    LEFT JOIN noetl.catalog c ON c.catalog_id = e.catalog_id
+                    ORDER BY COALESCE(e.start_time, e.created_at) DESC NULLS LAST, e.execution_id DESC
                     LIMIT %(limit)s
                     OFFSET %(offset)s
                 """, {"limit": page_size, "offset": offset})
                 rows = await cursor.fetchall()
                 candidate_execution_ids = [
-                    str(row["execution_id"])
+                    row["execution_id"]
                     for row in rows
                     if row.get("derived_event_type") == "batch.completed"
                     and str(row.get("event_status") or "").upper() == "COMPLETED"

--- a/tests/api/execution/test_executions_status_consistency.py
+++ b/tests/api/execution/test_executions_status_consistency.py
@@ -119,6 +119,14 @@ def test_pending_command_count_sql_tracks_command_ids():
 
 
 @pytest.mark.asyncio
+async def test_pending_command_count_lookup_rejects_invalid_execution_ids():
+    cursor = _FakeCursor([])
+
+    with pytest.raises(ValueError):
+        await execution_api._fetch_pending_command_counts_for_executions(cursor, ["not-a-snowflake"])
+
+
+@pytest.mark.asyncio
 async def test_get_executions_normalizes_non_terminal_completed_to_running(monkeypatch):
     now = datetime(2026, 3, 21, 7, 0, 0, tzinfo=timezone.utc)
     rows = [
@@ -307,6 +315,9 @@ async def test_get_executions_applies_page_size_and_offset(monkeypatch):
 
     assert len(result) == 1
     assert cursor._params == {"limit": 25, "offset": 25}
+    assert "FROM noetl.execution e" in cursor._query
+    assert "FROM noetl.event" not in cursor._query
+    assert "WHEN e.last_event_type IN (" in cursor._query
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- List executions from the noetl.execution projection instead of scanning noetl.event with DISTINCT ON CTEs.
- Move pending command counts to the noetl.command projection with bigint execution-id predicates.
- Add projection pagination and command-status indexes, plus standard Snowflake event partition ranges for fresh/split installs.

## Validation
- uv run pytest -q tests/api/execution/test_executions_status_consistency.py
- Applied the new indexes in local kind-noetl Postgres and verified EXPLAIN uses idx_execution_list_page with ~2ms execution time against a database with 1,643,875 event rows.