### PR TITLE
fix(worker): preserve agent diagnosis in event context

### DIFF
--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -628,6 +628,16 @@ class Worker:
                     and str(nk) not in blocked_keys
                     and (not str(nk).startswith("command_") or str(nk) == "command_id")
                 }
+                if key_str == "error" and isinstance(child.get("diagnosis"), dict):
+                    diagnosis = {
+                        str(nk): nv
+                        for nk, nv in child["diagnosis"].items()
+                        if self._is_scalar(nv)
+                        and str(nk) not in blocked_keys
+                        and (not str(nk).startswith("command_") or str(nk) == "command_id")
+                    }
+                    if diagnosis:
+                        nested["diagnosis"] = diagnosis
                 if nested:
                     context[key_str] = nested
 


### PR DESCRIPTION
## Summary
- preserve scalar auto-troubleshoot diagnosis fields under `error.diagnosis` in strict event result contexts
- keep the existing scalar-only data-plane filtering for all other nested context payloads

## Validation
- python3 scripts/agent_envelope_carveout_smoke.py
- python3 scripts/gap41_diagnosis_wait_smoke.py
- python3 scripts/auto_troubleshoot_smoke.py
- python3 scripts/optional_ai_smoke.py
- focused event diagnosis projection smoke

## Regression
This fixes the v2.35.8 regression sweep bucket where `trigger_failure` terminal events dropped `error.diagnosis` even though the downstream failed-envelope render context already carried the diagnosis.