### PR TITLE
feat(rbac): cluster RBAC for noetl-worker lifecycle-agent installs

### DIFF
--- a/ci/manifests/noetl/rbac.yaml
+++ b/ci/manifests/noetl/rbac.yaml
@@ -49,3 +49,89 @@ roleRef:
   kind: Role
   name: noetl-worker-role
   apiGroup: rbac.authorization.k8s.io
+---
+# Cluster-scoped RBAC for lifecycle-agent installs (helm-driven).
+#
+# The MCP lifecycle agents (automation/agents/kubernetes/lifecycle/
+# {deploy,undeploy,restart,status,discover,redeploy} in repos/ops)
+# run helm and kubectl from inside the worker pod. Helm's
+# `--create-namespace` flag and the kubernetes-mcp-server chart's
+# `extraClusterRoles`/`extraClusterRoleBindings` blocks both need
+# permissions outside the noetl namespace, so the existing
+# namespace-scoped Role above isn't sufficient.
+#
+# Scope deliberately narrowed to the verbs/resources lifecycle
+# installs actually need. NOT cluster-admin — a future PR can
+# tighten further (e.g. limit `namespaces` create to a label
+# selector once helm 3.x supports it cleanly), but this is the
+# minimum that lets the dispatcher path produce a real cluster
+# effect for an Mcp resource's lifecycle.deploy call.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: noetl-worker-lifecycle-installer
+rules:
+  # helm install --create-namespace needs to make/look up/cleanup
+  # the release namespace.
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "create", "delete", "patch"]
+
+  # Standard chart resources — the kubernetes-mcp-server chart and
+  # most helm charts in this fleet ship some combination of these.
+  - apiGroups: [""]
+    resources:
+      - "serviceaccounts"
+      - "services"
+      - "configmaps"
+      - "secrets"  # helm 3 stores release state as a Secret per release
+      - "pods"
+      - "persistentvolumeclaims"
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources:
+      - "deployments"
+      - "replicasets"
+      - "statefulsets"
+      - "daemonsets"
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Namespace-scoped RBAC the chart wires up for its own SA.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Cluster-scoped RBAC the chart's `extraClusterRoles` block ships
+  # (e.g. the runtime-observer ClusterRole the kubernetes-mcp-server
+  # uses to read pods/events/metrics across all namespaces).
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Read-only on cluster-scoped objects the lifecycle.status verb
+  # surfaces for diagnostics (kubectl get nodes / events / etc.).
+  - apiGroups: [""]
+    resources: ["nodes", "events"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: noetl-worker-lifecycle-installer
+subjects:
+  - kind: ServiceAccount
+    name: noetl-worker
+    namespace: noetl
+roleRef:
+  kind: ClusterRole
+  name: noetl-worker-lifecycle-installer
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
feat(rbac): cluster RBAC for noetl-worker lifecycle-agent installs

The noetl-worker ServiceAccount has a namespace-scoped Role that
covers the verbs `kind: script` jobs need (jobs / configmaps /
secrets / pods within the `noetl` namespace) but nothing
cluster-wide. With kind:shell now available in the distributed
worker (#400), the next blocker for MCP lifecycle deploys is RBAC:
helm `--create-namespace` and the kubernetes-mcp-server chart's
`extraClusterRoles` block both need permissions the worker SA
doesn't have. Confirmed earlier with:

    $ kubectl -n noetl exec deploy/noetl-worker -- \
        kubectl auth can-i create namespaces
    no

Adds a `ClusterRole` + `ClusterRoleBinding` named
`noetl-worker-lifecycle-installer`, narrowed to the verbs
lifecycle-agent installs actually need rather than the cluster-
admin ClusterRole:

  - **`namespaces`** — get/list/create/delete/patch (so
    `helm install --create-namespace mcp` works and undeploys
    can clean up).
  - **standard chart resources in any namespace** —
    serviceaccounts / services / configmaps / secrets (helm 3
    stores release state as a Secret per release) / pods /
    persistentvolumeclaims, and apps deployments / replicasets /
    statefulsets / daemonsets, and batch jobs / cronjobs. Full
    CRUD; helm reconciles all of these on each upgrade.
  - **namespace-scoped Roles + RoleBindings** the chart wires up
    for its own SA.
  - **cluster-scoped ClusterRoles + ClusterRoleBindings** the
    chart's `extraClusterRoles` block ships (e.g. the
    runtime-observer ClusterRole that lets the
    kubernetes-mcp-server read pods/events/metrics across all
    namespaces).
  - **read-only** on cluster-scoped diagnostics the
    lifecycle.status verb surfaces (nodes, events,
    metrics.k8s.io). No write — status is read-only by
    contract.

Deliberately NOT cluster-admin. A future PR can tighten further
(e.g. limit `namespaces` create to a label selector if/when helm
supports it cleanly, or drop the cluster-scoped RBAC verbs once
no chart in the fleet uses extraClusterRoles), but this is the
minimum that lets the dispatcher path produce a real cluster
effect for an Mcp resource's lifecycle.deploy.

Rollout — after this lands and the new noetl image publishes:

  1. Bump repos/noetl gitlink in ai-meta + redeploy the noetl
     stack on kind. The new manifest applies via the existing
     deploy script (or directly via `kubectl apply -f
     ci/manifests/noetl/rbac.yaml`).
  2. Confirm:
     ```
     kubectl -n noetl exec deploy/noetl-worker -- \
       kubectl auth can-i create namespaces
     # expect: yes
     ```
  3. Re-trigger the lifecycle.deploy round that's been failing:
     ```
     curl -s -X POST http://localhost:8082/api/mcp/mcp/kubernetes/lifecycle/deploy \
       -H "Content-Type: application/json" -d '{}' | python3 -m json.tool
     sleep 75
     kubectl -n mcp get all
     ```
     Expect: `deployment/kubernetes-mcp-server`, `service/...`,
     and a Running pod.

Refs: noetl/noetl#395, noetl/noetl#396, noetl/noetl#397,
      noetl/noetl#398, noetl/noetl#399, noetl/noetl#400,
      noetl/ops#15, noetl/ops#16, noetl/ops#17, noetl/ops#18.