### PR TITLE
fix(mcp): address Copilot pass 2 — cache mutation, error mapping, async DNS, multi-directive

### DIFF
--- a/noetl/server/api/mcp/endpoint.py
+++ b/noetl/server/api/mcp/endpoint.py
@@ -113,8 +113,9 @@ async def _fetch_url_default(url: str) -> str:
             status_code=400,
             detail=(
                 f"discovery URL host '{host}' resolves to a blocked address range "
-                "(loopback / link-local / multicast). Use the in-cluster service "
-                "DNS or a routable public host instead."
+                "(loopback / link-local / multicast / RFC 1918 private). "
+                "Use the in-cluster service DNS (e.g. *.svc.cluster.local) "
+                "or a routable public host instead."
             ),
         )
 

--- a/noetl/server/api/mcp/endpoint.py
+++ b/noetl/server/api/mcp/endpoint.py
@@ -95,6 +95,8 @@ async def _fetch_url_default(url: str) -> str:
     requests targeting loopback, link-local, multicast, or RFC 1918
     addresses unless the URL host explicitly resolves to a kind/cluster
     namespace (the most common case for kubernetes-native MCP servers).
+    DNS resolution and the actual HTTP fetch both run off the event
+    loop so a slow resolver can't stall the server.
     """
     parsed = urllib.parse.urlparse(url)
     if parsed.scheme not in ("http", "https"):
@@ -106,10 +108,7 @@ async def _fetch_url_default(url: str) -> str:
     if not host:
         raise HTTPException(status_code=400, detail="discovery URL missing host")
 
-    # Allow common in-cluster hostnames. Anything that resolves to a
-    # publicly-routable address is also fine; the only thing we block is the
-    # subset of private/loopback that's a likely SSRF target.
-    if not _host_is_safe_for_discovery(host):
+    if not await _host_is_safe_for_discovery(host):
         raise HTTPException(
             status_code=400,
             detail=(
@@ -138,10 +137,14 @@ async def _fetch_url_default(url: str) -> str:
     return await asyncio.get_running_loop().run_in_executor(None, _read)
 
 
-def _host_is_safe_for_discovery(host: str) -> bool:
+async def _host_is_safe_for_discovery(host: str) -> bool:
     """Best-effort SSRF guard. Allows in-cluster service DNS by name.
 
+    Async because DNS resolution is delegated to
+    ``loop.getaddrinfo`` so a slow resolver can't stall other handlers.
+
     We let through:
+
     - hostnames ending in `.svc`, `.svc.cluster.local`, `.cluster.local`
       (typical kubernetes service DNS — operators target the same MCP
       pod via these names).
@@ -149,13 +152,14 @@ def _host_is_safe_for_discovery(host: str) -> bool:
       loopback / link-local / multicast / private ranges.
 
     We block:
+
     - explicit IPs in loopback (127.0.0.0/8, ::1), link-local
       (169.254.0.0/16, fe80::/10), multicast (224.0.0.0/4),
-      RFC 1918 (10/8, 172.16/12, 192.168/16) when the URL is an IP literal
-      and *not* one of the in-cluster DNS suffixes above. (Cluster DNS
-      typically resolves to a private 10.x or 172.x address, but the
-      hostname-based allowlist short-circuits the check before we hit
-      that branch.)
+      RFC 1918 (10/8, 172.16/12, 192.168/16) when the URL is an IP
+      literal and *not* one of the in-cluster DNS suffixes above.
+      Cluster DNS typically resolves to a private 10.x or 172.x
+      address, but the hostname-based allowlist short-circuits the
+      check before we hit that branch.
     """
     suffix_allowlist = (
         ".svc",
@@ -167,14 +171,16 @@ def _host_is_safe_for_discovery(host: str) -> bool:
         return True
 
     try:
-        # If the hostname is a literal IP, this returns the IP back.
-        # Otherwise it does a DNS lookup.
-        infos = socket.getaddrinfo(host, None)
+        loop = asyncio.get_running_loop()
+        # loop.getaddrinfo runs the lookup in a thread/executor so the
+        # event loop stays responsive. Returns the same tuple shape as
+        # socket.getaddrinfo.
+        infos = await loop.getaddrinfo(host, None)
     except socket.gaierror:
         return False
 
     seen_ok = False
-    for family, _type, _proto, _canon, sockaddr in infos:
+    for _family, _type, _proto, _canon, sockaddr in infos:
         addr = sockaddr[0]
         try:
             ip = ipaddress.ip_address(addr)

--- a/noetl/server/api/mcp/schema.py
+++ b/noetl/server/api/mcp/schema.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from typing import Any, Optional
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field
 
 from noetl.core.common import AppBaseModel
 
@@ -112,7 +112,8 @@ class McpDiscoverResponse(AppBaseModel):
 class UiSchemaField(AppBaseModel):
     """One workload field inferred from a playbook's YAML.
 
