### PR TITLE
fix(spike): graceful degradation when AI subsystems are missing

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -254,8 +254,42 @@ def _invoke_noetl_playbook(
     that need block-on-result semantics with a particular sub-step
     output should use `tool: kind: playbook` with `return_step:`
     directly.
+
+    **Optional-dependency contract.** AI features are optional in
+    NoETL — a deployment without the workflow plugin available
+    must not crash the worker. We import ``execute_playbook_task``
+    lazily here and surface a structured error envelope on
+    ImportError rather than letting the exception leak. The worker
+    keeps running; the playbook step fails with a clear "this
+    feature is not available" message; non-AI playbooks are
+    completely unaffected.
     """
-    from noetl.core.workflow.playbook import execute_playbook_task
+    try:
+        from noetl.core.workflow.playbook import execute_playbook_task
+    except ImportError as exc:
+        # Workflow plugin not available in this deployment. Return a
+        # clean error envelope so the caller sees a typed, retryable
+        # failure rather than a worker-level traceback.
+        logger.warning(
+            "AGENT.EXECUTE framework=noetl unavailable — "
+            "noetl.core.workflow.playbook could not be imported (%s). "
+            "Returning structured error envelope.",
+            exc,
+        )
+        return {
+            "status": "error",
+            "framework": "noetl",
+            "entrypoint": entrypoint,
+            "error": {
+                "kind": "agent.dependency",
+                "code": "WORKFLOW_PLUGIN_UNAVAILABLE",
+                "message": (
+                    "framework=noetl requires noetl.core.workflow.playbook; "
+                    f"import failed: {exc}"
+                ),
+                "retryable": False,
+            },
+        }
 
     # The plugin's task_config contract expects `path` (catalog
     # playbook path) plus an optional `input` dict. Build that out

--- a/noetl/tools/ollama_bridge/__init__.py
+++ b/noetl/tools/ollama_bridge/__init__.py
@@ -13,9 +13,47 @@ complete surface. To run::
     python -m noetl.tools.ollama_bridge
 
 or, in-cluster, deploy as a sidecar to noetl-worker (see
-ops/charts/noetl/templates/ollama-bridge-deployment.yaml when it lands).
+``catalog_template.yaml`` for the catalog manifest and
+``docs/operations/ollama_bridge.md`` for the deployment runbook).
+
+**Optional-dependency contract.** This package is opt-in. NoETL's
+worker and server never import it for core functionality. Importing
+``noetl.tools.ollama_bridge`` itself only pulls stdlib modules —
+``aiohttp`` / ``fastapi`` / ``uvicorn`` are imported lazily inside
+the functions that need them, so a deployment without those
+packages can still load the module without a crash. Calling the
+sidecar (via ``python -m noetl.tools.ollama_bridge``) is what
+actually requires the optional deps; the noetl core has no such
+requirement.
 """
 
-from .server import build_app  # re-exported for tests / programmatic use
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 
 __all__ = ["build_app"]
+
+
+def __getattr__(name: str):
+    """Lazy loader for the package's public surface.
+
+    Defers the ``server.py`` import until something actually asks for
+    ``build_app``. Importing ``noetl.tools.ollama_bridge`` therefore
+    does *zero* work; importing ``build_app`` from it triggers the
+    server module which is itself stdlib-only at module level
+    (aiohttp / fastapi are lazy inside functions). This keeps the
+    package safe to import from any noetl core path without pulling
+    optional deps along for the ride.
+    """
+    if name == "build_app":
+        from .server import build_app
+
+        return build_app
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+if TYPE_CHECKING:
+    # Re-export for static analysers / IDE completion only — never runs
+    # at import time.
+    from .server import build_app  # noqa: F401


### PR DESCRIPTION
fix(spike): graceful degradation when AI subsystems are missing

Locks in the contract that AI features added by the NoETL-as-AI-OS
spike (Gaps 1/2/3/4/4.1/5) are *optional*: a deployment that doesn't
ship the workflow plugin, doesn't deploy the Ollama bridge, doesn't
register the troubleshoot agent, or doesn't have aiohttp / fastapi /
uvicorn installed must keep running. Worker + server core
functionality cannot regress; only the AI-feature playbook steps
should fail, and they should fail with structured error envelopes,
not tracebacks.

Audit results across the spike additions:

- **Gap 1 — `_invoke_noetl_playbook`**: lazy import of
  `execute_playbook_task` was unguarded. The outer
  `execute_agent_task` would have caught the ImportError and emitted
  a generic envelope, but the message ("an exception happened during
  agent execution") didn't say *why* it failed. **Fixed**: explicit
  ImportError handling returns
  ``error.kind = "agent.dependency"`` /
  ``error.code = "WORKFLOW_PLUGIN_UNAVAILABLE"`` with the
  underlying ImportError message in `error.message`.

- **Gap 2 — `playbook_mcp.py`**: already safe. All AI-only imports
  are inside try/except (`PlaybookMetadata` falls back to a
  duck-typed stub; `yaml` is wrapped). Module-level imports are
  stdlib + already-required noetl deps. No changes needed.

- **Gap 3 — `PlaybookMetadata`**: pure Pydantic model, no AI
  dependency at all. No changes needed.

- **Gap 4 — troubleshoot playbooks**: YAML catalog entries — they
  don't ship with noetl core. Operators register them on demand.
  No changes needed.

- **Gap 4.1 — `_dispatch_troubleshoot_diagnosis`**: already wraps
  the workflow-plugin import in try/except and returns None on
  failure. The original error envelope is preserved unchanged
  when the diagnostic itself can't run. No changes needed.

- **Gap 5 — `noetl/tools/ollama_bridge/`**:
  - `server.py` already lazy-imports `aiohttp` (with urllib
    fallback) and `fastapi` (only inside `build_app`). Module-level
    imports are stdlib only.
  - `__init__.py` was eagerly importing `build_app`, which
    transitively loaded server.py at package import time. Although
    server.py is itself stdlib-only at module level, this was more
    eager than necessary. **Fixed**: switched to a lazy
    `__getattr__` pattern. Importing
    `noetl.tools.ollama_bridge` now does *zero* work; asking for
    `build_app` triggers the server module on first access. This
    means the package is safe to introspect from any noetl core
    path (tool registry auto-discovery, etc.) without pulling
    optional deps along for the ride.
  - `__main__.py` already only imported uvicorn inside `main()`.
    No changes needed.

- **`noetl/tools/__init__.py`**: ollama_bridge is not registered in
  the `_MODULES` dict, so the tool dispatch machinery never auto-
  loads it. Verified clean.

Tests:

  scripts/optional_ai_smoke.py — 6/6 pass:

  - framework=noetl returns structured error when workflow plugin
    is missing (no crash; clean envelope)
  - execute_playbook_task code refs are confined to the noetl-
    framework helpers (verified by AST-style inspection: every
    code-level mention lives inside _invoke_noetl_playbook or
    _dispatch_troubleshoot_diagnosis; non-noetl frameworks can't
    accidentally pull the workflow plugin)
  - noetl.tools.ollama_bridge import is stdlib-only (verified by
    sys.modules diff: aiohttp/fastapi/uvicorn/starlette never
    appear after the package import)
  - ollama_bridge.build_app is reachable via lazy __getattr__
  - ollama_bridge raises AttributeError on unknown attribute
    access (lazy loader doesn't silently swallow typos)
  - _dispatch_troubleshoot_diagnosis returns None on import
    failure (Gap 4.1 best-effort behaviour preserved)

  Existing smokes re-run:
  - scripts/auto_troubleshoot_smoke.py — 9/9 still pass
    (hardening didn't regress the happy path)

Docs:

  repos/docs/docs/architecture/agent_orchestration.md — new
  "Optional-dependency contract" section documents the
  no-crash-on-missing-AI-deps guarantee, including the structured
  error envelope shape and a link to the smoke test that locks
  in the contract.

What this guarantees post-PR:

- A noetl deployment without aiohttp / fastapi / uvicorn loads
  cleanly. The Ollama bridge sidecar can't start (it needs them),
  but worker + server keep running normally.
- A noetl deployment without `noetl.core.workflow.playbook` (e.g.
  a stripped-down minimal worker image) still starts. Calls to
  `tool: agent framework=noetl` fail per-step with a typed
  dependency error; calls to `framework: adk|langchain|custom`
  work unchanged.
- A noetl deployment without the troubleshoot agent registered
  works fine. Auto-dispatch (Gap 4.1) silently no-ops; manual
  invocation returns 404 from the catalog.
- A noetl deployment without Ollama running works fine. Playbooks
  that try to call `mcp/ollama` get a JSON-RPC -32030 error with
  the upstream URL. Other playbooks unaffected.

The spike is now structurally optional end-to-end. AI features are
opt-in at deployment time (which packages are installed, which
catalog entries are registered, which sidecars are deployed); the
core stays running through every kind of AI-subsystem absence.

Refs: noetl/noetl#407, noetl/noetl#408, noetl/docs#22,
      sync/issues/2026-05-03-noetl-as-ai-os-architecture-spike.md.
