### PR TITLE
fix(api): keep terminal execution status stable

### DIFF
--- a/noetl/server/api/execution/endpoint.py
+++ b/noetl/server/api/execution/endpoint.py
@@ -869,8 +869,7 @@ async def get_executions(
                                 'workflow.completed'
                             )
                             THEN e.last_event_type
-                            WHEN e.last_event_type IS NULL
-                             AND e.status IN ('COMPLETED', 'FAILED', 'CANCELLED')
+                            WHEN e.status IN ('COMPLETED', 'FAILED', 'CANCELLED')
                             THEN 'execution.' || lower(e.status)
                             ELSE NULL
                         END AS terminal_event_type,
@@ -883,7 +882,7 @@ async def get_executions(
                                 'playbook.completed',
                                 'workflow.completed'
                             )
-                             OR (e.last_event_type IS NULL AND e.status IN ('COMPLETED', 'FAILED', 'CANCELLED'))
+                             OR e.status IN ('COMPLETED', 'FAILED', 'CANCELLED')
                             THEN e.status
                             ELSE NULL
                         END AS terminal_status,
@@ -896,7 +895,7 @@ async def get_executions(
                                 'playbook.completed',
                                 'workflow.completed'
                             )
-                             OR (e.last_event_type IS NULL AND e.status IN ('COMPLETED', 'FAILED', 'CANCELLED'))
+                             OR e.status IN ('COMPLETED', 'FAILED', 'CANCELLED')
                             THEN COALESCE(e.end_time, e.updated_at)
                             ELSE NULL
                         END AS terminal_end_time,

--- a/tests/api/execution/test_executions_status_consistency.py
+++ b/tests/api/execution/test_executions_status_consistency.py
@@ -141,7 +141,7 @@ async def test_get_executions_normalizes_non_terminal_completed_to_running(monke
             "result": None,
             "error": None,
             "parent_execution_id": None,
-            "path": "bhs/state_report_generation_prod_v10",
+            "path": "tests/state_report_generation_prod_v10",
             "version": 1,
         }
     ]
@@ -186,7 +186,7 @@ async def test_get_executions_keeps_terminal_completed(monkeypatch):
             "terminal_event_type": "playbook.completed",
             "terminal_status": "COMPLETED",
             "terminal_end_time": now,
-            "path": "bhs/state_report_generation_prod_v10",
+            "path": "tests/state_report_generation_prod_v10",
             "version": 1,
         }
     ]
@@ -225,7 +225,7 @@ async def test_get_executions_prefers_terminal_event_even_if_latest_is_non_termi
             "terminal_event_type": "execution.cancelled",
             "terminal_status": "CANCELLED",
             "terminal_end_time": terminal,
-            "path": "bhs/state_report_generation_prod_v10",
+            "path": "tests/state_report_generation_prod_v10",
             "version": 1,
         }
     ]
@@ -258,7 +258,7 @@ async def test_get_executions_infers_completed_from_batch_done_without_pending(m
             "result": None,
             "error": None,
             "parent_execution_id": None,
-            "path": "bhs/state_report_generation_prod_v10",
+            "path": "tests/state_report_generation_prod_v10",
             "version": 1,
         }
     ]
@@ -305,7 +305,7 @@ async def test_get_executions_keeps_terminal_status_when_latest_projection_event
             "terminal_event_type": "execution.completed",
             "terminal_status": "COMPLETED",
             "terminal_end_time": terminal,
-            "path": "bhs/state_report_generation_prod_v10",
+            "path": "tests/state_report_generation_prod_v10",
             "version": 1,
         }
     ]
@@ -413,7 +413,7 @@ async def test_get_execution_infers_completed_from_batch_done_without_pending_co
         "created_at": latest,
         "status": "COMPLETED",
     }
-    catalog_row = {"path": "bhs/state_report_generation_prod_v10", "version": 7}
+    catalog_row = {"path": "tests/state_report_generation_prod_v10", "version": 7}
 
     monkeypatch.setattr(
         execution_api,
@@ -480,7 +480,7 @@ async def test_get_execution_keeps_running_when_batch_done_still_has_pending_com
         "created_at": latest,
         "status": "COMPLETED",
     }