-    The inference rules (see service.infer_ui_schema):
+    The inference rules (see :mod:`noetl.server.api.mcp.ui_schema`,
+    function :func:`infer_ui_schema`):
     - Default-value type drives `kind`: string, number, integer, boolean,
       object, array, null.
     - Adjacent `# ui:enum=[...]` comment forces `kind=enum` and populates

--- a/noetl/server/api/mcp/service.py
+++ b/noetl/server/api/mcp/service.py
@@ -49,13 +49,18 @@ async def fetch_mcp_resource(catalog_service, path: str, version: Any) -> dict[s
             status_code=500,
             detail=f"Mcp resource '{path}' has unparseable payload",
         )
-    payload["_catalog"] = {
+    # Shallow-copy before mutating — the parsed payload may come from the
+    # CatalogService LRU cache and re-using it directly would leak the
+    # synthetic ``_catalog`` key into subsequent reads (and worse, into
+    # any future re-registration that round-trips the dict back to YAML).
+    resource_payload = dict(payload)
+    resource_payload["_catalog"] = {
         "catalog_id": entry.get("catalog_id"),
         "path": entry.get("path"),
         "version": entry.get("version"),
         "kind": entry.get("kind"),
     }
-    return payload
+    return resource_payload
 
 
 async def fetch_any_resource(catalog_service, path: str, version: Any) -> dict[str, Any]:
@@ -91,14 +96,25 @@ async def _fetch_entry(catalog_service, path: str, version: Any) -> dict[str, An
     requested_version = "latest" if version in (None, "", "latest") else version
     try:
         entry = await fetcher(path=path, version=requested_version)
-    except Exception as exc:  # pragma: no cover -- service-layer error surface varies
-        logger.warning("catalog lookup failed for %s@%s: %s", path, requested_version, exc)
+    except HTTPException:
+        # Catalog service may decide to surface its own typed HTTP errors —
+        # let them propagate unchanged so the client sees the right status.
+        raise
+    except Exception:  # pragma: no cover -- service-layer error surface varies
+        # Real DB/network/IO problems are 503, not 404. Masking them as
+        # "not found" makes incidents look like benign client errors.
+        logger.exception(
+            "catalog lookup failed for %s@%s; mapping to 503",
+            path,
+            requested_version,
+        )
         raise HTTPException(
-            status_code=404,
-            detail=f"resource not found: {path}@{requested_version}",
-        ) from exc
+            status_code=503,
+            detail="catalog service unavailable",
+        )
 
     if not entry:
+        # Explicit absence -- reserved 404 case.
         raise HTTPException(
             status_code=404,
             detail=f"resource not found: {path}@{requested_version}",
@@ -173,7 +189,23 @@ async def dispatch_lifecycle(
         },
         "verb": verb,
     }
+    # workload_overrides is a convenience for adding caller-specific values
+    # to the dispatched agent's workload (e.g. a ticket id or a forced
+    # image tag). It is NOT a way to overwrite the resource's own
+    # identity: blocking ``mcp_resource`` and ``verb`` here keeps audit
+    # trails and downstream dispatch logic consistent with the catalog
+    # entry that was actually resolved.
     if workload_overrides:
+        reserved = {"mcp_resource", "verb"}
+        clobbered = sorted(k for k in workload_overrides if k in reserved)
+        if clobbered:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "workload_overrides cannot override reserved fields: "
+                    f"{clobbered}"
+                ),
+            )
         workload.update(workload_overrides)
 
     execution_id = await execute_callable(path=agent_path, workload=workload)

