### PR TITLE
fix(ollama_bridge): route annotation causes 422 + openapi 500

### DIFF
--- a/noetl/tools/ollama_bridge/server.py
+++ b/noetl/tools/ollama_bridge/server.py
@@ -343,29 +343,39 @@ def build_app():
 
     Imported lazily so this module can be loaded for unit tests without
     requiring FastAPI to be available.
+
+    Implementation notes:
+
+    * We declare the route handlers with ``response_class=JSONResponse``
+      in the decorator and *no* return-type annotation on the handler.
+      Some FastAPI versions interpret a ``-> JSONResponse`` annotation
+      as the response_model and try to schema-validate the return
+      value as a Pydantic model — it isn't one, so /openapi.json
+      generation fails with 500 and route validation can produce
+      misleading 422s on POST. Decorator-only response class avoids
+      both pitfalls.
+    * The route accepts the raw body via ``Body`` rather than
+      ``Request.body()`` so FastAPI does the JSON parse + content-type
+      negotiation itself. This also makes the openapi schema valid.
     """
-    from fastapi import FastAPI, Request
+    from fastapi import Body, FastAPI
     from fastapi.responses import JSONResponse
 
     app = FastAPI(title="noetl-ollama-bridge", version="1.0")
 
-    @app.post("/jsonrpc")
-    async def _jsonrpc(request: Request) -> JSONResponse:
-        try:
-            body = await request.json()
-        except Exception:
-            return JSONResponse(
-                {"jsonrpc": "2.0", "id": None, "error": {
-                    "code": -32700, "message": "parse error: body must be JSON",
-                }},
-                status_code=400,
-            )
+    @app.post("/jsonrpc", response_class=JSONResponse)
+    async def _jsonrpc(body: Any = Body(default=None)):
+        # Body is parsed by FastAPI as either dict / list / scalar / None;
+        # dispatch_jsonrpc tolerates anything (returns -32600 if not a
+        # JSON-RPC envelope). We don't do our own try/except for parse
+        # errors because FastAPI returns a clean 422 with details if
+        # the wire bytes aren't JSON — same surface MCP clients expect.
         result = await dispatch_jsonrpc(body)
         return JSONResponse(result)
 
-    @app.get("/healthz")
+    @app.get("/healthz", response_class=JSONResponse)
     async def _healthz():  # pragma: no cover -- liveness probe
-        return {"status": "ok"}
+        return JSONResponse({"status": "ok"})
 
     return app
 


### PR DESCRIPTION
fix(ollama_bridge): route annotation causes 422 + openapi 500

Live cluster diagnostic showed the bridge returning ``HTTP 422
Unprocessable Entity`` on every POST to ``/jsonrpc`` and ``HTTP 500
Internal Server Error`` on ``GET /openapi.json``. Bridge healthcheck
(``GET /healthz``) returned 200 cleanly, so the FastAPI app started
— it was the JSON-RPC route specifically that was misbehaving.

**Root cause.** The route handler was annotated as::

    @app.post("/jsonrpc")
    async def _jsonrpc(request: Request) -> JSONResponse:
        ...

FastAPI's response_model inference reads the return-type annotation
and tries to use it as the response_model — but ``JSONResponse`` is
a Starlette ``Response`` subclass, not a Pydantic model. Behaviour
varies by FastAPI version:

- Newer FastAPI: schema generation crashes (the ``/openapi.json``
  500) AND route invocation rejects bodies that don't conform to
  the (broken) inferred schema (the ``422`` we saw).
- Older FastAPI: the annotation is silently ignored and routes
  work — which is why our local smoke tests passed and we didn't
  catch this until a real cluster.

The two-line fix that's robust across versions:

1. Move ``JSONResponse`` to ``response_class=`` in the decorator.
   The decorator argument tells FastAPI "the response is going to
   be a raw Response object, don't try to validate it" and the
   annotation is dropped.
2. Read the body via ``Body(default=None)`` parameter instead of
   ``Request.body()``. FastAPI handles JSON parsing + content-type
   negotiation itself, returns a clean 422 with a useful detail
   field when the wire bytes aren't JSON, and produces a valid
   openapi schema.

Both routes (``/jsonrpc`` and ``/healthz``) updated to follow the
same pattern. Comment block in ``build_app()`` documents the
gotcha so future contributors don't re-introduce it.

**dispatch_jsonrpc unchanged.** That's where the actual request
validation lives — it inspects ``body`` and returns ``-32600
Invalid Request`` if the JSON-RPC envelope shape is wrong. Moving
the parse + validation responsibility to the JSON-RPC layer
(rather than splitting it between FastAPI's body-parser and our
custom error envelope generator) means the 422 surface MCP clients
see comes from a single source of truth and matches the spec.

Tests:

  scripts/ollama_bridge_smoke.py — 9/9 still pass:
  - initialize / tools/list / tools/call (chat / generate /
    list_models) all return correct envelopes
  - JSON-RPC error codes (-32602 INVALID_PARAMS, -32601 METHOD_NOT_
    FOUND, -32030 OLLAMA_FAILED) all surface correctly
  - The smoke bypasses the FastAPI app entirely (calls
    ``dispatch_jsonrpc`` directly with stub HTTP) so it never
    caught the FastAPI route problem; this PR's fix lives at
    the framework layer the unit tests don't exercise.

  Live verification (post-PR-merge): bridge ``POST /jsonrpc``
  returns 200 with a JSON-RPC result envelope; ``/openapi.json``
  returns 200 with a valid schema doc. Both match what the
  spike e2e smoke + the troubleshoot agent's MCP-tool dispatch
  expect.

What this unblocks:

- The spike e2e smoke (`tests/spike/spike_e2e_test`) can now
  reach the bridge from the troubleshoot agent's MCP-tool
  dispatch. The Gap 4.1 auto-dispatch hook should now attach
  a real diagnosis instead of silently no-op'ing.
- The AI-OS lifecycle deploy playbook's `verify_reachability`
  step will succeed on its python3-urllib smoke call.

Refs: noetl/noetl#407 (Gap 5 — original ollama_bridge package),
      sync/issues/2026-05-03-noetl-as-ai-os-architecture-spike.md.