-    catalog_row = {"path": "bhs/state_report_generation_prod_v10", "version": 7}
+    catalog_row = {"path": "tests/state_report_generation_prod_v10", "version": 7}
 
     monkeypatch.setattr(
         execution_api,
@@ -529,7 +529,7 @@ async def test_get_execution_can_omit_events_payload(monkeypatch):
         "created_at": latest,
         "status": "COMPLETED",
     }
-    catalog_row = {"path": "bhs/state_report_generation_prod_v10", "version": 7}
+    catalog_row = {"path": "tests/state_report_generation_prod_v10", "version": 7}
 
     monkeypatch.setattr(
         execution_api,
@@ -604,7 +604,7 @@ async def test_get_execution_prefers_terminal_failure_over_batch_completion_infe
         "status": "FAILED",
         "created_at": terminal,
     }
-    catalog_row = {"path": "bhs/state_report_generation_prod_v10", "version": 7}
+    catalog_row = {"path": "tests/state_report_generation_prod_v10", "version": 7}
 
     monkeypatch.setattr(
         execution_api,

--- a/tests/api/execution/test_executions_status_consistency.py
+++ b/tests/api/execution/test_executions_status_consistency.py
@@ -284,6 +284,49 @@ async def test_get_executions_infers_completed_from_batch_done_without_pending(m
 
 
 @pytest.mark.asyncio
+async def test_get_executions_keeps_terminal_status_when_latest_projection_event_is_non_terminal(monkeypatch):
+    start = datetime(2026, 5, 18, 7, 0, 0, tzinfo=timezone.utc)
+    terminal = datetime(2026, 5, 18, 7, 30, 0, tzinfo=timezone.utc)
+    latest = datetime(2026, 5, 18, 7, 31, 0, tzinfo=timezone.utc)
+    rows = [
+        {
+            "execution_id": "123",
+            "catalog_id": "321",
+            "event_type": "call.done",
+            "node_name": "fetch_facility",
+            "status": "COMPLETED",
+            "event_status": "COMPLETED",
+            "derived_event_type": "call.done",
+            "start_time": start,
+            "end_time": latest,
+            "result": None,
+            "error": None,
+            "parent_execution_id": None,
+            "terminal_event_type": "execution.completed",
+            "terminal_status": "COMPLETED",
+            "terminal_end_time": terminal,
+            "path": "bhs/state_report_generation_prod_v10",
+            "version": 1,
+        }
+    ]
+    cursor = _FakeCursor(rows)
+
+    monkeypatch.setattr(
+        execution_api,
+        "get_pool_connection",
+        lambda: _ConnCtx(_FakeConn(cursor)),
+    )
+
+    result = await execution_api.get_executions()
+
+    assert len(result) == 1
+    assert result[0].status == "COMPLETED"
+    assert result[0].end_time == terminal
+    assert "WHEN e.status IN ('COMPLETED', 'FAILED', 'CANCELLED')" in cursor._query
+    assert "e.last_event_type IS NULL\n                             AND e.status" not in cursor._query
+
+
+@pytest.mark.asyncio
 async def test_get_executions_applies_page_size_and_offset(monkeypatch):
     now = datetime(2026, 3, 21, 7, 0, 0, tzinfo=timezone.utc)
     rows = [


### PR DESCRIPTION
## Summary
- fixes execution list status flicker when `noetl.execution.status` is terminal but `last_event_type` points at a later non-terminal projection event
- treats terminal execution status as terminal metadata even when the latest projected event is not terminal
- adds a regression for the facility-loop shape where a late `call.done` could otherwise render the execution as `RUNNING`

## Validation
- `.venv/bin/python -m pytest tests/api/execution/test_executions_status_consistency.py`
- `python -m compileall noetl/server/api/execution/endpoint.py`
- `git diff --check`

Tracks noetl/noetl#451.