--- a/noetl/server/api/mcp/ui_schema.py
+++ b/noetl/server/api/mcp/ui_schema.py
@@ -108,13 +108,24 @@ def _scan_inline_directives(yaml_text: str) -> dict[str, dict[str, Any]]:
     ["a", "b"], "description": "...", "credential": "pg_*"}``.
 
     Only inline comments on the same line as the key/value are
-    considered. The implementation deliberately ignores keys nested
-    deeper than the immediate workload children — Phase 1 covers the
-    flat case the GUI run-dialog needs first.
+    considered, and only for the *immediate children* of ``workload:``.
+    A directive on a nested mapping (e.g. ``workload.db.host``) is
+    intentionally ignored — without that filter the parser would
+    happily attach an inner ``# ui:secret`` to an unrelated top-level
+    field that just happens to share the same key name. Phase 1 only
+    covers the flat case the GUI run-dialog needs first.
+
+    Detection of "immediate child" is data-driven: the first non-empty,
+    deeper-than-``workload:`` line we see fixes ``child_indent`` for
+    the rest of the block. Lines at deeper indents are skipped; lines
+    at the same indent but inside a nested mapping (i.e. anything
+    that's not the very next sibling) are skipped because the regex
+    still matches them.
     """
     out: dict[str, dict[str, Any]] = {}
     in_workload = False
     workload_indent = -1
+    child_indent = -1  # established lazily on the first child we see
 
     for line in yaml_text.splitlines():
         stripped = line.lstrip()
@@ -123,14 +134,25 @@ def _scan_inline_directives(yaml_text: str) -> dict[str, dict[str, Any]]:
         if stripped.startswith("workload:"):
             in_workload = True
             workload_indent = len(line) - len(stripped)
+            child_indent = -1
             continue
         if not in_workload:
             continue
 
         indent = len(line) - len(stripped)
-        if stripped and indent <= workload_indent and not line.startswith(" "):
-            # Left the workload block.
+        if indent <= workload_indent:
+            # Left the workload block — `start:` or another top-level key.
             in_workload = False
+            child_indent = -1
+            continue
+
+        # Establish the immediate-child indent on the first qualifying line.
+        if child_indent == -1:
+            child_indent = indent
+
+        # Filter strictly to the immediate children of workload:. Anything
+        # deeper is a nested mapping and gets ignored for directive scope.
+        if indent != child_indent:
             continue
 
         match = _TOP_KEY_RE.match(line)

--- a/noetl/server/api/mcp/ui_schema.py
+++ b/noetl/server/api/mcp/ui_schema.py
@@ -35,17 +35,21 @@ import yaml as _yaml
 from .schema import UiSchemaField
 
 
-# Match an inline directive like `key: value # ui:secret` or
-# `key: value # ui:enum=[a,b]`. The leading capture lets us strip the
-# directive itself before parsing the value with PyYAML.
+# Match each `# ui:foo[=bar]` token within a line. We use ``finditer``
+# instead of an end-anchored match so two directives on one line both
+# get parsed (e.g. ``# ui:secret # ui:description=API key``). The
+# value capture stops at whitespace-then-``#`` so it doesn't swallow a
+# trailing directive.
 _DIRECTIVE_INLINE_RE = re.compile(
-    r"#\s*ui:(?P<key>[A-Za-z_][A-Za-z0-9_]*)(?:\s*=\s*(?P<value>[^\n]*))?$"
+    r"#\s*ui:(?P<key>[A-Za-z_][A-Za-z0-9_]*)"
+    r"(?:\s*=\s*(?P<value>[^\n#]*?))?(?=(?:\s+#|\s*$))"
 )
 
 # Match the start of a top-level workload key line so we can correlate
-# the parsed dict back to the raw text. We require at least two leading
-# spaces so we don't mistake `workload:` itself for one of its keys.
-_TOP_KEY_RE = re.compile(r"^(?P<indent> {2})(?P<name>[A-Za-z_][A-Za-z0-9_-]*)\s*:")
+# the parsed dict back to the raw text. We accept any indent of two or
+# more spaces so this works for the common 2-space indent and the
+# also-valid 4-space style.
+_TOP_KEY_RE = re.compile(r"^(?P<indent> {2,})(?P<name>[A-Za-z_][A-Za-z0-9_-]*)\s*:")
 
 
 def infer_ui_schema(yaml_text: str) -> list[UiSchemaField]:
@@ -141,27 +145,18 @@ def _scan_inline_directives(yaml_text: str) -> dict[str, dict[str, Any]]:
 
 
 def _extract_directives_from_line(line: str) -> dict[str, Any]:
-    """Pull every `# ui:foo` and `# ui:foo=bar` token from one raw line."""
+    """Pull every ``# ui:foo`` / ``# ui:foo=bar`` token from one raw line.
+
+    Uses :func:`re.finditer` so multiple directives on a single line are
+    parsed independently — each match is anchored only at the start of
+    a directive and the value capture is non-greedy with a lookahead
+    that terminates on the next ``# ui:`` token or end of line.
+    """
     out: dict[str, Any] = {}
-    # `# ui:` may appear more than once on a line, though rare. Find them
-    # all by repeatedly matching from the position after each hit.
-    cursor = 0
-    while True:
-        idx = line.find("# ui:", cursor)
-        if idx == -1:
-            break
-        rest = line[idx:]
-        # The directive runs until end-of-line. The regex grabs the key
-        # plus optional value.
-        m = _DIRECTIVE_INLINE_RE.search(rest)
-        if not m:
-            break
-        key = m.group("key")
-        raw_value = (m.group("value") or "").strip()
+    for match in _DIRECTIVE_INLINE_RE.finditer(line):
+        key = match.group("key")
+        raw_value = (match.group("value") or "").strip()
         out[key] = _parse_directive_value(raw_value) if raw_value else True
-        cursor = idx + len(m.group(0))
-        if cursor >= len(line):
-            break
     return out
 
 

--- a/tests/unit/server/api/mcp/test_lifecycle_dispatch.py
+++ b/tests/unit/server/api/mcp/test_lifecycle_dispatch.py
@@ -177,3 +177,61 @@ async def test_dispatch_falls_back_to_get_when_fetch_entry_missing():
     )
     assert response.execution_id == "exec-7"
     assert response.agent_path == "agents/k8s/status"
+
+
+@pytest.mark.asyncio
+async def test_workload_overrides_cannot_clobber_reserved_fields():
+    """workload_overrides must not be allowed to overwrite mcp_resource/verb."""
+    entry = _CatalogEntryStub(
+        catalog_id="100",
+        path="mcp/kubernetes",
+        version=1,
+        kind="Mcp",
+        payload={"spec": {"lifecycle": {"deploy": "agents/k8s/lifecycle/deploy"}}},
+    )
+
+    async def fake_execute(**_: Any) -> str:  # pragma: no cover
+        return "should-not-run"
+
+    with pytest.raises(HTTPException) as info:
+        await dispatch_lifecycle(
+            catalog_service=_FakeCatalogService(entry),
+            execute_callable=fake_execute,
+            path="mcp/kubernetes",
+            verb="deploy",
+            version="latest",
+            workload_overrides={"mcp_resource": {"hijacked": True}, "extra": 1},
+        )
+    assert info.value.status_code == 422
+    assert "mcp_resource" in info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_workload_overrides_merge_when_no_collision():
+    """Override keys outside the reserved set merge cleanly into workload."""
+    entry = _CatalogEntryStub(
+        catalog_id="100",
+        path="mcp/kubernetes",
+        version=2,
+        kind="Mcp",
+        payload={"spec": {"lifecycle": {"deploy": "agents/k8s/lifecycle/deploy"}}},
+    )
+    captured: dict[str, Any] = {}
+
+    async def fake_execute(*, path: str, workload: dict[str, Any]) -> str:
+        captured["workload"] = workload
+        return "exec-9"
+
+    response = await dispatch_lifecycle(
+        catalog_service=_FakeCatalogService(entry),
+        execute_callable=fake_execute,
+        path="mcp/kubernetes",
+        verb="deploy",
+        version="latest",
+        workload_overrides={"image_tag": "v1.2.3", "force": True},
+    )
+    assert response.execution_id == "exec-9"
+    assert captured["workload"]["mcp_resource"]["path"] == "mcp/kubernetes"
+    assert captured["workload"]["verb"] == "deploy"
+    assert captured["workload"]["image_tag"] == "v1.2.3"
+    assert captured["workload"]["force"] is True

--- a/tests/unit/server/api/mcp/test_ui_schema_inference.py
+++ b/tests/unit/server/api/mcp/test_ui_schema_inference.py
@@ -134,3 +134,25 @@ def test_four_space_indent_is_recognised():
     fields = {f.name: f for f in infer_ui_schema(yaml)}
     assert fields["api_key"].secret is True
     assert fields["username"].kind == "string"
+
+
+def test_nested_key_directive_does_not_bleed_to_top_level_with_same_name():
+    """A `# ui:secret` on a deeply-nested key must not promote up to a
+    top-level workload field that happens to share its name."""
+    yaml = textwrap.dedent(
+        """
+        workload:
+          host: public.example.com
+          db:
+            host: secrets.internal # ui:secret
+            port: 5432
+        """
+    )
+    fields = {f.name: f for f in infer_ui_schema(yaml)}
+    # Nested directive should not have polluted the top-level `host`.
+    assert fields["host"].secret is False
+    # The top-level `db` is itself an object; its child mappings are
+    # parsed structurally but the directive scope is intentionally only
+    # immediate-child of workload, so `db.host`'s secret tag is ignored
+    # in this phase.
+    assert fields["db"].kind == "object"

--- a/tests/unit/server/api/mcp/test_ui_schema_inference.py
+++ b/tests/unit/server/api/mcp/test_ui_schema_inference.py
@@ -109,3 +109,28 @@ def test_ignores_unknown_directives():
     field = infer_ui_schema(yaml)[0]
     assert field.kind == "string"
     assert field.secret is False
+
+
+def test_multiple_directives_on_one_line_are_all_parsed():
+    yaml = textwrap.dedent(
+        """
+        workload:
+          api_key: "" # ui:secret # ui:description=API key for upstream
+        """
+    )
+    field = infer_ui_schema(yaml)[0]
+    assert field.secret is True
+    assert field.description == "API key for upstream"
+
+
+def test_four_space_indent_is_recognised():
+    yaml = textwrap.dedent(
+        """
+        workload:
+            api_key: "" # ui:secret
+            username: alice
+        """
+    )
+    fields = {f.name: f for f in infer_ui_schema(yaml)}
+    assert fields["api_key"].secret is True
+    assert fields["username"].kind == "string"


### PR DESCRIPTION
Follow-up to noetl/noetl#392 (merged as v2.25.0 before this commit could be added to that PR). Addresses the eight findings Copilot raised on commit bf636e18 of #392:

- **service.fetch_mcp_resource** shallow-copies the parsed payload before injecting `_catalog` so we don't pollute the CatalogService LRU cache.
- **service._fetch_entry** stops masking real exceptions as 404. DB / network / IO problems now map to 503; explicit 'returns None' paths still return 404; HTTPException from the catalog service propagates.
- **service.dispatch_lifecycle** rejects workload_overrides keys that would clobber reserved fields (mcp_resource, verb) with 422. Two new unit tests cover both cases.
- **endpoint._host_is_safe_for_discovery** is now async and uses loop.getaddrinfo so DNS lookups don't block the event loop.
- **schema.py** drops unused field_validator / model_validator imports and updates the UiSchemaField docstring to reference noetl.server.api.mcp.ui_schema.infer_ui_schema.
- **ui_schema._TOP_KEY_RE** accepts indents of 2+ spaces (not exactly 2). **_DIRECTIVE_INLINE_RE** uses a non-anchored finditer pattern with a lookahead so multiple '# ui:' directives on one line are all parsed. Two new unit tests cover both cases.

All eight findings addressed; the existing test suite was extended rather than rewritten.