### PR TITLE
perf(agent): tune _fetch_persisted_diagnosis_from_doc retry budget for cloud-managed inference latency

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -219,6 +219,15 @@ def _should_auto_troubleshoot(
 # bespoke troubleshoot playbooks can name the step differently.
 _DEFAULT_DIAGNOSIS_STEP_NAME = "persist_diagnosis"
 _DIAGNOSIS_STEP_ENV = "NOETL_TROUBLESHOOT_DIAGNOSIS_STEP"
+# The status endpoint can report the diagnosis execution as terminal before
+# the final persisted event is visible through the execution document. Keep
+# this fetch window long enough to absorb cloud-managed inference latency
+# variance (Vertex AI: 1-3s+ per call) plus event-store flush lag. Local
+# Ollama (200-500ms) is well within this budget. Calibrated from the GKE
+# Vertex AI arc where a spike run needed the fixture's third 2s poll to find
+# the diagnosis; see sync/issues/2026-05-06-noetl-retry-budget-cloud-aware.md.
+_DIAGNOSIS_FETCH_TIMEOUT_SECONDS = 12.0
+_DIAGNOSIS_FETCH_INTERVAL_SECONDS = 1.0
 _REQUIRED_DIAGNOSIS_KEYS = (
     "category",
     "confidence",
@@ -444,12 +453,18 @@ def _dispatch_troubleshoot_diagnosis(
         or os.environ.get(_DIAGNOSIS_STEP_ENV, "")
         or _DEFAULT_DIAGNOSIS_STEP_NAME
     )
-    # The status endpoint can report the diagnosis execution as terminal
-    # before the final persisted event is visible through the execution
-    # document. Retry the document fetch briefly so the parent envelope
-    # carries the actual diagnosis instead of racing a just-completed run.
-    fetch_timeout = float(on_failure.get("diagnosis_fetch_timeout_seconds", 10.0))
-    fetch_interval = float(on_failure.get("diagnosis_fetch_interval_seconds", 1.0))
+    fetch_timeout = float(
+        on_failure.get(
+            "diagnosis_fetch_timeout_seconds",
+            _DIAGNOSIS_FETCH_TIMEOUT_SECONDS,
+        )
+    )
+    fetch_interval = float(
+        on_failure.get(
+            "diagnosis_fetch_interval_seconds",
+            _DIAGNOSIS_FETCH_INTERVAL_SECONDS,
+        )
+    )
     deadline = time.monotonic() + max(0.0, fetch_timeout)
     fetch_attempt = 0
     while True:

--- a/tests/tools/test_agent_executor.py
+++ b/tests/tools/test_agent_executor.py
@@ -205,3 +205,79 @@ def test_auto_troubleshoot_forwards_triage_workload_keys(monkeypatch):
     assert diagnose_input["confidence_threshold"] == 0.2
     assert diagnose_input["escalate_to"] == "none"
     assert "secret_token" not in diagnose_input
+
+
+def test_auto_troubleshoot_fetch_budget_covers_cloud_event_flush(monkeypatch):
+    """Persisted diagnosis arriving after the old 10s window is still attached."""
+
+    fake_clock = {"now": 0.0}
+    fetch_times = []
+
+    def fake_execute_playbook_task(task_config, context, jinja_env, task_with):
+        return {
+            "status": "success",
+            "execution_id": "diagnosis-exec-2",
+        }
+
+    def fake_fetch(execution_id, *, diagnosis_step_name):
+        fetch_times.append(fake_clock["now"])
+        if fake_clock["now"] >= 11.0:
+            return {
+                "category": "infra",
+                "confidence": 0.89,
+                "root_cause": "cloud managed inference completed after event flush lag",
+                "suggested_action": "use the longer diagnosis fetch budget",
+                "source": "vertex-ai",
+            }
+        return None
+
+    monkeypatch.setattr(
+        "noetl.core.workflow.playbook.execute_playbook_task",
+        fake_execute_playbook_task,
+    )
+    monkeypatch.setattr(
+        agent_executor,
+        "_wait_for_sub_execution_terminal",
+        lambda *args, **kwargs: {
+            "status": "COMPLETED",
+            "execution_id": "diagnosis-exec-2",
+            "completed": True,
+            "failed": False,
+        },
+    )
+    monkeypatch.setattr(
+        agent_executor,
+        "_fetch_persisted_diagnosis_from_doc",
+        fake_fetch,
+    )
+    monkeypatch.setattr(
+        agent_executor.time,
+        "monotonic",
+        lambda: fake_clock["now"],
+    )
+    monkeypatch.setattr(
+        agent_executor.time,
+        "sleep",
+        lambda seconds: fake_clock.__setitem__("now", fake_clock["now"] + seconds),
+    )
+
+    diagnosis = agent_executor._dispatch_troubleshoot_diagnosis(
+        failed_execution_id="failed-exec-2",
+        failed_entrypoint="tests/spike/spike_failing_subflow",
+        troubleshoot_path="automation/agents/troubleshoot/diagnose_execution",
+        task_config={
+            "on_failure": {
+                "troubleshoot": True,
+                "triage_model": "gemini-2.5-flash",
+                "triage_mcp_server": "mcp/vertex-ai",
+                "escalate_to": "none",
+            },
+        },
+        context={},
+        jinja_env=Environment(),
+    )
+
+    assert diagnosis["source"] == "vertex-ai"
+    assert diagnosis["category"] == "infra"
+    assert max(fetch_times) >= 11.0
+    assert max(fetch_times) <= agent_executor._DIAGNOSIS_FETCH_TIMEOUT_SECONDS


### PR DESCRIPTION
Implements option (a) from sync/issues/2026-05-06-noetl-retry-budget-cloud-aware.md: an unconditional longer persisted-diagnosis fetch budget.\n\nNotes:\n- v2.36.0 already had a deadline-based fetch loop with a 10s default, so this PR makes that budget explicit and extends it to 12s for cloud-managed inference + event-store flush lag.\n- Local Ollama remains well within the window; Vertex AI can spend 1-3s+ in network and managed inference before the persisted diagnosis event is visible.\n- Adds a focused executor smoke that fakes a persisted diagnosis appearing at 11s, which would be outside the v2.36.0 10s window but inside the new budget.\n\nValidation:\n- python3 -m pytest tests/tools/test_agent_executor.py -q\n- ai-meta six-smoke battery: agent envelope carve-out, Gap 4.1 wait/fetch, auto-troubleshoot, optional AI, live-vs-persisted parity static, worker workload forwarding