### PR TITLE
fix(worker): carve out kind:agent from tool_error coercion

### DIFF
--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -1990,9 +1990,26 @@ class Worker:
             # Check if tool returned error status FIRST (before case evaluation)
             # This allows case blocks to handle errors via call.error event
             # NOTE: task_sequence returns status="failed", other tools use status="error"
+            #
+            # CARVE-OUT for tool_kind == "agent":
+            # The agent envelope is the documented contract — callers inspect
+            # `framework`, `error.kind`, `error.code`, `error.diagnosis`,
+            # `execution_id`, etc., and decide downstream what to do. An
+            # envelope with `status: "error"` describes the OUTCOME of the
+            # sub-execution (or framework adapter call), not a step-level
+            # failure of the agent dispatcher itself. The dispatcher succeeded
+            # — it produced a well-formed envelope. Treating envelope.status
+            # as a step failure terminates the parent workflow before
+            # downstream steps (extract_envelope, auto_troubleshoot, etc.)
+            # can read the envelope, which defeats the contract.
+            #
+            # If a user wants to route on agent error, they declare case
+            # blocks against `result.status == "error"` or `result.error.kind`
+            # — which evaluate normally on the call.done path.
             tool_error = None
             error_response = None
-            if isinstance(response, dict):
+            is_agent_envelope = (str(tool_kind or "").strip().lower() == "agent")
+            if isinstance(response, dict) and not is_agent_envelope:
                 if response.get('status') in ('error', 'failed'):
                     # Extract error from either 'error' dict (task_sequence) or 'error' string (other tools)
                     error_val = response.get('error')


### PR DESCRIPTION
fix(worker): carve out kind:agent from tool_error coercion

Follow-up to v2.35.3 (which fixed the agent envelope unwrap + added
sub-execution wait). The Codex deploy validation surfaced a NEW
downstream bug:

    bridge/outbox/codex-spike-green-validation.md   (verdict: RED)

After v2.35.3 the envelope shape became correct:

    {status: "error", framework: "noetl", entrypoint: "...",
     error: {code: "PLAYBOOK_FAILED", kind: "agent.execution", ...},
     execution_id: "..."}

…but the parent playbook was still marked FAILED before
extract_envelope could run. Events sequence:

    command.failed   trigger_failure   FAILED
    step.exit        trigger_failure   COMPLETED
    call.error       trigger_failure   FAILED
    command.issued   extract_envelope  PENDING       <-- never ran

The bug
=======

`nats_worker.py:_execute_step` has a generic post-tool-execution block
(lines 1990-2030) that translates `response.status == "error"` into a
`tool_error` flag. That flag fires `call.error` → `command.failed` →
parent execution FAILED — which is the right behaviour for
`tool: kind: http`, `kind: postgres`, `kind: task_sequence`, etc.,
where the response is just a tool's data and an error means the step
itself failed.

But for `tool: kind: agent`, the response IS the envelope. The
agent dispatcher's job is to invoke a sub-runtime (NoETL playbook,
ADK agent, LangChain runnable, custom callable) and report back what
happened. Whether the sub-runtime succeeded or failed, the dispatcher
itself succeeded — it produced a well-formed envelope. The envelope's
`status: "error"` describes the OUTCOME of the sub-runtime, not a
step-level failure of the dispatcher.

Treating envelope.status as a step failure terminates the parent
workflow before downstream steps can read the envelope, defeating
the entire contract:

  - extract_envelope (the spike's pattern) can't run
  - auto_troubleshoot consumers can't surface error.diagnosis
  - case blocks routing on `result.status == "error"` get bypassed by
    the failure-event path even when they should evaluate normally
  - Any downstream step expecting "envelope as data" silently breaks

The fix
=======

Skip the tool_error coercion entirely when `tool_kind == "agent"`:

    is_agent_envelope = (str(tool_kind or "").strip().lower() == "agent")
    if isinstance(response, dict) and not is_agent_envelope:
        if response.get('status') in ('error', 'failed'):
            ...

Effect: agent envelopes flow straight to call.done with the envelope
as the response payload. Downstream steps receive it via the normal
`{{ steps.<step>.result }}` path. Callers route on envelope shape:

    case:
      - when: "{{ result.status == 'error' }}"
        next: handle_failure
      - when: "{{ result.error.kind == 'agent.execution' }}"
        next: troubleshoot

If a user wants the step itself to fail when the agent reports error,
they declare:

    case:
      - when: "{{ result.status == 'error' }}"
        next: end:fail

…or wrap the agent call in a step that explicitly raises. The
default for kind:agent is "envelope IS the data" — which matches
how every framework adapter (ADK, LangChain, framework=noetl) is
already documented to behave.

Carve-out scope
===============

ONLY tool_kind == "agent". Every other tool kind keeps its existing
behaviour:
  - kind:http error → tool_error → call.error  ✓
  - kind:postgres nested data error → tool_error  ✓
  - kind:task_sequence status="failed" → tool_error  ✓
  - kind:python exception → tool_error  ✓

The carve-out is case-insensitive and whitespace-tolerant via
`str(tool_kind or "").strip().lower()`.

Tests
=====

scripts/agent_envelope_carveout_smoke.py — 8/8 pass:
  - static check: carve-out is wired into the conditional
  - kind:agent envelope.status='error' → no tool_error
  - kind:agent nested data error → no tool_error
  - kind:http error → tool_error (unchanged)
  - kind:task_sequence failed → tool_error (unchanged)
  - kind:postgres nested data error → tool_error (unchanged)
  - case-insensitive matching
  - unknown / None tool_kind → tool_error (default)

scripts/auto_troubleshoot_smoke.py — 9/9 pass (no behaviour change
for the executor; the worker carve-out is a separate layer).

scripts/optional_ai_smoke.py — 6/6 pass.

What this unblocks
==================

Spike e2e smoke goes GREEN end-to-end:
  - trigger_failure (kind:agent framework=noetl) → call.done with
    envelope payload, even when sub-playbook failed
  - extract_envelope → reads envelope.status, sets smoke_status=ok
  - assert_diagnosis_attached → sees error.diagnosis from Gap 4.1
    auto-troubleshoot hook
  - parent execution → COMPLETED, not FAILED

Refs
====

  - bridge/outbox/codex-spike-green-validation.md (RED report from
    v2.35.3 that surfaced this downstream bug)
  - noetl/noetl#407 (Gap 1 — original framework=noetl path)
  - noetl/noetl#408 (Gap 4.1 — auto-troubleshoot hook)
  - PR (this commit) — the worker-side carve-out completing the
    kind:agent envelope contract
