### PR TITLE
fix(worker): preserve nested content under error.diagnosis through event projection

### DIFF
--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -579,6 +579,42 @@ class Worker:
     def _is_scalar(value: Any) -> bool:
         return isinstance(value, (str, int, float, bool)) or value is None
 
+    @classmethod
+    def _preserve_recursive_control_value(
+        cls,
+        value: Any,
+        *,
+        max_depth: int = 8,
+    ) -> Any:
+        """Recursively preserve an explicitly allowed control value.
+
+        Recursive extension of the noetl#417 ``error.diagnosis`` carve-out.
+        This addresses the v2.37.0 ``_meta.diagnosis_fetch`` telemetry RED at
+        ``bridge/outbox/20260507-023206-adaptive-retry-backoff.result.json``.
+        The May 6 event-projection audit predicted that future nested control
+        contracts under explicit allow-paths would need matching carve-outs and
+        parity tests.
+        """
+        if max_depth <= 0:
+            return value
+        if isinstance(value, dict):
+            return {
+                str(key): cls._preserve_recursive_control_value(
+                    child,
+                    max_depth=max_depth - 1,
+                )
+                for key, child in value.items()
+            }
+        if isinstance(value, list):
+            return [
+                cls._preserve_recursive_control_value(
+                    item,
+                    max_depth=max_depth - 1,
+                )
+                for item in value
+            ]
+        return value
+
     def _extract_control_context(self, value: Any) -> Optional[dict[str, Any]]:
         if not isinstance(value, dict):
             return None
@@ -629,13 +665,7 @@ class Worker:
                     and (not str(nk).startswith("command_") or str(nk) == "command_id")
                 }
                 if key_str == "error" and isinstance(child.get("diagnosis"), dict):
-                    diagnosis = {
-                        str(nk): nv
-                        for nk, nv in child["diagnosis"].items()
-                        if self._is_scalar(nv)
-                        and str(nk) not in blocked_keys
-                        and (not str(nk).startswith("command_") or str(nk) == "command_id")
-                    }
+                    diagnosis = self._preserve_recursive_control_value(child["diagnosis"])
                     if diagnosis:
                         nested["diagnosis"] = diagnosis
                 if nested:

--- a/tests/worker/test_control_context_projection.py
+++ b/tests/worker/test_control_context_projection.py
@@ -1,0 +1,129 @@
+from noetl.worker.nats_worker import Worker
+
+
+def _worker() -> Worker:
+    return Worker.__new__(Worker)
+
+
+def test_error_diagnosis_diagnosis_fetch_meta_survives_projection():
+    worker = _worker()
+    projected = worker._extract_control_context(
+        {
+            "error": {
+                "kind": "subflow_failed",
+                "message": "subflow failed",
+                "diagnosis": {
+                    "category": "bad_request",
+                    "confidence": 0.95,
+                    "root_cause": "bad payload",
+                    "suggested_action": "fix the payload",
+                    "source": "vertex-ai",
+                    "_meta": {
+                        "diagnosis_fetch": {
+                            "poll_count": 3,
+                            "elapsed_seconds": 1.42,
+                            "deadline_seconds": 60.0,
+                            "hit_deadline": False,
+                        }
+                    },
+                },
+            }
+        }
+    )
+
+    diagnosis_fetch = projected["error"]["diagnosis"]["_meta"]["diagnosis_fetch"]
+    assert diagnosis_fetch == {
+        "poll_count": 3,
+        "elapsed_seconds": 1.42,
+        "deadline_seconds": 60.0,
+        "hit_deadline": False,
+    }
+
+
+def test_error_diagnosis_arbitrary_nested_dict_survives_projection():
+    worker = _worker()
+    projected = worker._extract_control_context(
+        {
+            "error": {
+                "kind": "subflow_failed",
+                "diagnosis": {
+                    "category": "infra",
+                    "confidence": 0.8,
+                    "root_cause": "synthetic",
+                    "suggested_action": "inspect",
+                    "source": "vertex-ai",
+                    "custom_field": {
+                        "nested": {
+                            "deeper": {
+                                "a": 1,
+                                "b": 2,
+                            }
+                        }
+                    },
+                },
+            }
+        }
+    )
+
+    assert projected["error"]["diagnosis"]["custom_field"]["nested"]["deeper"] == {
+        "a": 1,
+        "b": 2,
+    }
+
+
+def test_error_diagnosis_recursive_projection_has_depth_guard():
+    worker = _worker()
+    nested = {"leaf": "ok"}
+    for idx in range(10):
+        nested = {f"level_{idx}": nested}
+
+    projected = worker._extract_control_context(
+        {
+            "error": {
+                "kind": "subflow_failed",
+                "diagnosis": {
+                    "category": "infra",
+                    "confidence": 0.8,
+                    "root_cause": "synthetic",
+                    "suggested_action": "inspect",
+                    "source": "vertex-ai",
+                    "deep": nested,
+                },
+            }
+        }
+    )
+
+    assert projected["error"]["diagnosis"]["deep"] == nested
+
+
+def test_error_diagnosis_scalar_root_fields_still_survive_projection():
+    worker = _worker()
+    projected = worker._extract_control_context(
+        {
+            "error": {
+                "kind": "subflow_failed",
+                "message": "subflow failed",
+                "diagnosis": {
+                    "category": "bad_request",
+                    "confidence": 0.95,
+                    "root_cause": "bad payload",
+                    "suggested_action": "fix the payload",
+                    "source": "vertex-ai",
+                    "model": "gemini-2.5-flash",
+                    "escalated": False,
+                },
+            }
+        }
+    )
+
+    assert projected["error"]["kind"] == "subflow_failed"
+    assert projected["error"]["message"] == "subflow failed"
+    assert projected["error"]["diagnosis"] == {
+        "category": "bad_request",
+        "confidence": 0.95,
+        "root_cause": "bad payload",
+        "suggested_action": "fix the payload",
+        "source": "vertex-ai",
+        "model": "gemini-2.5-flash",
+        "escalated": False,
+    }


### PR DESCRIPTION
## Summary

Extends the explicit `error.diagnosis` projection carve-out so nested control metadata survives event projection.

This is the focused follow-up to the v2.37.0 adaptive-backoff RED: `_meta.diagnosis_fetch` was attached by the agent executor, but `_extract_control_context` copied only scalar keys under `error.diagnosis`, so the nested telemetry disappeared from persisted execution documents.

Design choice: option B from the bridge task. Preserve `error.diagnosis` recursively, but only for that explicit allow-path. This avoids opening arbitrary nested projection for unrelated result payloads while making future diagnosis-local telemetry fields (`_meta.cost_breakdown`, `_meta.routing_history`, upstream latency, etc.) safe without carve-out churn. A max-depth guard of 8 prevents pathological recursion.

## Validation

- `python3 -m pytest tests/worker/test_control_context_projection.py -q` -> 4 passed
- `python3 -m pytest tests/tools/test_agent_executor.py -q` -> 10 passed
- `git diff --check`
- `python3 scripts/agent_envelope_carveout_smoke.py` -> 8/8
- `python3 scripts/gap41_diagnosis_wait_smoke.py` -> 7/7
- `python3 scripts/auto_troubleshoot_smoke.py` -> 9/9
- `python3 scripts/optional_ai_smoke.py` -> 6/6
- `python3 scripts/live_vs_persisted_parity_smoke.py` -> 3/3 static
- `python3 scripts/worker_workload_forwarding_smoke.py` -> 8/8
