### PR TITLE
fix(runtime): remove frame claim advisory lock

### DIFF
--- a/noetl/database/ddl/postgres/schema_ddl.sql
+++ b/noetl/database/ddl/postgres/schema_ddl.sql
@@ -785,6 +785,9 @@ CREATE INDEX IF NOT EXISTS idx_frame_stage_frame
     ON noetl.frame (stage_id, frame_id);
 CREATE INDEX IF NOT EXISTS idx_frame_stage_cursor_slot_index
     ON noetl.frame (stage_id, (cursor->>'worker_slot_id'), (cursor->>'frame_index'), frame_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_frame_claim_key_unique
+    ON noetl.frame (stage_id, (cursor->>'worker_slot_id'), (cursor->>'frame_index'))
+    WHERE cursor ? 'worker_slot_id' AND cursor ? 'frame_index';
 CREATE INDEX IF NOT EXISTS idx_frame_idempotent_claim
     ON noetl.frame (
         stage_id,

--- a/noetl/server/api/frames/endpoint.py
+++ b/noetl/server/api/frames/endpoint.py
@@ -127,6 +127,38 @@ async def _load_idempotent_claimed_frame(
     return dict(frame) if frame else None
 
 
+async def _load_frame_by_claim_key(
+    cur: Any,
+    *,
+    stage_id: int,
+    cursor: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    claim_key = _frame_claim_key(stage_id=stage_id, cursor=cursor)
+    if claim_key is None:
+        return None
+    _, worker_slot_id, frame_index = claim_key
+    await cur.execute(
+        """
+        SELECT f.*,
+               (
+                   f.status IN ('CLAIMED','RUNNING')
+                   AND (f.lease_until IS NULL OR f.lease_until < now())
+               ) AS expired_lease
+        FROM noetl.frame f
+        WHERE f.stage_id = %s
+          AND f.cursor->>'worker_slot_id' = %s
+          AND f.cursor->>'frame_index' = %s
+          AND f.status IN ('PENDING','CLAIMED','RUNNING')
+        ORDER BY f.frame_id DESC
+        FOR UPDATE SKIP LOCKED
+        LIMIT 1
+        """,
+        (stage_id, worker_slot_id, frame_index),
+    )
+    frame = await cur.fetchone()
+    return dict(frame) if frame else None
+
+
 def _frame_stream_id(*, execution_id: int, stage_id: int) -> str:
     return f"execution/{execution_id}/stage/{stage_id}"
 
@@ -135,28 +167,13 @@ def _frame_event_stream_id(*, execution_id: int, stage_id: int, frame_id: int) -
     return f"{_frame_stream_id(execution_id=execution_id, stage_id=stage_id)}/frame/{frame_id}"
 
 
-def _frame_mint_stream_id(*, execution_id: int, stage_id: int, cursor: dict[str, Any] | None) -> str:
+def _frame_claim_key(*, stage_id: int, cursor: dict[str, Any] | None) -> tuple[int, str, str] | None:
     if isinstance(cursor, dict):
         worker_slot_id = cursor.get("worker_slot_id")
         frame_index = cursor.get("frame_index")
         if worker_slot_id is not None and frame_index is not None:
-            return (
-                f"{_frame_stream_id(execution_id=execution_id, stage_id=stage_id)}"
-                f"/slot/{worker_slot_id}/frame-index/{frame_index}"
-            )
-    return f"{_frame_stream_id(execution_id=execution_id, stage_id=stage_id)}/mint"
-
-
-async def _lock_frame_mint_stream(
-    cur: Any,
-    *,
-    execution_id: int,
-    stage_id: int,
-    cursor: dict[str, Any] | None,
-) -> str:
-    stream_id = _frame_mint_stream_id(execution_id=execution_id, stage_id=stage_id, cursor=cursor)
-    await cur.execute("SELECT pg_advisory_xact_lock(hashtext(%s)::bigint)", (stream_id,))
-    return stream_id
+            return (stage_id, str(worker_slot_id), str(frame_index))
+    return None
 
 
 async def _resolve_parent_frame_id(cur: Any, *, stage_id: int, cursor: dict[str, Any] | None) -> int | None:
@@ -515,16 +532,10 @@ async def claim_frames(stage_id: int, req: FrameClaimRequest) -> dict[str, Any]:
                     frame_id: int | None = None
                     if not frame:
                         # Frame rows are minted lazily after the cursor driver has
-                        # claimed external work. Mint locks are scoped to the cursor
-                        # shard so duplicate retries converge without serializing the
-                        # whole stage.
+                        # claimed external work. Duplicate retries converge on the
+                        # stage/worker-slot/frame-index key via the partial unique
+                        # index instead of a hot-path advisory transaction lock.
                         frame_id = await _next_snowflake_id(cur)
-                        await _lock_frame_mint_stream(
-                            cur,
-                            execution_id=int(stage["execution_id"]),
-                            stage_id=stage_id,
-                            cursor=req.cursor,
-                        )
                         frame = await _load_idempotent_claimed_frame(
                             cur,
                             stage_id=stage_id,
@@ -563,6 +574,7 @@ async def claim_frames(stage_id: int, req: FrameClaimRequest) -> dict[str, Any]:
                                 tenant_id, organization_id
                             )
                             VALUES (%s, %s, %s, %s, %s, 0, 'PENDING', %s, %s, %s)
+                            ON CONFLICT DO NOTHING
                             RETURNING *
                             """,
                             (
@@ -577,6 +589,24 @@ async def claim_frames(stage_id: int, req: FrameClaimRequest) -> dict[str, Any]:
                             ),
                         )
                         frame = await cur.fetchone()
+                        if not frame:
+                            claim_key = _frame_claim_key(stage_id=stage_id, cursor=req.cursor)
+                            frame = await _load_frame_by_claim_key(
+                                cur,
+                                stage_id=stage_id,
+                                cursor=req.cursor,
+                            )
+                        if not frame and claim_key is None:
+                            frame = await _load_claimable_frame(cur, stage_id=stage_id)
+                        if not frame:
+                            raise HTTPException(
+                                status_code=409,
+                                detail={
+                                    "code": "frame_claim_conflict",
+                                    "stage_id": stage_id,
+                                    "claim_key": claim_key,
+                                },
+                            )
                         frame = dict(frame)
                         frame["step_name"] = stage["step_name"]
                     else:

--- a/tests/api/test_frame_routes.py
+++ b/tests/api/test_frame_routes.py
@@ -224,6 +224,36 @@ async def test_load_idempotent_claimed_frame_matches_worker_slot_and_frame_index
 
 
 @pytest.mark.asyncio
+async def test_load_frame_by_claim_key_matches_pending_frame():
+    from noetl.server.api.frames import endpoint
+
+    class Cursor:
+        def __init__(self):
+            self.calls = []
+
+        async def execute(self, query, params=None):
+            self.calls.append((query, params))
+
+        async def fetchone(self):
+            return {"frame_id": 9, "status": "PENDING"}
+
+    cur = Cursor()
+
+    frame = await endpoint._load_frame_by_claim_key(
+        cur,
+        stage_id=8,
+        cursor={"worker_slot_id": "slot-1", "frame_index": 3},
+    )
+
+    assert frame == {"frame_id": 9, "status": "PENDING"}
+    query, params = cur.calls[0]
+    assert "f.cursor->>'worker_slot_id'" in query
+    assert "f.cursor->>'frame_index'" in query
+    assert "PENDING" in query
+    assert params == (8, "slot-1", "3")
+
+
+@pytest.mark.asyncio
 async def test_frame_event_mirror_publishes_when_enabled(monkeypatch):
     from noetl.server.api.frames import endpoint
 
@@ -495,9 +525,6 @@ async def test_claim_frames_reclaims_expired_frame_with_abandoned_event(monkeypa
         emitted.append(kwargs)
         return {"event_id": 100 + len(emitted), "event_type": kwargs["event_type"]}
 
-    async def fail_mint_lock(*_args, **_kwargs):
-        raise AssertionError("existing claimable frames must not take the mint lock")
-
     async def mirror_frame_events(_events):
         return None
 
@@ -505,7 +532,6 @@ async def test_claim_frames_reclaims_expired_frame_with_abandoned_event(monkeypa
     monkeypatch.setattr(endpoint, "_load_stage", load_stage)
     monkeypatch.setattr(endpoint, "_resolve_claim_command_id", resolve_command_id)
     monkeypatch.setattr(endpoint, "_insert_frame_event", insert_frame_event)
-    monkeypatch.setattr(endpoint, "_lock_frame_mint_stream", fail_mint_lock)
     monkeypatch.setattr(endpoint, "_mirror_frame_events", mirror_frame_events)
 
     response = await endpoint.claim_frames(
@@ -533,4 +559,129 @@ async def test_claim_frames_reclaims_expired_frame_with_abandoned_event(monkeypa
     }
     assert emitted[1]["meta_extra"]["attempt"] == 2
     assert emitted[1]["meta_extra"]["recovery"]["retry_mode"] == "whole_frame"
+    assert conn.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_frames_mints_without_advisory_lock(monkeypatch):
+    from noetl.server.api.frames import endpoint
+    from noetl.server.api.frames.schema import FrameClaimRequest
+
+    class Cursor:
+        def __init__(self):
+            self.queries = []
+            self.fetchone_count = 0
+
+        async def execute(self, query, params=None):
+            assert "pg_advisory_xact_lock" not in query
+            self.queries.append((query, params))
+
+        async def fetchone(self):
+            self.fetchone_count += 1
+            query = self.queries[-1][0]
+            if "SELECT *" in query:
+                return None
+            if "SELECT f.*" in query:
+                return None
+            if "INSERT INTO noetl.frame" in query:
+                return {
+                    "frame_id": 9,
+                    "stage_id": 8,
+                    "execution_id": 7,
+                    "parent_frame_id": None,
+                    "command_id": 5,
+                    "claimed_event_id": None,
+                    "terminal_event_id": None,
+                    "cursor": {"worker_slot_id": "slot-1", "frame_index": 0},
+                    "row_count": 0,
+                    "status": "PENDING",
+                    "owner_worker": None,
+                    "lease_until": None,
+                    "output_ref": None,
+                    "events_emitted": 0,
+                    "attempts": 0,
+                    "tenant_id": "tenant-a",
+                    "organization_id": "org-a",
+                }
+            if "UPDATE noetl.frame" in query and "RETURNING *" in query:
+                return {
+                    "frame_id": 9,
+                    "stage_id": 8,
+                    "execution_id": 7,
+                    "parent_frame_id": None,
+                    "command_id": 5,
+                    "claimed_event_id": 102,
+                    "terminal_event_id": None,
+                    "cursor": {"worker_slot_id": "slot-1", "frame_index": 0},
+                    "row_count": 0,
+                    "status": "CLAIMED",
+                    "owner_worker": "worker-a",
+                    "lease_until": "later",
+                    "output_ref": None,
+                    "events_emitted": 0,
+                    "attempts": 1,
+                    "tenant_id": "tenant-a",
+                    "organization_id": "org-a",
+                    "step_name": "fetch_rows",
+                }
+            if "SELECT frame_id" in query:
+                return None
+            raise AssertionError(f"Unexpected fetchone query: {query}")
+
+    cursor = Cursor()
+    conn = _FrameEndpointConn(cursor)
+    emitted = []
+
+    async def load_stage(_cur, stage_id):
+        assert stage_id == 8
+        return {
+            "stage_id": 8,
+            "execution_id": 7,
+            "catalog_id": 6,
+            "kind": "loop",
+            "step_name": "fetch_rows",
+            "dsl_ref": "steps.fetch_rows",
+            "status": "RUNNING",
+            "frame_policy": {"process": "frame", "max_rows": 50},
+            "tenant_id": "tenant-a",
+            "organization_id": "org-a",
+        }
+
+    async def resolve_command_id(_cur, **_kwargs):
+        return 5
+
+    async def next_snowflake_id(_cur):
+        return 9
+
+    async def insert_frame_event(_cur, **kwargs):  # noqa: ARG001
+        emitted.append(kwargs)
+        return {"event_id": kwargs["event_id"], "event_type": kwargs["event_type"]}
+
+    async def mirror_frame_events(_events):
+        return None
+
+    monkeypatch.setattr(endpoint, "get_pool_connection", lambda: _ConnCtx(conn))
+    monkeypatch.setattr(endpoint, "_load_stage", load_stage)
+    monkeypatch.setattr(endpoint, "_resolve_claim_command_id", resolve_command_id)
+    monkeypatch.setattr(endpoint, "_next_snowflake_id", next_snowflake_id)
+    monkeypatch.setattr(endpoint, "_insert_frame_event", insert_frame_event)
+    monkeypatch.setattr(endpoint, "_mirror_frame_events", mirror_frame_events)
+
+    response = await endpoint.claim_frames(
+        8,
+        FrameClaimRequest(
+            worker_id="worker-a",
+            command_id=5,
+            requested_count=1,
+            lease_seconds=60,
+            cursor={"worker_slot_id": "slot-1", "frame_index": 0},
+            frame_policy={"process": "frame", "max_rows": 50},
+        ),
+    )
+
+    assert response["status"] == "ok"
+    assert response["frames"][0]["frame_id"] == 9
+    assert response["frames"][0]["claimed_event_id"] == 102
+    assert [item["event_type"] for item in emitted] == ["frame.dispatched"]
+    assert any("ON CONFLICT DO NOTHING" in query for query, _ in cursor.queries)
     assert conn.commits == 1

--- a/tests/database/test_distributed_runtime_schema.py
+++ b/tests/database/test_distributed_runtime_schema.py
@@ -13,6 +13,7 @@ def test_distributed_runtime_schema_contract_is_present():
     assert "CREATE TABLE IF NOT EXISTS noetl.projection_snapshot" in ddl
     assert "CREATE INDEX IF NOT EXISTS frame_open_idx" in ddl
     assert "CREATE INDEX IF NOT EXISTS idx_frame_stage_cursor_slot_index" in ddl
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS idx_frame_claim_key_unique" in ddl
     assert "CREATE INDEX IF NOT EXISTS idx_frame_idempotent_claim" in ddl
     assert "CREATE INDEX IF NOT EXISTS idx_projection_tenant_type" in ddl
 


### PR DESCRIPTION
## Summary
- removes the frame-mint `pg_advisory_xact_lock(hashtext(...))` from the `/stages/{stage_id}/frames/claim` hot path
- adds a partial unique frame claim key on `(stage_id, cursor->>'worker_slot_id', cursor->>'frame_index')` so duplicate cursor retries converge through indexed state instead of a transaction-wide advisory lock
- makes lazy frame minting use `INSERT ... ON CONFLICT DO NOTHING` and reload the matching pending/active frame

## Validation
- `.venv/bin/python -m pytest tests/api/test_frame_routes.py tests/database/test_distributed_runtime_schema.py`
- `.venv/bin/python -m pytest tests/worker/test_cursor_worker_frames.py tests/core/test_replay_golden_corpus.py tests/core/test_replay_state_projector.py tests/core/test_event_store_ports.py tests/core/test_storage_ipc_cache.py tests/core/test_storage_ipc_hint.py`
- `python -m compileall noetl/server/api/frames/endpoint.py`
- `git diff --check`

Tracks noetl/noetl#450.
