### PR TITLE
feat(mcp): lifecycle / discover / ui_schema endpoints (architecture phase 1)

### DIFF
--- a/noetl/server/api/__init__.py
+++ b/noetl/server/api/__init__.py
@@ -17,6 +17,9 @@ from . import core
 # Essential management APIs (catalog, credentials, database utilities)
 from . import credential, catalog, database, keychain, playbook_tests
 
+# MCP lifecycle / discovery / ui_schema operations on top of the catalog.
+from . import mcp
+
 # Query/monitoring APIs
 from . import execution, vars, dashboard, system, runtime
 
@@ -45,6 +48,9 @@ router.include_router(database.router)
 router.include_router(keychain.router)
 router.include_router(playbook_tests.router)
 
+# MCP lifecycle / discovery / ui_schema endpoints — depend on catalog.
+router.include_router(mcp.router)
+
 # Query/monitoring APIs
 router.include_router(execution.router)
 router.include_router(vars.router)
@@ -64,7 +70,7 @@ router.include_router(temp.router)
 __all__ = [
     "router",
     "core",
-    "catalog", "credential", "database", "keychain", "playbook_tests",
+    "catalog", "credential", "database", "keychain", "playbook_tests", "mcp",
     "execution", "vars", "dashboard", "system", "runtime",
     "context", "result", "temp"
 ]

--- a/noetl/server/api/mcp/__init__.py
+++ b/noetl/server/api/mcp/__init__.py
@@ -1,0 +1,23 @@
+"""MCP server lifecycle and discovery API.
+
+Adds a catalog-driven shape for managing MCP servers without requiring
+the GUI / CLI / external automation to know how each server is
+provisioned: every Mcp catalog entry can declare a `lifecycle:` block
+with verb -> Agent playbook path mappings (deploy / redeploy / status /
+restart / undeploy / discover), a `discovery:` block for refreshing
+the tool list against the running server, and a `runtime:` block for
+the agent the GUI dispatches normal tool calls through.
+
+Endpoints exposed under /api/mcp:
+- POST /api/mcp/{path:path}/lifecycle/{verb} -- dispatch lifecycle agent
+- POST /api/mcp/{path:path}/discover         -- refresh catalog tool list
+- GET  /api/catalog/{path:path}/ui_schema    -- inferred workload form
+
+The catalog still stores Mcp resources via the existing
+`/api/catalog/register` endpoint with `resource_type: mcp`; this module
+adds *operations* on top, it does not change registration semantics.
+"""
+
+from .endpoint import router
+
+__all__ = ["router"]

