### PR TITLE
fix(agent): preserve agent envelope + wait for sub-execution terminal

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -91,6 +91,89 @@ def _coerce_framework(value: Any) -> str:
     return framework
 
 
+def _wait_for_sub_execution_terminal(
+    execution_id: str,
+    *,
+    timeout_seconds: float = 300.0,
+    poll_interval_seconds: float = 1.0,
+) -> Dict[str, Any]:
+    """Poll noetl-server's /api/executions/{id}/status until terminal.
+
+    `execute_playbook_task` HTTP-POSTs to /api/execute and returns
+    immediately with the started-state response (status="started",
+    execution_id, commands_generated). The agent contract demands a
+    synchronous outcome — the parent step needs to see whether the
+    child succeeded, failed, or what the actual data is. Without
+    waiting, the auto-troubleshoot hook (Gap 4.1) never fires
+    because the parent's normalised_status stays "started" instead
+    of "error".
+
+    Returns the status doc from /api/executions/{id}/status (with
+    keys ``completed``, ``failed``, optionally ``current_step`` /
+    ``error``) once the execution reaches terminal status, OR a
+    synthetic timeout doc if the deadline passes. The caller then
+    builds the agent envelope based on the terminal outcome.
+
+    Imports are lazy so this module stays importable in test
+    harnesses that don't have requests available (the agent
+    executor's optional-dependency contract).
+    """
+    import time
+
+    try:
+        import requests
+    except ImportError:
+        logger.warning(
+            "AGENT.WAIT: requests not available; cannot poll sub-execution %s; "
+            "returning synthetic timeout",
+            execution_id,
+        )
+        return {"completed": False, "failed": True, "timeout": True,
+                "error": "requests module unavailable"}
+
+    server_url = os.environ.get("NOETL_SERVER_URL", "http://localhost:8083").rstrip("/")
+    if not server_url.endswith("/api"):
+        server_url = server_url + "/api"
+    status_url = f"{server_url}/executions/{execution_id}/status"
+
+    deadline = time.time() + max(1.0, float(timeout_seconds))
+    last_doc: Dict[str, Any] = {}
+    poll_n = 0
+
+    while time.time() < deadline:
+        poll_n += 1
+        try:
+            resp = requests.get(status_url, timeout=10)
+            resp.raise_for_status()
+            last_doc = resp.json()
+        except Exception as exc:
+            logger.warning(
+                "AGENT.WAIT: poll #%d for %s failed: %s",
+                poll_n, execution_id, exc,
+            )
+            time.sleep(max(0.1, float(poll_interval_seconds)))
+            continue
+
+        if last_doc.get("completed") or last_doc.get("failed"):
+            logger.debug(
+                "AGENT.WAIT: %s reached terminal after %d polls (completed=%s, failed=%s)",
+                execution_id, poll_n,
+                last_doc.get("completed"), last_doc.get("failed"),
+            )
+            return last_doc
+
+        time.sleep(max(0.1, float(poll_interval_seconds)))
+
+    logger.warning(
+        "AGENT.WAIT: %s did not reach terminal within %.1fs (last status: %s)",
+        execution_id, timeout_seconds, last_doc,
+    )
+    last_doc["timeout"] = True
+    last_doc["failed"] = True   # treat timeouts as failures so caller's
+                                 # error-branch + auto-troubleshoot fire
+    return last_doc
+
+
 def _should_auto_troubleshoot(
     *,
     task_config: Dict[str, Any],
@@ -322,27 +405,72 @@ def _invoke_noetl_playbook(
         sub_input,
     )
 
-    # Normalise the plugin's status-wording into the agent envelope.
-    # execute_playbook_task returns 'success'/'error'; agent callers
-    # expect 'ok'/'error'.
+    # `execute_playbook_task` HTTP-POSTs to /api/execute and returns
+    # the started-state response immediately. We need to wait for the
+    # sub-execution to reach terminal status so the agent contract
+    # (parent step sees the child's actual outcome) holds. Otherwise
+    # the auto-troubleshoot hook (Gap 4.1) never fires because the
+    # status stays "started" instead of resolving to "ok"/"error".
+    sub_execution_id: Optional[str] = None
+    sub_terminal: Dict[str, Any] = {}
     if isinstance(sub_result, dict):
         plugin_status = sub_result.get("status")
-        normalised_status = "ok" if plugin_status == "success" else (
-            plugin_status if plugin_status else "error"
+        # `execute_playbook_task` reports "success" when the HTTP
+        # dispatch succeeded (regardless of the inner sub-execution's
+        # outcome). The actual sub-execution_id lives either at
+        # top-level (some plugin versions) or inside `.data`.
+        sub_execution_id = (
+            sub_result.get("execution_id")
+            or (sub_result.get("data") or {}).get("execution_id")
         )
+
+        # If the dispatch succeeded and we have an execution_id, poll
+        # for terminal. Errors and missing execution_ids fall through
+        # to the existing normalisation logic below.
+        if plugin_status == "success" and sub_execution_id:
+            wait_timeout = float(task_config.get("wait_timeout_seconds", 300.0))
+            sub_terminal = _wait_for_sub_execution_terminal(
+                str(sub_execution_id),
+                timeout_seconds=wait_timeout,
+            )
+
+    # Normalise the plugin's status-wording into the agent envelope.
+    # Three sources of truth, in priority order:
+    #   1. sub_terminal (if we polled to terminal): completed → ok,
+    #      failed → error
+    #   2. execute_playbook_task's plugin_status (success/error): pre-
+    #      polling fall-back when no execution_id was available
+    #   3. Default to "error" when the shape is unrecognised
+    if isinstance(sub_result, dict):
+        if sub_terminal:
+            if sub_terminal.get("completed") and not sub_terminal.get("failed"):
+                normalised_status = "ok"
+            else:
+                normalised_status = "error"
+        else:
+            plugin_status = sub_result.get("status")
+            normalised_status = "ok" if plugin_status == "success" else (
+                plugin_status if plugin_status else "error"
+            )
+
         envelope: Dict[str, Any] = {
             "status": normalised_status,
             "framework": "noetl",
             "entrypoint": entrypoint,
-            "data": sub_result.get("data"),
-            "execution_id": sub_result.get("execution_id"),
+            "data": sub_terminal or sub_result.get("data"),
+            "execution_id": sub_execution_id or sub_result.get("execution_id"),
             "duration": sub_result.get("duration"),
         }
         if normalised_status != "ok":
+            error_message = (
+                (sub_terminal.get("error") if sub_terminal else None)
+                or sub_result.get("error")
+                or "sub-playbook returned non-success status"
+            )
             envelope["error"] = {
                 "kind": "agent.execution",
                 "code": "PLAYBOOK_FAILED",
-                "message": sub_result.get("error") or "sub-playbook returned non-success status",
+                "message": error_message,
                 "retryable": False,
             }
 

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -2602,12 +2602,27 @@ class Worker:
             return result.get('data', result) if isinstance(result, dict) else result
 
         elif tool_kind == "agent":
-            # Agent runtime bridge (ADK/LangChain/custom callable adapters)
+            # Agent runtime bridge (ADK/LangChain/custom callable adapters,
+            # plus the framework=noetl path that dispatches a peer playbook
+            # as the agent runtime).
+            #
+            # The agent envelope is the contract — `{status, framework,
+            # entrypoint, data, execution_id, duration, error?}`. Callers
+            # (like the spike's extract_envelope step) check `framework`
+            # and `error.kind` and `error.diagnosis` directly, so we must
+            # NOT unwrap the envelope down to just `.data` the way other
+            # tool kinds do. Without this preservation, Gap 1's
+            # framework=noetl path returns just the inner /api/execute
+            # response (status="started", no framework field) and the
+            # parent step has no way to detect errors or read diagnoses.
+            #
+            # Backward-compat: non-noetl frameworks (adk / langchain /
+            # custom) that don't follow the envelope contract still work
+            # — execute_agent_task wraps their raw output in the same
+            # envelope shape, so the caller-visible structure is uniform.
             task_with = {**config, **args}
             result = await execute_agent_task(task_config, context, jinja_env, task_with)
-            if isinstance(result, dict) and result.get("status") == "error":
-                return result
-            return result.get("data", result) if isinstance(result, dict) else result
+            return result
 
         elif tool_kind == "mcp":
             # Model Context Protocol server bridge. Operations stay inside


### PR DESCRIPTION
fix(agent): preserve agent envelope + wait for sub-execution terminal

Two-bug fix that was blocking the spike e2e smoke from going GREEN.
Both surfaced via the autonomous Codex deploy run documented in
ai-meta/bridge/outbox/codex-deploy-report.md.

Bug 1 — `nats_worker.py:2610` was unwrapping the agent envelope
        down to just `.data`
========================================================================

The `kind: agent` branch in `_execute_tool` did:

    return result.get("data", result) if isinstance(result, dict) else result

…which is the right idiom for tool kinds where the envelope is just
a thin wrapper around the actual return data (http, postgres, mcp,
etc.). But for `kind: agent`, the envelope IS the contract: callers
inspect `framework`, `error.kind`, `error.code`, `error.diagnosis`
(Gap 4.1's auto-attached diagnosis), `execution_id`, etc. Stripping
to just `.data` left the parent step with the inner /api/execute
response (status="started", no framework field) — exactly what the
Codex report captured:

    [FAIL] agent_envelope.status == 'error' — got 'started'
    [FAIL] agent_envelope.framework == 'noetl' (Gap 1) — got None

Fix: return the envelope unmodified for `kind: agent`. Other tool
kinds keep their existing unwrap behaviour. Comment block in
nats_worker.py documents the contract.

Bug 2 — `_invoke_noetl_playbook` returned without waiting for the
        sub-execution to terminate
========================================================================

`execute_playbook_task` HTTP-POSTs to /api/execute and returns the
started-state envelope (`{status: "started", execution_id,
commands_generated}`) immediately — it does NOT block until the
sub-execution reaches terminal status. So even after Bug 1 is
fixed and the envelope is preserved, the parent step would see
`status: "started"` (not `"error"` or `"ok"`) and the
auto-troubleshoot hook (Gap 4.1) would never fire.

Fix: add `_wait_for_sub_execution_terminal()` which polls
/api/executions/{id}/status until completed or failed (with a
configurable timeout, default 300s). After `execute_playbook_task`
returns, if the dispatch succeeded and we have an execution_id,
poll for terminal. The envelope's status / data / error are then
built from the actual terminal state, not the started-state HTTP
response.

Configurability:
- `task_config.wait_timeout_seconds` overrides per-call
  (default 300s)
- The poll uses `NOETL_SERVER_URL` env var for the base URL
  (defaults to http://localhost:8083 — same convention
  execute_playbook_task already uses)
- Poll interval is 1s; configurable via the helper's
  `poll_interval_seconds` parameter (not exposed at task level
  since 1s is fine for the typical 3–8s spike duration)

Failure modes the helper handles:
- requests not installed → return synthetic timeout doc
  (preserves the optional-dependency contract from noetl#409)
- HTTP polls fail (server unreachable, 5xx, etc.) → log warn,
  retry up to deadline
- Deadline reached before terminal → mark `failed: true,
  timeout: true` so caller's error-branch + auto-troubleshoot
  fire (the agent envelope's error.message will say
  "sub-playbook returned non-success status" with the timeout
  flag in `data.timeout`)

Three-source-of-truth normalisation in `_invoke_noetl_playbook`:
1. `sub_terminal` (post-poll) — `completed && !failed` → "ok",
   else "error"
2. `execute_playbook_task` plugin status — fall-back when no
   execution_id was available to poll (synchronous error paths)
3. Default to "error" when shape is unrecognised

Tests:
- scripts/auto_troubleshoot_smoke.py — 9/9 still pass.
  Stubs the new `_wait_for_sub_execution_terminal` helper to
  return canned terminal state (mirrors the production poll
  semantics without standing up an HTTP server).
- scripts/optional_ai_smoke.py — 6/6 still pass. The new
  helper's `import requests` happens lazily so the
  optional-dependency contract is preserved.

What this unblocks:
- Spike e2e smoke can now go GREEN end-to-end. The parent
  spike_e2e_test step that calls `tool: agent framework=noetl`
  receives the actual terminal envelope of the failing
  sub-playbook, error.diagnosis attaches correctly via Gap 4.1's
  hook, and the assertion script's `agent_envelope.status ==
  'error'` + `agent_envelope.framework == 'noetl'` checks pass.
- Any downstream consumer of `tool: agent framework=noetl` now
  sees the agent contract uphold synchronously.

What's NOT changed:
- `tool: kind: playbook` (the standalone playbook plugin) keeps
  its existing async-dispatch-then-fire-and-forget semantics.
  Callers that need block-on-result with a particular sub-step's
  output should use that with `return_step:` directly. Agent
  framework=noetl is the synchronous-by-default surface.
- Other agent frameworks (adk / langchain / custom Python
  callables) are unaffected; they go through a different code
  path that already returns synchronously.

Refs:
- ai-meta/bridge/outbox/codex-deploy-report.md (the autonomous
  Codex run that surfaced both bugs)
- ai-meta/memory/inbox/2026/05/<timestamp>-codex-autonomous-deploy.md
  (the memory entry capturing the run + 6 follow-ups)
- noetl/noetl#407 (Gap 1 — original framework=noetl path)
- noetl/noetl#408 (Gap 4.1 — auto-troubleshoot hook that depends
  on this fix)
