### PR TITLE
fix(catalog): YAML payload kind: is authoritative on register

### DIFF
--- a/noetl/server/api/catalog/service.py
+++ b/noetl/server/api/catalog/service.py
@@ -337,6 +337,30 @@ class CatalogService:
         return aliases.get(value, value).strip().lower()
 
     @staticmethod
+    def _resolve_resource_kind(*, payload: Any, fallback: Optional[str]) -> str:
+        """Resolve the catalog kind for a registration request.
+
+        The YAML's own ``kind:`` field is authoritative — the request
+        ``resource_type`` parameter is a hint that callers (e.g. the
+        CLI's ``noetl catalog register``) tend to default to
+        "Playbook" without sniffing the file. Without this precedence,
+        an ``kind: Mcp`` template registered via the catch-all
+        ``catalog register`` path lands in the catalog as
+        ``kind: playbook`` and downstream lookups (e.g.
+        ``fetch_mcp_resource``, which guards
+        ``kind.lower() == "mcp"``) reject it as the wrong type.
+
+        Fall back to the request parameter only when the payload
+        doesn't declare a kind. Both branches go through
+        ``_normalize_resource_type`` so the alias table is the single
+        place that knows ``MCP``/``Mcp``/``mcp`` collapse to ``mcp``.
+        """
+        payload_kind = payload.get("kind") if isinstance(payload, dict) else None
+        if isinstance(payload_kind, str) and payload_kind.strip():
+            return CatalogService._normalize_resource_type(payload_kind)
+        return CatalogService._normalize_resource_type(fallback)
+
+    @staticmethod
     def _resource_type_meta(resource_type: str) -> Dict[str, Any]:
         catalog_types = {
             "playbook": {
@@ -370,7 +394,10 @@ class CatalogService:
     @staticmethod
     async def register_resource(content: str, resource_type: str = "Playbook") -> Dict[str, Any]:
         resource_data = yaml.safe_load(content) or {}
-        resource_type = CatalogService._normalize_resource_type(resource_type)
+        resource_type = CatalogService._resolve_resource_kind(
+            payload=resource_data,
+            fallback=resource_type,
+        )
         path = (resource_data.get("metadata") or {}).get("path") or resource_data.get("path") or (
             resource_data.get("metadata") or {}).get("name") or resource_data.get("name") or "unknown"
 

--- a/tests/unit/server/api/catalog/test_resource_kind_resolution.py
+++ b/tests/unit/server/api/catalog/test_resource_kind_resolution.py
@@ -1,0 +1,124 @@
+"""Unit tests for the catalog kind-precedence helper.
+
+The DB-backed register_resource path is exercised by integration tests;
+these focus on the pure resolution logic so a regression in the
+"YAML kind: is authoritative" rule is caught without standing up
+Postgres.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from noetl.server.api.catalog.service import CatalogService
+
+
+# ---------------------------------------------------------------------------
+# Payload kind wins over the request parameter
+# ---------------------------------------------------------------------------
+
+
+def test_payload_mcp_kind_overrides_default_playbook_fallback():
+    """An ``kind: Mcp`` template registered via the catch-all
+    ``catalog register`` (which the CLI sends as resource_type="Playbook")
+    must land in the catalog as kind=mcp, not kind=playbook.
+    """
+    payload = {"kind": "Mcp", "metadata": {"path": "mcp/kubernetes"}, "spec": {}}
+    assert CatalogService._resolve_resource_kind(
+        payload=payload,
+        fallback="Playbook",
+    ) == "mcp"
+
+
+def test_payload_kind_aliases_normalised():
+    """All recognised aliases collapse through _normalize_resource_type."""
+    cases = [
+        ("Playbook", "playbook"),
+        ("Mcp", "mcp"),
+        ("MCP", "mcp"),
+        ("ModelContextProtocol", "mcp"),
+        ("Agent", "agent"),
+        ("Credential", "credential"),
+        ("Memory", "memory"),
+    ]
+    for raw, expected in cases:
+        payload = {"kind": raw}
+        assert (
+            CatalogService._resolve_resource_kind(payload=payload, fallback="Playbook")
+            == expected
+        ), f"kind={raw!r} should normalise to {expected!r}"
+
+
+def test_payload_kind_with_surrounding_whitespace_is_used():
+    """A whitespace-surrounded but non-empty kind should still beat the fallback."""
+    payload = {"kind": "  Mcp  "}
+    assert CatalogService._resolve_resource_kind(
+        payload=payload,
+        fallback="Playbook",
+    ) == "mcp"
+
+
+# ---------------------------------------------------------------------------
+# Fallback to request parameter
+# ---------------------------------------------------------------------------
+
+
+def test_missing_payload_kind_falls_back_to_parameter():
+    """Older YAMLs without an explicit kind: still register correctly via the parameter."""
+    payload = {"metadata": {"path": "x"}, "spec": {}}
+    assert CatalogService._resolve_resource_kind(
+        payload=payload,
+        fallback="Playbook",
+    ) == "playbook"
+    assert CatalogService._resolve_resource_kind(
+        payload=payload,
+        fallback="Mcp",
+    ) == "mcp"
+
+
+def test_blank_payload_kind_falls_back_to_parameter():
+    payload = {"kind": "", "metadata": {"path": "x"}}
+    assert CatalogService._resolve_resource_kind(
+        payload=payload,
+        fallback="Playbook",
+    ) == "playbook"
+
+    payload = {"kind": "   "}
+    assert CatalogService._resolve_resource_kind(
+        payload=payload,
+        fallback="Mcp",
+    ) == "mcp"
+
+
+def test_non_string_payload_kind_falls_back_to_parameter():
+    """Defensive: an integer / list / dict in `kind:` shouldn't crash the resolver."""
+    for bad in (42, ["Mcp"], {"name": "Mcp"}):
+        assert CatalogService._resolve_resource_kind(
+            payload={"kind": bad},
+            fallback="Playbook",
+        ) == "playbook"
+
+
+def test_non_dict_payload_falls_back_to_parameter():
+    """An empty / scalar / list YAML body shouldn't crash — treat as no payload kind."""
+    for payload in (None, "", [], "scalar", 123):
+        assert CatalogService._resolve_resource_kind(
+            payload=payload,
+            fallback="Mcp",
+        ) == "mcp"
+
+
+# ---------------------------------------------------------------------------
+# Both empty -> default playbook (preserves prior behaviour)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_payload_and_blank_fallback_uses_default_playbook():
+    assert CatalogService._resolve_resource_kind(
+        payload={},
+        fallback=None,
+    ) == "playbook"
+    assert CatalogService._resolve_resource_kind(
+        payload={},
+        fallback="",
+    ) == "playbook"


### PR DESCRIPTION
# fix(catalog): YAML payload `kind:` is authoritative on register

## What

Makes the YAML payload's own `kind:` field authoritative on
`POST /api/catalog/register`. Without this, the catch-all
`noetl catalog register <file>` path (which always sends
`resource_type: "Playbook"`) registers an `kind: Mcp` template as
`kind: playbook`, and `POST /api/mcp/{path}/lifecycle/{verb}` then
400s with "expected mcp".

## Repro that motivated the fix

After registering the curated `mcp_kubernetes.yaml` template from
[noetl/ops#15](https://github.com/noetl/ops/pull/15) on a kind cluster:

```
$ noetl catalog get mcp/kubernetes
{
  "kind": "playbook",          # ← wrong
  "payload": {
    "kind": "Mcp",             # ← right
    "spec": {"lifecycle": {"deploy": "..."}, ...},
    ...
  }
}
```

The dispatcher's `fetch_mcp_resource` guards
`kind.lower() == "mcp"` and rejects the entry, breaking every lifecycle
verb on the freshly-registered Mcp resource.

## Fix

`CatalogService.register_resource` now resolves the kind via a small
helper:

```python
@staticmethod
def _resolve_resource_kind(*, payload, fallback) -> str:
    payload_kind = payload.get("kind") if isinstance(payload, dict) else None
    if isinstance(payload_kind, str) and payload_kind.strip():
        return CatalogService._normalize_resource_type(payload_kind)
    return CatalogService._normalize_resource_type(fallback)
```

The YAML's own `kind:` is the source of truth; the request parameter
remains as a fallback for older YAMLs that don't declare a top-level
kind. Both branches funnel through `_normalize_resource_type` so the
existing Mcp/MCP/ModelContextProtocol alias table is the only place
that knows about case normalisation.

## Tests

`tests/unit/server/api/catalog/test_resource_kind_resolution.py` —
8 cases covering:

- payload `kind: Mcp` beats request `resource_type: Playbook` fallback
- all aliases (Mcp / MCP / ModelContextProtocol / Agent / Credential / Memory) normalise consistently
- whitespace-padded kinds still win
- missing / blank / non-string / non-dict payload kinds fall back gracefully
- both empty defaults to `playbook` (preserves prior behaviour)

Hand-rolled smoke check in the sandbox confirms all 8 scenarios pass.

## Rollout

After this lands, re-register any Mcp / Agent / etc. resources that
were registered through the catch-all `catalog register` path while
the bug was live. For the kind cluster this is just:

```
noetl catalog register automation/agents/kubernetes/templates/mcp_kubernetes.yaml
```

— the same command that originally produced the wrong `kind: playbook`
will now produce `kind: mcp` and unblock the lifecycle dispatcher.

## Follow-ups

- A future PR can extend `repos/cli`'s `register_resource` helper to
  also sniff the YAML's `kind:` when constructing the request body, so
  the intent is correct on the wire before it even reaches the server.
  Less critical now that the server is robust to a wrong hint, but
  nice-to-have for clarity.

Refs: noetl/ops#15, noetl/noetl#392, noetl/noetl#394.
