### PR TITLE
docs(storage): use S3-compatible storage naming

### DIFF
--- a/ci/manifests/noetl/configmap-server.yaml
+++ b/ci/manifests/noetl/configmap-server.yaml
@@ -59,11 +59,11 @@ data:
   NOETL_PREVIEW_MAX_BYTES: "1024"
   # Default storage tier: memory, kv, disk, s3, gcs
   NOETL_DEFAULT_STORAGE_TIER: "kv"
-  # Cloud tier for DISK async spill ('s3' covers MinIO via NOETL_S3_ENDPOINT, or 'gcs').
+  # Cloud tier for DISK async spill ('s3' covers S3-compatible endpoints, or 'gcs').
   NOETL_STORAGE_CLOUD_TIER: "s3"
-  NOETL_S3_ENDPOINT: "http://minio.minio.svc.cluster.local:9000"
-  NOETL_S3_BUCKET: "noetl-results"
+  NOETL_S3_ENDPOINT: "http://object-store.object-store.svc.cluster.local:9000"
+  NOETL_S3_BUCKET: "noetl"
   NOETL_S3_REGION: "us-east-1"
-  # MinIO default dev credentials. Replace with a Secret in prod.
-  AWS_ACCESS_KEY_ID: "minioadmin"
-  AWS_SECRET_ACCESS_KEY: "minioadmin"
+  # Default dev credentials. Replace with a Secret in prod.
+  AWS_ACCESS_KEY_ID: "noetl-access"
+  AWS_SECRET_ACCESS_KEY: "noetl-secret"

--- a/ci/manifests/noetl/configmap-worker.yaml
+++ b/ci/manifests/noetl/configmap-worker.yaml
@@ -40,15 +40,15 @@ data:
   NOETL_PREVIEW_MAX_BYTES: "1024"
   # Default storage tier: memory, kv, disk, s3, gcs
   NOETL_DEFAULT_STORAGE_TIER: "kv"
-  # Cloud tier for DISK async spill ('s3' covers MinIO via NOETL_S3_ENDPOINT, or 'gcs').
+  # Cloud tier for DISK async spill ('s3' covers S3-compatible endpoints, or 'gcs').
   NOETL_STORAGE_CLOUD_TIER: "s3"
-  # MinIO (S3-compatible) endpoint in the local kind cluster.
-  NOETL_S3_ENDPOINT: "http://minio.minio.svc.cluster.local:9000"
-  NOETL_S3_BUCKET: "noetl-results"
+  # S3-compatible object-store endpoint in the local kind cluster.
+  NOETL_S3_ENDPOINT: "http://object-store.object-store.svc.cluster.local:9000"
+  NOETL_S3_BUCKET: "noetl"
   NOETL_S3_REGION: "us-east-1"
-  # MinIO default dev credentials. Replace with a Secret in prod.
-  AWS_ACCESS_KEY_ID: "minioadmin"
-  AWS_SECRET_ACCESS_KEY: "minioadmin"
+  # Default dev credentials. Replace with a Secret in prod.
+  AWS_ACCESS_KEY_ID: "noetl-access"
+  AWS_SECRET_ACCESS_KEY: "noetl-secret"
   # GCS configuration
   NOETL_GCS_BUCKET: "noetl-demo-output"
   NOETL_GCS_PREFIX: "results/"

--- a/noetl/core/config.py
+++ b/noetl/core/config.py
@@ -192,7 +192,7 @@ class Settings(BaseModel):
     # (legacy value 'object' is auto-remapped to 'disk' with a deprecation warning)
     default_storage_tier: str = Field(default="kv", alias="NOETL_DEFAULT_STORAGE_TIER")
     # Cloud-tier selection for DISK async spill and >=1MB writes. One of: s3, gcs.
-    # MinIO is not a separate tier; it runs under s3 with NOETL_S3_ENDPOINT.
+    # S3-compatible systems use the abstract s3 tier with NOETL_S3_ENDPOINT.
     storage_cloud_tier: str = Field(default="s3", alias="NOETL_STORAGE_CLOUD_TIER")
 
     # Local disk-cache configuration (reserved, implemented in phase 1).
@@ -213,7 +213,7 @@ class Settings(BaseModel):
         default="None", alias="NOETL_STORAGE_LOCAL_CACHE_RECOVER_MODE"
     )
 
-    # S3 configuration for result storage (covers MinIO via endpoint override)
+    # S3-compatible configuration for result storage.
     s3_endpoint_url: Optional[str] = Field(default=None, alias="S3_ENDPOINT_URL")
     # Alias honored by newer deployments; mirrors s3_endpoint_url when set.
     s3_endpoint: Optional[str] = Field(default=None, alias="NOETL_S3_ENDPOINT")

