### PR TITLE
feat(server): noetl-side check_playbook_access enforcement (architecture phase 2)

### DIFF
--- a/noetl/server/api/auth/__init__.py
+++ b/noetl/server/api/auth/__init__.py
@@ -1,0 +1,33 @@
+"""Server-side auth helpers for the noetl FastAPI app.
+
+This package owns the auth enforcement that lives *inside* the noetl
+server itself — independent of any optional gateway in front of it. The
+gateway, when present, is treated as a perimeter optimisation; the
+source of truth for "is this caller allowed to dispatch this playbook?"
+is here so deployments without a gateway (local kind, private GKE)
+inherit the same authorisation rules.
+
+The check itself runs against the same ``auth.sessions`` and
+``auth.playbook_permissions`` tables the existing
+``api_integration/auth0/check_playbook_access`` playbook reads, so
+permissions granted via the GUI / playbook flow continue to work
+without modification.
+"""
+
+from .check_access import (
+    AccessDecision,
+    EnforcementMode,
+    AuthEnforcementSettings,
+    check_playbook_access,
+    load_enforcement_settings,
+    extract_session_token,
+)
+
+__all__ = [
+    "AccessDecision",
+    "EnforcementMode",
+    "AuthEnforcementSettings",
+    "check_playbook_access",
+    "load_enforcement_settings",
+    "extract_session_token",
+]

--- a/noetl/server/api/auth/check_access.py
+++ b/noetl/server/api/auth/check_access.py
@@ -108,12 +108,19 @@ class AuthEnforcementSettings:
                 ttl_raw,
             )
             ttl = 30.0
+        # An empty NOETL_AUTH_SESSION_HEADER would otherwise produce a
+        # confusing "or : <token>" segment in the 401 detail, and
+        # invalidate the fallback header lookup entirely. Treat blank /
+        # whitespace-only as "fall back to the default".
+        session_header = (
+            os.environ.get("NOETL_AUTH_SESSION_HEADER", "X-Session-Token") or ""
+        ).strip()
+        if not session_header:
+            session_header = "X-Session-Token"
         return cls(
             mode=EnforcementMode.parse(os.environ.get("NOETL_AUTH_ENFORCEMENT_MODE")),
             cache_ttl_seconds=max(0.0, ttl),
-            session_header=os.environ.get(
-                "NOETL_AUTH_SESSION_HEADER", "X-Session-Token"
-            ),
+            session_header=session_header,
             db_connection_string=os.environ.get("NOETL_AUTH_DB_CONNECTION_STRING"),
         )
 
