### PR TITLE
feat(worker): generalise workload key forwarding so triage_* propagates without compat mirror

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -226,6 +226,26 @@ _REQUIRED_DIAGNOSIS_KEYS = (
     "suggested_action",
     "source",
 )
+_TROUBLESHOOT_ON_FAILURE_KEYS = {
+    "confidence_threshold",
+    "escalate_to",
+    "openai_credential",
+    "openai_model",
+    "anthropic_credential",
+    "anthropic_model",
+    "noetl_url",
+}
+_TROUBLESHOOT_ON_FAILURE_PREFIXES = (
+    "triage_",
+    "ollama_",
+)
+
+
+def _should_forward_troubleshoot_workload_key(key: str) -> bool:
+    """Return true for safe workload knobs forwarded to diagnose_execution."""
+    return key in _TROUBLESHOOT_ON_FAILURE_KEYS or key.startswith(
+        _TROUBLESHOOT_ON_FAILURE_PREFIXES
+    )
 
 
 def _fetch_persisted_diagnosis_from_doc(
@@ -345,22 +365,15 @@ def _dispatch_troubleshoot_diagnosis(
     diagnose_input: Dict[str, Any] = {
         "execution_id": str(failed_execution_id),
     }
-    # Pass-through workload overrides: operators can pin Ollama model,
-    # tighten the confidence threshold, swap escalation target. We
-    # filter to the troubleshoot agent's known knobs to avoid
-    # accidentally leaking arbitrary on_failure config into the
-    # workload (where it would be silently ignored anyway).
-    for key in (
-        "ollama_model",
-        "ollama_mcp_server",
-        "confidence_threshold",
-        "escalate_to",
-        "openai_credential",
-        "openai_model",
-        "noetl_url",
-    ):
-        if key in on_failure:
-            diagnose_input[key] = on_failure[key]
+    # Pass-through workload overrides: operators can pin a triage
+    # backend/model, tune the confidence threshold, or swap escalation
+    # target. Keep the allow-pattern narrow so arbitrary on_failure
+    # data is not leaked into the diagnose workload, but make the
+    # backend/model prefixes generic enough that new triage_* knobs do
+    # not need compatibility mirrors through deprecated ollama_* names.
+    for key, value in on_failure.items():
+        if _should_forward_troubleshoot_workload_key(str(key)):
+            diagnose_input[key] = value
 
     sub_task_config: Dict[str, Any] = {
         "task": "agent_auto_troubleshoot",

--- a/tests/tools/test_agent_executor.py
+++ b/tests/tools/test_agent_executor.py
@@ -7,6 +7,7 @@ from jinja2 import Environment
 # Avoid import-order circulars in legacy package init path.
 import noetl.worker.auth_resolver  # noqa: F401
 from noetl.tools.agent import execute_agent_task
+from noetl.tools.agent import executor as agent_executor
 
 
 @pytest.mark.asyncio
@@ -129,3 +130,78 @@ async def test_agent_executor_adk_keyword_payload_and_async_generator():
         ]
     finally:
         sys.modules.pop(module_name, None)
+
+
+def test_auto_troubleshoot_forwards_triage_workload_keys(monkeypatch):
+    calls = []
+
+    def fake_execute_playbook_task(task_config, context, jinja_env, task_with):
+        calls.append(
+            {
+                "task_config": dict(task_config),
+                "task_with": dict(task_with or {}),
+            }
+        )
+        return {
+            "status": "success",
+            "execution_id": "diagnosis-exec-1",
+        }
+
+    monkeypatch.setattr(
+        "noetl.core.workflow.playbook.execute_playbook_task",
+        fake_execute_playbook_task,
+    )
+    monkeypatch.setattr(
+        agent_executor,
+        "_wait_for_sub_execution_terminal",
+        lambda *args, **kwargs: {
+            "status": "COMPLETED",
+            "execution_id": "diagnosis-exec-1",
+            "completed": True,
+            "failed": False,
+        },
+    )
+    monkeypatch.setattr(
+        agent_executor,
+        "_fetch_persisted_diagnosis_from_doc",
+        lambda *args, **kwargs: {
+            "category": "auth",
+            "confidence": 0.91,
+            "root_cause": "missing credentials",
+            "suggested_action": "configure Workload Identity",
+            "source": "vertex-ai",
+        },
+    )
+
+    diagnosis = agent_executor._dispatch_troubleshoot_diagnosis(
+        failed_execution_id="failed-exec-1",
+        failed_entrypoint="tests/spike/spike_failing_subflow",
+        troubleshoot_path="automation/agents/troubleshoot/diagnose_execution",
+        task_config={
+            "on_failure": {
+                "troubleshoot": True,
+                "triage_model": "gemini-2.5-flash",
+                "triage_mcp_server": "mcp/vertex-ai",
+                "triage_mcp_endpoint": "https://vertex.example/jsonrpc",
+                "triage_mcp_tool": "chat_completion",
+                "confidence_threshold": 0.2,
+                "escalate_to": "none",
+                "noetl_url": "http://noetl.noetl.svc.cluster.local:8082",
+                "secret_token": "do-not-forward",
+            },
+        },
+        context={},
+        jinja_env=Environment(),
+    )
+
+    assert diagnosis["source"] == "vertex-ai"
+    assert len(calls) == 1
+    diagnose_input = calls[0]["task_config"]["input"]
+    assert diagnose_input["execution_id"] == "failed-exec-1"
+    assert diagnose_input["triage_model"] == "gemini-2.5-flash"
+    assert diagnose_input["triage_mcp_server"] == "mcp/vertex-ai"
+    assert diagnose_input["triage_mcp_endpoint"] == "https://vertex.example/jsonrpc"
+    assert diagnose_input["triage_mcp_tool"] == "chat_completion"
+    assert diagnose_input["confidence_threshold"] == 0.2
+    assert diagnose_input["escalate_to"] == "none"
+    assert "secret_token" not in diagnose_input


### PR DESCRIPTION
Generalises the auto-troubleshoot workload forwarding path so canonical triage_* backend/model keys reach diagnose_execution without relying on the deprecated ollama_* compatibility mirror from e2e#9.\n\nDesign choice: option B-ish narrow allow-pattern. The helper forwards all triage_* and ollama_* workload knobs plus the documented confidence/escalation/provider credential knobs. It does not forward arbitrary on_failure keys, preserving the existing security intent.\n\nReferences:\n- noetl#416: persisted diagnosis retry race\n- ops#39: triage_* alias rollout\n- e2e#9: temporary compat mirror this obviates\n\nValidation:\n- python3 -m pytest tests/tools/test_agent_executor.py -q\n- python3 scripts/worker_workload_forwarding_smoke.py from ai-meta\n- existing 5 ai-meta smokes passed