### PR TITLE
fix(mcp): allow stateless JSON-RPC servers

### DIFF
--- a/noetl/tools/mcp/executor.py
+++ b/noetl/tools/mcp/executor.py
@@ -208,7 +208,10 @@ async def execute_mcp_task(
             )
             session_id = init_headers.get("mcp-session-id") or init_headers.get("Mcp-Session-Id")
             if not session_id:
-                raise RuntimeError("MCP server did not return a session id")
+                logger.debug(
+                    "MCP server %s did not return a session id; continuing as stateless JSON-RPC",
+                    server,
+                )
 
             if method == "tools/call":
                 tool_name = config.get("tool") or config.get("tool_name")


### PR DESCRIPTION
Allows MCP JSON-RPC servers that do not emit an MCP session header to continue as stateless JSON-RPC clients. The Ollama bridge responds to initialize/tools calls but does not provide a session id, so the previous strict requirement made troubleshoot diagnosis fail with `MCP server did not return a session id` even after the endpoint was configured.