### PR TITLE
fix(catalog): preserve HTTPException status on /catalog/register

### DIFF
--- a/noetl/server/api/catalog/endpoint.py
+++ b/noetl/server/api/catalog/endpoint.py
@@ -306,6 +306,14 @@ async def register_resource(
     try:
         result = await catalog_service.register_resource(request.content, request.resource_type)
         return CatalogRegisterResponse(**result)
+    except HTTPException:
+        # HTTPExceptions raised inside the service layer (e.g. the
+        # 422 from CatalogService._validate_payload when a Pydantic
+        # validation fails) carry their own status_code + detail.
+        # Don't downgrade them to a generic 500 with the message
+        # stringified — clients can't distinguish "bad YAML" from
+        # "DB unavailable" if both come back as 500.
+        raise
     except Exception as e:
         logger.exception(f"Error registering resource: {e}.")
         raise HTTPException(


### PR DESCRIPTION
fix(catalog): preserve HTTPException status on /catalog/register

The `/api/catalog/register` endpoint wraps the service-layer call in a
bare `except Exception` and rethrows everything as a 500 with the
original error stringified into `detail`. That's lossy for any
HTTPException intentionally raised inside the service layer — most
notably the 422 introduced in noetl/noetl#397 when
`CatalogService._validate_payload` rejects a malformed playbook.

Codex's smoke run on a fresh kind cluster against v2.27.0 caught this:

    $ noetl catalog register /tmp/bad_playbook.yaml
    Failed to register Playbook: 500 Internal Server Error -
    {"detail":"Error registering resource: 422: register_resource:
    'tests/scratch/bad_validation_smoke' is not a valid playbook:
    workflow.0.next: Input should be a valid dictionary or instance
    of NextRouter."}

The validation gate fires correctly, but the client sees a 500 with
the proper detail wrapped inside another error string. A real "DB
unavailable" 500 and a "bad YAML" 422 are now indistinguishable to
any caller that branches on status_code (the GUI's run dialog, the
CLI's error formatter, etc.).

Fix: catch `HTTPException` first and re-raise unchanged, only wrap
generic `Exception` as the 500. Same shape the MCP endpoint already
uses in noetl/server/api/mcp/endpoint.py for `dispatch_lifecycle` and
`dispatch_discover`.

After this lands, the smoke that motivated #397 produces what it
should:

    $ noetl catalog register /tmp/bad_playbook.yaml
    Failed to register Playbook: 422 Unprocessable Entity -
    {"detail":"register_resource: 'tests/scratch/bad_validation_smoke'
    is not a valid playbook: workflow.0.next: Input should be a valid
    dictionary or instance of NextRouter."}

Refs: noetl/noetl#397.