### PR TITLE
fix(agent): expose compact child data at agent data root

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -286,7 +286,14 @@ def _compact_mcp_result_for_agent_context(result: Any) -> Any:
         None,
     )
     if collection_key is None:
-        return result
+        compact_data = dict(data)
+        if "status" in result and "status" not in compact_data:
+            compact_data["_mcp_status"] = result["status"]
+        if "isError" in result and "isError" not in compact_data:
+            compact_data["isError"] = result["isError"]
+        if "_meta" in result and "_meta" not in compact_data:
+            compact_data["_meta"] = result["_meta"]
+        return compact_data
 
     max_items = 10
     collection = data.get(collection_key) or []
@@ -307,13 +314,13 @@ def _compact_mcp_result_for_agent_context(result: Any) -> Any:
             continue
         compact_data[key] = value
 
-    compact: Dict[str, Any] = {
-        key: result[key]
-        for key in ("status", "isError", "_meta")
-        if key in result
-    }
-    compact["data"] = compact_data
-    return compact
+    if "status" in result and "status" not in compact_data:
+        compact_data["_mcp_status"] = result["status"]
+    if "isError" in result and "isError" not in compact_data:
+        compact_data["isError"] = result["isError"]
+    if "_meta" in result and "_meta" not in compact_data:
+        compact_data["_meta"] = result["_meta"]
+    return compact_data
 
 
 def _expand_flattened_terminal_context(context: Dict[str, Any]) -> Dict[str, Any]:
@@ -348,6 +355,14 @@ def _expand_flattened_terminal_context(context: Dict[str, Any]) -> Dict[str, Any
             expanded["_meta"] = merged_meta
         else:
             expanded["_meta"] = meta
+    if data:
+        if "status" in expanded and "status" not in data:
+            data["_mcp_status"] = expanded["status"]
+        if "isError" in expanded and "isError" not in data:
+            data["isError"] = expanded["isError"]
+        if "_meta" in expanded and "_meta" not in data:
+            data["_meta"] = expanded["_meta"]
+        return data
     return expanded
 
 

--- a/tests/tools/test_agent_executor.py
+++ b/tests/tools/test_agent_executor.py
@@ -538,8 +538,8 @@ def test_fetch_sub_execution_terminal_result_resolves_reference_before_context(m
     )
 
     result = agent_executor._fetch_sub_execution_terminal_result("12345")
-    assert result["data"]["ok"] is True
-    assert result["data"]["items"][0]["name"] == "Full hydrated activity"
+    assert result["ok"] is True
+    assert result["items"][0]["name"] == "Full hydrated activity"
     assert "data_ok" not in result
 
 
@@ -584,12 +584,11 @@ def test_fetch_sub_execution_terminal_result_compacts_large_mcp_collections(monk
     )
 
     result = agent_executor._fetch_sub_execution_terminal_result("12345")
-    assert result["status"] == "ok"
     assert result["isError"] is False
-    assert result["data"]["ok"] is True
-    assert result["data"]["activities_total"] == 20
-    assert result["data"]["items"] == [{"id": idx} for idx in range(10)]
-    assert "activities" not in result["data"]
+    assert result["ok"] is True
+    assert result["activities_total"] == 20
+    assert result["items"] == [{"id": idx} for idx in range(10)]
+    assert "activities" not in result
 
 
 def test_fetch_sub_execution_terminal_result_expands_flattened_context(monkeypatch):
@@ -626,9 +625,9 @@ def test_fetch_sub_execution_terminal_result_expands_flattened_context(monkeypat
     monkeypatch.setattr(agent_executor, "_resolve_result_reference_sync", lambda reference: None)
 
     result = agent_executor._fetch_sub_execution_terminal_result("12345")
-    assert result["status"] == "ok"
     assert result["isError"] is False
-    assert result["data"] == {"ok": True, "status_code": 200}
+    assert result["ok"] is True
+    assert result["status_code"] == 200
     assert result["_meta"] == {"tool": "search_activities"}
 
 


### PR DESCRIPTION
## Summary\n- return compact child MCP data at the parent agent envelope data root\n- keep status/isError/_meta as control fields on that compact data object\n- update hydration tests for the routing shape consumed by travel render branches\n\n## Tests\n- uv run pytest tests/tools/test_agent_executor.py tests/worker/test_control_context_projection.py -q\n- python3 -m py_compile noetl/tools/agent/executor.py noetl/worker/nats_worker.py tests/tools/test_agent_executor.py tests/worker/test_control_context_projection.py\n- git diff --check\n\n## Context\nThe kind smoke after noetl#427 showed the compact MCP result was present but one level too deep for branch predicates like amadeus_via_mcp_activities.data.ok. This patch exposes ok/items directly at the parent agent data root.