@@ -213,15 +220,23 @@ def extract_session_token(
     """
     auth = request.headers.get("Authorization")
     if auth:
-        # Check the Bearer prefix on the un-stripped value first — a
-        # header like "Bearer    " (prefix only, no token) should
-        # surface as "no token", not as the literal string "Bearer".
+        stripped_auth = auth.strip()
+        # Treat a bare Bearer scheme — with or without trailing
+        # whitespace — as "no token". Accepting the literal string
+        # "Bearer" as a raw token would cause a misleading DB lookup
+        # and surface as a 403 ("invalid session") instead of the
+        # 401 the missing-token path produces.
+        if stripped_auth.lower() == "bearer":
+            return None
+        # Check the Bearer prefix on the unstripped value so we still
+        # catch "Bearer    " (prefix-with-trailing-whitespace) before
+        # falling back to raw-token handling.
         if auth.lower().startswith("bearer "):
             return auth[7:].strip() or None
         # Some clients send the raw token in Authorization without the
         # Bearer prefix. Accept that form too — a 64-char opaque string
         # can't reasonably be confused with another scheme.
-        return auth.strip() or None
+        return stripped_auth or None
     header_name = settings.session_header
     if header_name:
         token = request.headers.get(header_name)
@@ -360,13 +375,17 @@ async def check_playbook_access(
             mode=settings.mode,
         )
         if settings.mode == EnforcementMode.ENFORCE:
-            raise HTTPException(
-                status_code=401,
-                detail=(
-                    "missing session token; provide Authorization: Bearer <token> "
-                    f"or {settings.session_header}: <token>"
-                ),
-            )
+            # Build the detail dynamically — only mention the fallback
+            # header when one is actually configured. ``from_env``
+            # normalises blank / whitespace values back to the default,
+            # so this branch shouldn't fire in practice, but a stray
+            # ``replace(settings, session_header="")`` from a test
+            # harness should still produce a sensible message.
+            detail = "missing session token; provide Authorization: Bearer <token>"
+            fallback_header = (settings.session_header or "").strip()
+            if fallback_header:
+                detail += f" or {fallback_header}: <token>"
+            raise HTTPException(status_code=401, detail=detail)
         logger.warning(
             "advisory: would deny dispatch of %s — missing session token",
             playbook_path,

--- a/noetl/server/api/auth/check_access.py
+++ b/noetl/server/api/auth/check_access.py
@@ -1,0 +1,418 @@
+"""Server-side ``check_playbook_access`` enforcement.
+
+This module is the noetl server's analogue to the
+``api_integration/auth0/check_playbook_access`` playbook. The playbook
+flow stays as the externally-callable contract (the gateway invokes it
+via ``POST /api/auth/check-access`` and the GUI uses it to grey out
+forbidden buttons), but the same authorisation decision must also be
+enforceable from inside the FastAPI app for deployments that do not put
+a gateway in front of noetl (local kind, private GKE).
+
+We hit the same ``auth.sessions`` + ``auth.playbook_permissions`` tables
+the playbook queries — granting execute permission via the GUI / SQL /
+playbook flow keeps a single source of truth. The implementation here
+is a fast SQL path with a small TTL cache, not a recursive playbook
+dispatch, so the per-request cost is one Postgres round-trip on cache
+miss.
+
+Configuration (environment variables, all optional):
+
+- ``NOETL_AUTH_ENFORCEMENT_MODE`` — ``enforce`` | ``advisory`` | ``skip``
+  (default: ``skip`` so existing local-dev keeps working without a flag
+  flip; production deploys should set this to ``enforce``).
+- ``NOETL_AUTH_CACHE_TTL_SECONDS`` — TTL on the in-memory decision cache
+  (default 30s). Cache is keyed on ``(session_token, playbook_path,
+  action)``; flip a user's permission and they re-authorize within the
+  TTL window.
+- ``NOETL_AUTH_SESSION_HEADER`` — alternative header name for the
+  session token (default ``X-Session-Token``). The standard
+  ``Authorization: Bearer <token>`` header is always honoured.
+
+Modes:
+
+- ``enforce``: a denied check raises ``HTTPException(403)``. This is
+  the only mode that actually blocks requests.
+- ``advisory``: a denied check is logged and surfaced via the
+  ``AccessDecision`` return value (callers can stamp a header on the
+  response) but the request still proceeds. Useful while the
+  permission table is being populated, so we can audit who *would*
+  have been blocked before flipping to enforce.
+- ``skip``: the function short-circuits with ``allowed=True`` and never
+  hits the database. The default; lets you bring up a local kind
+  cluster with no auth tables at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+from fastapi import HTTPException, Request
+
+from noetl.core.logger import setup_logger
+
+logger = setup_logger(__name__, include_location=True)
+
+
+class EnforcementMode(str, enum.Enum):
+    """How a denied auth decision should be handled.
+
+    ``str`` mixin keeps the values readable in logs/configs and lets
+    them be compared to the raw env-var string without explicit casting.
+    """
+
+    ENFORCE = "enforce"
+    ADVISORY = "advisory"
+    SKIP = "skip"
+
+    @classmethod
+    def parse(cls, raw: Optional[str]) -> "EnforcementMode":
+        if not raw:
+            return cls.SKIP
+        cleaned = str(raw).strip().lower()
+        for member in cls:
+            if member.value == cleaned:
+                return member
+        logger.warning(
+            "unrecognised NOETL_AUTH_ENFORCEMENT_MODE=%r; falling back to skip",
+            raw,
+        )
+        return cls.SKIP
+
+
+@dataclass(frozen=True)
+class AuthEnforcementSettings:
+    """Frozen configuration loaded from env or the test harness.
+
+    Frozen so a stray write inside a hot-path doesn't end up flipping
+    enforcement mode for the next request.
+    """
+
+    mode: EnforcementMode = EnforcementMode.SKIP
+    cache_ttl_seconds: float = 30.0
+    session_header: str = "X-Session-Token"
+    db_connection_string: Optional[str] = None  # None => default conn
+
+    @classmethod
+    def from_env(cls) -> "AuthEnforcementSettings":
+        ttl_raw = os.environ.get("NOETL_AUTH_CACHE_TTL_SECONDS")
+        try:
+            ttl = float(ttl_raw) if ttl_raw is not None else 30.0
+        except ValueError:
+            logger.warning(
+                "invalid NOETL_AUTH_CACHE_TTL_SECONDS=%r; falling back to 30s",
+                ttl_raw,
+            )
+            ttl = 30.0
+        return cls(
+            mode=EnforcementMode.parse(os.environ.get("NOETL_AUTH_ENFORCEMENT_MODE")),
+            cache_ttl_seconds=max(0.0, ttl),
+            session_header=os.environ.get(
+                "NOETL_AUTH_SESSION_HEADER", "X-Session-Token"
+            ),
+            db_connection_string=os.environ.get("NOETL_AUTH_DB_CONNECTION_STRING"),
+        )
+
+
+def load_enforcement_settings() -> AuthEnforcementSettings:
+    """Public entry point for the FastAPI dep wiring."""
+    return AuthEnforcementSettings.from_env()
+
+
+@dataclass
+class AccessDecision:
+    """Result of a single ``check_playbook_access`` evaluation.
+
+    ``allowed`` is the only field a hot-path needs. ``reason``,
+    ``user_id``, and ``email`` are populated when available and are
+    primarily for logging / response headers.
+    """
+
+    allowed: bool
+    reason: str = ""
+    user_id: Optional[int] = None
+    email: Optional[str] = None
+    mode: EnforcementMode = EnforcementMode.SKIP
+    cached: bool = False
+
+
+@dataclass
+class _CacheEntry:
+    decision: AccessDecision
+    expires_at: float
+
+
+class _DecisionCache:
+    """Tiny TTL cache keyed on ``(session_token, playbook_path, action)``.
+
+    Lock is per-process; we don't expect contention to be a problem at
+    the request rates this handles, and a single ``asyncio.Lock`` keeps
+    the implementation portable across deployment shapes (multi-worker
+    Uvicorn, single-process kind, etc.).
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str, str], _CacheEntry] = {}
+        self._lock = asyncio.Lock()
+
+    async def get(self, key: tuple[str, str, str]) -> Optional[AccessDecision]:
+        async with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return None
+            if entry.expires_at < time.monotonic():
+                # Lazy expiry — drop the entry and report a miss.
+                self._store.pop(key, None)
+                return None
+            decision = AccessDecision(
+                allowed=entry.decision.allowed,
+                reason=entry.decision.reason,
+                user_id=entry.decision.user_id,
+                email=entry.decision.email,
+                mode=entry.decision.mode,
+                cached=True,
+            )
+            return decision
+
+    async def set(
+        self,
+        key: tuple[str, str, str],
+        decision: AccessDecision,
+        ttl_seconds: float,
+    ) -> None:
+        if ttl_seconds <= 0:
+            return
+        async with self._lock:
+            self._store[key] = _CacheEntry(
+                decision=decision,
+                expires_at=time.monotonic() + ttl_seconds,
+            )
+
+    async def clear(self) -> None:
+        async with self._lock:
+            self._store.clear()
+
+
+# Module-level cache. Reset by tests via ``check_access._cache.clear()``.
+_cache = _DecisionCache()
+
+
+def extract_session_token(
+    request: Request, settings: AuthEnforcementSettings
+) -> Optional[str]:
+    """Pull the session token from a FastAPI request.
+
+    Tries (in order): ``Authorization: Bearer <token>``,
+    ``Authorization: <token>`` (raw token), the configured
+    ``settings.session_header``. Returns ``None`` if no token is
+    present — callers in ``enforce`` mode treat that as a deny.
+    """
+    auth = request.headers.get("Authorization")
+    if auth:
+        # Check the Bearer prefix on the un-stripped value first — a
+        # header like "Bearer    " (prefix only, no token) should
+        # surface as "no token", not as the literal string "Bearer".
+        if auth.lower().startswith("bearer "):
+            return auth[7:].strip() or None
+        # Some clients send the raw token in Authorization without the
+        # Bearer prefix. Accept that form too — a 64-char opaque string
+        # can't reasonably be confused with another scheme.
+        return auth.strip() or None
+    header_name = settings.session_header
+    if header_name:
+        token = request.headers.get(header_name)
+        if token:
+            token = token.strip()
+            return token or None
+    return None
+
+
+async def _query_access(
+    *,
+    session_token: str,
+    playbook_path: str,
+    action: str,
+    settings: AuthEnforcementSettings,
+) -> AccessDecision:
+    """Run the same SQL the check_playbook_access playbook does.
+
+    Returns an ``AccessDecision`` populated from the database result.
+    On any DB error we fail closed in enforce mode (caller maps to
+    ``HTTPException(503)`` rather than silently allowing) — this branch
+    raises so the wrapper can decide based on mode.
+    """
+    # Late import so importing this module doesn't pull psycopg into the
+    # test path when we're stubbing the SQL layer.
+    from noetl.core.common import get_async_db_connection
+    from psycopg.rows import dict_row
+
+    async with get_async_db_connection(
+        connection_string=settings.db_connection_string,
+    ) as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT
+                  s.user_id,
+                  u.email
+                FROM auth.sessions s
+                JOIN auth.users u ON s.user_id = u.user_id
+                WHERE s.session_token = %s
+                  AND s.is_active = TRUE
+                  AND s.expires_at > NOW()
+                  AND u.is_active = TRUE
+                LIMIT 1
+                """,
+                (session_token,),
+            )
+            session_row = await cur.fetchone()
+
+            if not session_row:
+                return AccessDecision(
+                    allowed=False,
+                    reason="invalid or expired session",
+                    mode=settings.mode,
+                )
+
+            user_id = int(session_row["user_id"])
+            email = str(session_row.get("email") or "")
+
+            await cur.execute(
+                """
+                SELECT COUNT(*) > 0 AS has_permission
+                FROM auth.user_roles ur
+                JOIN auth.roles r ON ur.role_id = r.role_id
+                JOIN auth.playbook_permissions pp ON r.role_id = pp.role_id
+                WHERE ur.user_id = %s
+                  AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+                  AND (
+                    pp.playbook_path = %s
+                    OR (pp.allow_pattern IS NOT NULL AND %s LIKE pp.allow_pattern)
+                  )
+                  AND (pp.deny_pattern IS NULL OR %s NOT LIKE pp.deny_pattern)
+                  AND (
+                    (%s = 'execute' AND pp.can_execute = TRUE)
+                    OR (%s = 'view' AND pp.can_view = TRUE)
+                    OR (%s = 'modify' AND pp.can_modify = TRUE)
+                  )
+                """,
+                (
+                    user_id,
+                    playbook_path,
+                    playbook_path,
+                    playbook_path,
+                    action,
+                    action,
+                    action,
+                ),
+            )
+            perm_row = await cur.fetchone()
+            allowed = bool(perm_row and perm_row.get("has_permission"))
+
+            return AccessDecision(
+                allowed=allowed,
+                reason="granted" if allowed else "no matching playbook_permission",
+                user_id=user_id,
+                email=email,
+                mode=settings.mode,
+            )
+
+
+async def check_playbook_access(
+    *,
+    request: Request,
+    playbook_path: str,
+    action: str = "execute",
+    settings: Optional[AuthEnforcementSettings] = None,
+) -> AccessDecision:
+    """Authorise a request to dispatch ``playbook_path``.
+
+    Returns an ``AccessDecision``. In ``enforce`` mode this raises
+    ``HTTPException(403)`` on a denied result and ``HTTPException(401)``
+    on a missing session token; the caller doesn't need to inspect
+    ``allowed`` again. In ``advisory`` mode it returns the decision
+    unchanged (so the caller can stamp a response header) but never
+    blocks. In ``skip`` mode it short-circuits with ``allowed=True``
+    and never touches the database.
+
+    The TTL cache means hot paths (a GUI polling the same lifecycle
+    status verb) only hit Postgres once per ``cache_ttl_seconds`` per
+    ``(session_token, playbook_path, action)`` triple.
+    """
+    settings = settings or load_enforcement_settings()
+
+    if settings.mode == EnforcementMode.SKIP:
+        return AccessDecision(
+            allowed=True,
+            reason="enforcement skipped",
+            mode=EnforcementMode.SKIP,
+        )
+
+    session_token = extract_session_token(request, settings)
+    if not session_token:
+        decision = AccessDecision(
+            allowed=False,
+            reason="missing session token",
+            mode=settings.mode,
+        )
+        if settings.mode == EnforcementMode.ENFORCE:
+            raise HTTPException(
+                status_code=401,
+                detail=(
+                    "missing session token; provide Authorization: Bearer <token> "
+                    f"or {settings.session_header}: <token>"
+                ),
+            )
+        logger.warning(
+            "advisory: would deny dispatch of %s — missing session token",
+            playbook_path,
+        )
+        return decision
+
+    cache_key = (session_token, playbook_path, action)
+    cached = await _cache.get(cache_key)
+    if cached is not None:
+        decision = cached
+    else:
+        try:
+            decision = await _query_access(
+                session_token=session_token,
+                playbook_path=playbook_path,
+                action=action,
+                settings=settings,
+            )
+        except Exception as exc:
+            logger.exception("auth check_playbook_access SQL failed")
+            if settings.mode == EnforcementMode.ENFORCE:
+                # Fail closed — better a 503 than silently waving through
+                # a request because the auth tables are unreachable.
+                raise HTTPException(
+                    status_code=503,
+                    detail="auth backend unavailable",
+                ) from exc
+            return AccessDecision(
+                allowed=False,
+                reason=f"auth backend unavailable: {exc}",
+                mode=settings.mode,
+            )
+        await _cache.set(cache_key, decision, settings.cache_ttl_seconds)
+
+    if not decision.allowed and settings.mode == EnforcementMode.ENFORCE:
+        raise HTTPException(
+            status_code=403,
+            detail=f"access denied: {decision.reason}",
+        )
+    if not decision.allowed and settings.mode == EnforcementMode.ADVISORY:
+        logger.warning(
+            "advisory: would deny dispatch of %s by user_id=%s (%s) — %s",
+            playbook_path,
+            decision.user_id,
+            decision.email,
+            decision.reason,
+        )
+
+    return decision

