### PR TITLE
Fix event constraint DDL reapply

### DIFF
--- a/noetl/database/ddl/postgres/schema_ddl.sql
+++ b/noetl/database/ddl/postgres/schema_ddl.sql
@@ -98,7 +98,7 @@ CREATE TABLE IF NOT EXISTS noetl.event (
     context_value       TEXT,
     trace_component     JSONB,
     stack_trace         TEXT,
-        CHECK (
+        CONSTRAINT chk_event_result_shape CHECK (
             result IS NULL
             OR (
                 jsonb_typeof(result) = 'object'
@@ -127,7 +127,8 @@ BEGIN
              AND t.relname = 'event'
        ) THEN
         ALTER TABLE noetl.event
-                CHECK (
+            ADD CONSTRAINT chk_event_result_shape
+            CHECK (
                     result IS NULL
                     OR (
                         jsonb_typeof(result) = 'object'


### PR DESCRIPTION
## Summary
- Fix the idempotent event result-shape constraint block to use ADD CONSTRAINT.
- This keeps full schema_ddl.sql re-application working on existing Postgres databases.

## Validation
- Applied the full noetl/database/ddl/postgres/schema_ddl.sql against local kind-noetl Postgres with ON_ERROR_STOP=1.
- uv run pytest -q tests/api/execution/test_executions_status_consistency.py