--- a/noetl/core/dsl/engine/models/tools.py
+++ b/noetl/core/dsl/engine/models/tools.py
@@ -17,7 +17,7 @@ class OutputStore(BaseModel):
         ),
     )
     driver: Optional[str] = Field(
-        default=None, description="Specific driver (e.g., minio for s3)"
+        default=None, description="Specific driver (e.g., s3-compatible for s3)"
     )
     bucket: Optional[str] = Field(default=None, description="Bucket name for disk/s3/gcs")
     prefix: Optional[str] = Field(default=None, description="Key prefix for storage")

--- a/noetl/core/dsl/playbook.schema.json
+++ b/noetl/core/dsl/playbook.schema.json
@@ -624,7 +624,7 @@
             }
           ],
           "default": null,
-          "description": "Specific driver (e.g., minio for s3)",
+          "description": "Specific driver (e.g., s3-compatible for s3)",
           "title": "Driver"
         },
         "bucket": {

--- a/noetl/core/storage/__init__.py
+++ b/noetl/core/storage/__init__.py
@@ -9,7 +9,7 @@ Storage Tiers (aligned with RisingWave 3-tier hot/warm/cold):
 - memory: In-process (<10KB, step-scoped)
 - kv: NATS KV (<1MB, execution-scoped)
 - disk: Local SSD cache + async cloud spill (>=1MB; phase 1 implements)
-- s3/gcs: Cloud storage, durable (MinIO via NOETL_S3_ENDPOINT)
+- s3/gcs: Cloud storage, durable (S3-compatible endpoints supported)
 - db: PostgreSQL (queryable intermediate data)
 
 Phase 0 removes the experimental `object` tier (NATS Object Store).

--- a/noetl/core/storage/backends.py
+++ b/noetl/core/storage/backends.py
@@ -7,7 +7,7 @@ three-tier hot/warm/cold hierarchy):
 - Memory (hot, <10KB, step-scoped, in-process dict)
 - NATS KV (warm, <1MB, execution-scoped, distributed cache)
 - DiskCache (warm, >=1MB, local SSD/NVMe + async cloud spill; phase 1)
-- S3/MinIO (cold/durable, any size; MinIO via NOETL_S3_ENDPOINT)
+- S3-compatible storage (cold/durable, any size; custom endpoint via NOETL_S3_ENDPOINT)
 - GCS (cold/durable, any size)
 
 Phase 0 removes the previous `NATSObjectBackend` ("object" tier).
@@ -626,7 +626,7 @@ class DiskCacheBackend(StorageBackend):
 
 
 class S3Backend(StorageBackend):
-    """S3/MinIO storage for large objects."""
+    """S3-compatible storage for large objects."""
 
     def __init__(
         self,

--- a/noetl/core/storage/models.py
+++ b/noetl/core/storage/models.py
@@ -9,7 +9,7 @@ Storage Tiers (aligned with RisingWave 3-tier hierarchy):
 - memory: In-process (<10KB, step-scoped)
 - kv: NATS KV (<1MB, execution-scoped)
 - disk: Local SSD/NVMe cache backed by cloud (>=1MB; phase 1)
-- s3/gcs: Cloud storage, durable (large blobs; MinIO via S3 endpoint)
+- s3/gcs: Cloud storage, durable (large blobs; S3-compatible endpoints supported)
 - db: PostgreSQL (queryable intermediate data)
 
 Scopes:
@@ -35,7 +35,7 @@ class StoreTier(str, Enum):
     MEMORY = "memory"       # In-process memory (fastest, step-scoped)
     KV = "kv"              # NATS KV (< 1MB, execution-scoped)
     DISK = "disk"          # Local SSD/NVMe cache + async cloud spill (>= 1MB)
-    S3 = "s3"              # S3/MinIO (durable large blobs; MinIO via NOETL_S3_ENDPOINT)
+    S3 = "s3"              # S3-compatible durable blobs (SeaweedFS, RustFS, AWS S3)
     GCS = "gcs"            # Google Cloud Storage
     DB = "db"              # PostgreSQL (queryable)
     DUCKDB = "duckdb"      # DuckDB (local analytics)

--- a/noetl/core/storage/result_store.py
+++ b/noetl/core/storage/result_store.py
@@ -547,7 +547,7 @@ class TempStore:
         except Exception as e:
             logger.debug(f"TEMP: KV fetch failed: {e}")
 
-        # Try S3/MinIO if configured (covers disk-tier writes spilled here in phase 0)
+        # Try S3-compatible storage if configured (covers disk-tier spill writes).
         import os
         if os.getenv("NOETL_S3_BUCKET"):
             try:
@@ -686,8 +686,9 @@ class TempStore:
         )
         from noetl.core.storage.router import default_router
 
-        # Pick the cloud backend used as the spill target. MinIO uses S3Backend
-        # with NOETL_S3_ENDPOINT honored by the existing env plumbing.
+        # Pick the cloud backend used as the spill target. S3-compatible
+        # deployments use S3Backend with NOETL_S3_ENDPOINT honored by the
+        # existing env plumbing.
         cloud_backend = None
         try:
             cloud_tier = default_router.default_cloud_tier

