### PR TITLE
feat(server): command-table-first runtime command reaper

### DIFF
--- a/noetl/server/app.py
+++ b/noetl/server/app.py
@@ -29,6 +29,10 @@ from noetl.server.auto_resume import (
     resume_interrupted_executions,
     get_auto_resume_metrics_snapshot,
 )
+from noetl.server.command_reaper import (
+    run_command_reaper,
+    is_reaper_enabled as is_command_reaper_enabled,
+)
 from noetl.server.runtime_leases import RuntimeLease, load_control_lease_seconds
 
 logger = setup_logger(__name__, include_location=True)
@@ -173,6 +177,14 @@ def _create_app(settings: Settings) -> FastAPI:
                 logical_name=logical_name,
                 lease_seconds=control_lease_seconds,
             )
+            command_reaper_lease = RuntimeLease(
+                task_name="command_reaper",
+                instance_name=instance_name,
+                server_url=server_url,
+                hostname=hostname,
+                logical_name=logical_name,
+                lease_seconds=control_lease_seconds,
+            )
             async def _server_heartbeat_loop():
                 while not stop_event.is_set():
                     try:
@@ -303,6 +315,7 @@ def _create_app(settings: Settings) -> FastAPI:
             heartbeat_task: Optional[asyncio.Task] = None
             sweeper_task: Optional[asyncio.Task] = None
             auto_resume_task: Optional[asyncio.Task] = None
+            command_reaper_task: Optional[asyncio.Task] = None
             try:
                 logger.info("Starting server heartbeat background task...")
                 heartbeat_task = asyncio.create_task(_server_heartbeat_loop(), name="server-heartbeat")
@@ -326,6 +339,23 @@ def _create_app(settings: Settings) -> FastAPI:
                 logger.info("Auto-resume coordination task started successfully")
             except Exception as e:
                 logger.error(f"Auto-resume startup failed (non-fatal): {e}", exc_info=True)
+
+            try:
+                if is_command_reaper_enabled():
+                    logger.info("Starting command reaper background task...")
+                    command_reaper_task = asyncio.create_task(
+                        run_command_reaper(
+                            stop_event=stop_event,
+                            server_url=command_server_url,
+                            lease=command_reaper_lease,
+                        ),
+                        name="command-reaper",
+                    )
+                    logger.info("Command reaper background task started successfully")
+                else:
+                    logger.info("Command reaper disabled via env; skipping startup")
+            except Exception as e:
+                logger.error(f"Command reaper startup failed (non-fatal): {e}", exc_info=True)
 
             yield
             # Shutdown
@@ -351,6 +381,13 @@ def _create_app(settings: Settings) -> FastAPI:
                         await auto_resume_task
                 except Exception as e:
                     logger.exception(f"Critical error during auto-resume task shutdown: {e}")
+            if command_reaper_task:
+                try:
+                    command_reaper_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await command_reaper_task
+                except Exception as e:
+                    logger.exception(f"Critical error during command reaper task shutdown: {e}")
             try:
                 await shutdown_publish_recovery_tasks()
             except Exception as e:

--- a/noetl/server/command_reaper.py
+++ b/noetl/server/command_reaper.py
@@ -1,0 +1,381 @@
+"""
+Periodic command reaper for orphaned or stranded NoETL commands.
+
+Background
+----------
+``noetl.command`` is the source of truth for command lifecycle. Commands move
+through PENDING -> CLAIMED -> RUNNING -> COMPLETED/FAILED/CANCELLED. Workers
+heartbeat through ``noetl.runtime``.
+
+When a worker dies hard (OOMKill, node eviction, network partition with no
+graceful drain), it cannot emit ``command.completed`` / ``command.failed``.
+Because NATS JetStream messages are ACKed at claim time, no automatic
+redelivery happens. Similarly, the API may successfully insert a PENDING
+``noetl.command`` row but fail to publish the NATS notification (publisher
+outage, brief disconnect). In both cases the command sits non-terminal
+forever and the playbook stalls.
+
+This module periodically scans ``noetl.command`` directly for stale
+non-terminal commands whose execution is also non-terminal, and re-publishes
+the original NATS command notification. From there the existing claim
+endpoint and ``noetl.claim_policy.decide_reclaim_for_existing_claim`` take
+over and arbitrate safely. The reaper never forces command completion and
+never duplicates the claim policy.
+
+Two recovery categories are covered:
+
+1. **Orphaned active commands** — ``CLAIMED`` / ``RUNNING`` rows whose
+   ``worker_id`` is missing from ``noetl.runtime``, marked non-ready, or
+   has a stale heartbeat. Healthy workers that have held a claim past the
+   hard timeout are also surfaced so the claim policy can take it back.
+
+2. **Stranded pending commands** — ``PENDING`` rows that have aged past the
+   retry window without ever being CLAIMED. These typically result from a
+   transient NATS publish failure right after the command row was committed.
+
+The loop runs under a ``RuntimeLease`` so only one server instance performs
+recovery at a time. See ``noetl.server.runtime_leases``.
+
+Environment variables
+---------------------
+NOETL_COMMAND_REAPER_ENABLED
+    Toggle the reaper entirely (default: ``true``).
+NOETL_COMMAND_REAPER_INTERVAL_SECONDS
+    Scan frequency (default: ``60``, minimum 10).
+NOETL_COMMAND_REAPER_WORKER_STALE_SECONDS
+    Worker heartbeat age (s) above which a CLAIMED/RUNNING command is
+    considered orphaned (default: ``60``, minimum 30). Should be >=
+    ``NOETL_RUNTIME_SWEEP_INTERVAL`` so the runtime_sweeper marks the
+    worker offline first.
+NOETL_COMMAND_REAPER_HEALTHY_HARD_TIMEOUT_SECONDS
+    Maximum lifetime (s) of a CLAIMED/RUNNING command on a still-healthy
+    worker before we re-publish anyway to let the claim policy decide
+    (default: ``1800``).
+NOETL_COMMAND_REAPER_PENDING_RETRY_SECONDS
+    Minimum age (s) of a PENDING row before we re-publish it as stranded
+    (default: ``60``, minimum 15).
+NOETL_COMMAND_REAPER_MAX_PER_RUN
+    Maximum commands re-published in a single cycle (default: ``100``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Optional
+
+from psycopg.rows import dict_row
+
+from noetl.core.db.pool import get_pool_connection
+from noetl.core.logger import setup_logger
+from noetl.core.urls import normalize_server_base_url
+
+logger = setup_logger(__name__, include_location=True)
+
+# Status values stored on ``noetl.command``.
+_ACTIVE_COMMAND_STATUSES = ("CLAIMED", "RUNNING")
+_NON_TERMINAL_COMMAND_STATUSES = ("PENDING", "CLAIMED", "RUNNING")
+
+# Execution-level terminal markers. Reaper must not republish commands for
+# executions that have already concluded (the playbook has decided one way
+# or the other and any stale rows are expected leftovers).
+_TERMINAL_EXECUTION_EVENT_TYPES = [
+    "playbook.completed",
+    "playbook.failed",
+    "workflow.completed",
+    "workflow.failed",
+    "execution.cancelled",
+]
+
+# Kept as a module attribute so historical event-based tests can still
+# reference it; some auxiliary tooling may also consult it.
+_TERMINAL_COMMAND_EVENT_TYPES = [
+    "command.completed",
+    "command.failed",
+    "command.cancelled",
+]
+
+_REAPER_ENABLED = os.getenv("NOETL_COMMAND_REAPER_ENABLED", "true").strip().lower() in {
+    "1", "true", "yes", "on"
+}
+_REAPER_INTERVAL_SECONDS = max(
+    10.0, float(os.getenv("NOETL_COMMAND_REAPER_INTERVAL_SECONDS", "60"))
+)
+_REAPER_WORKER_STALE_SECONDS = max(
+    30.0, float(os.getenv("NOETL_COMMAND_REAPER_WORKER_STALE_SECONDS", "60"))
+)
+_REAPER_HEALTHY_HARD_TIMEOUT_SECONDS = max(
+    60.0,
+    float(os.getenv("NOETL_COMMAND_REAPER_HEALTHY_HARD_TIMEOUT_SECONDS", "1800")),
+)
+_REAPER_PENDING_RETRY_SECONDS = max(
+    15.0, float(os.getenv("NOETL_COMMAND_REAPER_PENDING_RETRY_SECONDS", "60"))
+)
+_REAPER_MAX_PER_RUN = max(
+    1, int(os.getenv("NOETL_COMMAND_REAPER_MAX_PER_RUN", "100"))
+)
+
+
+def get_reaper_interval_seconds() -> float:
+    return _REAPER_INTERVAL_SECONDS
+
+
+def is_reaper_enabled() -> bool:
+    return _REAPER_ENABLED
+
+
+async def _find_stale_active_commands(
+    *,
+    stale_seconds: float,
+    healthy_hard_timeout_seconds: float,
+    max_commands: int,
+) -> list[dict]:
+    """
+    Return CLAIMED/RUNNING ``noetl.command`` rows that look orphaned.
+
+    A row is considered orphaned when its execution has not yet reached a
+    terminal lifecycle event AND any of the following holds:
+
+    * the ``worker_id`` is missing from ``noetl.runtime`` entirely;
+    * the worker's runtime status is not ``ready``;
+    * the worker's heartbeat is older than ``stale_seconds``;
+    * the claim has lived past ``healthy_hard_timeout_seconds``.
+
+    Each returned row carries the fields needed to republish via NATS:
+    ``event_id``, ``execution_id``, ``command_id`` (string), ``step``.
+    """
+    async with get_pool_connection(timeout=5.0) as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT
+                    c.event_id AS event_id,
+                    c.execution_id AS execution_id,
+                    c.command_id::text AS command_id,
+                    c.step_name AS step
+                FROM noetl.command c
+                LEFT JOIN noetl.runtime r
+                    ON r.kind = 'worker_pool'
+                   AND r.name = c.worker_id
+                WHERE c.status = ANY(%s)
+                  AND c.worker_id IS NOT NULL
+                  AND c.claimed_at IS NOT NULL
+                  AND (
+                        r.name IS NULL
+                     OR r.status IS DISTINCT FROM 'ready'
+                     OR r.heartbeat < (NOW() - make_interval(secs => %s))
+                     OR c.claimed_at < (NOW() - make_interval(secs => %s))
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1 FROM noetl.event et
+                      WHERE et.execution_id = c.execution_id
+                        AND et.event_type = ANY(%s)
+                  )
+                ORDER BY c.claimed_at ASC
+                LIMIT %s
+                """,
+                (
+                    list(_ACTIVE_COMMAND_STATUSES),
+                    stale_seconds,
+                    healthy_hard_timeout_seconds,
+                    _TERMINAL_EXECUTION_EVENT_TYPES,
+                    max_commands,
+                ),
+            )
+            rows = await cur.fetchall()
+    return list(rows or [])
+
+
+async def _find_stranded_pending_commands(
+    *,
+    pending_retry_seconds: float,
+    max_commands: int,
+) -> list[dict]:
+    """
+    Return ``noetl.command`` rows still in PENDING long after they were
+    persisted. These are typically commands whose NATS notification was
+    lost (publisher disconnect, transient broker outage) right after the
+    command row committed.
+
+    Rows for executions that have already terminated are excluded so we
+    do not republish work that the playbook has moved past.
+    """
+    async with get_pool_connection(timeout=5.0) as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT
+                    c.event_id AS event_id,
+                    c.execution_id AS execution_id,
+                    c.command_id::text AS command_id,
+                    c.step_name AS step
+                FROM noetl.command c
+                WHERE c.status = 'PENDING'
+                  AND c.created_at < (NOW() - make_interval(secs => %s))
+                  AND NOT EXISTS (
+                      SELECT 1 FROM noetl.event et
+                      WHERE et.execution_id = c.execution_id
+                        AND et.event_type = ANY(%s)
+                  )
+                ORDER BY c.created_at ASC
+                LIMIT %s
+                """,
+                (
+                    pending_retry_seconds,
+                    _TERMINAL_EXECUTION_EVENT_TYPES,
+                    max_commands,
+                ),
+            )
+            rows = await cur.fetchall()
+    return list(rows or [])
+
+
+async def _get_nats_publisher():
+    # Lazy import so unit tests can monkeypatch this attribute without
+    # pulling in the NATS publisher singleton at import time.
+    from noetl.server.api.core.core import get_nats_publisher
+
+    return await get_nats_publisher()
+
+
+async def reap_orphaned_commands_once(server_url: str) -> int:
+    """
+    Run a single reaper sweep: locate orphaned active commands and stranded
+    pending commands on ``noetl.command``, then republish each via NATS.
+
+    Returns the number of commands successfully republished. The claim
+    endpoint together with ``decide_reclaim_for_existing_claim`` decides
+    whether each republished notification translates into a fresh claim or
+    is ACKed as a duplicate.
+    """
+    server_url = normalize_server_base_url(server_url)
+
+    orphaned = await _find_stale_active_commands(
+        stale_seconds=_REAPER_WORKER_STALE_SECONDS,
+        healthy_hard_timeout_seconds=_REAPER_HEALTHY_HARD_TIMEOUT_SECONDS,
+        max_commands=_REAPER_MAX_PER_RUN,
+    )
+    remaining_capacity = max(0, _REAPER_MAX_PER_RUN - len(orphaned))
+    if remaining_capacity > 0:
+        stranded = await _find_stranded_pending_commands(
+            pending_retry_seconds=_REAPER_PENDING_RETRY_SECONDS,
+            max_commands=remaining_capacity,
+        )
+    else:
+        stranded = []
+
+    recovered = orphaned + stranded
+    if not recovered:
+        logger.debug("[COMMAND-REAPER] No orphaned or stranded commands found")
+        return 0
+
+    if orphaned:
+        logger.warning(
+            "[COMMAND-REAPER] Found %d orphaned active command(s); re-publishing",
+            len(orphaned),
+        )
+    if stranded:
+        logger.warning(
+            "[COMMAND-REAPER] Found %d stranded pending command(s); re-publishing",
+            len(stranded),
+        )
+
+    nats_pub = await _get_nats_publisher()
+    republished = 0
+    for cmd in recovered:
+        try:
+            await nats_pub.publish_command(
+                execution_id=int(cmd["execution_id"]),
+                event_id=int(cmd["event_id"]),
+                command_id=str(cmd["command_id"]),
+                step=str(cmd["step"]),
+                server_url=server_url,
+            )
+            republished += 1
+            logger.info(
+                "[COMMAND-REAPER] Re-published execution_id=%s command_id=%s step=%s",
+                cmd["execution_id"],
+                cmd["command_id"],
+                cmd["step"],
+            )
+        except Exception as pub_err:
+            logger.error(
+                "[COMMAND-REAPER] Failed to re-publish execution_id=%s event_id=%s command_id=%s: %s",
+                cmd.get("execution_id"),
+                cmd.get("event_id"),
+                cmd.get("command_id"),
+                pub_err,
+                exc_info=True,
+            )
+
+    logger.info(
+        "[COMMAND-REAPER] Re-published %d/%d recovered commands",
+        republished,
+        len(recovered),
+    )
+    return republished
+
+
+async def run_command_reaper(
+    *,
+    stop_event: asyncio.Event,
+    server_url: str,
+    lease,
+) -> None:
+    """
+    Background task: periodically sweep ``noetl.command`` for stale
+    non-terminal rows and republish their NATS notification.
+
+    A ``RuntimeLease`` (see :mod:`noetl.server.runtime_leases`) is required
+    so that exactly one server instance performs recovery even when several
+    API replicas are running. ``lease`` must expose
+    ``try_acquire_or_renew()`` returning an object with an ``acquired``
+    boolean attribute and an async ``release()`` method.
+
+    The loop exits cleanly when ``stop_event`` is set or the task is
+    cancelled.
+    """
+    if not _REAPER_ENABLED:
+        logger.info("[COMMAND-REAPER] Disabled via NOETL_COMMAND_REAPER_ENABLED=false")
+        return
+
+    logger.info(
+        "[COMMAND-REAPER] Started (interval=%.0fs, worker_stale=%.0fs, hard_timeout=%.0fs, "
+        "pending_retry=%.0fs, max_per_run=%d)",
+        _REAPER_INTERVAL_SECONDS,
+        _REAPER_WORKER_STALE_SECONDS,
+        _REAPER_HEALTHY_HARD_TIMEOUT_SECONDS,
+        _REAPER_PENDING_RETRY_SECONDS,
+        _REAPER_MAX_PER_RUN,
+    )
+
+    try:
+        while not stop_event.is_set():
+            try:
+                lease_state = await lease.try_acquire_or_renew()
+                if getattr(lease_state, "acquired", False):
+                    try:
+                        await reap_orphaned_commands_once(server_url)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as scan_err:
+                        logger.error(
+                            "[COMMAND-REAPER] Scan failed: %s",
+                            scan_err,
+                            exc_info=True,
+                        )
+            except asyncio.CancelledError:
+                raise
+            except Exception as outer_err:
+                logger.exception("[COMMAND-REAPER] Loop error: %s", outer_err)
+
+            try:
+                await asyncio.sleep(_REAPER_INTERVAL_SECONDS)
+            except asyncio.CancelledError:
+                logger.info("[COMMAND-REAPER] Cancelled during sleep; exiting")
+                break
+    finally:
+        try:
+            await lease.release()
+        except Exception:  # pragma: no cover - best-effort release
+            pass

--- a/tests/test_command_reaper.py
+++ b/tests/test_command_reaper.py
@@ -1,3 +1,19 @@
+"""
+Tests for the command-table-first runtime command reaper.
+
+The reaper scans ``noetl.command`` directly for non-terminal commands whose
+execution is still live, and republishes the original NATS notification.
+It must never duplicate the claim policy: the claim endpoint and
+``decide_reclaim_for_existing_claim`` arbitrate the reclaim.
+
+These tests cover both the historical orphaned-/stranded-recovery contract
+and the regression for the PFT v2 stall (execution 626611573817082718)
+where ``fetch_mds_details:task_sequence`` commands sat in CLAIMED/RUNNING
+on a dead worker and there was no active reaper to republish them.
+"""
+
+from __future__ import annotations
+
 import pytest
 
 import noetl.server.command_reaper as command_reaper
@@ -47,10 +63,7 @@ class _FakeConnCtx:
         return False
 
 
-@pytest.mark.asyncio
-async def test_find_orphaned_commands_sql_handles_meta_and_result_command_ids(monkeypatch):
-    rows = [{"event_id": 1, "execution_id": 2, "command_id": "cmd-1", "step": "start"}]
-    cursor = _FakeCursor(rows)
+def _patch_pool(monkeypatch, cursor):
     conn = _FakeConn(cursor)
 
     def _fake_get_pool_connection(*_args, **_kwargs):
@@ -58,100 +71,370 @@ async def test_find_orphaned_commands_sql_handles_meta_and_result_command_ids(mo
 
     monkeypatch.setattr(command_reaper, "get_pool_connection", _fake_get_pool_connection)
 
-    result = await command_reaper._find_orphaned_commands(
+
+@pytest.mark.asyncio
+async def test_find_stale_active_commands_scans_command_table_and_filters_terminal_executions(
+    monkeypatch,
+):
+    rows = [
+        {
+            "event_id": 626615919199912327,
+            "execution_id": 626611573817082718,
+            "command_id": "626611573817082718:fetch_mds_details:0",
+            "step": "fetch_mds_details",
+        }
+    ]
+    cursor = _FakeCursor(rows)
+    _patch_pool(monkeypatch, cursor)
+
+    result = await command_reaper._find_stale_active_commands(
         stale_seconds=90.0,
-        lookback_hours=24,
+        healthy_hard_timeout_seconds=1800.0,
         max_commands=50,
     )
 
     assert result == rows
-    assert cursor.params == (24, 90.0, command_reaper._TERMINAL_COMMAND_EVENT_TYPES, 50)
 
     sql = cursor.query
-    assert "COALESCE(meta->>'command_id', result->'data'->>'command_id')" in sql
-    assert "t.result->'data'->>'command_id' = claims.command_id" in sql
-    assert "t.event_type = ANY(%s)" in sql
+    # Primary scan is against noetl.command, not the event log.
+    assert "FROM noetl.command c" in sql
+    # Heartbeat join with noetl.runtime worker pool.
+    assert "LEFT JOIN noetl.runtime r" in sql
+    assert "r.kind = 'worker_pool'" in sql
+    # Status filter targets active non-terminal rows.
+    assert "c.status = ANY(%s)" in sql
+    # Stale worker / hard-timeout predicate.
+    assert "r.heartbeat" in sql
+    assert "c.claimed_at" in sql
+    # Execution-terminal exclusion via noetl.event.
+    assert "FROM noetl.event et" in sql
+    assert "et.event_type = ANY(%s)" in sql
+    # Bounded result set.
+    assert "LIMIT %s" in sql
+
+    assert cursor.params == (
+        list(command_reaper._ACTIVE_COMMAND_STATUSES),
+        90.0,
+        1800.0,
+        command_reaper._TERMINAL_EXECUTION_EVENT_TYPES,
+        50,
+    )
 
 
 @pytest.mark.asyncio
-async def test_find_unclaimed_pending_commands_sql_filters_claimed_and_terminal(monkeypatch):
-    rows = [{"event_id": 11, "execution_id": 22, "command_id": "cmd-11", "step": "start"}]
+async def test_find_stale_active_commands_returns_claimed_task_sequence_regression(
+    monkeypatch,
+):
+    """Regression for PFT v2 execution 626611573817082718.
+
+    The reaper must surface CLAIMED ``fetch_mds_details:task_sequence``
+    rows so the existing claim policy can take them back when the
+    notification is republished.
+    """
+    rows = [
+        {
+            "event_id": 626615919199912335,
+            "execution_id": 626611573817082718,
+            "command_id": "626611573817082718:fetch_mds_details:task_sequence:1",
+            "step": "fetch_mds_details:task_sequence",
+        },
+        {
+            "event_id": 626615919199912337,
+            "execution_id": 626611573817082718,
+            "command_id": "626611573817082718:fetch_mds_details:task_sequence:2",
+            "step": "fetch_mds_details:task_sequence",
+        },
+        {
+            "event_id": 626615919199912339,
+            "execution_id": 626611573817082718,
+            "command_id": "626611573817082718:fetch_mds_details:task_sequence:3",
+            "step": "fetch_mds_details:task_sequence",
+        },
+    ]
     cursor = _FakeCursor(rows)
-    conn = _FakeConn(cursor)
+    _patch_pool(monkeypatch, cursor)
 
-    def _fake_get_pool_connection(*_args, **_kwargs):
-        return _FakeConnCtx(conn)
+    result = await command_reaper._find_stale_active_commands(
+        stale_seconds=60.0,
+        healthy_hard_timeout_seconds=1800.0,
+        max_commands=10,
+    )
 
-    monkeypatch.setattr(command_reaper, "get_pool_connection", _fake_get_pool_connection)
+    assert [r["event_id"] for r in result] == [
+        626615919199912335,
+        626615919199912337,
+        626615919199912339,
+    ]
+    assert {r["step"] for r in result} == {"fetch_mds_details:task_sequence"}
 
-    result = await command_reaper._find_unclaimed_pending_commands(
-        pending_retry_seconds=60.0,
-        lookback_hours=24,
-        max_commands=50,
+
+@pytest.mark.asyncio
+async def test_find_stale_active_commands_returns_running_task_sequence_regression(
+    monkeypatch,
+):
+    """Regression for the RUNNING leg of the same stall.
+
+    Command 626615919199912327 was RUNNING on a worker that never emitted
+    ``command.completed`` and never recovered. The reaper must surface it
+    too — the CLAIMED filter alone is not enough.
+    """
+    rows = [
+        {
+            "event_id": 626615919199912327,
+            "execution_id": 626611573817082718,
+            "command_id": "626611573817082718:fetch_mds_details:task_sequence:0",
+            "step": "fetch_mds_details:task_sequence",
+        }
+    ]
+    cursor = _FakeCursor(rows)
+    _patch_pool(monkeypatch, cursor)
+
+    result = await command_reaper._find_stale_active_commands(
+        stale_seconds=60.0,
+        healthy_hard_timeout_seconds=1800.0,
+        max_commands=10,
     )
 
     assert result == rows
-    assert cursor.params == (24, 60.0, command_reaper._TERMINAL_COMMAND_EVENT_TYPES, 50)
+    # Status filter must include both CLAIMED and RUNNING.
+    assert "CLAIMED" in command_reaper._ACTIVE_COMMAND_STATUSES
+    assert "RUNNING" in command_reaper._ACTIVE_COMMAND_STATUSES
+
+
+@pytest.mark.asyncio
+async def test_find_stranded_pending_commands_filters_non_pending_and_terminal_executions(
+    monkeypatch,
+):
+    rows = [
+        {
+            "event_id": 700000000000000011,
+            "execution_id": 700000000000000010,
+            "command_id": "700000000000000010:start:0",
+            "step": "start",
+        }
+    ]
+    cursor = _FakeCursor(rows)
+    _patch_pool(monkeypatch, cursor)
+
+    result = await command_reaper._find_stranded_pending_commands(
+        pending_retry_seconds=60.0,
+        max_commands=25,
+    )
+
+    assert result == rows
 
     sql = cursor.query
-    assert "issued.event_type = 'command.issued'" in sql
-    assert "claims.event_type = 'command.claimed'" in sql
-    assert "terminal.event_type = ANY(%s)" in sql
+    assert "FROM noetl.command c" in sql
+    assert "c.status = 'PENDING'" in sql
+    assert "c.created_at" in sql
+    # Reaper must still exclude terminated executions.
+    assert "FROM noetl.event et" in sql
+    assert "et.event_type = ANY(%s)" in sql
+
+    assert cursor.params == (
+        60.0,
+        command_reaper._TERMINAL_EXECUTION_EVENT_TYPES,
+        25,
+    )
 
 
 @pytest.mark.asyncio
 async def test_reap_orphaned_commands_once_republishes_orphaned_and_stranded(monkeypatch):
-    orphaned = [{"event_id": 1, "execution_id": 2, "command_id": "cmd-orphaned", "step": "step-a"}]
-    stranded = [{"event_id": 3, "execution_id": 4, "command_id": "cmd-stranded", "step": "step-b"}]
+    orphaned = [
+        {
+            "event_id": 626615919199912327,
+            "execution_id": 626611573817082718,
+            "command_id": "626611573817082718:fetch_mds_details:task_sequence:0",
+            "step": "fetch_mds_details:task_sequence",
+        }
+    ]
+    stranded = [
+        {
+            "event_id": 700000000000000011,
+            "execution_id": 700000000000000010,
+            "command_id": "700000000000000010:start:0",
+            "step": "start",
+        }
+    ]
     published = []
 
     class _Publisher:
         async def publish_command(self, **kwargs):
             published.append(kwargs)
 
-    async def _fake_find_orphaned_commands(**_kwargs):
+    async def _fake_stale(**_kwargs):
         return orphaned
 
-    async def _fake_find_unclaimed_pending_commands(**_kwargs):
+    async def _fake_stranded(**_kwargs):
         return stranded
 
     async def _fake_get_nats_publisher():
         return _Publisher()
 
-    monkeypatch.setattr(command_reaper, "_find_orphaned_commands", _fake_find_orphaned_commands)
-    monkeypatch.setattr(command_reaper, "_find_unclaimed_pending_commands", _fake_find_unclaimed_pending_commands)
+    monkeypatch.setattr(command_reaper, "_find_stale_active_commands", _fake_stale)
+    monkeypatch.setattr(command_reaper, "_find_stranded_pending_commands", _fake_stranded)
     monkeypatch.setattr(command_reaper, "_get_nats_publisher", _fake_get_nats_publisher)
 
-    count = await command_reaper.reap_orphaned_commands_once("http://server-noetl.noetl.svc.cluster.local:80")
+    count = await command_reaper.reap_orphaned_commands_once(
+        "http://server-noetl.noetl.svc.cluster.local:80"
+    )
 
     assert count == 2
-    assert [item["command_id"] for item in published] == ["cmd-orphaned", "cmd-stranded"]
+    assert [item["command_id"] for item in published] == [
+        orphaned[0]["command_id"],
+        stranded[0]["command_id"],
+    ]
+    # publish_command receives an int execution_id and event_id, str command_id+step.
+    assert all(isinstance(item["execution_id"], int) for item in published)
+    assert all(isinstance(item["event_id"], int) for item in published)
+    assert all(isinstance(item["command_id"], str) for item in published)
+    assert all(isinstance(item["step"], str) for item in published)
 
 
 @pytest.mark.asyncio
-async def test_reap_orphaned_commands_once_skips_stranded_query_when_capacity_is_exhausted(monkeypatch):
-    orphaned = [{"event_id": i, "execution_id": i, "command_id": f"cmd-{i}", "step": "start"} for i in range(100)]
+async def test_reap_orphaned_commands_once_skips_stranded_query_when_capacity_is_exhausted(
+    monkeypatch,
+):
+    orphaned = [
+        {
+            "event_id": i,
+            "execution_id": i,
+            "command_id": f"{i}:step:{i}",
+            "step": "step",
+        }
+        for i in range(100)
+    ]
     published = []
 
     class _Publisher:
         async def publish_command(self, **kwargs):
             published.append(kwargs)
 
-    async def _fake_find_orphaned_commands(**_kwargs):
+    async def _fake_stale(**_kwargs):
         return orphaned
 
-    async def _fake_find_unclaimed_pending_commands(**_kwargs):
+    async def _fake_stranded(**_kwargs):
         raise AssertionError("Stranded query should be skipped when no remaining capacity")
 
     async def _fake_get_nats_publisher():
         return _Publisher()
 
     monkeypatch.setattr(command_reaper, "_REAPER_MAX_PER_RUN", 100)
-    monkeypatch.setattr(command_reaper, "_find_orphaned_commands", _fake_find_orphaned_commands)
-    monkeypatch.setattr(command_reaper, "_find_unclaimed_pending_commands", _fake_find_unclaimed_pending_commands)
+    monkeypatch.setattr(command_reaper, "_find_stale_active_commands", _fake_stale)
+    monkeypatch.setattr(command_reaper, "_find_stranded_pending_commands", _fake_stranded)
     monkeypatch.setattr(command_reaper, "_get_nats_publisher", _fake_get_nats_publisher)
 
-    count = await command_reaper.reap_orphaned_commands_once("http://server-noetl.noetl.svc.cluster.local:80")
+    count = await command_reaper.reap_orphaned_commands_once(
+        "http://server-noetl.noetl.svc.cluster.local:80"
+    )
 
     assert count == 100
     assert len(published) == 100
+
+
+@pytest.mark.asyncio
+async def test_reap_orphaned_commands_once_returns_zero_when_nothing_to_recover(monkeypatch):
+    async def _fake_stale(**_kwargs):
+        return []
+
+    async def _fake_stranded(**_kwargs):
+        return []
+
+    async def _fake_get_nats_publisher():  # pragma: no cover - should not be called
+        raise AssertionError("NATS publisher must not be acquired when nothing to recover")
+
+    monkeypatch.setattr(command_reaper, "_find_stale_active_commands", _fake_stale)
+    monkeypatch.setattr(command_reaper, "_find_stranded_pending_commands", _fake_stranded)
+    monkeypatch.setattr(command_reaper, "_get_nats_publisher", _fake_get_nats_publisher)
+
+    count = await command_reaper.reap_orphaned_commands_once(
+        "http://server-noetl.noetl.svc.cluster.local:80"
+    )
+
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_reap_orphaned_commands_once_continues_on_publish_error(monkeypatch):
+    """One bad command must not abort the rest of the sweep."""
+    orphaned = [
+        {"event_id": 1, "execution_id": 1, "command_id": "1:a:0", "step": "a"},
+        {"event_id": 2, "execution_id": 1, "command_id": "1:b:0", "step": "b"},
+    ]
+    published = []
+
+    class _Publisher:
+        async def publish_command(self, **kwargs):
+            if kwargs["command_id"] == "1:a:0":
+                raise RuntimeError("transient NATS failure")
+            published.append(kwargs)
+
+    async def _fake_stale(**_kwargs):
+        return orphaned
+
+    async def _fake_stranded(**_kwargs):
+        return []
+
+    async def _fake_get_nats_publisher():
+        return _Publisher()
+
+    monkeypatch.setattr(command_reaper, "_find_stale_active_commands", _fake_stale)
+    monkeypatch.setattr(command_reaper, "_find_stranded_pending_commands", _fake_stranded)
+    monkeypatch.setattr(command_reaper, "_get_nats_publisher", _fake_get_nats_publisher)
+
+    count = await command_reaper.reap_orphaned_commands_once(
+        "http://server-noetl.noetl.svc.cluster.local:80"
+    )
+
+    assert count == 1
+    assert [item["command_id"] for item in published] == ["1:b:0"]
+
+
+@pytest.mark.asyncio
+async def test_run_command_reaper_skips_work_when_lease_not_acquired(monkeypatch):
+    """Only the lease holder should sweep; followers must idle."""
+
+    class _Lease:
+        def __init__(self):
+            self.calls = 0
+            self.released = False
+
+        async def try_acquire_or_renew(self):
+            self.calls += 1
+
+            class _State:
+                acquired = False
+
+            return _State()
+
+        async def release(self):
+            self.released = True
+
+    async def _fake_reap(_server_url):
+        raise AssertionError("reap_orphaned_commands_once must not run without the lease")
+
+    monkeypatch.setattr(command_reaper, "_REAPER_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setattr(command_reaper, "_REAPER_ENABLED", True)
+    monkeypatch.setattr(command_reaper, "reap_orphaned_commands_once", _fake_reap)
+
+    import asyncio
+
+    stop_event = asyncio.Event()
+    lease = _Lease()
+    task = asyncio.create_task(
+        command_reaper.run_command_reaper(
+            stop_event=stop_event,
+            server_url="http://server",
+            lease=lease,
+        )
+    )
+    await asyncio.sleep(0.05)
+    stop_event.set()
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert lease.calls >= 1
+    assert lease.released is True


### PR DESCRIPTION
## Summary

Rebuilds the in-process command reaper that was removed in 435e3aa6.
Scans `noetl.command` directly (not the event log) for non-terminal
commands whose execution is still live, then republishes the
original NATS notification. The existing claim endpoint plus
`claim_policy.decide_reclaim_for_existing_claim` arbitrate the
reclaim — the reaper never duplicates claim policy or forces
completion.

Wired into `noetl/server/app.py` lifespan under a `RuntimeLease`
(`task_name="command_reaper"`), mirroring `runtime_sweeper` and
`auto_resume`.

Closes the stall observed on PFT v2 execution 626611573817082718
(fetch_mds_details:task_sequence rows stuck on a dead worker).

## Test plan

- [x] `tests/test_command_reaper.py` — 9 cases including regressions
      for stale CLAIMED + RUNNING task_sequence commands.
- [ ] Redeploy on kind via
      `repos/ops/automation/development/noetl.yaml action=redeploy`.
- [ ] Cancel exec 626611573817082718, rerun PFT v2, watch it advance
      past facility 1 MDS.

## Env knobs

```
NOETL_COMMAND_REAPER_ENABLED                          (default true)
NOETL_COMMAND_REAPER_INTERVAL_SECONDS                 (default 60)
NOETL_COMMAND_REAPER_WORKER_STALE_SECONDS             (default 60)
NOETL_COMMAND_REAPER_HEALTHY_HARD_TIMEOUT_SECONDS     (default 1800)
NOETL_COMMAND_REAPER_PENDING_RETRY_SECONDS            (default 60)
NOETL_COMMAND_REAPER_MAX_PER_RUN                      (default 100)
```
