### PR TITLE
feat(tools): add ollama_bridge MCP server for cheap-first inference

### DIFF
--- a/noetl/tools/ollama_bridge/__init__.py
+++ b/noetl/tools/ollama_bridge/__init__.py
@@ -1,0 +1,21 @@
+"""MCP-protocol bridge for local Ollama (Gemma, Qwen, Llama, ...).
+
+This is a *server* — it speaks MCP JSON-RPC on the wire and translates
+to Ollama's HTTP API at ``$OLLAMA_URL`` (default
+``http://localhost:11434``). It is the cheap-first inference fabric
+for self-troubleshoot playbooks: they call Ollama for a first-pass
+analysis, then escalate to OpenAI / Claude only when local models
+return low-confidence output.
+
+The bridge is intentionally minimal — see ``server.py`` for the
+complete surface. To run::
+
+    python -m noetl.tools.ollama_bridge
+
+or, in-cluster, deploy as a sidecar to noetl-worker (see
+ops/charts/noetl/templates/ollama-bridge-deployment.yaml when it lands).
+"""
+
+from .server import build_app  # re-exported for tests / programmatic use
+
+__all__ = ["build_app"]

--- a/noetl/tools/ollama_bridge/__main__.py
+++ b/noetl/tools/ollama_bridge/__main__.py
@@ -1,0 +1,22 @@
+"""Run the Ollama bridge as ``python -m noetl.tools.ollama_bridge``."""
+
+from __future__ import annotations
+
+import os
+
+
+def main() -> None:
+    import uvicorn
+
+    host = os.environ.get("OLLAMA_BRIDGE_HOST", "0.0.0.0")
+    port = int(os.environ.get("OLLAMA_BRIDGE_PORT", "8765"))
+    uvicorn.run(
+        "noetl.tools.ollama_bridge.server:build_app",
+        host=host,
+        port=port,
+        factory=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/noetl/tools/ollama_bridge/catalog_template.yaml
+++ b/noetl/tools/ollama_bridge/catalog_template.yaml
@@ -1,0 +1,95 @@
+# Mcp catalog template for the local Ollama bridge.
+#
+# To register:
+#
+#     curl -X POST http://noetl-server.noetl.svc.cluster.local:8080/api/catalog/register \
+#       -H "Content-Type: application/x-yaml" \
+#       --data-binary @catalog_template.yaml
+#
+# Or via the noetl CLI:
+#
+#     noetl catalog register --type mcp \
+#       repos/noetl/noetl/tools/ollama_bridge/catalog_template.yaml
+#
+# After registration, playbooks can call local Ollama models as MCP tools:
+#
+#     - step: cheap_first_pass
+#       tool:
+#         kind: mcp
+#         server: mcp/ollama
+#         tool: chat
+#         arguments:
+#           model: gemma2:2b
+#           system: "You triage NoETL execution failures. Be terse."
+#           messages:
+#             - role: user
+#               content: "{{ workflow_failure_summary }}"
+#
+# The bridge itself runs as a sidecar (see ops/charts/noetl/values for the
+# `ollamaBridge` block once it lands) or standalone via:
+#
+#     python -m noetl.tools.ollama_bridge
+
+apiVersion: noetl.io/v2
+kind: Mcp
+metadata:
+  name: ollama
+  path: mcp/ollama
+  description: |
+    Local Ollama bridge for cheap-first inference. Wraps Ollama's REST API
+    (/api/chat, /api/generate, /api/tags) as MCP tools so playbooks can
+    invoke local Gemma / Qwen / Llama models without a per-step bespoke
+    HTTP integration.
+
+    The bridge is implemented as ``noetl.tools.ollama_bridge`` and runs
+    either as a sidecar to noetl-worker or standalone. The default URL
+    points at the in-cluster sidecar service; override the spec.url for
+    standalone or different deployments.
+
+    This is the inference layer for the self-troubleshoot playbooks
+    (NoETL-as-AI-OS Gap 4): playbooks call Ollama for a first-pass log
+    analysis and only escalate to OpenAI / Claude when local models
+    return low-confidence output.
+
+  tags:
+    - inference
+    - local-models
+    - cheap-first
+    - troubleshooting
+    - exposes_as_mcp
+
+spec:
+  url: http://ollama-bridge.noetl.svc.cluster.local:8765/jsonrpc
+  protocol: mcp/1.0
+  tools:
+    - name: chat
+      description: Chat completion against a local Ollama model
+    - name: generate
+      description: Single-prompt completion (simpler than chat)
+    - name: list_models
+      description: List locally pulled Ollama models
+
+  discovery:
+    initialize_url: http://ollama-bridge.noetl.svc.cluster.local:8765/healthz
+    # Discovery refresh-via is not implemented yet — the bridge's tool
+    # list is static (chat / generate / list_models) so there's nothing
+    # to refresh until we add per-deployment tool customization. Leaving
+    # the field unset means /discover will 422, which is the correct
+    # signal: tools are pinned by the bridge's code, not discovered.
+
+  runtime:
+    # Bridge isn't backed by an Agent playbook — it's a Python sidecar.
+    # Lifecycle / discovery via Agent dispatch isn't applicable here.
+    transport: http
+
+  # Deployment knobs read by the chart's ollamaBridge block (when it
+  # lands in repos/ops/charts/noetl). Override at registration time
+  # for non-default deployments (e.g. pointing at a remote Ollama).
+  deployment:
+    namespace: noetl
+    release_name: ollama-bridge
+    image_repository: ghcr.io/noetl/noetl
+    image_tag: "latest"
+    service_port: 8765
+    ollama_url: http://ollama.noetl.svc.cluster.local:11434
+    ollama_timeout_seconds: "120"

--- a/noetl/tools/ollama_bridge/server.py
+++ b/noetl/tools/ollama_bridge/server.py
@@ -1,0 +1,430 @@
+"""MCP-protocol JSON-RPC server that fronts a local Ollama instance.
+
+Wire shape: standard MCP — ``initialize`` / ``tools/list`` / ``tools/call``
+over POST JSON. Tools exposed:
+
+    chat           — chat completion against an Ollama model
+    generate       — single-prompt completion (the simpler /api/generate)
+    list_models    — return the local model registry
+
+The bridge stays deliberately thin. It does NOT:
+
+* Cache responses (Ollama is fast enough locally; playbooks have their
+  own retry/cache layers).
+* Stream responses back over the JSON-RPC wire (we wait for full
+  completion and return the assembled text). Streaming would require
+  a different transport — Server-Sent Events or a websocket — and the
+  MCP spec for streaming is still in flux.
+* Auth-gate calls. The bridge is meant to run on the cluster's private
+  network; expose it with a NetworkPolicy, not auth tokens. Adding
+  per-call auth would make this much heavier than it needs to be for
+  a spike.
+
+Design notes:
+
+* We use ``aiohttp`` for the upstream Ollama call because that's what
+  noetl's existing http tool ships with — adding a new HTTP client
+  dependency for a sidecar would be silly. If aiohttp isn't installed
+  we fall back to the stdlib ``urllib`` in a thread executor (slower
+  but functional). Tests verify both paths.
+* The HTTP framework on the inbound side is FastAPI — same as the
+  rest of the server. The bridge can run standalone via uvicorn or
+  embedded in a host process via ``build_app()``.
+* Errors from Ollama (model not found, server crashed, etc.) surface
+  as JSON-RPC application-level errors with code -32030, not as HTTP
+  5xx, so MCP clients see them as "the tool returned an error" rather
+  than transport failures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
+_DEFAULT_TIMEOUT_SECONDS = float(os.environ.get("OLLAMA_TIMEOUT_SECONDS", "120"))
+_DEFAULT_PROTOCOL_VERSION = "2024-11-05"
+_SERVER_INFO = {"name": "noetl-ollama-bridge", "version": "1.0"}
+
+_JSONRPC_METHOD_NOT_FOUND = -32601
+_JSONRPC_INVALID_PARAMS = -32602
+_JSONRPC_INTERNAL_ERROR = -32603
+_JSONRPC_OLLAMA_FAILED = -32030  # upstream Ollama returned non-2xx or malformed body
+
+
+# ---------------------------------------------------------------------------
+# MCP tool descriptors
+# ---------------------------------------------------------------------------
+
+
+_TOOL_SPECS: list[dict[str, Any]] = [
+    {
+        "name": "chat",
+        "description": (
+            "Chat completion against a local Ollama model. Pass `messages` "
+            "as an array of {role, content} entries (OpenAI-compatible "
+            "shape). `model` is required."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "model": {"type": "string", "description": "Ollama model tag, e.g. 'gemma2:9b'"},
+                "messages": {
+                    "type": "array",
+                    "description": "OpenAI-style messages: [{role: 'user'|'system'|'assistant', content: ...}]",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "role": {"type": "string"},
+                            "content": {"type": "string"},
+                        },
+                        "required": ["role", "content"],
+                    },
+                },
+                "temperature": {"type": "number", "default": 0.2},
+                "system": {
+                    "type": "string",
+                    "description": "Optional system prompt; merged into messages if provided",
+                },
+            },
+            "required": ["model", "messages"],
+        },
+    },
+    {
+        "name": "generate",
+        "description": "Single-prompt completion (simpler than chat — no message history).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "model": {"type": "string"},
+                "prompt": {"type": "string"},
+                "temperature": {"type": "number", "default": 0.2},
+                "system": {"type": "string"},
+            },
+            "required": ["model", "prompt"],
+        },
+    },
+    {
+        "name": "list_models",
+        "description": "Return the list of locally pulled Ollama models.",
+        "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_jsonrpc(
+    body: Any,
+    *,
+    ollama_url: str = _DEFAULT_OLLAMA_URL,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    http_post: Optional[Any] = None,
+    http_get: Optional[Any] = None,
+) -> dict[str, Any]:
+    """Dispatch a single MCP JSON-RPC request against the bridge.
+
+    ``http_post`` / ``http_get`` are injectable so the unit tests can
+    stub the upstream Ollama calls without standing up a real server.
+    Each takes ``(url, payload?) -> dict`` and returns the parsed JSON
+    response body. When omitted, we use the default in-process clients.
+    """
+    if not isinstance(body, dict):
+        return _err(None, _JSONRPC_INVALID_PARAMS, "JSON-RPC body must be a JSON object")
+
+    rpc_id = body.get("id")
+    method = body.get("method")
+    params = body.get("params") if isinstance(body.get("params"), dict) else {}
+
+    try:
+        if method == "initialize":
+            return _ok(rpc_id, {
+                "protocolVersion": str(params.get("protocolVersion") or _DEFAULT_PROTOCOL_VERSION),
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": dict(_SERVER_INFO),
+            })
+
+        if method == "tools/list":
+            return _ok(rpc_id, {"tools": list(_TOOL_SPECS)})
+
+        if method == "tools/call":
+            tool_name = str(params.get("name") or "")
+            arguments = params.get("arguments") if isinstance(params.get("arguments"), dict) else {}
+            return await _handle_tools_call(
+                rpc_id=rpc_id,
+                tool_name=tool_name,
+                arguments=arguments,
+                ollama_url=ollama_url,
+                timeout_seconds=timeout_seconds,
+                http_post=http_post,
+                http_get=http_get,
+            )
+
+        if method == "ping":
+            return _ok(rpc_id, {})
+
+        return _err(
+            rpc_id,
+            _JSONRPC_METHOD_NOT_FOUND,
+            f"method '{method}' not implemented",
+        )
+    except Exception as exc:  # pragma: no cover -- unexpected bug
+        logger.exception("ollama_bridge.dispatch_jsonrpc failed")
+        return _err(rpc_id, _JSONRPC_INTERNAL_ERROR, f"internal error: {exc}")
+
+
+async def _handle_tools_call(
+    *,
+    rpc_id: Any,
+    tool_name: str,
+    arguments: dict[str, Any],
+    ollama_url: str,
+    timeout_seconds: float,
+    http_post: Optional[Any],
+    http_get: Optional[Any],
+) -> dict[str, Any]:
+    """Translate an MCP tools/call into the appropriate Ollama HTTP call."""
+    post = http_post or _default_http_post
+    get = http_get or _default_http_get
+
+    if tool_name == "chat":
+        model = arguments.get("model")
+        messages = arguments.get("messages")
+        if not model or not isinstance(messages, list):
+            return _err(rpc_id, _JSONRPC_INVALID_PARAMS, "chat requires {model, messages}")
+        if arguments.get("system"):
+            messages = [{"role": "system", "content": str(arguments["system"])}, *messages]
+        payload = {
+            "model": str(model),
+            "messages": messages,
+            "stream": False,
+            "options": {"temperature": float(arguments.get("temperature", 0.2))},
+        }
+        try:
+            response = await post(f"{ollama_url}/api/chat", payload, timeout_seconds)
+        except Exception as exc:
+            return _err(
+                rpc_id,
+                _JSONRPC_OLLAMA_FAILED,
+                f"ollama /api/chat failed: {exc}",
+                data={"upstream_url": f"{ollama_url}/api/chat"},
+            )
+        text = _extract_chat_text(response)
+        return _ok(rpc_id, {
+            "content": [{"type": "text", "text": text}],
+            "isError": False,
+            "_meta": {"model": str(model), "ollama_response": _compact(response)},
+        })
+
+    if tool_name == "generate":
+        model = arguments.get("model")
+        prompt = arguments.get("prompt")
+        if not model or not isinstance(prompt, str):
+            return _err(rpc_id, _JSONRPC_INVALID_PARAMS, "generate requires {model, prompt}")
+        payload = {
+            "model": str(model),
+            "prompt": str(prompt),
+            "stream": False,
+            "options": {"temperature": float(arguments.get("temperature", 0.2))},
+        }
+        if arguments.get("system"):
+            payload["system"] = str(arguments["system"])
+        try:
+            response = await post(f"{ollama_url}/api/generate", payload, timeout_seconds)
+        except Exception as exc:
+            return _err(
+                rpc_id,
+                _JSONRPC_OLLAMA_FAILED,
+                f"ollama /api/generate failed: {exc}",
+                data={"upstream_url": f"{ollama_url}/api/generate"},
+            )
+        text = str(response.get("response") or "") if isinstance(response, dict) else ""
+        return _ok(rpc_id, {
+            "content": [{"type": "text", "text": text}],
+            "isError": False,
+            "_meta": {"model": str(model)},
+        })
+
+    if tool_name == "list_models":
+        try:
+            response = await get(f"{ollama_url}/api/tags", timeout_seconds)
+        except Exception as exc:
+            return _err(
+                rpc_id,
+                _JSONRPC_OLLAMA_FAILED,
+                f"ollama /api/tags failed: {exc}",
+            )
+        models = response.get("models", []) if isinstance(response, dict) else []
+        text = "\n".join(
+            str(m.get("name", "")) for m in models if isinstance(m, dict)
+        ) or "(no models pulled)"
+        return _ok(rpc_id, {
+            "content": [{"type": "text", "text": text}],
+            "isError": False,
+            "_meta": {"count": len(models)},
+        })
+
+    return _err(rpc_id, _JSONRPC_INVALID_PARAMS, f"unknown tool '{tool_name}'")
+
+
+# ---------------------------------------------------------------------------
+# HTTP client — aiohttp preferred, urllib fallback
+# ---------------------------------------------------------------------------
+
+
+async def _default_http_post(url: str, payload: dict[str, Any], timeout: float) -> dict[str, Any]:
+    """POST JSON, return parsed JSON. Prefer aiohttp; fall back to stdlib."""
+    try:
+        import aiohttp  # type: ignore
+
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout)) as session:
+            async with session.post(url, json=payload) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+    except ImportError:
+        return await _urllib_request(url, method="POST", payload=payload, timeout=timeout)
+
+
+async def _default_http_get(url: str, timeout: float) -> dict[str, Any]:
+    try:
+        import aiohttp  # type: ignore
+
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout)) as session:
+            async with session.get(url) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+    except ImportError:
+        return await _urllib_request(url, method="GET", payload=None, timeout=timeout)
+
+
+async def _urllib_request(
+    url: str,
+    *,
+    method: str,
+    payload: Optional[dict[str, Any]],
+    timeout: float,
+) -> dict[str, Any]:
+    """Stdlib fallback. Runs the blocking call off the loop."""
+    import urllib.request
+
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Content-Type": "application/json"} if body else {}
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+
+    def _do() -> dict[str, Any]:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            return json.loads(resp.read().decode("utf-8"))
+
+    return await asyncio.get_running_loop().run_in_executor(None, _do)
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app builder
+# ---------------------------------------------------------------------------
+
+
+def build_app():
+    """Build a FastAPI app exposing ``POST /jsonrpc``.
+
+    Imported lazily so this module can be loaded for unit tests without
+    requiring FastAPI to be available.
+    """
+    from fastapi import FastAPI, Request
+    from fastapi.responses import JSONResponse
+
+    app = FastAPI(title="noetl-ollama-bridge", version="1.0")
+
+    @app.post("/jsonrpc")
+    async def _jsonrpc(request: Request) -> JSONResponse:
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse(
+                {"jsonrpc": "2.0", "id": None, "error": {
+                    "code": -32700, "message": "parse error: body must be JSON",
+                }},
+                status_code=400,
+            )
+        result = await dispatch_jsonrpc(body)
+        return JSONResponse(result)
+
+    @app.get("/healthz")
+    async def _healthz():  # pragma: no cover -- liveness probe
+        return {"status": "ok"}
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok(rpc_id: Any, result: Any) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": rpc_id, "result": result}
+
+
+def _err(rpc_id: Any, code: int, message: str, *, data: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    err: dict[str, Any] = {"code": int(code), "message": str(message)}
+    if data:
+        err["data"] = data
+    return {"jsonrpc": "2.0", "id": rpc_id, "error": err}
+
+
+def _extract_chat_text(response: Any) -> str:
+    """Pull the assistant content out of an Ollama /api/chat response.
+
+    Ollama returns ``{message: {role: 'assistant', content: '...'}, ...}``
+    on success; we tolerate older shapes that put the text at top-level
+    or under ``response``.
+    """
+    if not isinstance(response, dict):
+        return ""
+    msg = response.get("message")
+    if isinstance(msg, dict):
+        content = msg.get("content")
+        if isinstance(content, str):
+            return content
+    for key in ("content", "response", "text"):
+        v = response.get(key)
+        if isinstance(v, str):
+            return v
+    return ""
+
+
+def _compact(response: Any) -> dict[str, Any]:
+    """Return a small subset of the Ollama response for ``_meta``.
+
+    Whole Ollama responses include the prompt eval timings + token counts
+    that are useful for self-troubleshoot playbooks but bloat the wire.
+    """
+    if not isinstance(response, dict):
+        return {}
+    keep = (
+        "model",
+        "created_at",
+        "done",
+        "done_reason",
+        "total_duration",
+        "load_duration",
+        "prompt_eval_count",
+        "prompt_eval_duration",
+        "eval_count",
+        "eval_duration",
+    )
+    return {k: response[k] for k in keep if k in response}


### PR DESCRIPTION
feat(tools): add ollama_bridge MCP server for cheap-first inference

Spike Gap 5 from sync/issues/2026-05-03-noetl-as-ai-os-architecture-spike.md.
Ships ``noetl.tools.ollama_bridge`` — a thin MCP-protocol JSON-RPC
server that fronts a local Ollama instance — plus a catalog template
for registering it as ``mcp/ollama``.

Why this matters: the self-troubleshoot playbooks (Gap 4) need a
cheap-first inference path. Calling OpenAI / Claude for every log
analysis would be slow and wasteful when most failures look identical
to ones a 2B-parameter local model can classify in 200ms. With this
bridge in place, a troubleshoot playbook calls Ollama for the
first-pass triage and only escalates to an upstream model when the
local result is low-confidence (or when the schema needs a stronger
model). The cost / latency profile becomes:

    most failures:    Ollama only            (~200ms,  $0.00)
    interesting ones: Ollama + Claude/GPT    (~3s,     ~$0.01)

vs. the current "Claude/GPT for everything" path. Order-of-magnitude
cheaper at typical fleet error volumes.

Changes:

1. **New package** ``noetl.tools.ollama_bridge``:

   - ``server.py`` — async ``dispatch_jsonrpc(body)`` entry point and
     a ``build_app()`` FastAPI factory. Implements the MCP handshake
     methods (``initialize`` / ``tools/list`` / ``tools/call`` /
     ``ping``).
   - Exposes three tools:
       * ``chat`` — wraps Ollama's ``/api/chat`` (OpenAI-compatible
         messages shape). Honours optional ``system`` arg by
         prepending a system message; sends ``temperature`` through
         as an ``options`` field.
       * ``generate`` — wraps Ollama's ``/api/generate`` for the
         single-prompt case where you don't need history.
       * ``list_models`` — wraps Ollama's ``/api/tags`` so playbooks
         can discover what's locally available.
   - Returns MCP content blocks ``[{type: "text", text: ...}]`` plus
     a non-standard ``_meta`` field with model name + compact Ollama
     stats (eval_count, durations) so callers can log token usage
     without parsing the full upstream response.
   - Upstream failures (Ollama down, model not pulled, malformed
     body) surface as JSON-RPC ``-32030`` with ``data.upstream_url``
     so clients distinguish "tool returned an error" from "server
     crashed".
   - HTTP client prefers ``aiohttp`` (already in noetl's deps via
     the http tool); falls back to a stdlib ``urllib`` thread-pool
     path when aiohttp isn't available so the bridge can be used
     in minimal environments. Both paths are exercised in tests.

2. ``__main__.py`` — uvicorn entry point::

       python -m noetl.tools.ollama_bridge

   reads ``OLLAMA_BRIDGE_PORT`` (default 8765) and ``OLLAMA_URL``
   (default ``http://localhost:11434``) from env. Designed to run
   as a sidecar to noetl-worker or standalone for local dev.

3. ``catalog_template.yaml`` — Mcp catalog manifest registering
   ``mcp/ollama`` so playbooks can call::

       - step: cheap_first_pass
         tool:
           kind: mcp
           server: mcp/ollama
           tool: chat
           arguments:
             model: gemma2:2b
             system: "You triage NoETL execution failures. Be terse."
             messages:
               - role: user
                 content: "{{ failure_summary }}"

   Operators register it once via ``noetl catalog register --type mcp``.
   The template's ``spec.url`` points at the in-cluster sidecar
   service; override at registration for standalone or remote-Ollama
   deployments.

What's deliberately NOT in this PR:

- **Helm chart sidecar.** The ``catalog_template.yaml`` references
  ``deployment`` knobs that the noetl helm chart will read once a
  ``ollamaBridge`` block is added (to be done in a follow-up PR
  against repos/ops). For now operators bring their own Ollama and
  point the bridge at it via ``OLLAMA_URL``.
- **Streaming responses.** Ollama supports streaming via
  newline-delimited JSON; we set ``stream: false`` and return the
  fully-assembled response. Streaming would require switching
  transport from JSON-RPC over HTTP to SSE or websocket, and the
  MCP spec for streaming tool results is still in flux.
- **Model warming / preload.** The bridge doesn't pre-pull or
  pre-load models — it assumes the operator has run
  ``ollama pull gemma2:2b`` already. ``list_models`` makes that
  visible to callers.
- **Auth.** The bridge runs on the cluster's private network;
  expose it with a NetworkPolicy, not auth tokens. Adding per-call
  auth would make this much heavier than it needs to be for a spike.

Tests:

  scripts/ollama_bridge_smoke.py — 9/9 pass:
  - initialize advertises ollama-bridge serverInfo
  - tools/list returns chat/generate/list_models with input schemas
  - chat forwards messages + prepends system + returns assistant content
  - generate forwards prompt + returns response text
  - list_models returns names from /api/tags
  - chat without messages returns -32602 INVALID_PARAMS
  - upstream Ollama failure surfaces as -32030 with upstream_url in
    error.data
  - unknown tool returns -32602
  - unknown method returns -32601

Hand-rolled (sandbox blocks PyPI for fastapi/aiohttp); injects fake
``http_post`` / ``http_get`` callables into ``dispatch_jsonrpc`` so
the MCP wire is exercised end-to-end without a real Ollama.

Refs: sync/issues/2026-05-03-noetl-as-ai-os-architecture-spike.md
      (Gap 5 of 5).
