### PR TITLE
feat(docker): bake helm + kubectl into the noetl worker image

### DIFF
--- a/docker/noetl/dev/Dockerfile
+++ b/docker/noetl/dev/Dockerfile
@@ -31,10 +31,36 @@ FROM python:3.12-slim AS production
 LABEL org.opencontainers.image.source=https://github.com/noetl/noetl
 LABEL org.opencontainers.image.licenses=MIT
 
+# kubectl + helm are first-class tool dependencies for `kind: shell`
+# steps in lifecycle agents (e.g. the kubernetes MCP server's
+# automation/agents/kubernetes/lifecycle/{deploy,undeploy,...}). The
+# noetl worker dispatches those agents in-process; without these
+# binaries on PATH every helm-driven deploy fails with
+# "helm: not found".
+#
+# Multi-arch handled via dpkg --print-architecture (amd64 / arm64).
+# Versions pinned to recent stable releases — bump at the same
+# cadence as the upstream release notes.
+ARG KUBECTL_VERSION=v1.30.5
+ARG HELM_VERSION=v3.16.2
+
 RUN apt-get update && apt-get --no-install-recommends install -y \
     curl \
     libpq-dev \
-    && rm -rf /var/lib/apt/lists/*
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && DPKG_ARCH="$(dpkg --print-architecture)" \
+    && curl -fsSLo /usr/local/bin/kubectl \
+         "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${DPKG_ARCH}/kubectl" \
+    && chmod +x /usr/local/bin/kubectl \
+    && kubectl version --client \
+    && curl -fsSLo /tmp/helm.tar.gz \
+         "https://get.helm.sh/helm-${HELM_VERSION}-linux-${DPKG_ARCH}.tar.gz" \
+    && tar -xzf /tmp/helm.tar.gz -C /tmp \
+    && mv "/tmp/linux-${DPKG_ARCH}/helm" /usr/local/bin/helm \
+    && chmod +x /usr/local/bin/helm \
+    && rm -rf /tmp/helm.tar.gz "/tmp/linux-${DPKG_ARCH}" \
+    && helm version --short
 
 # ENV TZ=America/Chicago
 # RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone


### PR DESCRIPTION
feat(docker): bake helm + kubectl into the noetl worker image

The noetl worker image's production stage ships only python + libpq +
curl. That's enough for python / postgres / http / duckdb tools, but
not for `kind: shell` steps in lifecycle agents that drive helm
deploys against the cluster the worker is running in.

Concrete bug: every dispatch through
`POST /api/mcp/{path}/lifecycle/deploy` fails with
`helm: command not found` once it reaches the worker. Same for
`undeploy` and `restart`. `status` partially worked (its read-only
shell paths use `kubectl get`) but kubectl was also missing, so
even status was likely silently producing empty output before this
patch. Confirmed inside the running v2.27.0 worker:

  $ kubectl -n noetl exec deploy/noetl-worker -- which helm
  sh: 1: helm: not found
  $ kubectl -n noetl exec deploy/noetl-worker -- which kubectl
  sh: 1: kubectl: not found

Fix: install kubectl and helm into the production stage of
`docker/noetl/dev/Dockerfile`. Both:

  - pinned to recent stable versions via `ARG` so the bump cadence is
    visible in git history (KUBECTL_VERSION=v1.30.5, HELM_VERSION=v3.16.2)
  - multi-arch via `dpkg --print-architecture` (amd64 + arm64 — the
    same shape the build_on_release CI publishes)
  - smoke-tested in the same RUN layer (kubectl version --client,
    helm version --short) so a 404 from the upstream release URL fails
    the build instead of producing a broken image
  - ca-certificates added (helm pulls oci charts; without ca-certs the
    fetch fails on TLS verification)

Image size impact: ~50MB (kubectl ~50MB, helm ~50MB compressed).
Acceptable cost for first-class lifecycle support.

After this PR merges + a fresh image rolls out, the round-2 deploy
smoke that motivated this PR should produce an actual mcp namespace
deployment:

  $ curl -s -X POST http://localhost:8082/api/mcp/mcp/kubernetes/lifecycle/deploy \
      -H "Content-Type: application/json" -d '{}' | python3 -m json.tool
  $ sleep 60
  $ kubectl -n mcp get all
  # Expect: deployment/kubernetes-mcp-server, service/kubernetes-mcp-server,
  # pod/kubernetes-mcp-server-...

Refs: noetl/ops#15, noetl/ops#16, noetl/ops#17, noetl/ops#18.