--- a/noetl/core/storage/router.py
+++ b/noetl/core/storage/router.py
@@ -10,7 +10,7 @@ Selects optimal storage tier based on:
 Phase 0 (RisingWave alignment): removed the `OBJECT` (NATS Object
 Store) tier. Payloads >= 1 MB now route to `DISK` (local SSD cache
 with async cloud spill). The `DISK` backend is a phase-0 placeholder;
-TempStore falls back to the configured cloud tier (S3/MinIO or GCS)
+TempStore falls back to the configured cloud tier (S3-compatible storage or GCS)
 via `default_cloud_tier` until phase 1 lands the real implementation.
 See `docs/features/noetl_storage_and_streaming_alignment.md`.
 """
@@ -28,14 +28,14 @@ def _resolve_default_cloud_tier() -> StoreTier:
     """
     Resolve default cloud tier from env var.
 
-    `NOETL_STORAGE_CLOUD_TIER=s3|gcs` picks the durable backend. MinIO
-    is S3 with a custom endpoint (`NOETL_S3_ENDPOINT`); it is not a
-    separate tier value.
+    `NOETL_STORAGE_CLOUD_TIER=s3|gcs` picks the durable backend. SeaweedFS,
+    RustFS, AWS S3, and other S3-compatible systems all use the abstract
+    `s3` tier with a custom endpoint (`NOETL_S3_ENDPOINT`) when needed.
     """
     raw = (os.getenv("NOETL_STORAGE_CLOUD_TIER") or "s3").strip().lower()
     if raw == "gcs":
         return StoreTier.GCS
-    # Default and explicit `s3` both resolve here. MinIO lives under S3.
+    # Default and explicit `s3` both resolve here.
     return StoreTier.S3
 
 

--- a/noetl/database/ddl/postgres/schema_ddl.sql
+++ b/noetl/database/ddl/postgres/schema_ddl.sql
@@ -481,7 +481,7 @@ CREATE INDEX IF NOT EXISTS idx_result_ref_store_tier ON noetl.result_ref (store_
 COMMENT ON TABLE noetl.result_ref IS 'ResultRef projection table - metadata index for result storage. Actual data in NATS/cloud storage.';
 COMMENT ON COLUMN noetl.result_ref.ref IS 'Logical URI: noetl://execution/<eid>/result/<name>/<id>';
 COMMENT ON COLUMN noetl.result_ref.scope IS 'Lifecycle scope: step (cleanup on step done), execution (cleanup on playbook done), workflow (cleanup on root done), permanent (never auto-cleaned)';
-COMMENT ON COLUMN noetl.result_ref.store_tier IS 'Storage backend: memory (in-process), kv (NATS KV), disk (local SSD cache + cloud spill), s3 (S3/MinIO), gcs, db (PostgreSQL), duckdb, eventlog. "object" retained for in-flight rows; auto-remapped to "disk" on read.';
+COMMENT ON COLUMN noetl.result_ref.store_tier IS 'Storage backend: memory (in-process), kv (NATS KV), disk (local SSD cache + cloud spill), s3 (S3-compatible storage), gcs, db (PostgreSQL), duckdb, eventlog. "object" retained for in-flight rows; auto-remapped to "disk" on read.';
 COMMENT ON COLUMN noetl.result_ref.physical_uri IS 'Actual storage URI (s3://bucket/key, kv://bucket/key, etc.)';
 COMMENT ON COLUMN noetl.result_ref.preview IS 'Truncated sample of data for UI preview (max 1KB JSON)';
 COMMENT ON COLUMN noetl.result_ref.extracted IS 'Fields from output.select available without resolution';

--- a/noetl/tools/artifact/executor.py
+++ b/noetl/tools/artifact/executor.py
@@ -152,7 +152,7 @@ def execute_artifact_get(
         # reference rather than silently fall through.
         raise ValueError(
             "nats-obj:// URIs reference the removed NATS Object Store tier. "
-            "Migrate artifacts to s3:// (MinIO/S3), gcs://, or the new "
+            "Migrate artifacts to s3:// (S3-compatible storage), gcs://, or the new "
             "DISK tier. See docs/features/noetl_storage_and_streaming_alignment.md"
         )
     else:


### PR DESCRIPTION
## Summary
- Update storage comments/docstrings/schema descriptions from backend-specific wording to S3-compatible storage
- Keep StoreTier.S3 and endpoint-agnostic code behavior unchanged
- Update static NoETL manifests to the canonical object-store service and credentials

## Validation
- uv run pytest tests/unit/storage/test_disk_cache_backend.py tests/core/test_result_store_cache_tracking.py tests/core/test_result_store_preview.py (19 passed)
- Broad pytest collection still has unrelated legacy collection errors in existing tests, documented in the bridge result