### PR TITLE
fix(agent): preserve compact NoETL child data for parent routing

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -216,6 +216,96 @@ def _resolve_result_reference_sync(reference: Any) -> Any:
         return None
 
 
+def _compact_mcp_result_for_agent_context(result: Any) -> Any:
+    """Bound MCP-like child results so parent steps can template them.
+
+    Agent-to-NoETL calls use the child playbook's terminal result as the
+    parent agent step's ``data``. Some MCP tools legitimately return very
+    large collections; carrying the whole payload through the parent step
+    makes the parent result externalize again, which hides ``data`` from
+    immediate downstream branch predicates. Keep the MCP contract fields
+    and the first few collection items, preserving counts for observability.
+    The full child result remains available from the child execution's own
+    ResultRef; this is the control-plane view for parent routing/rendering.
+    """
+    if not isinstance(result, dict):
+        return result
+
+    data = result.get("data")
+    if not isinstance(data, dict):
+        return result
+
+    collection_keys = ("items", "offers", "hotels", "activities", "locations")
+    collection_key = next(
+        (key for key in collection_keys if isinstance(data.get(key), list)),
+        None,
+    )
+    if collection_key is None:
+        return result
+
+    max_items = 10
+    collection = data.get(collection_key) or []
+    compact_data: Dict[str, Any] = {}
+    for key, value in data.items():
+        if isinstance(value, list):
+            if key == collection_key:
+                if key in {"offers", "items"}:
+                    compact_data[key] = value[:max_items]
+                else:
+                    # Travel renderers and most MCP consumers expect the
+                    # canonical collection field to be `items`; Amadeus uses
+                    # domain-specific names for hotels/activities.
+                    compact_data["items"] = value[:max_items]
+                compact_data.setdefault(f"{key}_total", len(value))
+            else:
+                compact_data[f"{key}_total"] = len(value)
+            continue
+        compact_data[key] = value
+
+    compact: Dict[str, Any] = {
+        key: result[key]
+        for key in ("status", "isError", "_meta")
+        if key in result
+    }
+    compact["data"] = compact_data
+    return compact
+
+
+def _expand_flattened_terminal_context(context: Dict[str, Any]) -> Dict[str, Any]:
+    """Rehydrate auto-extracted ``data_*`` / ``_meta_*`` fields.
+
+    When a child result reference cannot be resolved, the terminal event
+    still carries scalar fields produced by ResultHandler's auto-extractor
+    (for example ``data_ok`` and ``data_status_code``). Expand those back
+    into an MCP-shaped envelope so parent predicates can still distinguish
+    a successful upstream call from a real failure.
+    """
+    expanded: Dict[str, Any] = {}
+    data: Dict[str, Any] = {}
+    meta: Dict[str, Any] = {}
+
+    for key, value in context.items():
+        key_str = str(key)
+        if key_str.startswith("data_"):
+            data[key_str.removeprefix("data_")] = value
+        elif key_str.startswith("_meta_"):
+            meta[key_str.removeprefix("_meta_")] = value
+        else:
+            expanded[key_str] = value
+
+    if data:
+        expanded["data"] = data
+    if meta:
+        existing_meta = expanded.get("_meta")
+        if isinstance(existing_meta, dict):
+            merged_meta = dict(existing_meta)
+            merged_meta.update(meta)
+            expanded["_meta"] = merged_meta
+        else:
+            expanded["_meta"] = meta
+    return expanded
+
+
 def _fetch_sub_execution_terminal_result(
     execution_id: str,
     *,
@@ -318,11 +408,12 @@ def _fetch_sub_execution_terminal_result(
         return None
     resolved = _resolve_result_reference_sync(result.get("reference"))
     if resolved is not None:
-        return resolved if isinstance(resolved, dict) else {"data": resolved}
+        compact = _compact_mcp_result_for_agent_context(resolved)
+        return compact if isinstance(compact, dict) else {"data": compact}
     context = result.get("context")
     if not isinstance(context, dict):
         return None
-    return context
+    return _expand_flattened_terminal_context(context)
 
 
 def _should_auto_troubleshoot(

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -644,6 +644,21 @@ class Worker:
 
         for key, child in candidate.items():
             key_str = str(key)
+            if (
+                key_str == "data"
+                and candidate.get("framework") == "noetl"
+                and isinstance(child, (dict, list))
+            ):
+                # NoETL-as-agent bridge contract: the child playbook's
+                # control-plane result is exposed under `data` so parent
+                # branches can use predicates such as
+                # `agent_step.data.ok`. Preserve the bounded/compacted
+                # data emitted by the agent executor without opening the
+                # generic data-plane keys below.
+                projected_data = self._preserve_recursive_control_value(child)
+                if projected_data is not None:
+                    context[key_str] = projected_data
+                continue
             if key_str in blocked_keys:
                 continue
             if key_str.startswith("command_") and key_str != "command_id":

--- a/tests/tools/test_agent_executor.py
+++ b/tests/tools/test_agent_executor.py
@@ -543,6 +543,95 @@ def test_fetch_sub_execution_terminal_result_resolves_reference_before_context(m
     assert "data_ok" not in result
 
 
+def test_fetch_sub_execution_terminal_result_compacts_large_mcp_collections(monkeypatch):
+    events = [
+        {
+            "event_id": 200,
+            "event_type": "command.completed",
+            "node_name": "amadeus_search_activities",
+            "result": {
+                "reference": {
+                    "locator": "noetl://execution/123/result/amadeus_search_activities/abc",
+                    "store": "disk",
+                },
+                "context": {"status": "ok", "data_ok": True},
+            },
+        },
+    ]
+
+    class _FakeRequests:
+        def get(self, url, timeout=None):
+            return _fake_events_response(events)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "requests",
+        types.SimpleNamespace(get=_FakeRequests().get),
+    )
+    monkeypatch.setattr(
+        agent_executor,
+        "_resolve_result_reference_sync",
+        lambda reference: {
+            "status": "ok",
+            "isError": False,
+            "_meta": {"tool": "search_activities"},
+            "data": {
+                "ok": True,
+                "status_code": 200,
+                "activities": [{"id": idx} for idx in range(20)],
+            },
+        },
+    )
+
+    result = agent_executor._fetch_sub_execution_terminal_result("12345")
+    assert result["status"] == "ok"
+    assert result["isError"] is False
+    assert result["data"]["ok"] is True
+    assert result["data"]["activities_total"] == 20
+    assert result["data"]["items"] == [{"id": idx} for idx in range(10)]
+    assert "activities" not in result["data"]
+
+
+def test_fetch_sub_execution_terminal_result_expands_flattened_context(monkeypatch):
+    events = [
+        {
+            "event_id": 200,
+            "event_type": "command.completed",
+            "node_name": "amadeus_search_activities",
+            "result": {
+                "reference": {
+                    "locator": "noetl://execution/123/result/amadeus_search_activities/abc",
+                    "store": "disk",
+                },
+                "context": {
+                    "status": "ok",
+                    "isError": False,
+                    "data_ok": True,
+                    "data_status_code": 200,
+                    "_meta_tool": "search_activities",
+                },
+            },
+        },
+    ]
+
+    class _FakeRequests:
+        def get(self, url, timeout=None):
+            return _fake_events_response(events)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "requests",
+        types.SimpleNamespace(get=_FakeRequests().get),
+    )
+    monkeypatch.setattr(agent_executor, "_resolve_result_reference_sync", lambda reference: None)
+
+    result = agent_executor._fetch_sub_execution_terminal_result("12345")
+    assert result["status"] == "ok"
+    assert result["isError"] is False
+    assert result["data"] == {"ok": True, "status_code": 200}
+    assert result["_meta"] == {"tool": "search_activities"}
+
+
 def test_fetch_sub_execution_terminal_result_returns_none_when_no_terminal(monkeypatch):
     """No qualifying terminal event → None → caller falls back to status doc."""
 

--- a/tests/worker/test_control_context_projection.py
+++ b/tests/worker/test_control_context_projection.py
@@ -262,3 +262,39 @@ def test_render_args_top_level_list_survives_projection():
     assert isinstance(projected["render"]["args"], list)
     assert len(projected["render"]["args"]) == 2
     assert projected["render"]["args"][0]["args"]["message"] == "first"
+
+
+def test_noetl_agent_data_survives_projection():
+    worker = _worker()
+    projected = worker._extract_control_context(
+        {
+            "status": "ok",
+            "framework": "noetl",
+            "entrypoint": "automation/agents/mcp/amadeus",
+            "data": {
+                "status": "ok",
+                "isError": False,
+                "data": {
+                    "ok": True,
+                    "items": [{"name": "hydrated activity"}],
+                    "items_total": 1,
+                },
+            },
+        }
+    )
+
+    assert projected["framework"] == "noetl"
+    assert projected["data"]["data"]["ok"] is True
+    assert projected["data"]["data"]["items"] == [{"name": "hydrated activity"}]
+
+
+def test_non_agent_data_stays_out_of_projection():
+    worker = _worker()
+    projected = worker._extract_control_context(
+        {
+            "status": "ok",
+            "data": {"ok": True, "items": [{"name": "too broad"}]},
+        }
+    )
+
+    assert projected == {"status": "ok"}


### PR DESCRIPTION
## Summary\n- compact large MCP child results before attaching them to parent NoETL agent envelopes\n- expand flattened terminal child context when the full result ref cannot be resolved\n- preserve compact NoETL agent data through event/control projection for parent branch predicates\n\n## Tests\n- uv run pytest tests/tools/test_agent_executor.py tests/worker/test_control_context_projection.py -q\n- python3 -m py_compile noetl/tools/agent/executor.py noetl/worker/nats_worker.py tests/tools/test_agent_executor.py tests/worker/test_control_context_projection.py\n\n## Context\nThe first hydration PRs located the child terminal event and tried to resolve its result ref. The real kind smoke showed one more boundary: large Amadeus activity results can be disk-backed on a different worker pod, so the parent must still get a bounded MCP control-plane view for routing and rendering.