### PR TITLE
fix(agent): resolve terminal event result references

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -175,6 +175,47 @@ def _wait_for_sub_execution_terminal(
     return last_doc
 
 
+def _normalise_result_reference(reference: Any) -> Optional[Dict[str, Any]]:
+    """Convert compact event ``result.reference`` into ResultStore ref shape."""
+    if not isinstance(reference, dict):
+        return None
+    locator = str(reference.get("locator") or reference.get("ref") or "").strip()
+    if not locator.startswith("noetl://"):
+        return None
+    store = str(reference.get("store") or "kv").strip().lower() or "kv"
+    return {
+        "kind": "temp_ref" if store == "memory" else "result_ref",
+        "ref": locator,
+        "store": store,
+    }
+
+
+def _resolve_result_reference_sync(reference: Any) -> Any:
+    """Resolve a compact event result reference from sync agent code."""
+    ref = _normalise_result_reference(reference)
+    if not isinstance(ref, dict):
+        return None
+    try:
+        import asyncio
+        import concurrent.futures
+        from noetl.core.storage.result_store import default_store
+
+        try:
+            asyncio.get_running_loop()
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(asyncio.run, default_store.resolve(ref))
+                return future.result(timeout=10.0)
+        except RuntimeError:
+            return asyncio.run(default_store.resolve(ref))
+    except Exception as exc:
+        logger.warning(
+            "AGENT.RESULT.FETCH: failed to resolve result reference %s: %s",
+            ref.get("ref") if isinstance(ref, dict) else reference,
+            exc,
+        )
+        return None
+
+
 def _fetch_sub_execution_terminal_result(
     execution_id: str,
     *,
@@ -275,6 +316,9 @@ def _fetch_sub_execution_terminal_result(
     result = candidate_event.get("result")
     if not isinstance(result, dict):
         return None
+    resolved = _resolve_result_reference_sync(result.get("reference"))
+    if resolved is not None:
+        return resolved if isinstance(resolved, dict) else {"data": resolved}
     context = result.get("context")
     if not isinstance(context, dict):
         return None

--- a/tests/tools/test_agent_executor.py
+++ b/tests/tools/test_agent_executor.py
@@ -486,6 +486,63 @@ def test_fetch_sub_execution_terminal_result_picks_last_terminal_step(monkeypatc
     assert result["isError"] is False
 
 
+def test_fetch_sub_execution_terminal_result_resolves_reference_before_context(monkeypatch):
+    """Large results use event result.reference before compact context.
+
+    Projection keeps summary fields in result.context for large payloads,
+    while the full child output is behind result.reference. The parent
+    agent envelope needs the resolved reference so templates can read
+    envelope.data.ok and envelope.data.items.
+    """
+    events = [
+        {
+            "event_id": 200,
+            "event_type": "command.completed",
+            "node_name": "shape_search_activities",
+            "result": {
+                "status": "ok",
+                "reference": {
+                    "locator": "noetl://execution/123/result/shape_search_activities/abc",
+                    "store": "disk",
+                },
+                "context": {
+                    "status": "ok",
+                    "data_ok": True,
+                    "data_activities_total": 1786,
+                },
+            },
+        },
+    ]
+
+    class _FakeRequests:
+        def get(self, url, timeout=None):
+            return _fake_events_response(events)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "requests",
+        types.SimpleNamespace(get=_FakeRequests().get),
+    )
+    monkeypatch.setattr(
+        agent_executor,
+        "_resolve_result_reference_sync",
+        lambda reference: {
+            "status": "ok",
+            "data": {
+                "ok": True,
+                "items": [{"name": "Full hydrated activity"}],
+                "items_total": 1,
+            },
+            "isError": False,
+        },
+    )
+
+    result = agent_executor._fetch_sub_execution_terminal_result("12345")
+    assert result["data"]["ok"] is True
+    assert result["data"]["items"][0]["name"] == "Full hydrated activity"
+    assert "data_ok" not in result
+
+
 def test_fetch_sub_execution_terminal_result_returns_none_when_no_terminal(monkeypatch):
     """No qualifying terminal event → None → caller falls back to status doc."""
 


### PR DESCRIPTION
## Summary
- resolve the terminal event `result.reference` before falling back to compact `result.context`
- preserve the existing status/data fallback order when reference resolution is unavailable
- add regression coverage for large projected results whose context only has flattened summary fields

## Why
The first terminal-event hydration patch found the right child event, but large child results are stored behind `result.reference`; their event context only carries compact summary fields. Parent agent envelopes need the resolved reference so templates can read nested `envelope.data.*` fields.

## Validation
- `uv run pytest tests/tools/test_agent_executor.py -q` -> 14 passed
- `python3 -m py_compile noetl/tools/agent/executor.py tests/tools/test_agent_executor.py`
- local kind smoke from noetl#424 exposed the reference/context split this PR addresses
