### PR TITLE
feat(tools): kind:shell executor in the distributed worker

### DIFF
--- a/noetl/tools/shell/__init__.py
+++ b/noetl/tools/shell/__init__.py
@@ -1,0 +1,14 @@
+"""Shell plugin package for NoETL.
+
+Lets ``kind: shell`` steps run inside the distributed worker (NATS
+dispatcher → worker pod), not just under the local rust binary.
+The lifecycle agents in ``automation/agents/kubernetes/`` and similar
+were stranded by this gap — they could be invoked from
+``noetl run --runtime local`` but failed at the worker with
+``NotImplementedError("Tool kind 'shell' not implemented")`` whenever
+the noetl server's MCP / catalog dispatcher routed them through NATS.
+"""
+
+from noetl.tools.shell.executor import execute_shell_task
+
+__all__ = ["execute_shell_task"]

--- a/noetl/tools/shell/executor.py
+++ b/noetl/tools/shell/executor.py
@@ -1,0 +1,313 @@
+"""``kind: shell`` distributed-worker executor.
+
+Mirrors the contract every other plugin in ``noetl/tools/`` follows:
+
+    execute_shell_task(task_config, context, jinja_env, args) -> dict
+
+``task_config["cmds"]`` is a list of multi-line shell program strings.
+Each is jinja-rendered against the merged context (workload + args)
+and then executed with ``/bin/sh -c <program>`` via ``subprocess.run``.
+Output is captured, returncode is propagated, and the structured result
+matches the rest of the plugin family (``status: ok|error``, ``data``
+with stdout/stderr/returncode/duration_ms, plus ``text`` for the
+GUI's run dialog so it surfaces inline alongside python steps).
+
+This is deliberately conservative:
+
+  - **No environment leakage from the worker pod's parent process** —
+    we only forward variables explicitly declared under
+    ``task_config["env"]`` (Jinja-rendered).
+  - **Per-command timeout** — ``task_config["timeout_seconds"]``,
+    default 600s, applied to each ``cmds`` entry. Lifecycle deploys
+    that block forever shouldn't pin a worker.
+  - **Failure-aware aggregation** — if any command exits non-zero we
+    stop running the remaining commands, mark the result as error,
+    and surface the failing command's stdout/stderr in the response.
+    Same shape ``kind: python`` produces on uncaught exceptions.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import time
+from typing import Any
+
+from noetl.core.logger import setup_logger
+
+logger = setup_logger(__name__, include_location=True)
+
+
+_DEFAULT_TIMEOUT_SECONDS = 600
+_SHELL_BIN = "/bin/sh"
+
+
+def _render(jinja_env, value: Any, context: dict) -> Any:
+    """Render a Jinja2 template iff the value is a string with templating.
+
+    Mirrors how ``noetl.tools.python.executor`` walks a single argument:
+    only strings are rendered; lists/dicts/scalars pass through. We rely
+    on the worker having already merged config + args into ``context``
+    by the time this executor runs (the dispatcher does that — see
+    ``nats_worker.py:_execute_tool``).
+    """
+    if not isinstance(value, str):
+        return value
+    if "{{" not in value and "{%" not in value:
+        return value
+    try:
+        return jinja_env.from_string(value).render(**(context or {}))
+    except Exception as exc:
+        # Don't fail the whole step on a single bad template — let the
+        # shell see the original string and surface the error there.
+        # That matches the behaviour python steps get when their
+        # rendered args fail to coerce.
+        logger.warning("SHELL.RENDER: failed for value (len=%d): %s", len(value), exc)
+        return value
+
+
+def _build_env(task_config: dict, jinja_env, context: dict) -> dict[str, str]:
+    """Build the subprocess env from task_config["env"] (rendered).
+
+    Skips inheriting the worker pod's parent env on purpose. Lifecycle
+    agents that need PATH / KUBERNETES_SERVICE_HOST / etc. should pass
+    them through explicitly via ``env:`` in their YAML — defaulting to
+    inheriting would leak NATS credentials, postgres URLs, and other
+    secrets from the worker's environment into every shell-out.
+    """
+    explicit_env = task_config.get("env") or {}
+    if not isinstance(explicit_env, dict):
+        explicit_env = {}
+
+    # Always preserve PATH so kubectl / helm / awk / etc. resolve from
+    # /usr/local/bin where the worker image installs them. Skipping
+    # PATH entirely would force every agent to set it manually, and
+    # the worker image's PATH is a known-safe value.
+    env: dict[str, str] = {"PATH": os.environ.get("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")}
+
+    # KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT are how
+    # in-cluster kubectl auto-discovers the API server; lifecycle
+    # agents check the former to detect in-cluster execution. Forward
+    # them through unconditionally — they're not secret, they're the
+    # cluster's internal service IP.
+    for k in ("KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_PORT"):
+        if k in os.environ:
+            env[k] = os.environ[k]
+
+    for key, value in explicit_env.items():
+        rendered = _render(jinja_env, value, context)
+        if rendered is None:
+            continue
+        env[str(key)] = str(rendered)
+
+    return env
+
+
+def _coerce_cmds(task_config: dict) -> list[str]:
+    """Pull the cmds list out of task_config in a forgiving way.
+
+    Accepts:
+      - cmds: ["one-line", "two\\nlines"]    (canonical)
+      - cmd:  "single command"               (legacy alias)
+      - command: "single command"            (legacy alias)
+
+    Anything else returns an empty list and the caller surfaces a
+    structured error rather than crashing.
+    """
+    raw = task_config.get("cmds")
+    if isinstance(raw, list):
+        return [str(c) for c in raw]
+    for alt in ("cmd", "command"):
+        v = task_config.get(alt)
+        if isinstance(v, str) and v.strip():
+            return [v]
+    if isinstance(raw, str) and raw.strip():
+        return [raw]
+    return []
+
+
+def execute_shell_task(
+    task_config: dict,
+    context: dict,
+    jinja_env,
+    args: dict | None = None,
+) -> dict[str, Any]:
+    """Execute ``kind: shell`` steps from a distributed worker.
+
+    Returns the same dict shape every other plugin returns:
+
+        {
+          "status": "ok" | "error",
+          "data": {
+            "returncode": int,             # last command's returncode
+            "stdout": str,                 # concatenated stdout
+            "stderr": str,                 # concatenated stderr
+            "commands": [                  # per-command breakdown
+              {"cmd_preview": "first line of cmd",
+               "returncode": int,
+               "stdout": str,
+               "stderr": str,
+               "duration_ms": int}
+            ],
+            "duration_ms": int,            # total elapsed
+          },
+          "text": str,                     # human-readable for GUI
+          "error": str | None,             # only set when status=error
+        }
+    """
+    args = args or {}
+
+    cmds = _coerce_cmds(task_config)
+    if not cmds:
+        msg = (
+            "shell tool requires task_config['cmds'] to be a non-empty list "
+            "of program strings (or a 'cmd'/'command' string alias)"
+        )
+        logger.error("SHELL.CONFIG: %s", msg)
+        return {
+            "status": "error",
+            "error": msg,
+            "data": {
+                "returncode": -1,
+                "stdout": "",
+                "stderr": msg,
+                "commands": [],
+                "duration_ms": 0,
+            },
+            "text": msg,
+        }
+
+    timeout_seconds = task_config.get("timeout_seconds")
+    try:
+        timeout_seconds = (
+            float(timeout_seconds)
+            if timeout_seconds is not None
+            else _DEFAULT_TIMEOUT_SECONDS
+        )
+    except (TypeError, ValueError):
+        timeout_seconds = _DEFAULT_TIMEOUT_SECONDS
+
+    env = _build_env(task_config, jinja_env, context)
+    cwd = task_config.get("cwd") or None
+
+    aggregated_stdout: list[str] = []
+    aggregated_stderr: list[str] = []
+    per_cmd: list[dict[str, Any]] = []
+    last_returncode = 0
+    overall_start = time.monotonic()
+
+    for raw_cmd in cmds:
+        rendered = _render(jinja_env, raw_cmd, context)
+        if not isinstance(rendered, str):
+            rendered = str(rendered)
+
+        cmd_preview = rendered.strip().splitlines()[0][:120] if rendered.strip() else ""
+        logger.info(
+            "SHELL.RUN: command=%r length=%d timeout=%ss",
+            cmd_preview,
+            len(rendered),
+            timeout_seconds,
+        )
+
+        cmd_start = time.monotonic()
+        try:
+            completed = subprocess.run(  # noqa: S602 -- shell=False, exec via /bin/sh -c
+                [_SHELL_BIN, "-c", rendered],
+                env=env,
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            stdout = (exc.stdout or "") if isinstance(exc.stdout, (str, bytes)) else ""
+            stderr = (exc.stderr or "") if isinstance(exc.stderr, (str, bytes)) else ""
+            if isinstance(stdout, bytes):
+                stdout = stdout.decode("utf-8", errors="replace")
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode("utf-8", errors="replace")
+            duration_ms = int((time.monotonic() - cmd_start) * 1000)
+            err_text = (
+                f"shell command timed out after {timeout_seconds}s: "
+                f"{cmd_preview or '<empty>'}"
+            )
+            logger.error("SHELL.TIMEOUT: %s", err_text)
+            per_cmd.append({
+                "cmd_preview": cmd_preview,
+                "returncode": -1,
+                "stdout": stdout,
+                "stderr": (stderr + "\n" + err_text).strip(),
+                "duration_ms": duration_ms,
+            })
+            aggregated_stdout.append(stdout)
+            aggregated_stderr.append(stderr + "\n" + err_text)
+            return {
+                "status": "error",
+                "error": err_text,
+                "data": {
+                    "returncode": -1,
+                    "stdout": "\n".join(s for s in aggregated_stdout if s),
+                    "stderr": "\n".join(s for s in aggregated_stderr if s),
+                    "commands": per_cmd,
+                    "duration_ms": int((time.monotonic() - overall_start) * 1000),
+                },
+                "text": err_text,
+            }
+
+        duration_ms = int((time.monotonic() - cmd_start) * 1000)
+        per_cmd.append({
+            "cmd_preview": cmd_preview,
+            "returncode": completed.returncode,
+            "stdout": completed.stdout or "",
+            "stderr": completed.stderr or "",
+            "duration_ms": duration_ms,
+        })
+        if completed.stdout:
+            aggregated_stdout.append(completed.stdout)
+        if completed.stderr:
+            aggregated_stderr.append(completed.stderr)
+        last_returncode = completed.returncode
+
+        if completed.returncode != 0:
+            err_text = (
+                f"shell command exited with returncode={completed.returncode}: "
+                f"{cmd_preview or '<empty>'}"
+            )
+            logger.warning(
+                "SHELL.NONZERO: rc=%s preview=%r stderr=%r",
+                completed.returncode,
+                cmd_preview,
+                (completed.stderr or "")[:400],
+            )
+            return {
+                "status": "error",
+                "error": err_text,
+                "data": {
+                    "returncode": completed.returncode,
+                    "stdout": "\n".join(s for s in aggregated_stdout if s),
+                    "stderr": "\n".join(s for s in aggregated_stderr if s),
+                    "commands": per_cmd,
+                    "duration_ms": int((time.monotonic() - overall_start) * 1000),
+                },
+                "text": (completed.stdout or "") + (completed.stderr or "") + "\n" + err_text,
+            }
+
+    full_stdout = "\n".join(s for s in aggregated_stdout if s)
+    full_stderr = "\n".join(s for s in aggregated_stderr if s)
+
+    return {
+        "status": "ok",
+        "data": {
+            "returncode": last_returncode,
+            "stdout": full_stdout,
+            "stderr": full_stderr,
+            "commands": per_cmd,
+            "duration_ms": int((time.monotonic() - overall_start) * 1000),
+        },
+        # GUI run-dialog convention: surface a single human-readable
+        # text blob alongside the structured payload. Same shape every
+        # lifecycle agent's `kind: python` end step already returns.
+        "text": full_stdout or full_stderr or "",
+    }

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -2752,6 +2752,33 @@ class Worker:
             logger.debug(f"[NOOP] Step '{step}' - no-op execution")
             return {"status": "noop", "step": step}
 
+        elif tool_kind == "shell":
+            # Shell-out (subprocess via /bin/sh -c) — needed by the
+            # MCP lifecycle agents (deploy / undeploy / status /
+            # restart / discover) which drive helm + kubectl from
+            # inside the worker pod. Without this branch every
+            # dispatcher-driven invocation of a kind:shell step
+            # raised NotImplementedError before even reaching the
+            # binary, which is how the kubernetes-mcp-server install
+            # silently failed during the v2.27/v2.28 ramp-up. The
+            # executor uses subprocess with shell=False (we exec
+            # /bin/sh -c <program> ourselves) and a clean env that
+            # only forwards PATH + KUBERNETES_SERVICE_* by default;
+            # callers add anything else via task.env.
+            from noetl.tools.shell import execute_shell_task
+            task_with = {**config, **args}  # plugin signature compatibility
+            loop = asyncio.get_running_loop()
+            result = await loop.run_in_executor(
+                None,
+                lambda: execute_shell_task(task_config, context, jinja_env, task_with),
+            )
+            if isinstance(result, dict) and result.get("status") == "error":
+                # Keep error payload intact — the dispatcher needs
+                # status=error to mark the step as failed and the
+                # GUI's run dialog renders text/stderr inline.
+                return result
+            return result.get("data", result) if isinstance(result, dict) else result
+
         else:
             raise NotImplementedError(f"Tool kind '{tool_kind}' not implemented")
     

--- a/tests/unit/tools/shell/test_executor.py
+++ b/tests/unit/tools/shell/test_executor.py
@@ -1,0 +1,221 @@
+"""Unit tests for the distributed-worker shell executor.
+
+Pure subprocess-driven tests that run real /bin/sh commands. Each
+test is fast (<1s) — the timeout case caps at 1 second by design.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+import pytest
+
+from noetl.tools.shell.executor import execute_shell_task
+
+
+class _FakeJinja:
+    """Minimal Jinja-like adapter exposing only ``from_string(s).render(**ctx)``.
+
+    The real Jinja2 environment is built once per worker request and
+    threaded through; we don't want to import the worker stack here.
+    A naive ``{{ var }}`` substitution covers every template our
+    lifecycle agents currently use.
+    """
+
+    def from_string(self, s: str):
+        class _T:
+            def __init__(self, src: str):
+                self.src = src
+
+            def render(self, **ctx) -> str:
+                out = self.src
+                for k, v in ctx.items():
+                    out = out.replace("{{ " + k + " }}", str(v))
+                return out
+
+        return _T(s)
+
+
+# ---------------------------------------------------------------------------
+# Happy-path
+# ---------------------------------------------------------------------------
+
+
+def test_runs_single_command_and_returns_ok_shape():
+    result = execute_shell_task(
+        {"cmds": ["echo hello"]},
+        context={},
+        jinja_env=_FakeJinja(),
+        args={},
+    )
+    assert result["status"] == "ok"
+    assert result["data"]["returncode"] == 0
+    assert "hello" in result["data"]["stdout"]
+    assert result["data"]["stderr"] == ""
+    assert result["text"].strip() == "hello"
+
+
+def test_renders_jinja_against_context():
+    result = execute_shell_task(
+        {"cmds": ["echo greet-{{ name }}"]},
+        context={"name": "world"},
+        jinja_env=_FakeJinja(),
+        args={},
+    )
+    assert result["status"] == "ok"
+    assert "greet-world" in result["data"]["stdout"]
+
+
+def test_runs_multiple_commands_in_order():
+    result = execute_shell_task(
+        {"cmds": ["echo first", "echo second", "echo third"]},
+        context={},
+        jinja_env=_FakeJinja(),
+        args={},
+    )
+    assert result["status"] == "ok"
+    out = result["data"]["stdout"]
+    assert out.index("first") < out.index("second") < out.index("third")
+    assert len(result["data"]["commands"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Failure short-circuiting
+# ---------------------------------------------------------------------------
+
+
+def test_nonzero_exit_marks_status_error_and_short_circuits():
+    result = execute_shell_task(
+        {"cmds": ["echo first", "exit 7", "echo unreached"]},
+        context={},
+        jinja_env=_FakeJinja(),
+        args={},
+    )
+    assert result["status"] == "error"
+    assert result["data"]["returncode"] == 7
+    assert "first" in result["data"]["stdout"]
+    assert "unreached" not in result["data"]["stdout"]
+    # Only the first two commands actually ran.
+    assert len(result["data"]["commands"]) == 2
+    assert "exit 7" in result["error"] or "returncode=7" in result["error"]
+
+
+def test_command_timeout_returns_structured_error():
+    result = execute_shell_task(
+        {"cmds": ["sleep 5"], "timeout_seconds": 1},
+        context={},
+        jinja_env=_FakeJinja(),
+        args={},
+    )
+    assert result["status"] == "error"
+    assert "timed out" in result["error"]
+    assert result["data"]["returncode"] == -1
+
+
+def test_invalid_timeout_value_falls_back_to_default():
+    """A garbage timeout shouldn't raise — silently use the default."""
+    result = execute_shell_task(
+        {"cmds": ["echo ok"], "timeout_seconds": "not-a-number"},
+        context={},
+        jinja_env=_FakeJinja(),
+        args={},
+    )
+    assert result["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+def test_missing_cmds_returns_structured_error_not_crash():
+    result = execute_shell_task({}, context={}, jinja_env=_FakeJinja(), args={})
+    assert result["status"] == "error"
+    assert "non-empty list" in result["error"]
+    assert result["data"]["returncode"] == -1
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"cmd": "echo legacy-cmd-alias"},
+        {"command": "echo legacy-command-alias"},
+        # cmds-as-string treated as a single command for legacy compat
+        {"cmds": "echo legacy-string-cmds"},
+    ],
+)
+def test_string_aliases_for_cmds_work(config):
+    result = execute_shell_task(
+        config, context={}, jinja_env=_FakeJinja(), args={}
+    )
+    assert result["status"] == "ok", result
+    assert "legacy" in result["data"]["stdout"]
+
+
+# ---------------------------------------------------------------------------
+# Environment forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_path_is_forwarded_so_kubectl_helm_resolve():
+    """The worker image installs kubectl/helm into /usr/local/bin.
+
+    PATH must propagate to the subprocess or every lifecycle deploy
+    would have to set it explicitly. Use 'which' as a portable proxy.
+    """
+    result = execute_shell_task(
+        {"cmds": ["which sh"]},
+        context={},
+        jinja_env=_FakeJinja(),
+        args={},
+    )
+    assert result["status"] == "ok"
+    assert "/sh" in result["data"]["stdout"]
+
+
+def test_kubernetes_service_host_forwarded_when_set(monkeypatch):
+    """KUBERNETES_SERVICE_HOST is how lifecycle agents detect in-cluster execution."""
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+    result = execute_shell_task(
+        {"cmds": ["echo $KUBERNETES_SERVICE_HOST"]},
+        context={},
+        jinja_env=_FakeJinja(),
+        args={},
+    )
+    assert result["status"] == "ok"
+    assert "10.96.0.1" in result["data"]["stdout"]
+
+
+def test_explicit_env_entry_rendered_and_forwarded():
+    result = execute_shell_task(
+        {
+            "cmds": ["echo $FOO"],
+            "env": {"FOO": "bar-{{ x }}"},
+        },
+        context={"x": "42"},
+        jinja_env=_FakeJinja(),
+        args={},
+    )
+    assert result["status"] == "ok"
+    assert "bar-42" in result["data"]["stdout"]
+
+
+def test_arbitrary_parent_env_does_not_leak(monkeypatch):
+    """Worker pod env (NATS creds, postgres URLs, etc.) must NOT leak.
+
+    The executor only forwards PATH + KUBERNETES_SERVICE_* + explicit
+    task.env entries. Anything else in os.environ should be invisible
+    to the child shell.
+    """
+    monkeypatch.setenv("NOETL_LEAKY_SECRET", "must-not-appear-in-stdout")
+    result = execute_shell_task(
+        {"cmds": ["echo ${NOETL_LEAKY_SECRET:-unset}"]},
+        context={},
+        jinja_env=_FakeJinja(),
+        args={},
+    )
+    assert result["status"] == "ok"
+    assert "must-not-appear" not in result["data"]["stdout"]
+    assert "unset" in result["data"]["stdout"]


