### PR TITLE
fix(agent): Gap 4.1 — wait for diagnose sub-execution + extract persisted diagnosis

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -213,6 +213,79 @@ def _should_auto_troubleshoot(
     return env_value in ("1", "true", "yes", "on")
 
 
+# Default step name the troubleshoot playbook persists its diagnosis to.
+# Configurable via task_config.on_failure.diagnosis_step or env var so
+# bespoke troubleshoot playbooks can name the step differently.
+_DEFAULT_DIAGNOSIS_STEP_NAME = "persist_diagnosis"
+_DIAGNOSIS_STEP_ENV = "NOETL_TROUBLESHOOT_DIAGNOSIS_STEP"
+_REQUIRED_DIAGNOSIS_KEYS = (
+    "category",
+    "confidence",
+    "root_cause",
+    "suggested_action",
+    "source",
+)
+
+
+def _fetch_persisted_diagnosis_from_doc(
+    execution_id: str,
+    *,
+    diagnosis_step_name: str = _DEFAULT_DIAGNOSIS_STEP_NAME,
+    request_timeout_seconds: float = 10.0,
+) -> Optional[Dict[str, Any]]:
+    """Fetch the full execution doc and pull the persisted diagnosis dict.
+
+    The troubleshoot playbook persists its result at
+    result.context.diagnosis on a terminal event, usually from the
+    persist_diagnosis step. Return None when the doc is unavailable or
+    no qualifying diagnosis exists so the original error remains intact.
+    """
+    try:
+        import requests
+    except ImportError:
+        logger.debug(
+            "AGENT.DIAGNOSIS.FETCH: requests module unavailable; cannot "
+            "extract persisted diagnosis"
+        )
+        return None
+
+    server_url = os.environ.get("NOETL_SERVER_URL", "http://localhost:8083").rstrip("/")
+    if not server_url.endswith("/api"):
+        server_url = server_url + "/api"
+    doc_url = f"{server_url}/executions/{execution_id}"
+
+    try:
+        resp = requests.get(doc_url, timeout=max(1.0, float(request_timeout_seconds)))
+        resp.raise_for_status()
+        doc = resp.json()
+    except Exception as exc:
+        logger.warning(
+            "AGENT.DIAGNOSIS.FETCH: failed to fetch %s: %s",
+            doc_url, exc,
+        )
+        return None
+
+    events = doc.get("events") if isinstance(doc, dict) else None
+    if not isinstance(events, list):
+        return None
+
+    # Walk newest-first so we pick the terminal event over command.issued.
+    for evt in reversed(events):
+        if not isinstance(evt, dict):
+            continue
+        if evt.get("node_name") != diagnosis_step_name:
+            continue
+        if evt.get("event_type") not in ("command.completed", "step.exit", "call.done"):
+            continue
+        result_block = evt.get("result") if isinstance(evt.get("result"), dict) else {}
+        ctx = result_block.get("context") if isinstance(result_block.get("context"), dict) else {}
+        candidate = ctx.get("diagnosis") if isinstance(ctx.get("diagnosis"), dict) else None
+        if candidate and set(_REQUIRED_DIAGNOSIS_KEYS).issubset(candidate.keys()):
+            return candidate
+
+    return None
+
+
 def _dispatch_troubleshoot_diagnosis(
     *,
     failed_execution_id: Optional[str],
@@ -224,11 +297,19 @@ def _dispatch_troubleshoot_diagnosis(
 ) -> Optional[Dict[str, Any]]:
     """Run the troubleshoot agent against a freshly failed sub-execution.
 
-    Returns the diagnosis dict (the inner ``data`` field of the
-    troubleshoot agent's envelope, which carries
-    ``{category, confidence, root_cause, suggested_action, source}``)
-    or ``None`` if the diagnosis itself fails. We swallow exceptions
-    here because a failing diagnostic should never *replace* the
+    Returns the diagnosis dict carrying
+    ``{category, confidence, root_cause, suggested_action, source}``
+    or ``None`` if the diagnosis itself fails.
+
+    Wait-for-terminal contract (mirrors Gap 1 fix in
+    ``_invoke_noetl_playbook``): ``execute_playbook_task`` HTTP-POSTs
+    to /api/execute and returns the started-state response immediately.
+    We poll /api/executions/<id>/status until the diagnose
+    sub-execution terminates, then fetch the full doc and extract the
+    persisted diagnosis from the terminal event.
+
+    We swallow exceptions here because a failing diagnostic should
+    never *replace* the
     original failure with a diagnosis-tool error — the original error
     is what the caller actually wants to see.
 
@@ -300,14 +381,51 @@ def _dispatch_troubleshoot_diagnosis(
         )
         return None
 
-    if not isinstance(sub_result, dict):
-        return None
-    if sub_result.get("status") not in ("success", "ok"):
-        # Diagnostic itself failed; leave the envelope untouched.
+    if not isinstance(sub_result, dict) or sub_result.get("status") not in ("success", "ok"):
+        # Dispatch itself failed (HTTP error, plugin import error, etc.)
+        # — leave the envelope untouched.
         return None
 
     data = sub_result.get("data")
-    return data if isinstance(data, dict) else None
+    if isinstance(data, dict) and set(_REQUIRED_DIAGNOSIS_KEYS).issubset(data.keys()):
+        return data
+
+    diag_execution_id = (
+        sub_result.get("execution_id")
+        or (data or {}).get("execution_id")
+    )
+    if not diag_execution_id:
+        logger.warning(
+            "AGENT.DIAGNOSIS: dispatch succeeded but no execution_id in response; "
+            "cannot wait for terminal or fetch persisted diagnosis"
+        )
+        return None
+
+    # Wait for the diagnose sub-execution to reach terminal status before
+    # fetching the persisted diagnosis. Default 60s; diagnoses are usually
+    # quick, but local model paths can stretch.
+    wait_timeout = float(on_failure.get("diagnosis_wait_timeout_seconds", 60.0))
+    terminal = _wait_for_sub_execution_terminal(
+        str(diag_execution_id),
+        timeout_seconds=wait_timeout,
+    )
+    if not terminal.get("completed") or terminal.get("failed"):
+        logger.warning(
+            "AGENT.DIAGNOSIS: sub-execution %s did not complete cleanly "
+            "(terminal=%s); returning no diagnosis",
+            diag_execution_id, terminal,
+        )
+        return None
+
+    diagnosis_step = str(
+        on_failure.get("diagnosis_step")
+        or os.environ.get(_DIAGNOSIS_STEP_ENV, "")
+        or _DEFAULT_DIAGNOSIS_STEP_NAME
+    )
+    return _fetch_persisted_diagnosis_from_doc(
+        str(diag_execution_id),
+        diagnosis_step_name=diagnosis_step,
+    )
 
 
 def _invoke_noetl_playbook(


### PR DESCRIPTION
fix(agent): Gap 4.1 — wait for diagnose sub-execution + extract persisted diagnosis

The auto-troubleshoot hook (Gap 4.1) had the same bug Gap 1 had before
v2.35.3: `_dispatch_troubleshoot_diagnosis` called
`execute_playbook_task` and read `sub_result.data` immediately —
without waiting for the diagnose sub-execution to reach terminal
status. Because `execute_playbook_task` HTTP-POSTs to /api/execute
and returns the started-state response synchronously, the "diagnosis"
attached to `error.diagnosis` was just the dispatch handle
(`{execution_id, status: "started"}`), NOT the actual diagnosis dict
the documented contract promises:

    error.diagnosis = {
      "category", "confidence", "root_cause",
      "suggested_action", "source", ...
    }

Surfaced by the v2.35.4 GREEN validation
(bridge/outbox/codex-spike-green-validation.md follow-up). To get the
spike e2e to GREEN, the smoke fixture
(repos/e2e/fixtures/playbooks/spike/spike_e2e_test.yaml) had to add a
30-attempt poll loop in extract_envelope to fetch the full doc and
walk events for the persisted diagnosis. That fixture-side workaround
masked this server-side bug.

The fix
=======

Mirror Gap 1's wait-for-terminal pattern in the diagnosis dispatch:

1. Get the diagnose sub-execution_id from
   `execute_playbook_task`'s started-state envelope.
2. Call `_wait_for_sub_execution_terminal()` (existing helper from
   v2.35.3) to poll `/api/executions/<id>/status` until
   completed/failed/timeout.
3. On clean completion, call the new
   `_fetch_persisted_diagnosis_from_doc()` helper which fetches the
   full execution doc, walks events newest-first for a terminal event
   on the `persist_diagnosis` step, and returns the
   `result.context.diagnosis` dict if it carries all five required
   keys.
4. On failed/timed-out sub-execution, return None (original error
   stays untouched — same best-effort contract as before).

Configurability:
  - `task_config.on_failure.diagnosis_wait_timeout_seconds` overrides
    per-call (default 60s — diagnoses typically <5s, but Ollama
    escalation can stretch).
  - `task_config.on_failure.diagnosis_step` (or
    `NOETL_TROUBLESHOOT_DIAGNOSIS_STEP` env) lets bespoke
    troubleshoot playbooks name the persisting step differently.
    Default: `persist_diagnosis`.

Required diagnosis keys are defined as a module constant
`_REQUIRED_DIAGNOSIS_KEYS` so callers and tests share the same
contract definition.

What this unblocks
==================

- `error.diagnosis` arrives populated with the actual diagnosis dict,
  not the dispatch handle. Downstream consumers
  (`spike_e2e_test.yaml`, GUI rendering of error.diagnosis, the
  troubleshoot dashboard, etc.) read the contract directly without
  poll-and-extract workarounds.
- The repos/e2e spike fixture's polling loop becomes redundant —
  harmless but no longer necessary. We'll mark it with a TODO
  pointing at this commit so a future cleanup pass can drop it.

What's NOT changed
==================

- The `on_failure: {troubleshoot: true|false}` opt-in surface, env
  toggle, and recursion guard all stay the same.
- Non-noetl agent frameworks (adk / langchain / custom callable) are
  unaffected — they don't go through this code path.
- The diagnosis itself, including the troubleshoot playbook's
  Ollama-then-escalate logic, is unchanged.

Tests
=====

scripts/gap41_diagnosis_wait_smoke.py — 7/7 pass:
  - extracts diagnosis from terminal `persist_diagnosis` event
  - returns None when sub-execution failed
  - returns None when sub-execution timed out
  - returns None when no `persist_diagnosis` event present
  - returns None when diagnosis dict is missing required keys
  - respects `diagnosis_step` override
  - newest-first event walk picks terminal event over command.issued

scripts/auto_troubleshoot_smoke.py — 9/9 still pass (the executor's
opt-in / recursion / per-task knobs are unchanged).

scripts/optional_ai_smoke.py — 6/6 still pass (lazy imports
preserved).

Refs
====

  - bridge/outbox/codex-spike-green-validation.md (v2.35.4 GREEN
    follow-up that surfaced this through the fixture-level
    workaround)
  - bridge/outbox/20260505-153729-gap1-carveout-spike-green.result.json
    (Codex iteration log showing the async dispatch handle issue at
    iteration #7)
  - noetl/noetl#408 (Gap 4.1 — original auto-troubleshoot hook)
  - noetl/noetl#411 (v2.35.3 — Gap 1 envelope+wait, the pattern this
    commit mirrors)
  - noetl/noetl#412 (v2.35.4 — kind:agent tool_error carve-out)
