### PR TITLE
feat(catalog): validate Playbook/Agent payloads at register time

### DIFF
--- a/noetl/server/api/catalog/service.py
+++ b/noetl/server/api/catalog/service.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from collections import OrderedDict
 import time
 import yaml
+from fastapi import HTTPException
 from psycopg.rows import dict_row
 from psycopg.types.json import Json
 from noetl.core.db.pool import get_pool_connection
@@ -361,6 +362,81 @@ class CatalogService:
         return CatalogService._normalize_resource_type(fallback)
 
     @staticmethod
+    def _validate_payload(*, resource_type: str, payload: Any, path: str) -> None:
+        """Validate a catalog payload against its Pydantic model.
+
+        Catches DSL bugs at register time with a Pydantic error path
+        (``workflow.0.next: Input should be a valid dictionary or
+        instance of NextRouter``) instead of letting them surface at
+        first execute time as the misleading
+        ``"Playbook not found: catalog_id=..."`` from
+        ``PlaybookRepo.load_playbook_by_id`` swallowing the
+        ``ValidationError``.
+
+        Strategy:
+
+        - ``playbook`` / ``agent`` → validate against
+          ``Playbook.model_validate``. Agents are
+          playbook-shaped — same Pydantic model, same constraints.
+        - any other kind (``mcp``, ``credential``, ``memory``) →
+          skip. The Mcp resource has its own (less strict)
+          shape that the catalog stores opaquely; we don't yet have
+          a Pydantic model for it. Leaving an explicit branch here
+          documents the intent so a future PR can wire those up.
+
+        Raises ``HTTPException(422)`` on validation failure. The
+        detail string carries the first few field paths so the GUI's
+        run dialog or the CLI can surface them inline without forcing
+        the caller to dig through server logs.
+        """
+        if resource_type not in {"playbook", "agent"}:
+            return
+
+        if not isinstance(payload, dict):
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"register_resource: '{path}' kind='{resource_type}' "
+                    "payload is not a YAML mapping"
+                ),
+            )
+
+        # Late import — keeps the catalog service importable in a
+        # bare environment (tests, scripts) without dragging the full
+        # engine model graph along for the ride.
+        from pydantic import ValidationError
+        from noetl.core.dsl.engine.models.executor import Playbook
+
+        try:
+            Playbook.model_validate(payload)
+        except ValidationError as exc:
+            # Surface up to three field paths in the HTTP detail so
+            # the run dialog can show them inline. Server logs still
+            # carry the full structured error for debugging.
+            errors = exc.errors()
+            preview = []
+            for err in errors[:3]:
+                loc = ".".join(str(part) for part in err.get("loc", []))
+                msg = err.get("msg", "invalid")
+                preview.append(f"{loc}: {msg}" if loc else msg)
+            more = f" (+{len(errors) - 3} more)" if len(errors) > 3 else ""
+            logger.warning(
+                "CATALOG: rejecting %s '%s' — %d Pydantic validation error(s): %s",
+                resource_type,
+                path,
+                len(errors),
+                errors,
+            )
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"register_resource: '{path}' is not a valid {resource_type}: "
+                    + "; ".join(preview)
+                    + more
+                ),
+            ) from exc
+
+    @staticmethod
     def _resource_type_meta(resource_type: str) -> Dict[str, Any]:
         catalog_types = {
             "playbook": {
@@ -400,6 +476,18 @@ class CatalogService:
         )
         path = (resource_data.get("metadata") or {}).get("path") or resource_data.get("path") or (
             resource_data.get("metadata") or {}).get("name") or resource_data.get("name") or "unknown"
+
+        # Validate the payload against its Pydantic model BEFORE the
+        # implicit-end injection so the caller's intent is what's
+        # validated (a deprecated `next: - step:` form, a missing
+        # `tool:` block, etc.). The implicit-end step we tack on
+        # below is a server-side convenience and is always
+        # well-formed; we don't need to re-validate after that.
+        CatalogService._validate_payload(
+            resource_type=resource_type,
+            payload=resource_data,
+            path=str(path),
+        )
 
         # Inject implicit "end" step if playbook doesn't have one
         if resource_type in {"playbook", "agent"}:

--- a/tests/unit/server/api/catalog/test_resource_kind_resolution.py
+++ b/tests/unit/server/api/catalog/test_resource_kind_resolution.py
@@ -1,14 +1,15 @@
-"""Unit tests for the catalog kind-precedence helper.
+"""Unit tests for the catalog kind-precedence helper + register-time validation.
 
 The DB-backed register_resource path is exercised by integration tests;
-these focus on the pure resolution logic so a regression in the
-"YAML kind: is authoritative" rule is caught without standing up
-Postgres.
+these focus on the pure resolution + validation logic so regressions in
+the "YAML kind: is authoritative" rule and the Pydantic validation
+gate are caught without standing up Postgres.
 """
 
 from __future__ import annotations
 
 import pytest
+from fastapi import HTTPException
 
 from noetl.server.api.catalog.service import CatalogService
 
@@ -122,3 +123,109 @@ def test_empty_payload_and_blank_fallback_uses_default_playbook():
         payload={},
         fallback="",
     ) == "playbook"
+
+
+# ---------------------------------------------------------------------------
+# _validate_payload — register-time Pydantic validation
+# ---------------------------------------------------------------------------
+
+
+def _valid_playbook_dict():
+    """Minimal v10 playbook that passes Pydantic validation."""
+    return {
+        "apiVersion": "noetl.io/v2",
+        "kind": "Playbook",
+        "metadata": {"name": "test_pb", "path": "tests/fixtures/test_pb"},
+        "workflow": [
+            {
+                "step": "start",
+                "tool": {"kind": "noop"},
+                "next": {
+                    "spec": {"mode": "exclusive"},
+                    "arcs": [{"step": "end"}],
+                },
+            },
+            {"step": "end", "tool": {"kind": "noop"}},
+        ],
+    }
+
+
+def test_validate_payload_skips_non_playbook_kinds():
+    """mcp / credential / memory kinds skip Pydantic validation entirely."""
+    for kind in ("mcp", "credential", "memory"):
+        # An obviously invalid playbook shouldn't raise — those kinds aren't
+        # validated against the Playbook model.
+        CatalogService._validate_payload(
+            resource_type=kind,
+            payload={"apiVersion": "noetl.io/v2", "kind": kind, "metadata": {"name": "x"}},
+            path="x",
+        )
+
+
+def test_validate_payload_accepts_valid_playbook():
+    CatalogService._validate_payload(
+        resource_type="playbook",
+        payload=_valid_playbook_dict(),
+        path="tests/fixtures/test_pb",
+    )
+
+
+def test_validate_payload_rejects_deprecated_list_form_next():
+    """Locks in the regression that motivated this PR.
+
+    The deprecated `next: - step: end` form (an Arc list rather than
+    a NextRouter dict) must surface as 422 at register time, not as
+    a misleading "Playbook not found" at execute time.
+    """
+    bad = _valid_playbook_dict()
+    bad["workflow"][0]["next"] = [{"step": "end"}]  # the deprecated v9 form
+
+    with pytest.raises(HTTPException) as info:
+        CatalogService._validate_payload(
+            resource_type="playbook",
+            payload=bad,
+            path="tests/fixtures/bad_pb",
+        )
+    assert info.value.status_code == 422
+    assert "tests/fixtures/bad_pb" in info.value.detail
+    assert "next" in info.value.detail.lower()
+
+
+def test_validate_payload_rejects_invalid_kind_field():
+    """An apiVersion / kind mismatch should also be a 422."""
+    bad = _valid_playbook_dict()
+    bad["kind"] = "NotAPlaybook"
+
+    with pytest.raises(HTTPException) as info:
+        CatalogService._validate_payload(
+            resource_type="playbook",
+            payload=bad,
+            path="x",
+        )
+    assert info.value.status_code == 422
+
+
+def test_validate_payload_rejects_non_dict_payload():
+    """A YAML body that parses to a list / scalar / None should 422."""
+    for bad in ([], "scalar", 42, None):
+        with pytest.raises(HTTPException) as info:
+            CatalogService._validate_payload(
+                resource_type="playbook",
+                payload=bad,
+                path="x",
+            )
+        assert info.value.status_code == 422
+
+
+def test_validate_payload_validates_agents_too():
+    """`agent` resources are playbook-shaped — same Pydantic model gates them."""
+    bad = _valid_playbook_dict()
+    bad["workflow"] = []  # empty workflow trips the validator
+
+    with pytest.raises(HTTPException) as info:
+        CatalogService._validate_payload(
+            resource_type="agent",
+            payload=bad,
+            path="x",
+        )
+    assert info.value.status_code == 422


### PR DESCRIPTION
# feat(catalog): validate Playbook/Agent payloads at register time

## What

Wires `Playbook.model_validate()` into `CatalogService.register_resource`
so DSL bugs surface immediately at register time with a Pydantic field
path, instead of being stored in the catalog and surfacing as the
misleading `"Playbook not found: catalog_id=..."` at the first execute
attempt.

## Why this PR exists

Concrete bug that motivated it: six lifecycle agents shipped in
[noetl/ops#15](https://github.com/noetl/ops/pull/15) declared their
terminal-step transitions as `next: - step: end` (deprecated v9 list
form), which the v10 `Step.next: Optional[NextRouter]` field rejects.
The flow today:

1. `noetl catalog register agent.yaml` succeeds. Catalog stores the YAML.
2. Operator clicks "Run".
3. `PlaybookRepo.load_playbook_by_id` calls `Playbook(**parsed)`, hits a
   Pydantic `ValidationError`, swallows it, returns `None`.
4. `Engine.start_execution` re-raises the `None` as
   `ValueError("Playbook not found: catalog_id=... path=...")`.
5. FastAPI surfaces that as a 500 with the misleading detail.

Catalog row is right there. Error is anywhere but the bug. Fixed in
[noetl/ops#16](https://github.com/noetl/ops/pull/16) at the YAML side,
but the underlying gap — the catalog accepting playbooks the engine
can't load — needs the server-side fix.

## What changed

`noetl/server/api/catalog/service.py`:

- New static `CatalogService._validate_payload(resource_type, payload, path)`:
  - Returns immediately for non-playbook/non-agent kinds. `mcp` /
    `credential` / `memory` are stored opaquely; future PRs can wire
    Pydantic models for those when they exist.
  - Lazily imports the v10 `Playbook` model so the catalog service stays
    importable in bare environments (tests, scripts, scratch envs).
  - Calls `Playbook.model_validate(payload)`. On `ValidationError`,
    raises `HTTPException(422)` with up to three field-path/message
    pairs in the `detail` (so the GUI run dialog and `noetl catalog
    register` CLI surface them inline), and logs the full structured
    errors at WARNING for server-side debugging.
- Wired into `register_resource` after kind resolution and **before**
  the implicit-end injection — we want to validate the caller's intent,
  not the server-side rewrite.

`tests/unit/server/api/catalog/test_resource_kind_resolution.py`:

| case | asserts |
|---|---|
| skips non-playbook kinds | `mcp`/`credential`/`memory` payloads pass through unvalidated |
| accepts canonical v10 playbook | minimal valid v10 payload validates |
| rejects deprecated `next: - step:` form | 422 with field path + resource path — locks in the regression |
| rejects invalid `kind:` | wrong `kind: NotAPlaybook` 422 |
| rejects non-dict payloads | list / scalar / None 422 |
| validates agents too | `kind: agent` resources validate against the same Playbook model |

## Behaviour change

- **Before**: malformed playbook stored, fails at first execute as
  "Playbook not found: catalog_id=...". Operator stares at server logs.
- **After**: malformed playbook rejected at register with
  `422: register_resource: 'path/x' is not a valid playbook:
  workflow.0.next: Input should be a valid dictionary or instance of
  NextRouter`. Operator fixes the YAML and tries again.

## Compat

- Existing valid playbooks continue to register unchanged.
- Existing **invalid** playbooks already in the catalog are not affected
  — this only gates new registrations. Operators with broken catalog
  entries should re-register the corrected YAML.
- Non-playbook kinds (mcp/credential/memory) skip the new validation
  entirely; their behaviour is unchanged.

## Follow-ups (separate PRs)

- Wire a Pydantic model for `kind: Mcp` resources and extend
  `_validate_payload` to gate them too.
- The GUI run dialog can display the 422 detail (which carries field
  paths) inline against the offending YAML field once an editor-side
  schema validator (`playbook.schema.json`, shipped in
  [noetl/noetl#396](https://github.com/noetl/noetl/pull/396)) is wired
  into the GUI's YAML editor.

Refs: noetl/ops#15, noetl/ops#16, noetl/noetl#395, noetl/noetl#396.