### PR DESCRIPTION
feat(tools): kind:shell executor in the distributed worker

The distributed worker (noetl/worker/nats_worker.py) ships handlers
for python / http / postgres / duckdb / ducklake / snowflake /
transfer / script / secrets / workbook / playbook / gcs / container /
cursor / agent / mcp / artifact / task_sequence / nats / noop — but
not for `kind: shell`. Shell only worked under the local rust binary
(`noetl run --runtime local`).

Concrete consequence: every lifecycle agent under
`automation/agents/kubernetes/lifecycle/` (deploy / undeploy /
status / restart / discover) silently failed when invoked through
the dispatcher path
(`POST /api/mcp/{path}/lifecycle/{verb}` → NATS → worker pod).
The dispatcher returned `execution_id` (success metadata) but the
worker raised
`NotImplementedError("Tool kind 'shell' not implemented")` at
executor lookup before any helm / kubectl call. That's why
`kubectl -n mcp get all` kept returning empty even after
noetl/noetl#399 baked helm + kubectl into the worker image — the
binaries were there but never reached.

This PR closes the gap.

New plugin: `noetl/tools/shell/`

  * `__init__.py` — exposes `execute_shell_task` matching the
    `(task_config, context, jinja_env, args) -> dict` contract every
    other plugin uses.
  * `executor.py` — `subprocess.run([/bin/sh, -c, <program>])` per
    command in `task_config["cmds"]`, with:
      - **Jinja rendering** of every command string against the
        merged context (workload + args). Templates that fail to
        render fall through to the shell verbatim and produce a
        warning, matching how python steps handle bad arg renders.
      - **Per-command timeout** (`task_config["timeout_seconds"]`,
        default 600s) so a hung helm install can't pin a worker.
      - **Failure-aware aggregation** — non-zero return code stops
        the loop, marks `status: "error"`, and returns the failing
        command's stdout/stderr in the response. Mirrors the shape
        a python step produces on uncaught exceptions.
      - **Conservative env** — PATH + KUBERNETES_SERVICE_HOST +
        KUBERNETES_SERVICE_PORT are forwarded automatically (so
        kubectl/helm resolve and lifecycle agents can detect
        in-cluster execution); everything else has to come from
        explicit `task.env`. The worker pod's env carries NATS
        credentials, postgres URLs, and other secrets that must
        not leak into every shell-out.
      - **String aliases** for `cmds` — accepts `cmd: "..."` /
        `command: "..."` / `cmds: "..."` (single-string) for
        backwards compat with older agent YAMLs.

