### PR TITLE
feat(agent): adaptive retry backoff with elapsed-time telemetry for diagnose-fetch

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -23,7 +23,7 @@ import importlib
 import inspect
 import os
 import time
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from jinja2 import Environment
 
@@ -219,15 +219,17 @@ def _should_auto_troubleshoot(
 # bespoke troubleshoot playbooks can name the step differently.
 _DEFAULT_DIAGNOSIS_STEP_NAME = "persist_diagnosis"
 _DIAGNOSIS_STEP_ENV = "NOETL_TROUBLESHOOT_DIAGNOSIS_STEP"
-# The status endpoint can report the diagnosis execution as terminal before
-# the final persisted event is visible through the execution document. Keep
-# this fetch window long enough to absorb cloud-managed inference latency
-# variance (Vertex AI: 1-3s+ per call) plus event-store flush lag. Local
-# Ollama (200-500ms) is well within this budget. Calibrated from the GKE
-# Vertex AI arc where a spike run needed the fixture's third 2s poll to find
-# the diagnosis; see sync/issues/2026-05-06-noetl-retry-budget-cloud-aware.md.
-_DIAGNOSIS_FETCH_TIMEOUT_SECONDS = 12.0
-_DIAGNOSIS_FETCH_INTERVAL_SECONDS = 1.0
+# Adaptive persisted-diagnosis fetch backoff, tuned for cloud-managed
+# inference latency. Warm path (Vertex AI ~1-3s, Ollama ~200-500ms)
+# typically completes in 1-3 polls (~0.5-2s wall time). Cold path
+# (~30s+ tail latency) completes in ~10-12 polls within the 60s
+# deadline. Calibrated against the GKE Vertex AI arc's v2.36.1
+# cold-start outlier (`diagnosis_lookup.attempts=16`) — see
+# sync/issues/2026-05-07-noetl-adaptive-retry-backoff-tail-latency.md.
+_DIAGNOSIS_BACKOFF_INITIAL_SLEEP = 0.5
+_DIAGNOSIS_BACKOFF_MULTIPLIER = 1.5
+_DIAGNOSIS_BACKOFF_MAX_SLEEP = 4.0
+_DIAGNOSIS_BACKOFF_DEADLINE = 60.0
 _REQUIRED_DIAGNOSIS_KEYS = (
     "category",
     "confidence",
@@ -314,6 +316,86 @@ def _fetch_persisted_diagnosis_from_doc(
             return candidate
 
     return None
+
+
+def _diagnosis_fetch_meta(
+    *,
+    started_at: float,
+    poll_count: int,
+    deadline_seconds: float,
+    hit_deadline: bool,
+) -> Dict[str, Any]:
+    elapsed = max(0.0, time.monotonic() - started_at)
+    return {
+        "poll_count": int(poll_count),
+        "elapsed_seconds": round(elapsed, 3),
+        "deadline_seconds": float(deadline_seconds),
+        "hit_deadline": bool(hit_deadline),
+    }
+
+
+def _attach_diagnosis_fetch_meta(
+    diagnosis: Dict[str, Any],
+    fetch_meta: Dict[str, Any],
+) -> Dict[str, Any]:
+    result = dict(diagnosis)
+    meta = result.get("_meta")
+    if not isinstance(meta, dict):
+        meta = {}
+    else:
+        meta = dict(meta)
+    meta["diagnosis_fetch"] = dict(fetch_meta)
+    result["_meta"] = meta
+    return result
+
+
+def _fetch_persisted_diagnosis_with_backoff(
+    execution_id: str,
+    *,
+    diagnosis_step_name: str = _DEFAULT_DIAGNOSIS_STEP_NAME,
+    deadline_seconds: float = _DIAGNOSIS_BACKOFF_DEADLINE,
+    initial_sleep_seconds: float = _DIAGNOSIS_BACKOFF_INITIAL_SLEEP,
+    multiplier: float = _DIAGNOSIS_BACKOFF_MULTIPLIER,
+    max_sleep_seconds: float = _DIAGNOSIS_BACKOFF_MAX_SLEEP,
+    fetch_func: Optional[Callable[..., Optional[Dict[str, Any]]]] = None,
+) -> Tuple[Optional[Dict[str, Any]], Dict[str, Any]]:
+    """Fetch a persisted diagnosis using adaptive exponential backoff."""
+    fetch = fetch_func or _fetch_persisted_diagnosis_from_doc
+    deadline_seconds = max(0.0, float(deadline_seconds))
+    sleep_seconds = max(0.1, float(initial_sleep_seconds))
+    multiplier = max(1.0, float(multiplier))
+    max_sleep_seconds = max(sleep_seconds, float(max_sleep_seconds))
+
+    started_at = time.monotonic()
+    deadline_at = started_at + deadline_seconds
+    poll_count = 0
+
+    while True:
+        poll_count += 1
+        diagnosis = fetch(
+            str(execution_id),
+            diagnosis_step_name=diagnosis_step_name,
+        )
+        now = time.monotonic()
+        if diagnosis is not None:
+            return diagnosis, _diagnosis_fetch_meta(
+                started_at=started_at,
+                poll_count=poll_count,
+                deadline_seconds=deadline_seconds,
+                hit_deadline=False,
+            )
+
+        if now >= deadline_at:
+            return None, _diagnosis_fetch_meta(
+                started_at=started_at,
+                poll_count=poll_count,
+                deadline_seconds=deadline_seconds,
+                hit_deadline=True,
+            )
+
+        remaining = max(0.0, deadline_at - now)
+        time.sleep(min(sleep_seconds, remaining))
+        sleep_seconds = min(sleep_seconds * multiplier, max_sleep_seconds)
 
 
 def _dispatch_troubleshoot_diagnosis(
@@ -453,38 +535,54 @@ def _dispatch_troubleshoot_diagnosis(
         or os.environ.get(_DIAGNOSIS_STEP_ENV, "")
         or _DEFAULT_DIAGNOSIS_STEP_NAME
     )
-    fetch_timeout = float(
+    fetch_deadline = float(
         on_failure.get(
-            "diagnosis_fetch_timeout_seconds",
-            _DIAGNOSIS_FETCH_TIMEOUT_SECONDS,
+            "diagnosis_fetch_deadline_seconds",
+            on_failure.get(
+                "diagnosis_fetch_timeout_seconds",
+                _DIAGNOSIS_BACKOFF_DEADLINE,
+            ),
         )
     )
-    fetch_interval = float(
+    fetch_initial_sleep = float(
         on_failure.get(
-            "diagnosis_fetch_interval_seconds",
-            _DIAGNOSIS_FETCH_INTERVAL_SECONDS,
+            "diagnosis_fetch_initial_sleep_seconds",
+            on_failure.get(
+                "diagnosis_fetch_interval_seconds",
+                _DIAGNOSIS_BACKOFF_INITIAL_SLEEP,
+            ),
         )
     )
-    deadline = time.monotonic() + max(0.0, fetch_timeout)
-    fetch_attempt = 0
-    while True:
-        fetch_attempt += 1
-        diagnosis = _fetch_persisted_diagnosis_from_doc(
-            str(diag_execution_id),
-            diagnosis_step_name=diagnosis_step,
+    fetch_max_sleep = float(
+        on_failure.get(
+            "diagnosis_fetch_max_sleep_seconds",
+            _DIAGNOSIS_BACKOFF_MAX_SLEEP,
         )
-        if diagnosis is not None:
-            if fetch_attempt > 1:
-                logger.info(
-                    "AGENT.DIAGNOSIS: fetched persisted diagnosis for %s "
-                    "after %d attempts",
-                    diag_execution_id,
-                    fetch_attempt,
-                )
-            return diagnosis
-        if time.monotonic() >= deadline:
-            break
-        time.sleep(max(0.1, fetch_interval))
+    )
+    fetch_multiplier = float(
+        on_failure.get(
+            "diagnosis_fetch_backoff_multiplier",
+            _DIAGNOSIS_BACKOFF_MULTIPLIER,
+        )
+    )
+    diagnosis, fetch_meta = _fetch_persisted_diagnosis_with_backoff(
+        str(diag_execution_id),
+        diagnosis_step_name=diagnosis_step,
+        deadline_seconds=fetch_deadline,
+        initial_sleep_seconds=fetch_initial_sleep,
+        multiplier=fetch_multiplier,
+        max_sleep_seconds=fetch_max_sleep,
+    )
+    if diagnosis is not None:
+        if fetch_meta.get("poll_count", 0) > 1:
+            logger.info(
+                "AGENT.DIAGNOSIS: fetched persisted diagnosis for %s "
+                "after %d polls in %.3fs",
+                diag_execution_id,
+                fetch_meta.get("poll_count"),
+                fetch_meta.get("elapsed_seconds"),
+            )
+        return _attach_diagnosis_fetch_meta(diagnosis, fetch_meta)
     if terminal.get("failed"):
         logger.warning(
             "AGENT.DIAGNOSIS: sub-execution %s failed and no persisted "

--- a/tests/tools/test_agent_executor.py
+++ b/tests/tools/test_agent_executor.py
@@ -207,10 +207,84 @@ def test_auto_troubleshoot_forwards_triage_workload_keys(monkeypatch):
     assert "secret_token" not in diagnose_input
 
 
-def test_auto_troubleshoot_fetch_budget_covers_cloud_event_flush(monkeypatch):
-    """Persisted diagnosis arriving after the old 10s window is still attached."""
-
+def _install_fake_clock(monkeypatch):
     fake_clock = {"now": 0.0}
+    monkeypatch.setattr(
+        agent_executor.time,
+        "monotonic",
+        lambda: fake_clock["now"],
+    )
+    monkeypatch.setattr(
+        agent_executor.time,
+        "sleep",
+        lambda seconds: fake_clock.__setitem__("now", fake_clock["now"] + seconds),
+    )
+    return fake_clock
+
+
+def _diagnosis_after(fake_clock, threshold_seconds, fetch_times):
+    def fake_fetch(execution_id, *, diagnosis_step_name):
+        fetch_times.append(fake_clock["now"])
+        if fake_clock["now"] >= threshold_seconds:
+            return {
+                "category": "infra",
+                "confidence": 0.89,
+                "root_cause": "cloud managed inference completed after event flush lag",
+                "suggested_action": "use the adaptive diagnosis fetch backoff",
+                "source": "vertex-ai",
+            }
+        return None
+
+    return fake_fetch
+
+
+def test_adaptive_diagnosis_fetch_warm_path(monkeypatch):
+    fake_clock = _install_fake_clock(monkeypatch)
+    fetch_times = []
+
+    diagnosis, meta = agent_executor._fetch_persisted_diagnosis_with_backoff(
+        "diagnosis-exec-warm",
+        fetch_func=_diagnosis_after(fake_clock, 0.8, fetch_times),
+    )
+
+    assert diagnosis["source"] == "vertex-ai"
+    assert meta["poll_count"] <= 3
+    assert meta["elapsed_seconds"] < 2.0
+    assert meta["hit_deadline"] is False
+
+
+def test_adaptive_diagnosis_fetch_cold_path(monkeypatch):
+    fake_clock = _install_fake_clock(monkeypatch)
+    fetch_times = []
+
+    diagnosis, meta = agent_executor._fetch_persisted_diagnosis_with_backoff(
+        "diagnosis-exec-cold",
+        fetch_func=_diagnosis_after(fake_clock, 25.0, fetch_times),
+    )
+
+    assert diagnosis["source"] == "vertex-ai"
+    assert 10 <= meta["poll_count"] <= 14
+    assert 20.0 < meta["elapsed_seconds"] < 30.0
+    assert meta["hit_deadline"] is False
+
+
+def test_adaptive_diagnosis_fetch_missing_hits_deadline(monkeypatch):
+    fake_clock = _install_fake_clock(monkeypatch)
+    fetch_times = []
+
+    diagnosis, meta = agent_executor._fetch_persisted_diagnosis_with_backoff(
+        "diagnosis-exec-missing",
+        fetch_func=_diagnosis_after(fake_clock, 999.0, fetch_times),
+    )
+
+    assert diagnosis is None
+    assert meta["elapsed_seconds"] >= 59.0
+    assert meta["deadline_seconds"] == agent_executor._DIAGNOSIS_BACKOFF_DEADLINE
+    assert meta["hit_deadline"] is True
+
+
+def test_auto_troubleshoot_attaches_diagnosis_fetch_telemetry(monkeypatch):
+    fake_clock = _install_fake_clock(monkeypatch)
     fetch_times = []
 
     def fake_execute_playbook_task(task_config, context, jinja_env, task_with):
@@ -218,18 +292,6 @@ def test_auto_troubleshoot_fetch_budget_covers_cloud_event_flush(monkeypatch):
             "status": "success",
             "execution_id": "diagnosis-exec-2",
         }
-
-    def fake_fetch(execution_id, *, diagnosis_step_name):
-        fetch_times.append(fake_clock["now"])
-        if fake_clock["now"] >= 11.0:
-            return {
-                "category": "infra",
-                "confidence": 0.89,
-                "root_cause": "cloud managed inference completed after event flush lag",
-                "suggested_action": "use the longer diagnosis fetch budget",
-                "source": "vertex-ai",
-            }
-        return None
 
     monkeypatch.setattr(
         "noetl.core.workflow.playbook.execute_playbook_task",
@@ -248,17 +310,7 @@ def test_auto_troubleshoot_fetch_budget_covers_cloud_event_flush(monkeypatch):
     monkeypatch.setattr(
         agent_executor,
         "_fetch_persisted_diagnosis_from_doc",
-        fake_fetch,
-    )
-    monkeypatch.setattr(
-        agent_executor.time,
-        "monotonic",
-        lambda: fake_clock["now"],
-    )
-    monkeypatch.setattr(
-        agent_executor.time,
-        "sleep",
-        lambda seconds: fake_clock.__setitem__("now", fake_clock["now"] + seconds),
+        _diagnosis_after(fake_clock, 0.8, fetch_times),
     )
 
     diagnosis = agent_executor._dispatch_troubleshoot_diagnosis(
@@ -279,5 +331,67 @@ def test_auto_troubleshoot_fetch_budget_covers_cloud_event_flush(monkeypatch):
 
     assert diagnosis["source"] == "vertex-ai"
     assert diagnosis["category"] == "infra"
-    assert max(fetch_times) >= 11.0
-    assert max(fetch_times) <= agent_executor._DIAGNOSIS_FETCH_TIMEOUT_SECONDS
+    fetch_meta = diagnosis["_meta"]["diagnosis_fetch"]
+    assert set(fetch_meta) == {
+        "poll_count",
+        "elapsed_seconds",
+        "deadline_seconds",
+        "hit_deadline",
+    }
+    assert fetch_meta["poll_count"] <= 3
+    assert fetch_meta["elapsed_seconds"] < 2.0
+    assert fetch_meta["deadline_seconds"] == agent_executor._DIAGNOSIS_BACKOFF_DEADLINE
+    assert fetch_meta["hit_deadline"] is False
+
+
+def test_auto_troubleshoot_adaptive_fetch_covers_legacy_11s_flush(monkeypatch):
+    """Regression guard for the v2.36.1 static-budget edge case."""
+
+    fake_clock = _install_fake_clock(monkeypatch)
+    fetch_times = []
+
+    def fake_execute_playbook_task(task_config, context, jinja_env, task_with):
+        return {
+            "status": "success",
+            "execution_id": "diagnosis-exec-3",
+        }
+
+    monkeypatch.setattr(
+        "noetl.core.workflow.playbook.execute_playbook_task",
+        fake_execute_playbook_task,
+    )
+    monkeypatch.setattr(
+        agent_executor,
+        "_wait_for_sub_execution_terminal",
+        lambda *args, **kwargs: {
+            "status": "COMPLETED",
+            "execution_id": "diagnosis-exec-3",
+            "completed": True,
+            "failed": False,
+        },
+    )
+    monkeypatch.setattr(
+        agent_executor,
+        "_fetch_persisted_diagnosis_from_doc",
+        _diagnosis_after(fake_clock, 11.0, fetch_times),
+    )
+
+    diagnosis = agent_executor._dispatch_troubleshoot_diagnosis(
+        failed_execution_id="failed-exec-3",
+        failed_entrypoint="tests/spike/spike_failing_subflow",
+        troubleshoot_path="automation/agents/troubleshoot/diagnose_execution",
+        task_config={
+            "on_failure": {
+                "troubleshoot": True,
+                "triage_model": "gemini-2.5-flash",
+                "triage_mcp_server": "mcp/vertex-ai",
+                "escalate_to": "none",
+            },
+        },
+        context={},
+        jinja_env=Environment(),
+    )
+
+    assert diagnosis["source"] == "vertex-ai"
+    assert diagnosis["_meta"]["diagnosis_fetch"]["elapsed_seconds"] > 10.0
+    assert diagnosis["_meta"]["diagnosis_fetch"]["hit_deadline"] is False


### PR DESCRIPTION
## Summary

Implements adaptive exponential backoff for persisted diagnosis fetch after a diagnose sub-execution reaches terminal state. This replaces the v2.36.1 static 12s fetch window with the option (c) design from `sync/issues/2026-05-07-noetl-adaptive-retry-backoff-tail-latency.md`.

- Adds adaptive fetch constants: 0.5s initial sleep, 1.5x multiplier, 4s max sleep, 60s deadline.
- Preserves existing `diagnosis_fetch_timeout_seconds` compatibility and maps legacy `diagnosis_fetch_interval_seconds` onto the new initial sleep knob.
- Attaches `_meta.diagnosis_fetch` telemetry: `poll_count`, `elapsed_seconds`, `deadline_seconds`, `hit_deadline`.
- Leaves `_wait_for_sub_execution_terminal` unchanged because it already has a separate long terminal wait; the observed GKE/Vertex bottleneck was post-terminal persisted-event visibility.

## Validation

- `python3 -m pytest tests/tools/test_agent_executor.py -q` -> 10 passed, 1 existing Pydantic warning
- `git diff --check`
- `python3 scripts/agent_envelope_carveout_smoke.py` -> 8/8
- `python3 scripts/gap41_diagnosis_wait_smoke.py` -> 7/7
- `python3 scripts/auto_troubleshoot_smoke.py` -> 9/9
- `python3 scripts/optional_ai_smoke.py` -> 6/6
- `python3 scripts/live_vs_persisted_parity_smoke.py` -> 2/2 static
- `python3 scripts/worker_workload_forwarding_smoke.py` -> 8/8