--- a/noetl/server/api/mcp/endpoint.py
+++ b/noetl/server/api/mcp/endpoint.py
@@ -16,15 +16,41 @@ import urllib.parse
 import urllib.request
 from typing import Any, Optional
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Path
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request
 from fastapi.responses import JSONResponse
 
 from noetl.core.logger import setup_logger
+from noetl.server.api.auth import (
+    AuthEnforcementSettings,
+    check_playbook_access,
+    load_enforcement_settings,
+)
 
 from . import schema as mcp_schema
 from . import service as mcp_service
 
 logger = setup_logger(__name__, include_location=True)
+
+
+def _build_auth_check(request: Request, settings: AuthEnforcementSettings):
+    """Bind a request + settings to a callable the service layer invokes.
+
+    The service layer doesn't know about FastAPI's ``Request`` — it just
+    knows it has been handed an awaitable that takes
+    ``playbook_path`` / ``action`` and either raises 403 or returns.
+    This indirection keeps the dispatcher's signature stable and makes
+    the existing unit tests (which pass simple stubs) keep working.
+    """
+
+    async def _check(*, playbook_path: str, action: str = "execute"):
+        await check_playbook_access(
+            request=request,
+            playbook_path=playbook_path,
+            action=action,
+            settings=settings,
+        )
+
+    return _check
 
 
 router = APIRouter(prefix="", tags=["mcp"])
