### PR TITLE
chore(cli): remove Python CLI distribution references

### DIFF
--- a/.github/ai-instructions.md
+++ b/.github/ai-instructions.md
@@ -26,7 +26,7 @@ NoETL is a workflow automation framework for data processing and MLOps orchestra
 **Core Components:**
 - **Server** (`noetl/server/`): FastAPI-based orchestration engine with REST APIs for catalog, events, and execution coordination
 - **Worker** (`noetl/worker/`): Event-driven workers that receive command notifications via NATS JetStream and fetch details from event table
-- **CLI** (`noetlctl/src/main.rs`): Rust-based command interface (binary: `noetl`) managing server/worker lifecycle, build, and K8s deployment
+- **CLI** (`https://github.com/noetl/cli`): Rust-based command interface (binary: `noetl`) managing server/worker lifecycle, build, and K8s deployment
 - **Plugins** (`noetl/tools/`): Extensible action executors (http, postgres, duckdb, python, secrets, etc.)
 - **Observability** (`ci/manifests/clickhouse/`): ClickHouse-based observability stack with OpenTelemetry schema for logs, metrics, and traces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1307,7 +1307,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-* add local playbook execution to noetlctl CLI ([b46ba98](https://github.com/noetl/noetl/commit/b46ba98666f715603c43c9880d9e4506c74ec101))
+* add local playbook execution to the CLI ([b46ba98](https://github.com/noetl/noetl/commit/b46ba98666f715603c43c9880d9e4506c74ec101))
 
 ## [2.5.2](https://github.com/noetl/noetl/compare/v2.5.1...v2.5.2) (2026-01-07)
 
@@ -1325,8 +1325,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-* Phase 1 - Rename noetlctl to noetl and add server/worker/db management commands ([9b404ef](https://github.com/noetl/noetl/commit/9b404ef339189068cc05878ea9543d4a1154535e))
-* remove Python CLI and complete Rust CLI migration (Phase 3) ([6823d3d](https://github.com/noetl/noetl/commit/6823d3d5a768c0176a15899df0956888092c8ef0))
+* Phase 1 - add server/worker/db management commands to the CLI ([9b404ef](https://github.com/noetl/noetl/commit/9b404ef339189068cc05878ea9543d4a1154535e))
+* complete Rust CLI migration (Phase 3) ([6823d3d](https://github.com/noetl/noetl/commit/6823d3d5a768c0176a15899df0956888092c8ef0))
 
 ### Bug Fixes
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -91,8 +91,7 @@ In use (do not delete):
 - docker/jupyter/Dockerfile — used by docker-compose jupyter service
 
 Rust CLI source:
-- noetlctl/src/main.rs — Rust CLI implementation (compiled in rust-builder stage)
-- noetlctl/Cargo.toml — Rust dependencies and build configuration
+- https://github.com/noetl/cli — Rust CLI implementation and release source
 
 Not used by current build scripts or K8s deploys (safe to remove):
 - k8s/noetl/Dockerfile

--- a/docker/noetl/dev/Dockerfile
+++ b/docker/noetl/dev/Dockerfile
@@ -68,10 +68,9 @@ RUN apt-get update && apt-get --no-install-recommends install -y \
 COPY --from=builder /opt/noetl/.venv /opt/noetl/.venv
 
 # Optional: Copy pre-compiled Rust binary if available
-# Binaries must be built separately using: scripts/build_rust_multiarch.sh
-# For now, Rust CLI is optional - Python CLI works fine
+# Binaries must be built separately from https://github.com/noetl/cli.
 # ARG TARGETARCH
-# COPY noetlctl/target/x86_64-unknown-linux-gnu/release/noetl /usr/local/bin/noetl || echo "No Rust binary"
+# COPY target/x86_64-unknown-linux-gnu/release/noetl /usr/local/bin/noetl || echo "No Rust binary"
 
 WORKDIR /opt/noetl
 
@@ -87,5 +86,5 @@ ENV PYTHONPATH="/opt/noetl"
 ENV PATH="/opt/noetl/.venv/bin:$PATH"
 
 # Default command: Use Python directly (more reliable across architectures)
-# Rust CLI can be used manually: noetl server start --host 0.0.0.0 --port 8082
+# Rust CLI can be added manually: noetl server start --host 0.0.0.0 --port 8082
 CMD ["python", "-m", "noetl.server", "--host", "0.0.0.0", "--port", "8082", "--init-db"]

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -94,9 +94,9 @@ noetl k8s reset
 If you prefer to build from source:
 
 ```bash
-git clone https://github.com/noetl/noetl.git
-cd noetl
-cargo build --release -p noetl-cli
+git clone https://github.com/noetl/cli.git
+cd cli
+cargo build --release --bins
 cp target/release/noetl /usr/local/bin/
 ```
 
@@ -104,8 +104,7 @@ cp target/release/noetl /usr/local/bin/
 
 - **Homepage**: https://noetl.io
 - **Documentation**: https://noetl.io/docs
-- **GitHub**: https://github.com/noetl/noetl
-- **PyPI Package**: https://pypi.org/project/noetl-cli/
+- **CLI GitHub**: https://github.com/noetl/cli
 
 ## Support
 

--- a/noetl/main.py
+++ b/noetl/main.py
@@ -1,24 +1,7 @@
-"""
-DEPRECATED: Python CLI has been replaced by the Rust CLI.
+"""Retired Python command entry point.
 
-This Python entry point is deprecated and will be removed in a future version.
-The NoETL CLI is now implemented in Rust (noetlctl) and bundled with the Python package.
-
-When you run `noetl` after installing via pip, you are using the Rust binary through
-a Python wrapper (noetl.cli_wrapper). This file exists only for backwards compatibility.
-
-Migration:
-- The `noetl` command automatically uses the new Rust CLI
-- All commands and functionality remain the same
-- No action required - the transition is transparent to users
-
-For more information, see:
-- documentation/docs/development/rust_cli_migration.md
-- documentation/docs/development/pypi_rust_bundling.md
-
-Note: This module remains for backward compatibility only.
-
-to be removed in future releases.
+The maintained NoETL CLI is the Rust binary released from:
+https://github.com/noetl/cli
 """
 
 import sys
@@ -26,18 +9,16 @@ import warnings
 
 
 def main():
-    """Deprecated Python CLI entry point."""
+    """Exit with guidance for the maintained Rust CLI."""
     warnings.warn(
-        "The Python-based CLI (noetl.cli.ctl) is deprecated and has been replaced "
-        "by the Rust-based CLI. This entry point exists only for backwards compatibility. "
-        "Please use 'noetl' command directly (bundled Rust binary via cli_wrapper).",
+        "This Python command entry point is retired. Install the maintained "
+        "Rust NoETL CLI from https://github.com/noetl/cli.",
         DeprecationWarning,
         stacklevel=2
     )
     
-    print("ERROR: Python CLI has been removed.", file=sys.stderr)
-    print("Please use the 'noetl' command instead (Rust CLI via wrapper).", file=sys.stderr)
-    print("If you installed via pip, the command should already be available.", file=sys.stderr)
+    print("ERROR: this Python command entry point is retired.", file=sys.stderr)
+    print("Install the maintained Rust NoETL CLI from https://github.com/noetl/cli.", file=sys.stderr)
     sys.exit(1)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,15 +84,12 @@ notebook = [
     "pandas>=2.2.3",
     "matplotlib>=3.10.3",
 ]
-# Rust CLI (optional for users who need command-line interface)
-cli = ["noetl-cli==2.5.3"]
-
 # Optional helper dependencies for automating IBKR Gateway browser login.
 # Note: Playwright also requires: `playwright install chromium`
 ibkr = ["playwright>=1.43.0"]
 
-# CLI moved to optional dependency [cli] - install with: uv pip install "noetl[cli]"
-# This avoids conflicts with the Rust noetl binary from noetl-cli package
+# The NoETL CLI is maintained and released from https://github.com/noetl/cli.
+# Do not add Python/PyPI CLI extras here.
 
 [project.urls]
 Homepage = "https://noetl.io"
@@ -108,7 +105,7 @@ where = ["."]
 include = ["noetl*"]
 
 [tool.setuptools.package-data]
-# Removed bin/noetl - now distributed via noetl-cli package
+# The maintained CLI is released from https://github.com/noetl/cli.
 "noetl" = ["core/ui/**/*", "database/ddl/**/*"]
 
 [dependency-groups]

--- a/release-notes-v2.5.10.md
+++ b/release-notes-v2.5.10.md
@@ -27,14 +27,9 @@ sudo apt-get update
 sudo apt-get install noetl
 ```
 
-### PyPI
-```bash
-pip install noetlctl
-```
-
 ### Cargo
 ```bash
-cargo install noetl
+cargo install --bins noetl
 ```
 
 ## Documentation

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -55,7 +55,8 @@ if [ "$BUILD_RUST" = true ]; then
     echo "Step 1: Building Rust CLI for Linux platforms..."
     echo "-------------------------------------------------------------------"
     
-    cd noetlctl
+    CLI_DIR="${NOETL_CLI_REPO:-../cli}"
+    cd "$CLI_DIR"
     
     # Install cross if needed
     if ! command -v cross &> /dev/null; then
@@ -144,8 +145,8 @@ echo "Docker image:  $TAG"
 
 if [ "$BUILD_RUST" = true ]; then
     echo "Rust binaries:"
-    echo "  - noetlctl/target/x86_64-unknown-linux-gnu/release/noetl"
-    echo "  - noetlctl/target/aarch64-unknown-linux-gnu/release/noetl"
+    echo "  - ${NOETL_CLI_REPO:-../cli}/target/x86_64-unknown-linux-gnu/release/noetl"
+    echo "  - ${NOETL_CLI_REPO:-../cli}/target/aarch64-unknown-linux-gnu/release/noetl"
     if [[ "$OSTYPE" == "darwin"* ]]; then
         echo "  - bin/noetl (local Mac)"
     fi

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -11,14 +11,20 @@ echo "📦 Building NoETL .deb package v${VERSION} for ${ARCH}..."
 rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR"
 
-# Clone or copy source
-if [ -d ".git" ] || [ -f "Cargo.toml" ]; then
-    echo "📂 Using current repository..."
+# Clone or copy CLI source
+if [ -n "${NOETL_CLI_REPO:-}" ] && [ -f "${NOETL_CLI_REPO}/Cargo.toml" ]; then
+    echo "📂 Using CLI repository from NOETL_CLI_REPO..."
+    REPO_DIR="$NOETL_CLI_REPO"
+elif [ -f "../cli/Cargo.toml" ]; then
+    echo "📂 Using sibling CLI repository..."
+    REPO_DIR="$(cd ../cli && pwd)"
+elif [ -f "Cargo.toml" ]; then
+    echo "📂 Using current CLI repository..."
     REPO_DIR=$(pwd)
 else
-    echo "📥 Cloning repository..."
-    git clone https://github.com/noetl/noetl.git "$BUILD_DIR/noetl-${VERSION}"
-    REPO_DIR="$BUILD_DIR/noetl-${VERSION}"
+    echo "📥 Cloning CLI repository..."
+    git clone https://github.com/noetl/cli.git "$BUILD_DIR/cli-${VERSION}"
+    REPO_DIR="$BUILD_DIR/cli-${VERSION}"
     cd "$REPO_DIR"
     git checkout "v${VERSION}"
 fi
@@ -41,15 +47,8 @@ fi
 echo "🔨 Building Rust binary..."
 cd "$REPO_DIR"
 
-# Try noetl first, fallback to noetl-cli for older versions
-if cargo metadata --no-deps --format-version 1 | grep -q '"name":"noetl"'; then
-    PACKAGE_NAME="noetl"
-else
-    PACKAGE_NAME="noetl-cli"
-fi
-
-echo "📦 Building package: $PACKAGE_NAME"
-cargo build --release -p "$PACKAGE_NAME"
+echo "📦 Building package: noetl"
+cargo build --release -p noetl
 
 # Create debian package structure
 PKG_DIR="$BUILD_DIR/noetl_${VERSION}-1_${ARCH}"

--- a/scripts/build_rust_multiarch.sh
+++ b/scripts/build_rust_multiarch.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 set -e
 
-# Build noetlctl for multiple architectures
+# Build the NoETL Rust CLI for multiple architectures
 # This should be run before building Docker images for multi-platform support
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-NOETLCTL_DIR="$PROJECT_ROOT/noetlctl"
+CLI_DIR="${NOETL_CLI_REPO:-$PROJECT_ROOT/../cli}"
 
-cd "$NOETLCTL_DIR"
+cd "$CLI_DIR"
 
-echo "=== Building noetlctl for multiple architectures ==="
+echo "=== Building NoETL Rust CLI for multiple architectures ==="
 
 # Install cross-compilation tools if not already installed
 if ! command -v cross &> /dev/null; then

--- a/scripts/setup_local_dev.sh
+++ b/scripts/setup_local_dev.sh
@@ -60,9 +60,10 @@ fi
 echo
 
 # Build Rust CLI
-if [ -d "${REPO_ROOT}/noetlctl" ]; then
+CLI_DIR="${NOETL_CLI_REPO:-${REPO_ROOT}/../cli}"
+if [ -d "${CLI_DIR}" ]; then
     echo -e "${GREEN}Building Rust CLI binary...${NC}"
-    cd "${REPO_ROOT}/noetlctl"
+    cd "${CLI_DIR}"
     
     if ! command -v cargo &> /dev/null; then
         echo -e "${RED}Error: cargo is not installed${NC}"
@@ -86,7 +87,8 @@ if [ -d "${REPO_ROOT}/noetlctl" ]; then
     echo -e "${GREEN}Rust CLI built successfully${NC}"
     echo "Binary location: ${REPO_ROOT}/bin/noetl"
 else
-    echo -e "${YELLOW}Skipping Rust CLI build (noetlctl not found)${NC}"
+    echo -e "${YELLOW}Skipping Rust CLI build (CLI repo not found at ${CLI_DIR})${NC}"
+    echo "Clone https://github.com/noetl/cli next to this repo or set NOETL_CLI_REPO."
 fi
 
 echo

--- a/uv.lock
+++ b/uv.lock
@@ -2176,9 +2176,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-cli = [
-    { name = "noetl-cli" },
-]
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -2239,7 +2236,6 @@ requires-dist = [
     { name = "memray", specifier = ">=1.17.2" },
     { name = "nats-py", specifier = ">=2.10.0" },
     { name = "networkx", specifier = ">=3.5" },
-    { name = "noetl-cli", marker = "extra == 'cli'", specifier = "==2.5.3" },
     { name = "ortools", specifier = ">=9.10" },
     { name = "pandas", marker = "extra == 'notebook'", specifier = ">=2.2.3" },
     { name = "playwright", marker = "extra == 'ibkr'", specifier = ">=1.43.0" },
@@ -2264,21 +2260,12 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.34.0" },
     { name = "xlsxwriter", specifier = ">=3.2.9" },
 ]
-provides-extras = ["dev", "publish", "notebook", "cli", "ibkr"]
+provides-extras = ["dev", "publish", "notebook", "ibkr"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "build", specifier = ">=1.2.2.post1" },
     { name = "twine", specifier = ">=6.1.0" },
-]
-
-[[package]]
-name = "noetl-cli"
-version = "2.5.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/53/356f655603fd860bdad49b0790b09e6ef3bb5d5565144cea93c83f623aea/noetl_cli-2.5.3.tar.gz", hash = "sha256:c76221bf00259a6317baee58c7b72ffbb1548363ca35cd1fc77bde2a9f8a9427", size = 39927, upload-time = "2026-01-10T03:53:03.992Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/0b/e04dd53c7ca8d5aa53fc84e180d37b3252eb5002ec57dcafe7634ac0869c/noetl_cli-2.5.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ed1a4ee80ca08e0728d35343a95956667d88d0850b00947bc722e96b5cfb89b7", size = 2511543, upload-time = "2026-01-10T03:53:02.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- remove the Python CLI optional extra and lockfile dependency
- update retired command entrypoint messaging to point at noetl/cli
- update local build/docs scripts to use the sibling Rust CLI repo

## Validation
- uv lock --locked
- bash -n scripts/setup_local_dev.sh scripts/build_rust_multiarch.sh scripts/build_deb.sh scripts/build_all.sh
- git diff --check