--- a/noetl/server/api/mcp/endpoint.py
+++ b/noetl/server/api/mcp/endpoint.py
@@ -1,0 +1,158 @@
+"""FastAPI endpoints for MCP lifecycle / discovery / ui_schema."""
+
+from __future__ import annotations
+
+import urllib.request
+from typing import Any
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Path
+from fastapi.responses import JSONResponse
+
+from noetl.core.logger import setup_logger
+
+from . import schema as mcp_schema
+from . import service as mcp_service
+
+logger = setup_logger(__name__, include_location=True)
+
+
+router = APIRouter(prefix="", tags=["mcp"])
+
+
+# ---------------------------------------------------------------------------
+# Dependency wiring -- lazily resolves the catalog service + execute helper.
+# Keeping these as injectables makes the module testable without standing up
+# the full server wiring; the test suite passes mocks.
+# ---------------------------------------------------------------------------
+
+
+def _get_catalog_service():
+    """Resolve the catalog service singleton."""
+    # Late import to avoid pulling the full app graph during module import.
+    from noetl.server.api.catalog import get_catalog_service
+
+    return get_catalog_service()
+
+
+async def _execute_via_core(*, path: str, workload: dict[str, Any]) -> str:
+    """Default execute helper: delegate to the core /api/execute path."""
+    # Late import keeps optional dependency on the broker subsystem.
+    from noetl.server.api.core import execute_resource_default  # type: ignore[import-not-found]
+
+    response = await execute_resource_default(path=path, workload=workload)
+    if isinstance(response, dict) and response.get("execution_id"):
+        return str(response["execution_id"])
+    raise HTTPException(
+        status_code=500,
+        detail=f"agent dispatch for {path} returned no execution_id",
+    )
+
+
+async def _fetch_url_default(url: str) -> str:
+    """Default URL fetcher used by direct-discovery."""
+    # Network calls are kept synchronous via run_in_executor to avoid pulling
+    # in a new HTTP client dependency for what should be a rare code path.
+    import asyncio
+
+    def _read() -> str:
+        with urllib.request.urlopen(url, timeout=10) as response:  # noqa: S310 -- caller-controlled URL
+            return response.read().decode("utf-8")
+
+    return await asyncio.get_event_loop().run_in_executor(None, _read)
+
+
+async def _register_default(*, content: str, resource_type: str) -> dict[str, Any]:
+    """Default catalog register helper used by direct-discovery."""
+    from noetl.server.api.catalog import get_catalog_service
+
+    service = get_catalog_service()
+    return await service.register(content=content, resource_type=resource_type)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle dispatch
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/api/mcp/{path:path}/lifecycle/{verb}",
+    response_model=mcp_schema.McpLifecycleResponse,
+    summary="Dispatch a lifecycle verb on a registered Mcp resource",
+)
+async def post_lifecycle_verb(
+    path: str = Path(..., description="Mcp catalog path"),
+    verb: str = Path(..., description="Lifecycle verb (deploy / restart / etc.)"),
+    body: mcp_schema.McpLifecycleRequest = Body(default_factory=mcp_schema.McpLifecycleRequest),
+    catalog_service=Depends(_get_catalog_service),
+):
+    cleaned_verb = mcp_schema.coerce_lifecycle_verb(verb)
+    try:
+        return await mcp_service.dispatch_lifecycle(
+            catalog_service=catalog_service,
+            execute_callable=_execute_via_core,
+            path=path,
+            verb=cleaned_verb,
+            version=body.version,
+            workload_overrides=body.workload_overrides,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("MCP lifecycle dispatch failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/api/mcp/{path:path}/discover",
+    response_model=mcp_schema.McpDiscoverResponse,
+    summary="Refresh the tool list of a registered Mcp resource",
+)
+async def post_discover(
+    path: str = Path(..., description="Mcp catalog path"),
+    body: mcp_schema.McpDiscoverRequest = Body(default_factory=mcp_schema.McpDiscoverRequest),
+    catalog_service=Depends(_get_catalog_service),
+):
+    try:
+        return await mcp_service.dispatch_discover(
+            catalog_service=catalog_service,
+            execute_callable=_execute_via_core,
+            fetch_url_callable=_fetch_url_default,
+            register_callable=_register_default,
+            path=path,
+            version=body.version,
+            force=body.force,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("MCP discover failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# UI schema
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/api/catalog/{path:path}/ui_schema",
+    response_model=mcp_schema.UiSchemaResponse,
+    summary="Inferred workload form for a Playbook / Agent / Mcp resource",
+)
+async def get_ui_schema(
+    path: str = Path(..., description="Catalog path"),
+    version: Any = "latest",
+    catalog_service=Depends(_get_catalog_service),
+):
+    try:
+        return await mcp_service.build_ui_schema(catalog_service, path, version)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("ui_schema build failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/noetl/server/api/mcp/endpoint.py
+++ b/noetl/server/api/mcp/endpoint.py
@@ -1,9 +1,20 @@
-"""FastAPI endpoints for MCP lifecycle / discovery / ui_schema."""
+"""FastAPI endpoints for MCP lifecycle / discovery / ui_schema.
+
+Routes are mounted into the main API router (``noetl.server.api.router``)
+which is itself prefixed at ``/api``; therefore the decorators here use
+paths *without* a leading ``/api`` so the final URL stays at
+``/api/mcp/{path}/lifecycle/{verb}`` and friends.
+"""
 
 from __future__ import annotations
 
+import asyncio
+import ipaddress
+import json
+import socket
+import urllib.parse
 import urllib.request
-from typing import Any
+from typing import Any, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path
 from fastapi.responses import JSONResponse
@@ -19,6 +30,13 @@ logger = setup_logger(__name__, include_location=True)
 router = APIRouter(prefix="", tags=["mcp"])
 
 
+# Maximum size we'll accept from a discovery URL fetch. Twenty kilobytes is
+# more than any reasonable MCP `tools/list` response while still preventing
+# a hostile server from streaming endless data into the worker.
+_DISCOVERY_FETCH_MAX_BYTES = 20 * 1024
+_DISCOVERY_FETCH_TIMEOUT_SECONDS = 10
+
+
 # ---------------------------------------------------------------------------
 # Dependency wiring -- lazily resolves the catalog service + execute helper.
 # Keeping these as injectables makes the module testable without standing up
@@ -27,21 +45,43 @@ router = APIRouter(prefix="", tags=["mcp"])
 
 
 def _get_catalog_service():
-    """Resolve the catalog service singleton."""
-    # Late import to avoid pulling the full app graph during module import.
-    from noetl.server.api.catalog import get_catalog_service
+    """Return the CatalogService class.
 
-    return get_catalog_service()
+    `CatalogService` exposes its lookup methods (``fetch_entry``, ``get``,
+    ``register_resource``) as ``@staticmethod``, so the "service" here is
+    really just the class itself. Returning the class lets callers do
+    ``service.fetch_entry(...)`` interchangeably with the rest of the
+    server code without instantiating anything.
+    """
+    from noetl.server.api.catalog import CatalogService
+
+    return CatalogService
 
 
 async def _execute_via_core(*, path: str, workload: dict[str, Any]) -> str:
-    """Default execute helper: delegate to the core /api/execute path."""
-    # Late import keeps optional dependency on the broker subsystem.
-    from noetl.server.api.core import execute_resource_default  # type: ignore[import-not-found]
+    """Default execute helper: delegate to ``noetl.server.api.core.execute``."""
+    # Late imports keep the module importable without pulling the full broker
+    # graph at server-startup time.
+    from noetl.server.api.core.execution import execute as core_execute
+    from noetl.server.api.core.models import ExecuteRequest
 
-    response = await execute_resource_default(path=path, workload=workload)
-    if isinstance(response, dict) and response.get("execution_id"):
-        return str(response["execution_id"])
+    request = ExecuteRequest(path=path, payload=workload or {})
+    response = await core_execute(request)
+
+    payload: Optional[dict[str, Any]] = None
+    if hasattr(response, "model_dump"):
+        payload = response.model_dump()
+    elif isinstance(response, dict):
+        payload = response
+    elif isinstance(response, JSONResponse):
+        try:
+            payload = json.loads(response.body.decode("utf-8"))
+        except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
+            payload = None
+
+    if isinstance(payload, dict) and payload.get("execution_id"):
+        return str(payload["execution_id"])
+
     raise HTTPException(
         status_code=500,
         detail=f"agent dispatch for {path} returned no execution_id",
@@ -49,24 +89,113 @@ async def _execute_via_core(*, path: str, workload: dict[str, Any]) -> str:
 
 
 async def _fetch_url_default(url: str) -> str:
-    """Default URL fetcher used by direct-discovery."""
-    # Network calls are kept synchronous via run_in_executor to avoid pulling
-    # in a new HTTP client dependency for what should be a rare code path.
-    import asyncio
+    """Fetcher for direct discovery -- validates the URL, caps the response.
+
+    SSRF mitigation: refuses anything other than http/https, blocks
+    requests targeting loopback, link-local, multicast, or RFC 1918
+    addresses unless the URL host explicitly resolves to a kind/cluster
+    namespace (the most common case for kubernetes-native MCP servers).
+    """
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"discovery URL must be http or https; got '{parsed.scheme}'",
+        )
+    host = parsed.hostname
+    if not host:
+        raise HTTPException(status_code=400, detail="discovery URL missing host")
+
+    # Allow common in-cluster hostnames. Anything that resolves to a
+    # publicly-routable address is also fine; the only thing we block is the
+    # subset of private/loopback that's a likely SSRF target.
+    if not _host_is_safe_for_discovery(host):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"discovery URL host '{host}' resolves to a blocked address range "
+                "(loopback / link-local / multicast). Use the in-cluster service "
+                "DNS or a routable public host instead."
+            ),
+        )
 
     def _read() -> str:
-        with urllib.request.urlopen(url, timeout=10) as response:  # noqa: S310 -- caller-controlled URL
-            return response.read().decode("utf-8")
+        with urllib.request.urlopen(  # noqa: S310 -- validated above
+            url,
+            timeout=_DISCOVERY_FETCH_TIMEOUT_SECONDS,
+        ) as response:
+            data = response.read(_DISCOVERY_FETCH_MAX_BYTES + 1)
+        if len(data) > _DISCOVERY_FETCH_MAX_BYTES:
+            raise HTTPException(
+                status_code=502,
+                detail=(
+                    f"discovery URL response exceeded "
+                    f"{_DISCOVERY_FETCH_MAX_BYTES} bytes"
+                ),
+            )
+        return data.decode("utf-8")
 
-    return await asyncio.get_event_loop().run_in_executor(None, _read)
+    return await asyncio.get_running_loop().run_in_executor(None, _read)
+
+
+def _host_is_safe_for_discovery(host: str) -> bool:
+    """Best-effort SSRF guard. Allows in-cluster service DNS by name.
+
+    We let through:
+    - hostnames ending in `.svc`, `.svc.cluster.local`, `.cluster.local`
+      (typical kubernetes service DNS — operators target the same MCP
+      pod via these names).
+    - any host that, after DNS resolution, lies outside the
+      loopback / link-local / multicast / private ranges.
+
+    We block:
+    - explicit IPs in loopback (127.0.0.0/8, ::1), link-local
+      (169.254.0.0/16, fe80::/10), multicast (224.0.0.0/4),
+      RFC 1918 (10/8, 172.16/12, 192.168/16) when the URL is an IP literal
+      and *not* one of the in-cluster DNS suffixes above. (Cluster DNS
+      typically resolves to a private 10.x or 172.x address, but the
+      hostname-based allowlist short-circuits the check before we hit
+      that branch.)
+    """
+    suffix_allowlist = (
+        ".svc",
+        ".svc.cluster.local",
+        ".cluster.local",
+    )
+    lowered = host.lower()
+    if any(lowered.endswith(suffix) for suffix in suffix_allowlist):
+        return True
+
+    try:
+        # If the hostname is a literal IP, this returns the IP back.
+        # Otherwise it does a DNS lookup.
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return False
+
+    seen_ok = False
+    for family, _type, _proto, _canon, sockaddr in infos:
+        addr = sockaddr[0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            continue
+        if ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_unspecified:
+            return False
+        if ip.is_private:
+            return False
+        seen_ok = True
+    return seen_ok
 
 
 async def _register_default(*, content: str, resource_type: str) -> dict[str, Any]:
     """Default catalog register helper used by direct-discovery."""
-    from noetl.server.api.catalog import get_catalog_service
+    from noetl.server.api.catalog import CatalogService
 
-    service = get_catalog_service()
-    return await service.register(content=content, resource_type=resource_type)
+    return await CatalogService.register_resource(
+        content=content,
+        resource_type=resource_type,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -75,7 +204,7 @@ async def _register_default(*, content: str, resource_type: str) -> dict[str, An
 
 
 @router.post(
-    "/api/mcp/{path:path}/lifecycle/{verb}",
+    "/mcp/{path:path}/lifecycle/{verb}",
     response_model=mcp_schema.McpLifecycleResponse,
     summary="Dispatch a lifecycle verb on a registered Mcp resource",
 )
@@ -108,7 +237,7 @@ async def post_lifecycle_verb(
 
 
 @router.post(
-    "/api/mcp/{path:path}/discover",
+    "/mcp/{path:path}/discover",
     response_model=mcp_schema.McpDiscoverResponse,
     summary="Refresh the tool list of a registered Mcp resource",
 )
@@ -140,7 +269,7 @@ async def post_discover(
 
 
 @router.get(
-    "/api/catalog/{path:path}/ui_schema",
+    "/catalog/{path:path}/ui_schema",
     response_model=mcp_schema.UiSchemaResponse,
     summary="Inferred workload form for a Playbook / Agent / Mcp resource",
 )

--- a/noetl/server/api/mcp/schema.py
+++ b/noetl/server/api/mcp/schema.py
@@ -1,0 +1,208 @@
+"""Schemas for the MCP server lifecycle / discovery / ui_schema API."""
+
+from datetime import datetime
+from typing import Any, Optional
+from pydantic import Field, field_validator, model_validator
+
+from noetl.core.common import AppBaseModel
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle dispatch
+# ---------------------------------------------------------------------------
+
+
+class McpLifecycleRequest(AppBaseModel):
+    """Trigger a lifecycle verb on a registered Mcp catalog resource.
+
+    The Mcp resource's spec.lifecycle.{verb} field resolves to an Agent
+    playbook path. The endpoint dispatches that agent via /api/execute,
+    passing the Mcp resource (path + version + payload) as workload so
+    the agent has everything it needs to deploy / restart / etc.
+    """
+
+    workload_overrides: Optional[dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Overrides merged onto the lifecycle agent's workload. "
+            "Use sparingly; most callers should rely on the resource's "
+            "own spec values."
+        ),
+    )
+    version: Optional[str | int] = Field(
+        default="latest",
+        description="Mcp resource version (default 'latest')",
+    )
+
+
+class McpLifecycleResponse(AppBaseModel):
+    """Result of a lifecycle dispatch -- pointer to the started run."""
+
+    status: str = Field(description="'started' on success", example="started")
+    verb: str = Field(description="The lifecycle verb that was dispatched")
+    mcp_path: str = Field(description="The Mcp resource path")
+    mcp_version: int = Field(description="The Mcp resource version")
+    agent_path: str = Field(description="Agent playbook path resolved")
+    execution_id: str = Field(description="Started agent execution id")
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+class McpDiscoverRequest(AppBaseModel):
+    """Refresh the Mcp resource's tool list.
+
+    Two strategies, in priority order:
+    1. spec.discovery.refresh_via -- run the named Agent playbook,
+       expect the agent's output to contain a `tools` array, and patch
+       it onto the catalog entry.
+    2. spec.discovery.tools_list_url -- fetch the URL directly, parse
+       the response as JSON, expect `tools` array.
+
+    If neither is configured, returns 422.
+    """
+
+    version: Optional[str | int] = Field(
+        default="latest",
+        description="Mcp resource version (default 'latest')",
+    )
+    force: bool = Field(
+        default=False,
+        description=(
+            "If true, register a new catalog version even when the tool "
+            "list hasn't changed. Default false (only re-register on diff)."
+        ),
+    )
+
+
+class McpDiscoverResponse(AppBaseModel):
+    """Discovery outcome -- one of agent_dispatched / direct_fetch."""
+
+    status: str = Field(description="'started' or 'updated'")
+    mcp_path: str = Field(description="The Mcp resource path")
+    mcp_version_old: int = Field(description="Version that was inspected")
+    mcp_version_new: Optional[int] = Field(
+        default=None,
+        description="New catalog version if tool list changed; null otherwise",
+    )
+    strategy: str = Field(
+        description="Which discovery path was used: 'agent' or 'direct'",
+    )
+    execution_id: Optional[str] = Field(
+        default=None,
+        description="Agent execution id (only when strategy='agent')",
+    )
+    tool_count_before: Optional[int] = Field(
+        default=None,
+        description="Number of tools before refresh",
+    )
+    tool_count_after: Optional[int] = Field(
+        default=None,
+        description="Number of tools after refresh (only when strategy='direct')",
+    )
+
+
+# ---------------------------------------------------------------------------
+# UI schema inference
+# ---------------------------------------------------------------------------
+
+
+class UiSchemaField(AppBaseModel):
+    """One workload field inferred from a playbook's YAML.
+
+    The inference rules (see service.infer_ui_schema):
+    - Default-value type drives `kind`: string, number, integer, boolean,
+      object, array, null.
+    - Adjacent `# ui:enum=[...]` comment forces `kind=enum` and populates
+      `options`.
+    - `# ui:secret` flag marks the field as sensitive (mask in UI).
+    - `# ui:credential=pg_*` constrains the field to a credential picker
+      filtered by the given glob.
+    - `# ui:description=...` sets the field description.
+    - Nested objects produce nested fields in `children`.
+    """
+
+    name: str = Field(description="Workload key")
+    kind: str = Field(
+        description="Field kind: string|integer|number|boolean|object|array|null|enum",
+    )
+    default: Any = Field(default=None, description="Default value parsed from YAML")
+    description: Optional[str] = Field(
+        default=None,
+        description="Human-readable hint, taken from `# ui:description=...` comment",
+    )
+    secret: bool = Field(
+        default=False,
+        description="True when `# ui:secret` directive is present",
+    )
+    credential_glob: Optional[str] = Field(
+        default=None,
+        description="Credential picker filter, e.g. 'pg_*'",
+    )
+    options: Optional[list[Any]] = Field(
+        default=None,
+        description="Enum options, when kind=enum",
+    )
+    children: Optional[list["UiSchemaField"]] = Field(
+        default=None,
+        description="Nested fields when kind=object",
+    )
+
+
+UiSchemaField.model_rebuild()
+
+
+class UiSchemaResponse(AppBaseModel):
+    """Inferred workload form for a catalog resource (Playbook or Agent)."""
+
+    path: str = Field(description="Catalog path")
+    version: int = Field(description="Catalog version inspected")
+    kind: str = Field(description="Resource kind (Playbook | Agent | Mcp)")
+    title: Optional[str] = Field(
+        default=None,
+        description="metadata.name from the resource",
+    )
+    description_markdown: Optional[str] = Field(
+        default=None,
+        description="metadata.description rendered as markdown source",
+    )
+    exposed_in_ui: bool = Field(
+        default=False,
+        description="True when metadata.exposed_in_ui is set on the resource",
+    )
+    fields: list[UiSchemaField] = Field(
+        default_factory=list,
+        description="Top-level workload fields",
+    )
+    generated_at: datetime = Field(description="Inference timestamp (UTC)")
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers (re-used across endpoints)
+# ---------------------------------------------------------------------------
+
+
+KNOWN_LIFECYCLE_VERBS: tuple[str, ...] = (
+    "deploy",
+    "redeploy",
+    "undeploy",
+    "status",
+    "restart",
+    "discover",
+)
+
+
+def coerce_lifecycle_verb(verb: str) -> str:
+    """Normalize and validate the verb path component."""
+    cleaned = (verb or "").strip().lower()
+    if not cleaned:
+        raise ValueError("lifecycle verb cannot be empty")
+    if cleaned not in KNOWN_LIFECYCLE_VERBS:
+        # We don't hard-block unknown verbs at the schema layer; the
+        # service tests resource.spec.lifecycle.{verb} and 422s if the
+        # author hasn't wired it. Schema-level whitelist would prevent
+        # custom verbs (e.g. "smoke-test"), which we want to allow.
+        pass
+    return cleaned

--- a/noetl/server/api/mcp/service.py
+++ b/noetl/server/api/mcp/service.py
@@ -1,0 +1,295 @@
+"""MCP lifecycle / discovery service helpers.
+
+Wraps catalog lookups, agent dispatch, and tool-list refresh so the
+endpoints stay thin. All public helpers are async to fit the existing
+catalog/service layer.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import yaml as _yaml
+
+from fastapi import HTTPException
+
+from noetl.core.logger import setup_logger
+
+from . import schema as mcp_schema
+from .ui_schema import infer_ui_schema
+
+logger = setup_logger(__name__, include_location=True)
+
+
+# ---------------------------------------------------------------------------
+# Catalog accessors
+# ---------------------------------------------------------------------------
+
+
+async def fetch_mcp_resource(catalog_service, path: str, version: Any) -> dict[str, Any]:
+    """Look up an Mcp catalog entry by path + version.
+
+    Returns the parsed YAML payload as a dict so callers can read
+    spec.lifecycle / spec.discovery / spec.runtime without re-parsing.
+    Raises HTTPException(404) when the entry is absent or not an Mcp.
+    """
+    entry = await _fetch_entry(catalog_service, path, version)
+    kind = (entry.get("kind") or "").lower()
+    if kind not in ("mcp",):
+        raise HTTPException(
+            status_code=400,
+            detail=f"resource '{path}' is kind='{kind}', expected 'mcp'",
+        )
+
+    payload = entry.get("payload") or _parse_yaml_string(entry.get("content"))
+    if not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=500,
+            detail=f"Mcp resource '{path}' has unparseable payload",
+        )
+    payload["_catalog"] = {
+        "catalog_id": entry.get("catalog_id"),
+        "path": entry.get("path"),
+        "version": entry.get("version"),
+        "kind": entry.get("kind"),
+    }
+    return payload
+
+
+async def fetch_any_resource(catalog_service, path: str, version: Any) -> dict[str, Any]:
+    """Look up any catalog entry (Playbook / Agent / Mcp) for ui_schema."""
+    return await _fetch_entry(catalog_service, path, version)
+
+
+async def _fetch_entry(catalog_service, path: str, version: Any) -> dict[str, Any]:
+    if catalog_service is None:
+        raise HTTPException(status_code=503, detail="catalog service unavailable")
+
+    requested_version = "latest" if version in (None, "", "latest") else version
+    try:
+        entry = await catalog_service.get_entry(path=path, version=requested_version)
+    except Exception as exc:  # pragma: no cover -- service-layer error surface varies
+        logger.warning("catalog lookup failed for %s@%s: %s", path, requested_version, exc)
+        raise HTTPException(status_code=404, detail=f"resource not found: {path}@{requested_version}") from exc
+
+    if not entry:
+        raise HTTPException(status_code=404, detail=f"resource not found: {path}@{requested_version}")
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle dispatch
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_lifecycle(
+    *,
+    catalog_service,
+    execute_callable,
+    path: str,
+    verb: str,
+    version: Any,
+    workload_overrides: Optional[dict[str, Any]] = None,
+) -> mcp_schema.McpLifecycleResponse:
+    """Resolve resource.lifecycle.{verb} -> Agent path and dispatch.
+
+    `execute_callable(path: str, workload: dict) -> str` is injected so
+    this stays testable without standing up the full /api/execute
+    machinery in unit tests. Pass a thin wrapper around the existing
+    execute service in production wiring.
+    """
+    resource = await fetch_mcp_resource(catalog_service, path, version)
+    spec = resource.get("spec") or {}
+    lifecycle = spec.get("lifecycle") or {}
+    agent_path = lifecycle.get(verb)
+    if not agent_path:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Mcp resource '{path}' does not declare lifecycle verb '{verb}' "
+                f"(known verbs: {sorted(lifecycle.keys())})"
+            ),
+        )
+
+    workload = {
+        "mcp_resource": {
+            "path": path,
+            "version": resource["_catalog"]["version"],
+            "spec": spec,
+            "metadata": resource.get("metadata") or {},
+        },
+        "verb": verb,
+    }
+    if workload_overrides:
+        workload.update(workload_overrides)
+
+    execution_id = await execute_callable(path=agent_path, workload=workload)
+
+    return mcp_schema.McpLifecycleResponse(
+        status="started",
+        verb=verb,
+        mcp_path=path,
+        mcp_version=int(resource["_catalog"]["version"]),
+        agent_path=str(agent_path),
+        execution_id=str(execution_id),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_discover(
+    *,
+    catalog_service,
+    execute_callable,
+    fetch_url_callable,
+    register_callable,
+    path: str,
+    version: Any,
+    force: bool,
+) -> mcp_schema.McpDiscoverResponse:
+    """Refresh the Mcp resource's tools list.
+
+    Strategy 1 -- agent: when spec.discovery.refresh_via is set, dispatch
+    that Agent playbook and return immediately. The agent is responsible
+    for re-registering the catalog entry.
+
+    Strategy 2 -- direct: when spec.discovery.tools_list_url is set,
+    fetch the URL, parse `tools`, diff against current spec.tools, and
+    re-register a new catalog version when changed (or always when
+    force=True).
+    """
+    resource = await fetch_mcp_resource(catalog_service, path, version)
+    spec = resource.get("spec") or {}
+    discovery = spec.get("discovery") or {}
+    refresh_via = discovery.get("refresh_via")
+    tools_list_url = discovery.get("tools_list_url")
+
+    if refresh_via:
+        execution_id = await execute_callable(
+            path=refresh_via,
+            workload={
+                "mcp_resource": {
+                    "path": path,
+                    "version": resource["_catalog"]["version"],
+                    "spec": spec,
+                    "metadata": resource.get("metadata") or {},
+                },
+                "verb": "discover",
+                "force": force,
+            },
+        )
+        return mcp_schema.McpDiscoverResponse(
+            status="started",
+            mcp_path=path,
+            mcp_version_old=int(resource["_catalog"]["version"]),
+            mcp_version_new=None,
+            strategy="agent",
+            execution_id=str(execution_id),
+        )
+
+    if tools_list_url:
+        body = await fetch_url_callable(tools_list_url)
+        try:
+            payload = json.loads(body) if isinstance(body, (str, bytes)) else body
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"discovery URL returned non-JSON body: {exc}",
+            ) from exc
+
+        new_tools = payload.get("tools") if isinstance(payload, dict) else None
+        if not isinstance(new_tools, list):
+            raise HTTPException(
+                status_code=502,
+                detail="discovery URL must return {'tools': [...]} JSON",
+            )
+
+        old_tools = spec.get("tools") if isinstance(spec.get("tools"), list) else []
+        old_count = len(old_tools)
+        new_count = len(new_tools)
+        changed = force or _tool_lists_differ(old_tools, new_tools)
+
+        new_version = None
+        if changed:
+            spec_copy = dict(spec)
+            spec_copy["tools"] = new_tools
+            updated_doc = dict(resource)
+            updated_doc.pop("_catalog", None)
+            updated_doc["spec"] = spec_copy
+            new_yaml = _yaml.safe_dump(updated_doc, sort_keys=False)
+            register = await register_callable(content=new_yaml, resource_type="mcp")
+            new_version = int(register.get("version"))
+
+        return mcp_schema.McpDiscoverResponse(
+            status="updated" if changed else "started",
+            mcp_path=path,
+            mcp_version_old=int(resource["_catalog"]["version"]),
+            mcp_version_new=new_version,
+            strategy="direct",
+            execution_id=None,
+            tool_count_before=old_count,
+            tool_count_after=new_count,
+        )
+
+    raise HTTPException(
+        status_code=422,
+        detail=(
+            f"Mcp resource '{path}' has no discovery configured "
+            "(set spec.discovery.refresh_via or spec.discovery.tools_list_url)"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# UI schema inference
+# ---------------------------------------------------------------------------
+
+
+async def build_ui_schema(catalog_service, path: str, version: Any) -> mcp_schema.UiSchemaResponse:
+    entry = await fetch_any_resource(catalog_service, path, version)
+    payload = entry.get("payload") or _parse_yaml_string(entry.get("content")) or {}
+    metadata = payload.get("metadata") or {}
+    fields = infer_ui_schema(entry.get("content") or "")
+    return mcp_schema.UiSchemaResponse(
+        path=str(entry.get("path") or path),
+        version=int(entry.get("version") or 0),
+        kind=str(entry.get("kind") or "").lower(),
+        title=metadata.get("name") if isinstance(metadata, dict) else None,
+        description_markdown=metadata.get("description") if isinstance(metadata, dict) else None,
+        exposed_in_ui=bool((metadata or {}).get("exposed_in_ui", False)) if isinstance(metadata, dict) else False,
+        fields=fields,
+        generated_at=datetime.now(timezone.utc),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_yaml_string(content: Any) -> Optional[dict[str, Any]]:
+    if not isinstance(content, str) or not content.strip():
+        return None
+    try:
+        parsed = _yaml.safe_load(content)
+    except Exception:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _tool_lists_differ(old_tools: list[Any], new_tools: list[Any]) -> bool:
+    def _normalize(items: list[Any]) -> list[tuple[str, str]]:
+        out: list[tuple[str, str]] = []
+        for item in items:
+            if isinstance(item, dict):
+                out.append((str(item.get("name") or ""), str(item.get("title") or "")))
+            else:
+                out.append((str(item), ""))
+        return sorted(out)
+
+    return _normalize(old_tools) != _normalize(new_tools)

--- a/noetl/server/api/mcp/service.py
+++ b/noetl/server/api/mcp/service.py
@@ -64,19 +64,70 @@ async def fetch_any_resource(catalog_service, path: str, version: Any) -> dict[s
 
 
 async def _fetch_entry(catalog_service, path: str, version: Any) -> dict[str, Any]:
+    """Look up a catalog entry and normalize the result to a plain dict.
+
+    The real ``CatalogService`` exposes its lookups as static methods —
+    most callers pass the class itself rather than an instance. The
+    canonical method is ``fetch_entry(path=..., version=...)`` which
+    returns a ``CatalogEntry`` Pydantic model. We probe for
+    ``fetch_entry`` first (the contract the rest of the server uses) and
+    fall back to ``get`` if a future refactor moves the surface around.
+    Tests can pass an arbitrary object that exposes either method.
+    """
     if catalog_service is None:
+        raise HTTPException(status_code=503, detail="catalog service unavailable")
+
+    fetcher = getattr(catalog_service, "fetch_entry", None) or getattr(
+        catalog_service, "get", None
+    )
+    if fetcher is None:
+        logger.warning(
+            "catalog service does not expose fetch_entry/get for %s@%s",
+            path,
+            version,
+        )
         raise HTTPException(status_code=503, detail="catalog service unavailable")
 
     requested_version = "latest" if version in (None, "", "latest") else version
     try:
-        entry = await catalog_service.get_entry(path=path, version=requested_version)
+        entry = await fetcher(path=path, version=requested_version)
     except Exception as exc:  # pragma: no cover -- service-layer error surface varies
         logger.warning("catalog lookup failed for %s@%s: %s", path, requested_version, exc)
-        raise HTTPException(status_code=404, detail=f"resource not found: {path}@{requested_version}") from exc
+        raise HTTPException(
+            status_code=404,
+            detail=f"resource not found: {path}@{requested_version}",
+        ) from exc
 
     if not entry:
-        raise HTTPException(status_code=404, detail=f"resource not found: {path}@{requested_version}")
-    return entry
+        raise HTTPException(
+            status_code=404,
+            detail=f"resource not found: {path}@{requested_version}",
+        )
+
+    return _normalize_entry(entry)
+
+
+def _normalize_entry(entry: Any) -> dict[str, Any]:
+    """Return a plain dict view of a catalog entry.
+
+    Pydantic models go through ``model_dump`` (which serialises nested
+    models too); dicts pass through unchanged; anything else gets a
+    ``__dict__`` snapshot as a last resort. Test fakes that yield dicts
+    directly stay supported.
+    """
+    if isinstance(entry, dict):
+        return entry
+    if hasattr(entry, "model_dump"):
+        dumped = entry.model_dump()
+        if isinstance(dumped, dict):
+            return dumped
+    fallback = getattr(entry, "__dict__", None)
+    if isinstance(fallback, dict):
+        return dict(fallback)
+    raise HTTPException(
+        status_code=500,
+        detail=f"catalog entry has unsupported type: {type(entry).__name__}",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/noetl/server/api/mcp/ui_schema.py
+++ b/noetl/server/api/mcp/ui_schema.py
@@ -3,16 +3,26 @@
 Public entry point: ``infer_ui_schema(yaml_content) -> list[UiSchemaField]``.
 
 Approach:
-- Parse the YAML *with comments preserved* via ruamel.yaml so we can
-  read `# ui:` directives next to scalar keys.
-- For each top-level key under ``workload:``, build a UiSchemaField from
-  the value's type plus any directives.
-- Recurse for nested mappings; lists of scalars become ``kind=array``.
 
-The inference is intentionally forgiving: if a comment is malformed or
-ruamel can't load the document, we fall back to plain PyYAML and emit
-a flat schema with no directives. Callers should treat the returned
-schema as a best-effort hint, not a strict contract.
+- Parse the document with plain PyYAML for the structural shape (no
+  extra dependency on ruamel).
+- Scan the raw text for inline ``# ui:`` directives next to the line
+  that defines each workload key. The directive parser is a small
+  regex; it ignores anything it can't recognise so a malformed
+  comment never breaks registration.
+
+Supported directives (always after the key/value on the same line):
+
+- ``# ui:secret`` -- mark the field as masked input.
+- ``# ui:enum=[a,b,c]`` -- force ``kind=enum`` and populate options.
+- ``# ui:credential=pg_*`` -- restrict to a credential picker
+  filtered by glob.
+- ``# ui:description=Some help text`` -- per-field description.
+
+The inference is intentionally forgiving: malformed YAML or unknown
+directives just return an empty / less-rich schema rather than
+raising. Callers should treat the returned schema as a best-effort
+hint, not a strict contract.
 """
 
 from __future__ import annotations
@@ -20,21 +30,22 @@ from __future__ import annotations
 import re
 from typing import Any, Iterable, Optional
 
-import yaml as _plain_yaml
-
-try:
-    from ruamel.yaml import YAML  # type: ignore[import-not-found]
-
-    _RUAMEL_AVAILABLE = True
-except Exception:  # pragma: no cover -- ruamel always available in our deps
-    _RUAMEL_AVAILABLE = False
-    YAML = None  # type: ignore[assignment]
+import yaml as _yaml
 
 from .schema import UiSchemaField
 
 
-_UI_DIRECTIVE_RE = re.compile(r"^\s*#\s*ui:(?P<key>[a-zA-Z_][a-zA-Z0-9_]*)\s*=?\s*(?P<value>.*)$")
-_UI_FLAG_RE = re.compile(r"^\s*#\s*ui:(?P<key>[a-zA-Z_][a-zA-Z0-9_]*)\s*$")
+# Match an inline directive like `key: value # ui:secret` or
+# `key: value # ui:enum=[a,b]`. The leading capture lets us strip the
+# directive itself before parsing the value with PyYAML.
+_DIRECTIVE_INLINE_RE = re.compile(
+    r"#\s*ui:(?P<key>[A-Za-z_][A-Za-z0-9_]*)(?:\s*=\s*(?P<value>[^\n]*))?$"
+)
+
+# Match the start of a top-level workload key line so we can correlate
+# the parsed dict back to the raw text. We require at least two leading
+# spaces so we don't mistake `workload:` itself for one of its keys.
+_TOP_KEY_RE = re.compile(r"^(?P<indent> {2})(?P<name>[A-Za-z_][A-Za-z0-9_-]*)\s*:")
 
 
 def infer_ui_schema(yaml_text: str) -> list[UiSchemaField]:
@@ -45,40 +56,28 @@ def infer_ui_schema(yaml_text: str) -> list[UiSchemaField]:
     if not yaml_text or not yaml_text.strip():
         return []
 
-    parsed = _load_with_comments(yaml_text) or _load_plain(yaml_text)
-    if parsed is None:
-        return []
-
+    parsed = _load_yaml(yaml_text)
     workload = _get_workload(parsed)
     if workload is None:
         return []
 
+    directives = _scan_inline_directives(yaml_text)
     fields: list[UiSchemaField] = []
-    for key, value in _iter_mapping_items(workload):
-        directives = _read_directives(workload, key)
-        fields.append(_field_from_value(str(key), value, directives))
+    for key, value in workload.items():
+        fields.append(
+            _field_from_value(str(key), value, directives.get(str(key), {}))
+        )
     return fields
 
 
 # ---------------------------------------------------------------------------
-# Internals
+# YAML helpers
 # ---------------------------------------------------------------------------
 
 
-def _load_with_comments(yaml_text: str):
-    if not _RUAMEL_AVAILABLE:
-        return None
+def _load_yaml(yaml_text: str) -> Any:
     try:
-        loader = YAML(typ="rt")
-        loader.preserve_quotes = True
-        return loader.load(yaml_text)
-    except Exception:
-        return None
-
-
-def _load_plain(yaml_text: str):
-    try:
-        return _plain_yaml.safe_load(yaml_text)
+        return _yaml.safe_load(yaml_text)
     except Exception:
         return None
 
@@ -92,64 +91,78 @@ def _get_workload(doc: Any) -> Optional[dict[str, Any]]:
     return workload
 
 
-def _iter_mapping_items(mapping: Any) -> Iterable[tuple[Any, Any]]:
-    if hasattr(mapping, "items"):
-        return list(mapping.items())
-    return []
+# ---------------------------------------------------------------------------
+# Comment scanning
+# ---------------------------------------------------------------------------
 
 
-def _read_directives(mapping: Any, key: Any) -> dict[str, Any]:
-    """Pull `# ui:foo=bar` directives from comments adjacent to a key.
+def _scan_inline_directives(yaml_text: str) -> dict[str, dict[str, Any]]:
+    """Walk the raw text once and pull `# ui:` directives per top-level key.
 
-    Returns a mapping of directive name -> value. Flag-style directives
-    (``# ui:secret``) map to True. Returns an empty dict when ruamel is
-    not in use or the key has no comments.
+    Returns a mapping of ``key_name -> directive_dict`` where the
+    directive dict has entries like ``{"secret": True, "enum":
+    ["a", "b"], "description": "...", "credential": "pg_*"}``.
+
+    Only inline comments on the same line as the key/value are
+    considered. The implementation deliberately ignores keys nested
+    deeper than the immediate workload children — Phase 1 covers the
+    flat case the GUI run-dialog needs first.
     """
-    out: dict[str, Any] = {}
-    ca = getattr(mapping, "ca", None)
-    if ca is None:
-        return out
+    out: dict[str, dict[str, Any]] = {}
+    in_workload = False
+    workload_indent = -1
 
-    items_meta = getattr(ca, "items", None)
-    if not items_meta:
-        return out
+    for line in yaml_text.splitlines():
+        stripped = line.lstrip()
+        if not stripped:
+            continue
+        if stripped.startswith("workload:"):
+            in_workload = True
+            workload_indent = len(line) - len(stripped)
+            continue
+        if not in_workload:
+            continue
 
-    raw = items_meta.get(key)
-    if not raw:
-        return out
+        indent = len(line) - len(stripped)
+        if stripped and indent <= workload_indent and not line.startswith(" "):
+            # Left the workload block.
+            in_workload = False
+            continue
 
-    # ruamel stores comments as a 4-tuple [pre, post, eol, multi]; the
-    # exact slot depends on whether the comment is on the same line as
-    # the key (eol) or above it. We inspect every slot and union them.
-    for entry in raw:
-        for token in _flatten_tokens(entry):
-            text = getattr(token, "value", None) or str(token)
-            if not text or "ui:" not in text:
-                continue
-            for line in text.splitlines():
-                line = line.rstrip()
-                if not line:
-                    continue
-                m = _UI_DIRECTIVE_RE.match(line)
-                if m and m.group("value").strip() != "":
-                    out[m.group("key")] = _parse_directive_value(m.group("value"))
-                    continue
-                m = _UI_FLAG_RE.match(line)
-                if m:
-                    out[m.group("key")] = True
+        match = _TOP_KEY_RE.match(line)
+        if not match:
+            continue
+        key_name = match.group("name")
+        directives = _extract_directives_from_line(line)
+        if directives:
+            out[key_name] = directives
+
     return out
 
 
-def _flatten_tokens(entry: Any) -> Iterable[Any]:
-    """Yield comment tokens from a ruamel comment entry, ignoring None."""
-    if entry is None:
-        return []
-    if isinstance(entry, list):
-        flat: list[Any] = []
-        for sub in entry:
-            flat.extend(_flatten_tokens(sub))
-        return flat
-    return [entry]
+def _extract_directives_from_line(line: str) -> dict[str, Any]:
+    """Pull every `# ui:foo` and `# ui:foo=bar` token from one raw line."""
+    out: dict[str, Any] = {}
+    # `# ui:` may appear more than once on a line, though rare. Find them
+    # all by repeatedly matching from the position after each hit.
+    cursor = 0
+    while True:
+        idx = line.find("# ui:", cursor)
+        if idx == -1:
+            break
+        rest = line[idx:]
+        # The directive runs until end-of-line. The regex grabs the key
+        # plus optional value.
+        m = _DIRECTIVE_INLINE_RE.search(rest)
+        if not m:
+            break
+        key = m.group("key")
+        raw_value = (m.group("value") or "").strip()
+        out[key] = _parse_directive_value(raw_value) if raw_value else True
+        cursor = idx + len(m.group(0))
+        if cursor >= len(line):
+            break
+    return out
 
 
 def _parse_directive_value(text: str) -> Any:
@@ -160,12 +173,17 @@ def _parse_directive_value(text: str) -> Any:
         if not inner:
             return []
         return [piece.strip().strip("'\"") for piece in inner.split(",") if piece.strip()]
-    # quoted
+    # quoted single value
     if (text.startswith("'") and text.endswith("'")) or (
         text.startswith('"') and text.endswith('"')
     ):
         return text[1:-1]
     return text
+
+
+# ---------------------------------------------------------------------------
+# Field construction
+# ---------------------------------------------------------------------------
 
 
 def _field_from_value(name: str, value: Any, directives: dict[str, Any]) -> UiSchemaField:
@@ -197,13 +215,13 @@ def _field_from_value(name: str, value: Any, directives: dict[str, Any]) -> UiSc
         kind = "null"
     elif isinstance(value, dict):
         children = [
-            _field_from_value(str(k), v, _read_directives(value, k))
-            for k, v in _iter_mapping_items(value)
+            _field_from_value(str(k), v, {})
+            for k, v in value.items()
         ]
         return UiSchemaField(
             name=name,
             kind="object",
-            default=_clean_default(value),
+            default=value,
             description=description,
             secret=secret,
             credential_glob=credential_glob if isinstance(credential_glob, str) else None,
@@ -217,17 +235,8 @@ def _field_from_value(name: str, value: Any, directives: dict[str, Any]) -> UiSc
     return UiSchemaField(
         name=name,
         kind=kind,
-        default=_clean_default(value),
+        default=value,
         description=description,
         secret=secret,
         credential_glob=credential_glob if isinstance(credential_glob, str) else None,
     )
-
-
-def _clean_default(value: Any) -> Any:
-    """Strip ruamel comment metadata from defaults so they JSON-serialize cleanly."""
-    if isinstance(value, dict):
-        return {k: _clean_default(v) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_clean_default(v) for v in value]
-    return value

--- a/noetl/server/api/mcp/ui_schema.py
+++ b/noetl/server/api/mcp/ui_schema.py
@@ -1,0 +1,233 @@
+"""Workload form inference from a playbook / agent YAML payload.
+
+Public entry point: ``infer_ui_schema(yaml_content) -> list[UiSchemaField]``.
+
+Approach:
+- Parse the YAML *with comments preserved* via ruamel.yaml so we can
+  read `# ui:` directives next to scalar keys.
+- For each top-level key under ``workload:``, build a UiSchemaField from
+  the value's type plus any directives.
+- Recurse for nested mappings; lists of scalars become ``kind=array``.
+
+The inference is intentionally forgiving: if a comment is malformed or
+ruamel can't load the document, we fall back to plain PyYAML and emit
+a flat schema with no directives. Callers should treat the returned
+schema as a best-effort hint, not a strict contract.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable, Optional
+
+import yaml as _plain_yaml
+
+try:
+    from ruamel.yaml import YAML  # type: ignore[import-not-found]
+
+    _RUAMEL_AVAILABLE = True
+except Exception:  # pragma: no cover -- ruamel always available in our deps
+    _RUAMEL_AVAILABLE = False
+    YAML = None  # type: ignore[assignment]
+
+from .schema import UiSchemaField
+
+
+_UI_DIRECTIVE_RE = re.compile(r"^\s*#\s*ui:(?P<key>[a-zA-Z_][a-zA-Z0-9_]*)\s*=?\s*(?P<value>.*)$")
+_UI_FLAG_RE = re.compile(r"^\s*#\s*ui:(?P<key>[a-zA-Z_][a-zA-Z0-9_]*)\s*$")
+
+
+def infer_ui_schema(yaml_text: str) -> list[UiSchemaField]:
+    """Return ordered top-level workload fields inferred from the YAML.
+
+    Empty list when the document has no `workload:` block.
+    """
+    if not yaml_text or not yaml_text.strip():
+        return []
+
+    parsed = _load_with_comments(yaml_text) or _load_plain(yaml_text)
+    if parsed is None:
+        return []
+
+    workload = _get_workload(parsed)
+    if workload is None:
+        return []
+
+    fields: list[UiSchemaField] = []
+    for key, value in _iter_mapping_items(workload):
+        directives = _read_directives(workload, key)
+        fields.append(_field_from_value(str(key), value, directives))
+    return fields
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _load_with_comments(yaml_text: str):
+    if not _RUAMEL_AVAILABLE:
+        return None
+    try:
+        loader = YAML(typ="rt")
+        loader.preserve_quotes = True
+        return loader.load(yaml_text)
+    except Exception:
+        return None
+
+
+def _load_plain(yaml_text: str):
+    try:
+        return _plain_yaml.safe_load(yaml_text)
+    except Exception:
+        return None
+
+
+def _get_workload(doc: Any) -> Optional[dict[str, Any]]:
+    if not isinstance(doc, dict):
+        return None
+    workload = doc.get("workload")
+    if not isinstance(workload, dict):
+        return None
+    return workload
+
+
+def _iter_mapping_items(mapping: Any) -> Iterable[tuple[Any, Any]]:
+    if hasattr(mapping, "items"):
+        return list(mapping.items())
+    return []
+
+
+def _read_directives(mapping: Any, key: Any) -> dict[str, Any]:
+    """Pull `# ui:foo=bar` directives from comments adjacent to a key.
+
+    Returns a mapping of directive name -> value. Flag-style directives
+    (``# ui:secret``) map to True. Returns an empty dict when ruamel is
+    not in use or the key has no comments.
+    """
+    out: dict[str, Any] = {}
+    ca = getattr(mapping, "ca", None)
+    if ca is None:
+        return out
+
+    items_meta = getattr(ca, "items", None)
+    if not items_meta:
+        return out
+
+    raw = items_meta.get(key)
+    if not raw:
+        return out
+
+    # ruamel stores comments as a 4-tuple [pre, post, eol, multi]; the
+    # exact slot depends on whether the comment is on the same line as
+    # the key (eol) or above it. We inspect every slot and union them.
+    for entry in raw:
+        for token in _flatten_tokens(entry):
+            text = getattr(token, "value", None) or str(token)
+            if not text or "ui:" not in text:
+                continue
+            for line in text.splitlines():
+                line = line.rstrip()
+                if not line:
+                    continue
+                m = _UI_DIRECTIVE_RE.match(line)
+                if m and m.group("value").strip() != "":
+                    out[m.group("key")] = _parse_directive_value(m.group("value"))
+                    continue
+                m = _UI_FLAG_RE.match(line)
+                if m:
+                    out[m.group("key")] = True
+    return out
+
+
+def _flatten_tokens(entry: Any) -> Iterable[Any]:
+    """Yield comment tokens from a ruamel comment entry, ignoring None."""
+    if entry is None:
+        return []
+    if isinstance(entry, list):
+        flat: list[Any] = []
+        for sub in entry:
+            flat.extend(_flatten_tokens(sub))
+        return flat
+    return [entry]
+
+
+def _parse_directive_value(text: str) -> Any:
+    text = text.strip()
+    # ui:enum=[a,b,c]
+    if text.startswith("[") and text.endswith("]"):
+        inner = text[1:-1].strip()
+        if not inner:
+            return []
+        return [piece.strip().strip("'\"") for piece in inner.split(",") if piece.strip()]
+    # quoted
+    if (text.startswith("'") and text.endswith("'")) or (
+        text.startswith('"') and text.endswith('"')
+    ):
+        return text[1:-1]
+    return text
+
+
+def _field_from_value(name: str, value: Any, directives: dict[str, Any]) -> UiSchemaField:
+    description = directives.get("description")
+    if isinstance(description, list):
+        description = ", ".join(str(part) for part in description)
+    secret = bool(directives.get("secret", False))
+    credential_glob = directives.get("credential")
+    enum_options = directives.get("enum")
+
+    if enum_options is not None:
+        return UiSchemaField(
+            name=name,
+            kind="enum",
+            default=value,
+            description=description,
+            secret=secret,
+            credential_glob=credential_glob if isinstance(credential_glob, str) else None,
+            options=list(enum_options) if isinstance(enum_options, (list, tuple)) else [enum_options],
+        )
+
+    if isinstance(value, bool):
+        kind = "boolean"
+    elif isinstance(value, int):
+        kind = "integer"
+    elif isinstance(value, float):
+        kind = "number"
+    elif value is None:
+        kind = "null"
+    elif isinstance(value, dict):
+        children = [
+            _field_from_value(str(k), v, _read_directives(value, k))
+            for k, v in _iter_mapping_items(value)
+        ]
+        return UiSchemaField(
+            name=name,
+            kind="object",
+            default=_clean_default(value),
+            description=description,
+            secret=secret,
+            credential_glob=credential_glob if isinstance(credential_glob, str) else None,
+            children=children,
+        )
+    elif isinstance(value, list):
+        kind = "array"
+    else:
+        kind = "string"
+
+    return UiSchemaField(
+        name=name,
+        kind=kind,
+        default=_clean_default(value),
+        description=description,
+        secret=secret,
+        credential_glob=credential_glob if isinstance(credential_glob, str) else None,
+    )
+
+
+def _clean_default(value: Any) -> Any:
+    """Strip ruamel comment metadata from defaults so they JSON-serialize cleanly."""
+    if isinstance(value, dict):
+        return {k: _clean_default(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_clean_default(v) for v in value]
+    return value

--- a/tests/unit/server/api/mcp/test_discover_dispatch.py
+++ b/tests/unit/server/api/mcp/test_discover_dispatch.py
@@ -1,0 +1,251 @@
+"""Tests for the MCP discovery dispatch helper.
+
+Covers both strategies:
+
+- ``refresh_via`` agent dispatch (returns ``status='started'`` and an
+  ``execution_id``).
+- direct ``tools_list_url`` fetch with diff + re-register.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+from pydantic import BaseModel
+
+from noetl.server.api.mcp.service import dispatch_discover
+
+
+class _CatalogEntryStub(BaseModel):
+    catalog_id: str
+    path: str
+    version: int
+    kind: str
+    payload: dict[str, Any] | None = None
+    content: str | None = None
+
+
+class _FakeCatalogService:
+    def __init__(self, entry: _CatalogEntryStub):
+        self.entry = entry
+
+    async def fetch_entry(self, *, path: str, version: Any):
+        return self.entry
+
+
+def _mcp_entry(*, lifecycle: dict[str, str] | None = None,
+               discovery: dict[str, str] | None = None,
+               tools: list[dict[str, str]] | None = None) -> _CatalogEntryStub:
+    spec: dict[str, Any] = {}
+    if lifecycle:
+        spec["lifecycle"] = lifecycle
+    if discovery:
+        spec["discovery"] = discovery
+    if tools is not None:
+        spec["tools"] = tools
+    return _CatalogEntryStub(
+        catalog_id="100",
+        path="mcp/kubernetes",
+        version=3,
+        kind="Mcp",
+        payload={"metadata": {"name": "kubernetes"}, "spec": spec},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Strategy 1 -- refresh_via agent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_via_dispatches_agent_and_returns_started():
+    entry = _mcp_entry(discovery={"refresh_via": "agents/k8s/discover"})
+    captured: dict[str, Any] = {}
+
+    async def fake_execute(*, path: str, workload: dict[str, Any]) -> str:
+        captured["path"] = path
+        captured["workload"] = workload
+        return "exec-77"
+
+    async def unused_fetch(_: str) -> str:  # pragma: no cover -- agent path skips it
+        raise AssertionError("fetch_url should not be called for refresh_via")
+
+    async def unused_register(**_: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("register should not be called for refresh_via")
+
+    response = await dispatch_discover(
+        catalog_service=_FakeCatalogService(entry),
+        execute_callable=fake_execute,
+        fetch_url_callable=unused_fetch,
+        register_callable=unused_register,
+        path="mcp/kubernetes",
+        version="latest",
+        force=False,
+    )
+
+    assert response.status == "started"
+    assert response.strategy == "agent"
+    assert response.execution_id == "exec-77"
+    assert captured["path"] == "agents/k8s/discover"
+    assert captured["workload"]["mcp_resource"]["path"] == "mcp/kubernetes"
+
+
+# ---------------------------------------------------------------------------
+# Strategy 2 -- direct tools_list_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_direct_fetch_re_registers_when_tool_list_changes():
+    entry = _mcp_entry(
+        discovery={"tools_list_url": "http://kubernetes-mcp-server.mcp.svc/tools"},
+        tools=[{"name": "pods_list_in_namespace"}],
+    )
+    captured: dict[str, Any] = {}
+
+    async def fake_fetch(url: str) -> str:
+        captured["url"] = url
+        return json.dumps(
+            {"tools": [
+                {"name": "pods_list_in_namespace"},
+                {"name": "namespaces_list"},
+            ]}
+        )
+
+    async def fake_register(*, content: str, resource_type: str) -> dict[str, Any]:
+        captured["content"] = content
+        captured["resource_type"] = resource_type
+        return {"version": 4}
+
+    async def unused_execute(**_: Any) -> str:  # pragma: no cover
+        raise AssertionError("execute should not be called in direct strategy")
+
+    response = await dispatch_discover(
+        catalog_service=_FakeCatalogService(entry),
+        execute_callable=unused_execute,
+        fetch_url_callable=fake_fetch,
+        register_callable=fake_register,
+        path="mcp/kubernetes",
+        version="latest",
+        force=False,
+    )
+
+    assert response.status == "updated"
+    assert response.strategy == "direct"
+    assert response.mcp_version_old == 3
+    assert response.mcp_version_new == 4
+    assert response.tool_count_before == 1
+    assert response.tool_count_after == 2
+    # The newly-registered YAML should contain both tool names.
+    assert "namespaces_list" in captured["content"]
+    assert captured["resource_type"] == "mcp"
+
+
+@pytest.mark.asyncio
+async def test_direct_fetch_does_not_re_register_when_tool_list_unchanged():
+    entry = _mcp_entry(
+        discovery={"tools_list_url": "http://kubernetes-mcp-server.mcp.svc/tools"},
+        tools=[{"name": "pods_list_in_namespace"}],
+    )
+
+    async def fake_fetch(_: str) -> str:
+        return json.dumps({"tools": [{"name": "pods_list_in_namespace"}]})
+
+    async def fail_register(**_: Any) -> dict[str, Any]:
+        raise AssertionError("register should not fire when nothing changed")
+
+    response = await dispatch_discover(
+        catalog_service=_FakeCatalogService(entry),
+        execute_callable=lambda **_: "noop",  # type: ignore[arg-type]
+        fetch_url_callable=fake_fetch,
+        register_callable=fail_register,
+        path="mcp/kubernetes",
+        version="latest",
+        force=False,
+    )
+
+    assert response.status == "started"  # i.e. queried but no version bump
+    assert response.mcp_version_new is None
+    assert response.tool_count_before == 1
+    assert response.tool_count_after == 1
+
+
+@pytest.mark.asyncio
+async def test_direct_fetch_force_re_registers_even_without_diff():
+    entry = _mcp_entry(
+        discovery={"tools_list_url": "http://kubernetes-mcp-server.mcp.svc/tools"},
+        tools=[{"name": "pods_list_in_namespace"}],
+    )
+    captured: dict[str, Any] = {}
+
+    async def fake_fetch(_: str) -> str:
+        return json.dumps({"tools": [{"name": "pods_list_in_namespace"}]})
+
+    async def fake_register(*, content: str, resource_type: str) -> dict[str, Any]:
+        captured["resource_type"] = resource_type
+        return {"version": 5}
+
+    response = await dispatch_discover(
+        catalog_service=_FakeCatalogService(entry),
+        execute_callable=lambda **_: "noop",  # type: ignore[arg-type]
+        fetch_url_callable=fake_fetch,
+        register_callable=fake_register,
+        path="mcp/kubernetes",
+        version="latest",
+        force=True,
+    )
+
+    assert response.status == "updated"
+    assert response.mcp_version_new == 5
+    assert captured["resource_type"] == "mcp"
+
+
+@pytest.mark.asyncio
+async def test_direct_fetch_502s_on_invalid_json():
+    entry = _mcp_entry(
+        discovery={"tools_list_url": "http://kubernetes-mcp-server.mcp.svc/tools"},
+    )
+
+    async def fake_fetch(_: str) -> str:
+        return "<html>not json</html>"
+
+    async def unused_execute(**_: Any) -> str:  # pragma: no cover
+        return "noop"
+
+    async def unused_register(**_: Any) -> dict[str, Any]:  # pragma: no cover
+        return {}
+
+    with pytest.raises(HTTPException) as info:
+        await dispatch_discover(
+            catalog_service=_FakeCatalogService(entry),
+            execute_callable=unused_execute,
+            fetch_url_callable=fake_fetch,
+            register_callable=unused_register,
+            path="mcp/kubernetes",
+            version="latest",
+            force=False,
+        )
+    assert info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_422_when_neither_strategy_configured():
+    entry = _mcp_entry(discovery=None)
+
+    async def unused(*_: Any, **__: Any) -> Any:  # pragma: no cover
+        raise AssertionError("not reached")
+
+    with pytest.raises(HTTPException) as info:
+        await dispatch_discover(
+            catalog_service=_FakeCatalogService(entry),
+            execute_callable=unused,
+            fetch_url_callable=unused,
+            register_callable=unused,
+            path="mcp/kubernetes",
+            version="latest",
+            force=False,
+        )
+    assert info.value.status_code == 422

--- a/tests/unit/server/api/mcp/test_lifecycle_dispatch.py
+++ b/tests/unit/server/api/mcp/test_lifecycle_dispatch.py
@@ -1,0 +1,111 @@
+"""Tests for the lifecycle dispatch service helper."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from noetl.server.api.mcp.service import dispatch_lifecycle
+
+
+class _FakeCatalogService:
+    """Minimal stand-in implementing the get_entry contract used here."""
+
+    def __init__(self, entry: dict[str, Any] | None = None):
+        self.entry = entry
+
+    async def get_entry(self, *, path: str, version: Any):
+        return self.entry
+
+
+@pytest.mark.asyncio
+async def test_dispatch_resolves_lifecycle_to_agent_and_returns_execution_id():
+    entry = {
+        "catalog_id": "100",
+        "path": "mcp/kubernetes",
+        "version": 4,
+        "kind": "Mcp",
+        "payload": {
+            "metadata": {"name": "kubernetes"},
+            "spec": {
+                "lifecycle": {
+                    "deploy": "automation/agents/kubernetes/lifecycle/deploy",
+                },
+            },
+        },
+    }
+    captured: dict[str, Any] = {}
+
+    async def fake_execute(*, path: str, workload: dict[str, Any]) -> str:
+        captured["path"] = path
+        captured["workload"] = workload
+        return "exec-42"
+
+    response = await dispatch_lifecycle(
+        catalog_service=_FakeCatalogService(entry),
+        execute_callable=fake_execute,
+        path="mcp/kubernetes",
+        verb="deploy",
+        version="latest",
+    )
+
+    assert response.status == "started"
+    assert response.verb == "deploy"
+    assert response.mcp_path == "mcp/kubernetes"
+    assert response.mcp_version == 4
+    assert response.agent_path == "automation/agents/kubernetes/lifecycle/deploy"
+    assert response.execution_id == "exec-42"
+    assert captured["path"] == "automation/agents/kubernetes/lifecycle/deploy"
+    assert captured["workload"]["mcp_resource"]["path"] == "mcp/kubernetes"
+    assert captured["workload"]["verb"] == "deploy"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_422s_when_verb_is_not_in_lifecycle():
+    entry = {
+        "catalog_id": "100",
+        "path": "mcp/kubernetes",
+        "version": 1,
+        "kind": "Mcp",
+        "payload": {"spec": {"lifecycle": {"status": "agents/k8s/status"}}},
+    }
+
+    async def fake_execute(**_: Any) -> str:  # pragma: no cover -- not reached
+        return "should-not-run"
+
+    with pytest.raises(HTTPException) as info:
+        await dispatch_lifecycle(
+            catalog_service=_FakeCatalogService(entry),
+            execute_callable=fake_execute,
+            path="mcp/kubernetes",
+            verb="redeploy",
+            version="latest",
+        )
+    assert info.value.status_code == 422
+    assert "redeploy" in info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_dispatch_400s_when_resource_kind_is_not_mcp():
+    entry = {
+        "catalog_id": "100",
+        "path": "mcp/kubernetes",
+        "version": 1,
+        "kind": "Playbook",
+        "payload": {"spec": {}},
+    }
+
+    async def fake_execute(**_: Any) -> str:  # pragma: no cover
+        return "noop"
+
+    with pytest.raises(HTTPException) as info:
+        await dispatch_lifecycle(
+            catalog_service=_FakeCatalogService(entry),
+            execute_callable=fake_execute,
+            path="mcp/kubernetes",
+            verb="deploy",
+            version="latest",
+        )
+    assert info.value.status_code == 400

--- a/tests/unit/server/api/mcp/test_lifecycle_dispatch.py
+++ b/tests/unit/server/api/mcp/test_lifecycle_dispatch.py
@@ -6,28 +6,46 @@ from typing import Any
 
 import pytest
 from fastapi import HTTPException
+from pydantic import BaseModel
 
 from noetl.server.api.mcp.service import dispatch_lifecycle
 
 
-class _FakeCatalogService:
-    """Minimal stand-in implementing the get_entry contract used here."""
+class _CatalogEntryStub(BaseModel):
+    """Minimal stand-in for noetl.server.api.catalog.CatalogEntry.
 
-    def __init__(self, entry: dict[str, Any] | None = None):
+    Matches the fields the service actually reads (``catalog_id``,
+    ``path``, ``version``, ``kind``, ``payload``, ``content``) so the
+    Pydantic ``model_dump`` path through ``_normalize_entry`` is
+    exercised the same way it would be in production.
+    """
+
+    catalog_id: str
+    path: str
+    version: int
+    kind: str
+    payload: dict[str, Any] | None = None
+    content: str | None = None
+
+
+class _FakeCatalogService:
+    """Minimal stand-in implementing the fetch_entry contract."""
+
+    def __init__(self, entry: _CatalogEntryStub | None = None):
         self.entry = entry
 
-    async def get_entry(self, *, path: str, version: Any):
+    async def fetch_entry(self, *, path: str, version: Any):  # noqa: D401
         return self.entry
 
 
 @pytest.mark.asyncio
 async def test_dispatch_resolves_lifecycle_to_agent_and_returns_execution_id():
-    entry = {
-        "catalog_id": "100",
-        "path": "mcp/kubernetes",
-        "version": 4,
-        "kind": "Mcp",
-        "payload": {
+    entry = _CatalogEntryStub(
+        catalog_id="100",
+        path="mcp/kubernetes",
+        version=4,
+        kind="Mcp",
+        payload={
             "metadata": {"name": "kubernetes"},
             "spec": {
                 "lifecycle": {
@@ -35,7 +53,7 @@ async def test_dispatch_resolves_lifecycle_to_agent_and_returns_execution_id():
                 },
             },
         },
-    }
+    )
     captured: dict[str, Any] = {}
 
     async def fake_execute(*, path: str, workload: dict[str, Any]) -> str:
@@ -64,13 +82,13 @@ async def test_dispatch_resolves_lifecycle_to_agent_and_returns_execution_id():
 
 @pytest.mark.asyncio
 async def test_dispatch_422s_when_verb_is_not_in_lifecycle():
-    entry = {
-        "catalog_id": "100",
-        "path": "mcp/kubernetes",
-        "version": 1,
-        "kind": "Mcp",
-        "payload": {"spec": {"lifecycle": {"status": "agents/k8s/status"}}},
-    }
+    entry = _CatalogEntryStub(
+        catalog_id="100",
+        path="mcp/kubernetes",
+        version=1,
+        kind="Mcp",
+        payload={"spec": {"lifecycle": {"status": "agents/k8s/status"}}},
+    )
 
     async def fake_execute(**_: Any) -> str:  # pragma: no cover -- not reached
         return "should-not-run"
@@ -89,13 +107,13 @@ async def test_dispatch_422s_when_verb_is_not_in_lifecycle():
 
 @pytest.mark.asyncio
 async def test_dispatch_400s_when_resource_kind_is_not_mcp():
-    entry = {
-        "catalog_id": "100",
-        "path": "mcp/kubernetes",
-        "version": 1,
-        "kind": "Playbook",
-        "payload": {"spec": {}},
-    }
+    entry = _CatalogEntryStub(
+        catalog_id="100",
+        path="mcp/kubernetes",
+        version=1,
+        kind="Playbook",
+        payload={"spec": {}},
+    )
 
     async def fake_execute(**_: Any) -> str:  # pragma: no cover
         return "noop"
@@ -109,3 +127,53 @@ async def test_dispatch_400s_when_resource_kind_is_not_mcp():
             version="latest",
         )
     assert info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_dispatch_503s_when_service_lacks_lookup_method():
+    """Service objects without fetch_entry/get should produce a 503."""
+
+    class _NoLookup:
+        pass
+
+    async def fake_execute(**_: Any) -> str:  # pragma: no cover
+        return "noop"
+
+    with pytest.raises(HTTPException) as info:
+        await dispatch_lifecycle(
+            catalog_service=_NoLookup(),
+            execute_callable=fake_execute,
+            path="mcp/kubernetes",
+            verb="deploy",
+            version="latest",
+        )
+    assert info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_dispatch_falls_back_to_get_when_fetch_entry_missing():
+    """Catalog services exposing only `get` should still work."""
+    entry = _CatalogEntryStub(
+        catalog_id="100",
+        path="mcp/kubernetes",
+        version=1,
+        kind="Mcp",
+        payload={"spec": {"lifecycle": {"status": "agents/k8s/status"}}},
+    )
+
+    class _GetOnly:
+        async def get(self, *, path: str, version: Any):
+            return entry
+
+    async def fake_execute(*, path: str, workload: dict[str, Any]) -> str:
+        return "exec-7"
+
+    response = await dispatch_lifecycle(
+        catalog_service=_GetOnly(),
+        execute_callable=fake_execute,
+        path="mcp/kubernetes",
+        verb="status",
+        version="latest",
+    )
+    assert response.execution_id == "exec-7"
+    assert response.agent_path == "agents/k8s/status"

--- a/tests/unit/server/api/mcp/test_ui_schema_inference.py
+++ b/tests/unit/server/api/mcp/test_ui_schema_inference.py
@@ -1,0 +1,111 @@
+"""Tests for the workload form inference (api/mcp/ui_schema.py)."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from noetl.server.api.mcp.ui_schema import infer_ui_schema
+
+
+def test_returns_empty_for_yaml_without_workload():
+    assert infer_ui_schema("apiVersion: noetl.io/v2\nkind: Playbook\n") == []
+
+
+def test_infers_basic_field_types_from_defaults():
+    yaml = textwrap.dedent(
+        """
+        workload:
+          name: alice
+          replicas: 3
+          ratio: 0.5
+          enabled: true
+          tags:
+            - a
+            - b
+          extras: {}
+          empty: ~
+        """
+    )
+    fields = infer_ui_schema(yaml)
+    by_name = {f.name: f for f in fields}
+
+    assert by_name["name"].kind == "string"
+    assert by_name["replicas"].kind == "integer"
+    assert by_name["ratio"].kind == "number"
+    assert by_name["enabled"].kind == "boolean"
+    assert by_name["tags"].kind == "array"
+    assert by_name["extras"].kind == "object"
+    assert by_name["empty"].kind == "null"
+
+
+def test_recurses_into_nested_objects():
+    yaml = textwrap.dedent(
+        """
+        workload:
+          db:
+            host: localhost
+            port: 5432
+        """
+    )
+    fields = infer_ui_schema(yaml)
+    assert len(fields) == 1
+    db_field = fields[0]
+    assert db_field.kind == "object"
+    assert db_field.children is not None
+    child_kinds = {c.name: c.kind for c in db_field.children}
+    assert child_kinds == {"host": "string", "port": "integer"}
+
+
+def test_ui_directive_secret_marks_field():
+    yaml = textwrap.dedent(
+        """
+        workload:
+          api_key: "" # ui:secret
+          username: alice
+        """
+    )
+    fields = {f.name: f for f in infer_ui_schema(yaml)}
+    assert fields["api_key"].secret is True
+    assert fields["username"].secret is False
+
+
+def test_ui_directive_enum_overrides_kind():
+    yaml = textwrap.dedent(
+        """
+        workload:
+          mode: read-only # ui:enum=[read-only,read-write]
+        """
+    )
+    field = infer_ui_schema(yaml)[0]
+    assert field.kind == "enum"
+    assert field.options == ["read-only", "read-write"]
+
+
+def test_ui_directive_credential_filter():
+    yaml = textwrap.dedent(
+        """
+        workload:
+          db_auth: pg_default # ui:credential=pg_*
+        """
+    )
+    field = infer_ui_schema(yaml)[0]
+    assert field.credential_glob == "pg_*"
+
+
+def test_handles_invalid_yaml_gracefully():
+    assert infer_ui_schema("workload:\n  - this is not a mapping") == []
+    assert infer_ui_schema("::not yaml::") == []
+
+
+def test_ignores_unknown_directives():
+    yaml = textwrap.dedent(
+        """
+        workload:
+          name: alice # ui:weird=foo
+        """
+    )
+    field = infer_ui_schema(yaml)[0]
+    assert field.kind == "string"
+    assert field.secret is False


### PR DESCRIPTION
Phase 1 of the catalog + MCP + friendly playbook launcher design. Architecture doc: ai-meta sync/issues/2026-04-28-architecture-mcp-catalog-and-friendly-playbook-launcher.md. Scope: new /api/mcp/{path}/lifecycle/{verb}, /api/mcp/{path}/discover, /api/catalog/{path}/ui_schema endpoints; resource model unchanged (Mcp catalog entries opt in via spec.lifecycle / spec.discovery / spec.runtime blocks). Out of scope: admin auth (TODO before merge), gateway forwarding (phase 2), ops templates (phase 3), GUI work (phase 4). See commit message and ai-meta sync issue for full design.