### PR TITLE
fix(agent): project bounded control data for large child results

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -332,6 +332,10 @@ def _expand_flattened_terminal_context(context: Dict[str, Any]) -> Dict[str, Any
     into an MCP-shaped envelope so parent predicates can still distinguish
     a successful upstream call from a real failure.
     """
+    control_data = context.get("control_data")
+    if isinstance(control_data, dict):
+        return control_data
+
     expanded: Dict[str, Any] = {}
     data: Dict[str, Any] = {}
     meta: Dict[str, Any] = {}

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -659,6 +659,15 @@ class Worker:
                 if projected_data is not None:
                     context[key_str] = projected_data
                 continue
+            if key_str == "control_data" and isinstance(child, (dict, list)):
+                # Bounded data deliberately emitted by ResultHandler for large
+                # MCP-like results. This is control-plane data, not the raw
+                # payload: first-page items plus counts/status for parent
+                # agent routing and widget rendering across worker pods.
+                projected_data = self._preserve_recursive_control_value(child)
+                if projected_data is not None:
+                    context[key_str] = projected_data
+                continue
             if key_str in blocked_keys:
                 continue
             if key_str.startswith("command_") and key_str != "command_id":

--- a/noetl/worker/result_handler.py
+++ b/noetl/worker/result_handler.py
@@ -44,6 +44,53 @@ INLINE_MAX_BYTES = int(os.getenv("NOETL_INLINE_MAX_BYTES", "10485760"))  # 64KB
 PREVIEW_MAX_BYTES = int(os.getenv("NOETL_PREVIEW_MAX_BYTES", "1024"))  # 1KB
 
 
+def _compact_control_data(result: Any, *, max_items: int = 10) -> Optional[Dict[str, Any]]:
+    """Return a bounded control-plane view for large MCP-like results.
+
+    Large child-agent results may externalize to local disk on one worker pod.
+    A parent step running on another worker cannot hydrate that disk ref, but it
+    still needs enough data to route and render. Keep status scalars, metadata,
+    and the first few collection items under a stable `items` key.
+    """
+    if not isinstance(result, dict):
+        return None
+    data = result.get("data")
+    if not isinstance(data, dict):
+        return None
+
+    collection_keys = ("items", "offers", "hotels", "activities", "locations")
+    collection_key = next(
+        (key for key in collection_keys if isinstance(data.get(key), list)),
+        None,
+    )
+
+    compact: Dict[str, Any] = {}
+    if collection_key is not None:
+        for key, value in data.items():
+            if isinstance(value, list):
+                if key == collection_key:
+                    if key in {"items", "offers"}:
+                        compact[key] = value[:max_items]
+                    else:
+                        compact["items"] = value[:max_items]
+                    compact.setdefault(f"{key}_total", len(value))
+                else:
+                    compact[f"{key}_total"] = len(value)
+                continue
+            compact[key] = value
+    else:
+        compact.update(data)
+
+    if "status" in result and "status" not in compact:
+        compact["_mcp_status"] = result["status"]
+    if "isError" in result and "isError" not in compact:
+        compact["isError"] = result["isError"]
+    if "_meta" in result and "_meta" not in compact:
+        compact["_meta"] = result["_meta"]
+
+    return compact or None
+
+
 class ResultHandler:
     """
     Handles result storage and output_select extraction for workers.
@@ -213,6 +260,9 @@ class ResultHandler:
             "_store": tier.value,
             **extracted,
         }
+        control_data = _compact_control_data(result)
+        if control_data is not None:
+            processed["control_data"] = control_data
 
         return processed
 

--- a/tests/tools/test_agent_executor.py
+++ b/tests/tools/test_agent_executor.py
@@ -631,6 +631,44 @@ def test_fetch_sub_execution_terminal_result_expands_flattened_context(monkeypat
     assert result["_meta"] == {"tool": "search_activities"}
 
 
+def test_fetch_sub_execution_terminal_result_prefers_control_data(monkeypatch):
+    events = [
+        {
+            "event_id": 200,
+            "event_type": "command.completed",
+            "node_name": "amadeus_search_activities",
+            "result": {
+                "context": {
+                    "status": "ok",
+                    "data_ok": True,
+                    "control_data": {
+                        "ok": True,
+                        "items": [{"name": "bounded activity"}],
+                        "activities_total": 1799,
+                    },
+                },
+            },
+        },
+    ]
+
+    class _FakeRequests:
+        def get(self, url, timeout=None):
+            return _fake_events_response(events)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "requests",
+        types.SimpleNamespace(get=_FakeRequests().get),
+    )
+
+    result = agent_executor._fetch_sub_execution_terminal_result("12345")
+    assert result == {
+        "ok": True,
+        "items": [{"name": "bounded activity"}],
+        "activities_total": 1799,
+    }
+
+
 def test_fetch_sub_execution_terminal_result_returns_none_when_no_terminal(monkeypatch):
     """No qualifying terminal event → None → caller falls back to status doc."""
 

--- a/tests/worker/test_control_context_projection.py
+++ b/tests/worker/test_control_context_projection.py
@@ -1,4 +1,5 @@
 from noetl.worker.nats_worker import Worker
+from noetl.worker.result_handler import _compact_control_data
 
 
 def _worker() -> Worker:
@@ -286,6 +287,48 @@ def test_noetl_agent_data_survives_projection():
     assert projected["framework"] == "noetl"
     assert projected["data"]["data"]["ok"] is True
     assert projected["data"]["data"]["items"] == [{"name": "hydrated activity"}]
+
+
+def test_control_data_survives_projection_for_large_mcp_results():
+    worker = _worker()
+    projected = worker._extract_control_context(
+        {
+            "status": "ok",
+            "control_data": {
+                "ok": True,
+                "items": [{"name": "bounded activity"}],
+                "activities_total": 1799,
+            },
+        }
+    )
+
+    assert projected["status"] == "ok"
+    assert projected["control_data"]["ok"] is True
+    assert projected["control_data"]["items"] == [{"name": "bounded activity"}]
+    assert projected["control_data"]["activities_total"] == 1799
+
+
+def test_large_mcp_result_compacts_control_data_to_items():
+    compact = _compact_control_data(
+        {
+            "status": "ok",
+            "isError": False,
+            "_meta": {"tool": "search_activities"},
+            "data": {
+                "ok": True,
+                "status_code": 200,
+                "activities": [{"id": idx} for idx in range(20)],
+            },
+        }
+    )
+
+    assert compact["ok"] is True
+    assert compact["status_code"] == 200
+    assert compact["isError"] is False
+    assert compact["_meta"] == {"tool": "search_activities"}
+    assert compact["activities_total"] == 20
+    assert compact["items"] == [{"id": idx} for idx in range(10)]
+    assert "activities" not in compact
 
 
 def test_non_agent_data_stays_out_of_projection():


### PR DESCRIPTION
## Summary
- emit a bounded control_data projection for large MCP-like results before event transport externalizes the raw payload
- preserve control_data through worker event projection
- let NoETL agent result hydration prefer control_data when child disk refs cannot be resolved across worker pods

## Tests
- uv run pytest tests/tools/test_agent_executor.py tests/worker/test_control_context_projection.py -q
- uv run python -m py_compile noetl/tools/agent/executor.py noetl/worker/nats_worker.py noetl/worker/result_handler.py