### PR TITLE
fix(agent): attach persisted diagnosis from inferred diagnostic runs

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -409,7 +409,15 @@ def _dispatch_troubleshoot_diagnosis(
         str(diag_execution_id),
         timeout_seconds=wait_timeout,
     )
-    if not terminal.get("completed") or terminal.get("failed"):
+    can_fetch_persisted = bool(
+        (terminal.get("completed") and not terminal.get("failed"))
+        or (
+            terminal.get("failed")
+            and terminal.get("completion_inferred")
+            and not terminal.get("timeout")
+        )
+    )
+    if not can_fetch_persisted:
         logger.warning(
             "AGENT.DIAGNOSIS: sub-execution %s did not complete cleanly "
             "(terminal=%s); returning no diagnosis",
@@ -422,10 +430,20 @@ def _dispatch_troubleshoot_diagnosis(
         or os.environ.get(_DIAGNOSIS_STEP_ENV, "")
         or _DEFAULT_DIAGNOSIS_STEP_NAME
     )
-    return _fetch_persisted_diagnosis_from_doc(
+    diagnosis = _fetch_persisted_diagnosis_from_doc(
         str(diag_execution_id),
         diagnosis_step_name=diagnosis_step,
     )
+    if diagnosis is not None:
+        return diagnosis
+    if terminal.get("failed"):
+        logger.warning(
+            "AGENT.DIAGNOSIS: sub-execution %s failed and no persisted "
+            "diagnosis was found (terminal=%s)",
+            diag_execution_id,
+            terminal,
+        )
+    return None
 
 
 def _invoke_noetl_playbook(


### PR DESCRIPTION
When a diagnostic sub-execution reaches an inferred terminal state with a failed step but has already persisted a diagnosis, fetch and attach that persisted diagnosis instead of dropping it. Hard failures without a persisted diagnosis and timeouts still leave the original agent error untouched. This preserves the original Gap 4.1 smoke semantics while allowing the deployed troubleshoot playbook's fallback diagnosis to attach when an optional local-model MCP call fails.