### PR TITLE
fix(worker): preserve nested render.args through event projection

### DIFF
--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -668,6 +668,17 @@ class Worker:
                     diagnosis = self._preserve_recursive_control_value(child["diagnosis"])
                     if diagnosis:
                         nested["diagnosis"] = diagnosis
+                # Widget render contract — see repos/gui/src/components/widgets/.
+                # Symmetric to the error.diagnosis carve-out above: render.args
+                # carries the chatui-aligned widget tree (`app:column.args.children[]`
+                # nests further `{type, args}` shapes), so we recursively preserve
+                # it under the same bounded-depth guard. Scalar `render.type` is
+                # already preserved by the loop above; this branch rescues the
+                # nested args tree that the GUI renderer dispatches on.
+                if key_str == "render" and isinstance(child.get("args"), (dict, list)):
+                    rendered_args = self._preserve_recursive_control_value(child["args"])
+                    if rendered_args is not None:
+                        nested["args"] = rendered_args
                 if nested:
                     context[key_str] = nested
 

--- a/tests/worker/test_control_context_projection.py
+++ b/tests/worker/test_control_context_projection.py
@@ -127,3 +127,138 @@ def test_error_diagnosis_scalar_root_fields_still_survive_projection():
         "model": "gemini-2.5-flash",
         "escalated": False,
     }
+
+
+# ---------------------------------------------------------------------------
+# render.args carve-out — mirrors the error.diagnosis tests above. The widget
+# render contract (`{type: "app:<kind>", args: {...}}`) carries the
+# chatui-aligned widget tree. Without an explicit allow-path, the projection
+# strips render.args and only `render.type` survives — see
+# bridge/outbox/20260508-064720-deploy-widget-renderer-round-2-local.result.json
+# (executions 622377612446270148 and 622377613679395529).
+# ---------------------------------------------------------------------------
+
+
+def test_render_args_nested_dict_survives_projection():
+    worker = _worker()
+    projected = worker._extract_control_context(
+        {
+            "render": {
+                "type": "app:column",
+                "args": {
+                    "children": [
+                        {
+                            "type": "app:alert",
+                            "args": {"message": "widget renderer is live", "variant": "success"},
+                        },
+                        {
+                            "type": "app:markdown",
+                            "args": {"text": "## Widget smoke\n\n* alert above"},
+                        },
+                        {
+                            "type": "app:button",
+                            "args": {
+                                "text": "reopen execution",
+                                "variant": "primary",
+                                "event": {"key": "command", "value": "report 1234"},
+                            },
+                        },
+                    ]
+                },
+            }
+        }
+    )
+
+    assert projected["render"]["type"] == "app:column"
+    children = projected["render"]["args"]["children"]
+    assert [child["type"] for child in children] == [
+        "app:alert",
+        "app:markdown",
+        "app:button",
+    ]
+    assert children[0]["args"] == {
+        "message": "widget renderer is live",
+        "variant": "success",
+    }
+    assert children[1]["args"] == {"text": "## Widget smoke\n\n* alert above"}
+    assert children[2]["args"]["event"] == {"key": "command", "value": "report 1234"}
+
+
+def test_render_args_unknown_type_still_survives_projection():
+    """Mirrors the 'unsupported widget' fallback smoke — args must reach the GUI
+    even when the GUI doesn't recognize the widget type, so the renderer can
+    show the JSON preview to the playbook author."""
+    worker = _worker()
+    projected = worker._extract_control_context(
+        {
+            "render": {
+                "type": "app:nonexistent",
+                "args": {"hello": "world", "nested": {"deeper": True}},
+            }
+        }
+    )
+
+    assert projected["render"]["type"] == "app:nonexistent"
+    assert projected["render"]["args"] == {
+        "hello": "world",
+        "nested": {"deeper": True},
+    }
+
+
+def test_render_args_recursive_projection_has_depth_guard():
+    worker = _worker()
+    nested = {"leaf": "ok"}
+    for idx in range(10):
+        nested = {f"level_{idx}": nested}
+
+    projected = worker._extract_control_context(
+        {
+            "render": {
+                "type": "app:column",
+                "args": {"children": [nested]},
+            }
+        }
+    )
+
+    # Depth guard mirrors error.diagnosis: max_depth=8 in
+    # _preserve_recursive_control_value. The projection should not crash on
+    # over-deep payloads — it just stops recursing past the cap.
+    assert projected["render"]["type"] == "app:column"
+    assert "args" in projected["render"]
+
+
+def test_render_with_only_type_no_args_still_projects():
+    """Defensive: if a playbook emits {type: ...} with no args, the projection
+    should still surface the type so the GUI's 'unsupported widget' fallback can
+    render and the playbook author sees what they emitted."""
+    worker = _worker()
+    projected = worker._extract_control_context(
+        {"render": {"type": "app:horizontalline"}}
+    )
+
+    assert projected["render"]["type"] == "app:horizontalline"
+    # No args carve-out triggered, but the scalar `type` survives.
+    assert "args" not in projected["render"]
+
+
+def test_render_args_top_level_list_survives_projection():
+    """Some widgets accept array-shaped args (e.g. infogrid.widgets), but the
+    canonical contract is `args: { ... }`. Defensively support a list-typed
+    `args` so a future widget kind that takes a top-level list isn't stripped."""
+    worker = _worker()
+    projected = worker._extract_control_context(
+        {
+            "render": {
+                "type": "app:custom_list_widget",
+                "args": [
+                    {"type": "app:alert", "args": {"message": "first", "variant": "info"}},
+                    {"type": "app:alert", "args": {"message": "second", "variant": "warning"}},
+                ],
+            }
+        }
+    )
+
+    assert projected["render"]["type"] == "app:custom_list_widget"
+    assert isinstance(projected["render"]["args"], list)
+    assert len(projected["render"]["args"]) == 2
+    assert projected["render"]["args"][0]["args"]["message"] == "first"


### PR DESCRIPTION
## Summary

Closes noetl/noetl#422.

AI-OS round 2 widget rendering needs `result.render = { type, args }` to survive worker event projection so the GUI can render smart messages from persisted execution documents.

This mirrors the noetl#417 / v2.37.1 `error.diagnosis` carve-out introduced in commit `4a4f9f6`: `_extract_control_context` now has an explicit `render` allow-path that preserves nested `render.args` through `_preserve_recursive_control_value` with the existing max_depth=8 guard.

The change stays deliberately narrow:

- `render.type` continues to survive through the existing scalar collector
- `render.args` is recursively preserved when it is a dict or list
- arbitrary data-plane dicts remain filtered
- no Widget catalog kind is introduced

Round-2 blocker evidence from ai-meta:

- `bridge/outbox/20260508-064720-deploy-widget-renderer-round-2-local.result.json`
- `622377612446270148` persisted only `{ "type": "app:column" }`
- `622377613679395529` persisted only `{ "type": "app:nonexistent" }`

## Tests

- `.venv/bin/python -m pytest tests/worker/test_control_context_projection.py -v`
  - 9 passed: 4 existing `error.diagnosis` projection tests + 5 new `render.args` projection tests