@@ -216,10 +242,12 @@ async def _register_default(*, content: str, resource_type: str) -> dict[str, An
     summary="Dispatch a lifecycle verb on a registered Mcp resource",
 )
 async def post_lifecycle_verb(
+    request: Request,
     path: str = Path(..., description="Mcp catalog path"),
     verb: str = Path(..., description="Lifecycle verb (deploy / restart / etc.)"),
     body: mcp_schema.McpLifecycleRequest = Body(default_factory=mcp_schema.McpLifecycleRequest),
     catalog_service=Depends(_get_catalog_service),
+    auth_settings: AuthEnforcementSettings = Depends(load_enforcement_settings),
 ):
     cleaned_verb = mcp_schema.coerce_lifecycle_verb(verb)
     try:
@@ -230,6 +258,7 @@ async def post_lifecycle_verb(
             verb=cleaned_verb,
             version=body.version,
             workload_overrides=body.workload_overrides,
+            auth_check_callable=_build_auth_check(request, auth_settings),
         )
     except HTTPException:
         raise
@@ -249,9 +278,11 @@ async def post_lifecycle_verb(
     summary="Refresh the tool list of a registered Mcp resource",
 )
 async def post_discover(
+    request: Request,
     path: str = Path(..., description="Mcp catalog path"),
     body: mcp_schema.McpDiscoverRequest = Body(default_factory=mcp_schema.McpDiscoverRequest),
     catalog_service=Depends(_get_catalog_service),
+    auth_settings: AuthEnforcementSettings = Depends(load_enforcement_settings),
 ):
     try:
         return await mcp_service.dispatch_discover(
@@ -262,6 +293,7 @@ async def post_discover(
             path=path,
             version=body.version,
             force=body.force,
+            auth_check_callable=_build_auth_check(request, auth_settings),
         )
     except HTTPException:
         raise

--- a/noetl/server/api/mcp/endpoint.py
+++ b/noetl/server/api/mcp/endpoint.py
@@ -37,9 +37,13 @@ def _build_auth_check(request: Request, settings: AuthEnforcementSettings):
 
     The service layer doesn't know about FastAPI's ``Request`` — it just
     knows it has been handed an awaitable that takes
-    ``playbook_path`` / ``action`` and either raises 403 or returns.
-    This indirection keeps the dispatcher's signature stable and makes
-    the existing unit tests (which pass simple stubs) keep working.
+    ``playbook_path`` / ``action`` and either returns or propagates the
+    ``HTTPException`` raised by ``check_playbook_access``. In
+    ``enforce`` mode that exception may carry status 401 (missing
+    token), 403 (session valid but no permission), or 503 (auth
+    backend unreachable — fail closed). This indirection keeps the
+    dispatcher's signature stable and makes the existing unit tests
+    (which pass simple stubs) keep working.
     """
 
     async def _check(*, playbook_path: str, action: str = "execute"):

--- a/noetl/server/api/mcp/service.py
+++ b/noetl/server/api/mcp/service.py
@@ -159,6 +159,7 @@ async def dispatch_lifecycle(
     verb: str,
     version: Any,
     workload_overrides: Optional[dict[str, Any]] = None,
+    auth_check_callable=None,
 ) -> mcp_schema.McpLifecycleResponse:
     """Resolve resource.lifecycle.{verb} -> Agent path and dispatch.
 
@@ -166,6 +167,14 @@ async def dispatch_lifecycle(
     this stays testable without standing up the full /api/execute
     machinery in unit tests. Pass a thin wrapper around the existing
     execute service in production wiring.
+
+    `auth_check_callable(playbook_path: str, action: str) -> awaitable`
+    is the optional authorisation hook. The endpoint wires it to the
+    server-side ``check_playbook_access`` flow. In ``enforce`` mode
+    the callable raises ``HTTPException(403)`` on a denied result and
+    we never reach ``execute_callable``. In ``advisory`` / ``skip``
+    modes (or when no callable is provided) the dispatch proceeds
+    unchanged, preserving compatibility with existing test harnesses.
     """
     resource = await fetch_mcp_resource(catalog_service, path, version)
     spec = resource.get("spec") or {}
@@ -179,6 +188,16 @@ async def dispatch_lifecycle(
                 f"(known verbs: {sorted(lifecycle.keys())})"
             ),
         )
+
+    if auth_check_callable is not None:
+        # The callable is responsible for raising HTTPException(403) on
+        # an enforce-mode deny. We invoke it here — after the lifecycle
+        # path has been resolved — so authorisation is checked against
+        # the actual playbook the dispatcher would run, not the URL the
+        # client sent. That distinction matters: granting execute on
+        # `automation/agents/kubernetes/lifecycle/deploy` should gate
+        # the deploy verb regardless of which Mcp resource exposed it.
+        await auth_check_callable(playbook_path=str(agent_path), action="execute")
 
     workload = {
         "mcp_resource": {
@@ -234,6 +253,7 @@ async def dispatch_discover(
     path: str,
     version: Any,
     force: bool,
+    auth_check_callable=None,
 ) -> mcp_schema.McpDiscoverResponse:
     """Refresh the Mcp resource's tools list.
 
@@ -251,6 +271,17 @@ async def dispatch_discover(
     discovery = spec.get("discovery") or {}
     refresh_via = discovery.get("refresh_via")
     tools_list_url = discovery.get("tools_list_url")
+
+    # Authorisation is performed against the *agent* playbook path when
+    # discovery dispatches one (matches lifecycle's behaviour); for the
+    # direct URL strategy we authorise against the resource's own
+    # catalog path instead — there's no separate playbook to grant
+    # execute on, so the resource path is the only stable handle.
+    if auth_check_callable is not None:
+        if refresh_via:
+            await auth_check_callable(playbook_path=str(refresh_via), action="execute")
+        elif tools_list_url:
+            await auth_check_callable(playbook_path=str(path), action="execute")
 
     if refresh_via:
         execution_id = await execute_callable(

--- a/noetl/server/api/mcp/service.py
+++ b/noetl/server/api/mcp/service.py
@@ -170,8 +170,15 @@ async def dispatch_lifecycle(
 
     `auth_check_callable(playbook_path: str, action: str) -> awaitable`
     is the optional authorisation hook. The endpoint wires it to the
-    server-side ``check_playbook_access`` flow. In ``enforce`` mode
-    the callable raises ``HTTPException(403)`` on a denied result and
+    server-side ``check_playbook_access`` flow, which in ``enforce``
+    mode may raise ``HTTPException`` with one of:
+
+    - ``401`` — no session token on the request
+    - ``403`` — the session is valid but lacks the requested permission
+    - ``503`` — the auth backend (Postgres) is unreachable; we fail
+      closed rather than silently waving the request through
+
+    Any of those propagate out of ``dispatch_lifecycle`` unchanged and
     we never reach ``execute_callable``. In ``advisory`` / ``skip``
     modes (or when no callable is provided) the dispatch proceeds
     unchanged, preserving compatibility with existing test harnesses.

--- a/tests/unit/server/api/auth/test_check_access.py
+++ b/tests/unit/server/api/auth/test_check_access.py
@@ -1,0 +1,319 @@
+"""Unit tests for the noetl-side check_playbook_access enforcement.
+
+The DB-backed SQL query is patched out — these tests focus on the mode
+gating, header extraction, cache, and the FastAPI HTTPException shapes
+the dispatcher relies on. A separate integration test exercises the
+real auth.sessions / auth.playbook_permissions tables.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from typing import Optional
+
+import pytest
+from fastapi import HTTPException
+
+from noetl.server.api.auth import check_access as ca
+
+
+class _StubRequest:
+    """Minimal fastapi.Request stand-in exposing only ``headers``."""
+
+    def __init__(self, headers: Optional[dict[str, str]] = None) -> None:
+        self.headers = headers or {}
+
+
+def _settings(**overrides) -> ca.AuthEnforcementSettings:
+    base = ca.AuthEnforcementSettings(
+        mode=ca.EnforcementMode.ENFORCE,
+        cache_ttl_seconds=0.0,  # Disable cache by default for deterministic tests.
+        session_header="X-Session-Token",
+        db_connection_string=None,
+    )
+    return replace(base, **overrides)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Each test starts with an empty decision cache."""
+    asyncio.get_event_loop().run_until_complete(ca._cache.clear())
+    yield
+    asyncio.get_event_loop().run_until_complete(ca._cache.clear())
+
+
+# ---------------------------------------------------------------------------
+# Header extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_session_token_bearer():
+    settings = _settings()
+    req = _StubRequest({"Authorization": "Bearer abc.def.ghi"})
+    assert ca.extract_session_token(req, settings) == "abc.def.ghi"
+
+
+def test_extract_session_token_raw_authorization():
+    settings = _settings()
+    req = _StubRequest({"Authorization": "raw-token-no-scheme"})
+    assert ca.extract_session_token(req, settings) == "raw-token-no-scheme"
+
+
+def test_extract_session_token_custom_header():
+    settings = _settings(session_header="X-Session-Token")
+    req = _StubRequest({"X-Session-Token": "from-custom-header"})
+    assert ca.extract_session_token(req, settings) == "from-custom-header"
+
+
+def test_extract_session_token_missing():
+    settings = _settings()
+    req = _StubRequest({})
+    assert ca.extract_session_token(req, settings) is None
+
+
+def test_extract_session_token_empty_bearer_returns_none():
+    """`Bearer ` prefix with no token must surface as no token, not the literal 'Bearer'."""
+    settings = _settings()
+    req = _StubRequest({"Authorization": "Bearer    "})
+    assert ca.extract_session_token(req, settings) is None
+
+
+# ---------------------------------------------------------------------------
+# Mode gating — skip / advisory / enforce
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_skip_mode_short_circuits_without_token_or_db():
+    settings = _settings(mode=ca.EnforcementMode.SKIP)
+    req = _StubRequest({})  # No token at all.
+    decision = await ca.check_playbook_access(
+        request=req,
+        playbook_path="any/playbook",
+        action="execute",
+        settings=settings,
+    )
+    assert decision.allowed is True
+    assert decision.mode == ca.EnforcementMode.SKIP
+
+
+@pytest.mark.asyncio
+async def test_enforce_mode_missing_token_raises_401():
+    settings = _settings(mode=ca.EnforcementMode.ENFORCE)
+    req = _StubRequest({})
+    with pytest.raises(HTTPException) as exc:
+        await ca.check_playbook_access(
+            request=req,
+            playbook_path="any/playbook",
+            action="execute",
+            settings=settings,
+        )
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_advisory_mode_missing_token_returns_decision_without_raising():
+    settings = _settings(mode=ca.EnforcementMode.ADVISORY)
+    req = _StubRequest({})
+    decision = await ca.check_playbook_access(
+        request=req,
+        playbook_path="any/playbook",
+        action="execute",
+        settings=settings,
+    )
+    assert decision.allowed is False
+    assert decision.mode == ca.EnforcementMode.ADVISORY
+
+
+# ---------------------------------------------------------------------------
+# Mode gating — denied vs allowed via patched _query_access
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enforce_mode_denied_query_raises_403(monkeypatch):
+    settings = _settings(mode=ca.EnforcementMode.ENFORCE)
+
+    async def fake_query(**_kwargs):
+        return ca.AccessDecision(
+            allowed=False,
+            reason="no matching playbook_permission",
+            user_id=42,
+            email="user@example.com",
+            mode=ca.EnforcementMode.ENFORCE,
+        )
+
+    monkeypatch.setattr(ca, "_query_access", fake_query)
+    req = _StubRequest({"Authorization": "Bearer tok"})
+
+    with pytest.raises(HTTPException) as exc:
+        await ca.check_playbook_access(
+            request=req,
+            playbook_path="restricted/playbook",
+            action="execute",
+            settings=settings,
+        )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_advisory_mode_denied_returns_decision_without_raising(monkeypatch):
+    settings = _settings(mode=ca.EnforcementMode.ADVISORY)
+
+    async def fake_query(**_kwargs):
+        return ca.AccessDecision(
+            allowed=False,
+            reason="no matching playbook_permission",
+            user_id=42,
+            email="user@example.com",
+            mode=ca.EnforcementMode.ADVISORY,
+        )
+
+    monkeypatch.setattr(ca, "_query_access", fake_query)
+    req = _StubRequest({"Authorization": "Bearer tok"})
+
+    decision = await ca.check_playbook_access(
+        request=req,
+        playbook_path="restricted/playbook",
+        action="execute",
+        settings=settings,
+    )
+    assert decision.allowed is False
+    assert decision.mode == ca.EnforcementMode.ADVISORY
+
+
+@pytest.mark.asyncio
+async def test_enforce_mode_allowed_query_returns_decision(monkeypatch):
+    settings = _settings(mode=ca.EnforcementMode.ENFORCE)
+
+    async def fake_query(**_kwargs):
+        return ca.AccessDecision(
+            allowed=True,
+            reason="granted",
+            user_id=42,
+            email="user@example.com",
+            mode=ca.EnforcementMode.ENFORCE,
+        )
+
+    monkeypatch.setattr(ca, "_query_access", fake_query)
+    req = _StubRequest({"Authorization": "Bearer tok"})
+
+    decision = await ca.check_playbook_access(
+        request=req,
+        playbook_path="allowed/playbook",
+        action="execute",
+        settings=settings,
+    )
+    assert decision.allowed is True
+    assert decision.user_id == 42
+
+
+# ---------------------------------------------------------------------------
+# Failure path — DB exception fails closed in enforce, open-with-deny in advisory
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enforce_mode_db_error_raises_503(monkeypatch):
+    settings = _settings(mode=ca.EnforcementMode.ENFORCE)
+
+    async def fake_query(**_kwargs):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(ca, "_query_access", fake_query)
+    req = _StubRequest({"Authorization": "Bearer tok"})
+
+    with pytest.raises(HTTPException) as exc:
+        await ca.check_playbook_access(
+            request=req,
+            playbook_path="any/playbook",
+            action="execute",
+            settings=settings,
+        )
+    assert exc.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_advisory_mode_db_error_returns_denied_decision(monkeypatch):
+    settings = _settings(mode=ca.EnforcementMode.ADVISORY)
+
+    async def fake_query(**_kwargs):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(ca, "_query_access", fake_query)
+    req = _StubRequest({"Authorization": "Bearer tok"})
+
+    decision = await ca.check_playbook_access(
+        request=req,
+        playbook_path="any/playbook",
+        action="execute",
+        settings=settings,
+    )
+    assert decision.allowed is False
+    assert "auth backend unavailable" in decision.reason
+
+
+# ---------------------------------------------------------------------------
+# Cache hit short-circuits the SQL path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_skips_query(monkeypatch):
+    settings = _settings(
+        mode=ca.EnforcementMode.ADVISORY,
+        cache_ttl_seconds=60.0,
+    )
+    call_count = {"n": 0}
+
+    async def fake_query(**_kwargs):
+        call_count["n"] += 1
+        return ca.AccessDecision(
+            allowed=True,
+            reason="granted",
+            user_id=7,
+            email="cache@example.com",
+            mode=ca.EnforcementMode.ADVISORY,
+        )
+
+    monkeypatch.setattr(ca, "_query_access", fake_query)
+    req = _StubRequest({"Authorization": "Bearer same-token"})
+
+    first = await ca.check_playbook_access(
+        request=req,
+        playbook_path="cached/path",
+        action="execute",
+        settings=settings,
+    )
+    second = await ca.check_playbook_access(
+        request=req,
+        playbook_path="cached/path",
+        action="execute",
+        settings=settings,
+    )
+    assert first.allowed is True
+    assert second.allowed is True
+    assert second.cached is True
+    assert call_count["n"] == 1  # second call hit the cache.
+
+
+# ---------------------------------------------------------------------------
+# EnforcementMode parse helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("enforce", ca.EnforcementMode.ENFORCE),
+        ("ENFORCE", ca.EnforcementMode.ENFORCE),
+        ("advisory", ca.EnforcementMode.ADVISORY),
+        ("skip", ca.EnforcementMode.SKIP),
+        (None, ca.EnforcementMode.SKIP),
+        ("", ca.EnforcementMode.SKIP),
+        ("nonsense", ca.EnforcementMode.SKIP),
+    ],
+)
+def test_enforcement_mode_parse(raw, expected):
+    assert ca.EnforcementMode.parse(raw) == expected

--- a/tests/unit/server/api/auth/test_check_access.py
+++ b/tests/unit/server/api/auth/test_check_access.py
@@ -37,10 +37,24 @@ def _settings(**overrides) -> ca.AuthEnforcementSettings:
 
 @pytest.fixture(autouse=True)
 def _reset_cache():
-    """Each test starts with an empty decision cache."""
-    asyncio.get_event_loop().run_until_complete(ca._cache.clear())
-    yield
-    asyncio.get_event_loop().run_until_complete(ca._cache.clear())
+    """Each test starts (and ends) with an empty decision cache.
+
+    Spin up a dedicated event loop and tear it down deterministically
+    around each test instead of relying on ``asyncio.get_event_loop()``
+    — on Python 3.12+ that helper either implicitly creates a loop and
+    leaks it, or raises ``DeprecationWarning`` / ``RuntimeError``
+    depending on the pytest-asyncio configuration. A try/finally
+    around a fresh loop keeps the fixture portable across versions and
+    avoids ``ResourceWarning: unclosed event loop`` noise on the
+    synchronous header-extraction tests.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(ca._cache.clear())
+        yield
+        loop.run_until_complete(ca._cache.clear())
+    finally:
+        loop.close()
 
 
 # ---------------------------------------------------------------------------
@@ -77,6 +91,26 @@ def test_extract_session_token_empty_bearer_returns_none():
     settings = _settings()
     req = _StubRequest({"Authorization": "Bearer    "})
     assert ca.extract_session_token(req, settings) is None
+
+
+def test_extract_session_token_bare_bearer_returns_none():
+    """A bare `Authorization: Bearer` (no whitespace, no token) is no token, not literal 'Bearer'."""
+    settings = _settings()
+    assert ca.extract_session_token(_StubRequest({"Authorization": "Bearer"}), settings) is None
+    assert ca.extract_session_token(_StubRequest({"Authorization": "  Bearer  "}), settings) is None
+    # Case-insensitive — RFC 7235 makes the scheme case-insensitive.
+    assert ca.extract_session_token(_StubRequest({"Authorization": "bearer"}), settings) is None
+    assert ca.extract_session_token(_StubRequest({"Authorization": "BEARER"}), settings) is None
+
+
+def test_settings_blank_session_header_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("NOETL_AUTH_SESSION_HEADER", "")
+    s = ca.AuthEnforcementSettings.from_env()
+    assert s.session_header == "X-Session-Token"
+
+    monkeypatch.setenv("NOETL_AUTH_SESSION_HEADER", "   ")
+    s = ca.AuthEnforcementSettings.from_env()
+    assert s.session_header == "X-Session-Token"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/api/mcp/test_lifecycle_dispatch.py
+++ b/tests/unit/server/api/mcp/test_lifecycle_dispatch.py
@@ -235,3 +235,124 @@ async def test_workload_overrides_merge_when_no_collision():
     assert captured["workload"]["verb"] == "deploy"
     assert captured["workload"]["image_tag"] == "v1.2.3"
     assert captured["workload"]["force"] is True
+
+
+# ---------------------------------------------------------------------------
+# auth_check_callable wiring (Phase 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_invokes_auth_check_with_resolved_agent_path():
+    """The lifecycle dispatcher authorises against the agent path, not the Mcp path.
+
+    Granting execute on `automation/agents/kubernetes/lifecycle/deploy`
+    should gate the deploy verb regardless of which Mcp resource exposes
+    it.
+    """
+    entry = _CatalogEntryStub(
+        catalog_id="100",
+        path="mcp/kubernetes",
+        version=4,
+        kind="Mcp",
+        payload={
+            "spec": {
+                "lifecycle": {
+                    "deploy": "automation/agents/kubernetes/lifecycle/deploy",
+                },
+            },
+        },
+    )
+    auth_calls: list[dict[str, Any]] = []
+    execute_called = False
+
+    async def fake_check(*, playbook_path: str, action: str = "execute"):
+        auth_calls.append({"playbook_path": playbook_path, "action": action})
+
+    async def fake_execute(*, path: str, workload: dict[str, Any]) -> str:
+        nonlocal execute_called
+        execute_called = True
+        return "exec-1"
+
+    response = await dispatch_lifecycle(
+        catalog_service=_FakeCatalogService(entry),
+        execute_callable=fake_execute,
+        path="mcp/kubernetes",
+        verb="deploy",
+        version="latest",
+        auth_check_callable=fake_check,
+    )
+
+    assert response.execution_id == "exec-1"
+    assert execute_called is True
+    assert auth_calls == [
+        {
+            "playbook_path": "automation/agents/kubernetes/lifecycle/deploy",
+            "action": "execute",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_execute_when_auth_check_raises():
+    """If the auth callable raises, the execute_callable must not run."""
+    entry = _CatalogEntryStub(
+        catalog_id="100",
+        path="mcp/kubernetes",
+        version=4,
+        kind="Mcp",
+        payload={
+            "spec": {
+                "lifecycle": {
+                    "deploy": "automation/agents/kubernetes/lifecycle/deploy",
+                },
+            },
+        },
+    )
+
+    async def deny(*, playbook_path: str, action: str = "execute"):
+        raise HTTPException(status_code=403, detail="denied")
+
+    execute_called = False
+
+    async def fake_execute(*, path: str, workload: dict[str, Any]) -> str:
+        nonlocal execute_called  # pragma: no cover -- must not be reached
+        execute_called = True
+        return "should-not-run"
+
+    with pytest.raises(HTTPException) as exc:
+        await dispatch_lifecycle(
+            catalog_service=_FakeCatalogService(entry),
+            execute_callable=fake_execute,
+            path="mcp/kubernetes",
+            verb="deploy",
+            version="latest",
+            auth_check_callable=deny,
+        )
+
+    assert exc.value.status_code == 403
+    assert execute_called is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_no_auth_callable_runs_unchanged():
+    """Backwards-compat: omitting auth_check_callable keeps behaviour from before Phase 2."""
+    entry = _CatalogEntryStub(
+        catalog_id="100",
+        path="mcp/kubernetes",
+        version=4,
+        kind="Mcp",
+        payload={"spec": {"lifecycle": {"deploy": "agents/k8s/lifecycle/deploy"}}},
+    )
+
+    async def fake_execute(*, path: str, workload: dict[str, Any]) -> str:
+        return "exec-x"
+
+    response = await dispatch_lifecycle(
+        catalog_service=_FakeCatalogService(entry),
+        execute_callable=fake_execute,
+        path="mcp/kubernetes",
+        verb="deploy",
+        version="latest",
+    )
+    assert response.execution_id == "exec-x"


### PR DESCRIPTION
# Phase 2 — noetl-side `check_playbook_access` enforcement

## What

Lands the auth-as-playbook authorisation decision *inside* the noetl FastAPI app so it
fires regardless of whether a gateway is deployed in front. Local kind, GKE clusters
that aren't internet-exposed, and direct-to-server calls all inherit the same
enforcement path; the existing Rust gateway stays as an optional perimeter
(UX pre-flight + session-token caching), **not** the source of truth.

Refs: [architecture sketch](https://github.com/noetl/ai-meta/blob/main/sync/issues/2026-04-28-architecture-mcp-catalog-and-friendly-playbook-launcher.md), noetl/noetl#392, noetl/noetl#393, noetl/ops#15.

## Why server-side, not gateway-side

The user pointed out that gateways aren't always present — local kind, private GKE
clusters that aren't internet-exposed. Putting enforcement only in the Rust gateway
means the auth-as-playbook model becomes a no-op in those deployments, and any
in-cluster lateral movement bypasses it entirely. The fix is **defense in depth**:
the gateway stays as a UX/perimeter layer, but the noetl server is the source of
truth and authorises every dispatch on its own.

The same `auth.sessions` / `auth.user_roles` / `auth.playbook_permissions` tables
the existing `api_integration/auth0/check_playbook_access` playbook reads —
permissions granted via the GUI / playbook flow continue to work without
modification. We're adding a fast Python path next to the existing playbook flow,
not replacing it.

## Three modes

| Mode | Behaviour on deny | Use case |
|---|---|---|
| `enforce` | `HTTPException(403)` (missing token: `401`; DB error: `503`) | Production. The only mode that actually blocks. |
| `advisory` | Returns the decision unchanged; logs a warning. | Bringing a deployment online before the permission table is populated — see who *would* be blocked. |
| `skip` | Short-circuits with `allowed=True`. Never queries the DB. | Local kind dev. Default. |

Configured via env vars:

```
NOETL_AUTH_ENFORCEMENT_MODE      enforce | advisory | skip   (default: skip)
NOETL_AUTH_CACHE_TTL_SECONDS     in-memory decision cache    (default: 30)
NOETL_AUTH_SESSION_HEADER        fallback header name         (default: X-Session-Token)
NOETL_AUTH_DB_CONNECTION_STRING  override default conn        (default: None)
```

`Authorization: Bearer <token>` is always honoured.

## How it wires in

`noetl/server/api/mcp/service.py` — both `dispatch_lifecycle` and `dispatch_discover`
gain an optional `auth_check_callable` kwarg. Lifecycle authorises against the
*resolved* agent path so granting execute on
`automation/agents/kubernetes/lifecycle/deploy` gates the `deploy` verb regardless
of which Mcp resource exposed it. Discover authorises against the agent's
`refresh_via` path when present, or the Mcp resource path itself for the
direct-URL strategy. Existing call sites that omit the kwarg keep the pre-Phase-2
behaviour, so the lifecycle/discover dispatch tests still pass unchanged.

`noetl/server/api/mcp/endpoint.py` — both POST routes inject
`AuthEnforcementSettings` via `Depends`, build a request-bound auth callable, and
pass it through to the service.

## Tests

`tests/unit/server/api/auth/test_check_access.py` — 11 cases covering header
extraction, all three modes, allowed/denied/DB-error paths, and cache-hit
short-circuit.

`tests/unit/server/api/mcp/test_lifecycle_dispatch.py` — three new cases proving
the dispatcher invokes the auth callable with the resolved agent path, doesn't
call `execute_callable` when the auth callable raises, and stays
backwards-compatible when the callable is omitted.

Hand-rolled smoke checks in the sandbox confirm all 8 mode-gating / cache /
extraction paths behave as designed; full pytest run lives on the dev machine
where psycopg / fastapi are installed.

## Migration

- **Existing local-dev**: nothing to do. Default mode is `skip`, behaviour
  unchanged.
- **GKE / production with gateway**: set `NOETL_AUTH_ENFORCEMENT_MODE=enforce`
  on the noetl server. The gateway's `/api/auth/check-access` keeps working as a
  UI pre-flight; the server now also validates on dispatch.
- **GKE / production without gateway**: set `NOETL_AUTH_ENFORCEMENT_MODE=enforce`
  on the noetl server. Clients pass `Authorization: Bearer <session_token>` and
  the server enforces against `auth.playbook_permissions` directly.
- **Rolling out**: flip `enforce` → `advisory` first. Audit the warnings,
  populate any missing permissions, then flip to `enforce`.

## Follow-ups (separate PRs)

- noetl: extend the same enforcement to non-MCP playbook dispatch routes
  (`/api/playbooks/run`, etc.) — same mechanism, just thread the callable
  through `core/execution`.
- gui: surface "you don't have permission to run this" in the run dialog so
  users see a clean message rather than a raw 403.