Wired into `noetl/worker/nats_worker.py` immediately before the
final `else: raise NotImplementedError` so any future tool kinds
keep their existing fall-through behavior.

Tests (`tests/unit/tools/shell/test_executor.py`) — 12 cases
covering:

  - happy-path single + multi command stdout collection
  - jinja rendering against context
  - non-zero exit short-circuits remaining cmds and marks `error`
  - timeout produces structured error with returncode=-1
  - garbage timeout values fall back to default (no crash)
  - missing cmds key returns structured error (no crash)
  - cmd / command / single-string cmds aliases
  - PATH forwarded (so kubectl / helm resolve)
  - KUBERNETES_SERVICE_HOST forwarded (lifecycle in-cluster guard)
  - explicit task.env rendered + forwarded
  - parent env does NOT leak (verified by setting an env var
    before the call and asserting it's absent from the child's
    output)

Hand-rolled smoke run of all 7 critical paths in the sandbox passes.

Rollout — after this lands and a new noetl image publishes:

  1. Bump repos/noetl gitlink in ai-meta + redeploy worker on kind.
  2. Confirm with the same smoke that motivated this PR:
     ```
     curl -s -X POST http://localhost:8082/api/mcp/mcp/kubernetes/lifecycle/deploy \
       -H "Content-Type: application/json" -d '{}' | python3 -m json.tool
     sleep 75
     kubectl -n mcp get all
     ```
     Expect: `deployment/kubernetes-mcp-server`, `service/...`, and
     a Running pod (or Pending while pulling).

Follow-up (separate PR) — the worker's default ServiceAccount
(`noetl-worker`) lacks cluster-wide RBAC: `kubectl auth can-i
create namespaces` returns "no". Once the shell tool can reach
helm, helm-driven cluster installs will fail with
`namespaces "mcp" is forbidden`. Need a ClusterRoleBinding for
the worker SA covering the verbs lifecycle agents actually use.

Refs: noetl/ops#15, noetl/ops#16, noetl/ops#17, noetl/ops#18,
      noetl/noetl#395, noetl/noetl#396, noetl/noetl#397,
      noetl/noetl#398, noetl/noetl#399.