### PR TITLE
feat(projector): record projection lag checkpoints

### DIFF
--- a/noetl/core/projector/service.py
+++ b/noetl/core/projector/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from datetime import datetime, timezone
 from typing import Any, Iterable
 
 from noetl.core.projection_store import ProjectionRecord, ProjectionStore
@@ -34,6 +35,7 @@ class ReplayStateProjector:
 
         written: list[ProjectionRecord] = []
         for (tenant_id, organization_id, execution_id), group in grouped.items():
+            projected_at = datetime.now(timezone.utc)
             ordered = sorted(
                 group,
                 key=lambda item: (
@@ -51,6 +53,7 @@ class ReplayStateProjector:
             )
             version = _projection_version(ordered)
             source_event_id = _last_event_id(ordered)
+            event_watermark = _event_time_watermark(ordered)
             record = ProjectionRecord(
                 projection_id=f"execution/{execution_id}/{self.projection}",
                 projection_type=f"replay_state:{self.projection}",
@@ -63,8 +66,12 @@ class ReplayStateProjector:
                 checksum=state.get("checksum"),
                 meta={
                     "event_count": len(ordered),
+                    "event_time_watermark": _format_dt(event_watermark),
+                    "projected_at": _format_dt(projected_at),
+                    "projection_lag_ms": _projection_lag_ms(event_watermark, projected_at),
                     "projector": "replay_state",
                     "projection": self.projection,
+                    "source_event_id": source_event_id,
                     "upcaster_registry_digest": state.get("upcaster_registry_digest"),
                 },
             )
@@ -86,3 +93,53 @@ def _last_event_id(events: list[dict[str, Any]]) -> int | None:
         if event_id is not None:
             return int(event_id)
     return None
+
+
+def _event_time_watermark(events: list[dict[str, Any]]) -> datetime | None:
+    watermarks = [
+        parsed
+        for event in events
+        for parsed in [_parse_event_time(event)]
+        if parsed is not None
+    ]
+    return max(watermarks) if watermarks else None
+
+
+def _parse_event_time(event: dict[str, Any]) -> datetime | None:
+    for key in ("event_time", "ingest_time", "created_at"):
+        value = event.get(key)
+        if value is None:
+            continue
+        if isinstance(value, datetime):
+            dt = value
+        elif isinstance(value, str):
+            raw = value.strip()
+            if not raw:
+                continue
+            if raw.endswith("Z"):
+                raw = f"{raw[:-1]}+00:00"
+            try:
+                dt = datetime.fromisoformat(raw)
+            except ValueError:
+                continue
+        else:
+            continue
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    return None
+
+
+def _projection_lag_ms(event_watermark: datetime | None, projected_at: datetime) -> int | None:
+    if event_watermark is None:
+        return None
+    lag = projected_at - event_watermark
+    return max(0, int(lag.total_seconds() * 1000))
+
+
+def _format_dt(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 
@@ -74,6 +76,7 @@ async def test_replay_state_projector_writes_grouped_projection_records():
     assert first.state["frames"]["1"]["status"] == "COMPLETED"
     assert first.checksum == first.state["checksum"]
     assert first.meta["projector"] == "replay_state"
+    assert first.meta["source_event_id"] == 10
 
 
 @pytest.mark.asyncio
@@ -115,6 +118,47 @@ async def test_replay_state_projector_respects_version_monotonic_store_writes():
     record = store.records["execution/7/all"]
     assert record.version == 3
     assert record.state["execution"]["status"] == "COMPLETED"
+
+
+@pytest.mark.asyncio
+async def test_replay_state_projector_records_lag_checkpoint_metadata():
+    from noetl.core.projector import ReplayStateProjector
+
+    now = datetime.now(timezone.utc)
+    store = _MemoryProjectionStore()
+    projector = ReplayStateProjector(store)
+
+    written = await projector.project(
+        [
+            {
+                "event_id": 31,
+                "stream_version": 4,
+                "tenant_id": "tenant-a",
+                "organization_id": "org-a",
+                "execution_id": 9,
+                "event_type": "workflow.completed",
+                "event_time": (now - timedelta(seconds=2)).isoformat().replace("+00:00", "Z"),
+            },
+            {
+                "event_id": 30,
+                "stream_version": 3,
+                "tenant_id": "tenant-a",
+                "organization_id": "org-a",
+                "execution_id": 9,
+                "event_type": "execution.started",
+                "event_time": now - timedelta(seconds=5),
+            },
+        ]
+    )
+
+    assert len(written) == 1
+    meta = store.records["execution/9/all"].meta
+    assert meta["event_count"] == 2
+    assert meta["source_event_id"] == 31
+    assert meta["event_time_watermark"].endswith("Z")
+    assert meta["projected_at"].endswith("Z")
+    assert isinstance(meta["projection_lag_ms"], int)
+    assert meta["projection_lag_ms"] >= 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- records projector checkpoint metadata on every replay-state projection write
- adds `event_time_watermark`, `projected_at`, and `projection_lag_ms` to `ProjectionRecord.meta`
- keeps the checkpoint surface durable in Postgres before adding Prometheus scrape/export wiring

## Validation
- `.venv/bin/python -m pytest tests/core/test_replay_state_projector.py tests/core/test_projection_store_ports.py tests/api/test_replay_routes.py tests/core/test_replay_golden_corpus.py`
- `python -m compileall noetl/core/projector/service.py`
- `git diff --check`

Tracks noetl/noetl#437.
