### PR TITLE
fix(kind): remove GOOGLE_APPLICATION_CREDENTIALS placeholder that breaks google.auth.default()

### DIFF
--- a/ci/manifests/noetl/worker-deployment.yaml
+++ b/ci/manifests/noetl/worker-deployment.yaml
@@ -43,15 +43,9 @@ spec:
           envFrom:
             - configMapRef:
                 name: noetl-worker-config
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /etc/gcs/gcs-key.json
           volumeMounts:
             - name: noetl-data
               mountPath: /opt/noetl/data
-            - name: gcs-credentials
-              mountPath: /etc/gcs
-              readOnly: true
           resources:
             requests:
               cpu: "100m"
@@ -63,6 +57,3 @@ spec:
         - name: noetl-data
           persistentVolumeClaim:
             claimName: noetl-data-shared # Use shared RWX PVC for DuckDB files
-        - name: gcs-credentials
-          secret:
-            secretName: gcs-credentials


### PR DESCRIPTION
## Summary

- The kind `noetl-worker` deployment had `GOOGLE_APPLICATION_CREDENTIALS=/etc/gcs/gcs-key.json` hardcoded, pointing at a `gcs-credentials` secret bootstrapped with `{}` (an empty JSON object).
- `google.auth.default()` reads that env var first, finds an empty key, and raises `DefaultCredentialsError: ... Type is None`, blocking all GCP API calls on kind. There is no GCE metadata server on kind to serve as a fallback.
- GKE is already correct: the Helm-rendered deployment omits both the env var and the mount; Workload Identity picks up credentials from the GKE metadata server automatically.

## Changes

- `ci/manifests/noetl/worker-deployment.yaml`: remove `env.GOOGLE_APPLICATION_CREDENTIALS`, the `gcs-credentials` volumeMount, and the `gcs-credentials` volume.

## Impact

- Kind workers will no longer be blocked by a poisoned ADC path. Playbooks that do not use GCP APIs are unaffected.
- Kind operators who need real GCP API access should mount a real SA JSON key as a secret and add `GOOGLE_APPLICATION_CREDENTIALS` back to the deployment out-of-band. Workload Identity is GKE-only.
- GKE deployment is unchanged.

## Test plan

- [ ] `kubectl apply --dry-run=client -f ci/manifests/noetl/worker-deployment.yaml` passes (verified locally before pushing).
- [ ] Redeploy kind cluster without the placeholder; confirm `google.auth.default()` no longer raises `DefaultCredentialsError: Type is None`.
- [ ] GKE rollout unchanged — Helm values not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)