### PR TITLE
Require durable frame output refs when IPC hints are present

### DIFF
--- a/noetl/server/api/frames/schema.py
+++ b/noetl/server/api/frames/schema.py
@@ -2,7 +2,30 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+
+_DURABLE_REF_KEYS = ("ref", "uri", "locator")
+
+
+def _has_ipc_hint(value: Any) -> bool:
+    if isinstance(value, dict):
+        if isinstance(value.get("ipc"), dict):
+            return True
+        return any(_has_ipc_hint(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_has_ipc_hint(item) for item in value)
+    return False
+
+
+def _has_durable_reference(value: Any) -> bool:
+    if isinstance(value, dict):
+        if any(str(value.get(key) or "").strip() for key in _DURABLE_REF_KEYS):
+            return True
+        return any(_has_durable_reference(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_has_durable_reference(item) for item in value)
+    return False
 
 
 class FrameClaimRequest(BaseModel):
@@ -34,3 +57,12 @@ class FrameCommitRequest(BaseModel):
     output_ref: Optional[dict[str, Any]] = None
     events_emitted: int = Field(0, ge=0)
     error: Optional[str] = None
+
+    @model_validator(mode="after")
+    def validate_output_ref_replay_authority(self) -> "FrameCommitRequest":
+        # IPC is a same-node cache hint only. If a committed frame advertises
+        # shared-memory metadata, the event must still contain a durable
+        # reference so replay/projectors can reproduce state after cache GC.
+        if self.output_ref and _has_ipc_hint(self.output_ref) and not _has_durable_reference(self.output_ref):
+            raise ValueError("output_ref with ipc hint must include a durable ref, uri, or locator")
+        return self

--- a/tests/api/test_frame_routes.py
+++ b/tests/api/test_frame_routes.py
@@ -44,6 +44,55 @@ def test_frame_request_contracts_validate_bounds():
         raise AssertionError("requested_count=0 should fail validation")
 
 
+def test_frame_commit_rejects_ipc_only_output_ref():
+    from pydantic import ValidationError
+
+    from noetl.server.api.frames import FrameCommitRequest
+
+    try:
+        FrameCommitRequest(
+            worker_id="worker-a",
+            row_count=10,
+            output_ref={
+                "rows_ref": {
+                    "ipc": {
+                        "kind": "arrow_ipc",
+                        "shm_name": "/noetl-frame-1",
+                        "schema_digest": "sha256:abc",
+                        "byte_length": 4096,
+                    }
+                }
+            },
+        )
+    except ValidationError as exc:
+        assert "durable ref, uri, or locator" in str(exc)
+    else:
+        raise AssertionError("ipc-only output_ref should fail validation")
+
+
+def test_frame_commit_allows_ipc_hint_with_nested_durable_ref():
+    from noetl.server.api.frames import FrameCommitRequest
+
+    commit = FrameCommitRequest(
+        worker_id="worker-a",
+        row_count=10,
+        output_ref={
+            "rows_ref": {
+                "ref": "noetl://execution/1/result/frame/abc",
+                "store": "kv",
+                "ipc": {
+                    "kind": "arrow_ipc",
+                    "shm_name": "/noetl-frame-1",
+                    "schema_digest": "sha256:abc",
+                    "byte_length": 4096,
+                },
+            }
+        },
+    )
+
+    assert commit.output_ref["rows_ref"]["ref"] == "noetl://execution/1/result/frame/abc"
+
+
 def test_frame_commit_result_keeps_event_result_shape():
     from noetl.server.api.frames import endpoint
 


### PR DESCRIPTION
## Summary
- adds a FrameCommitRequest release gate for IPC/shared-memory output refs
- rejects output_ref envelopes that advertise an ipc hint without any durable ref/uri/locator
- keeps nested rows_ref durable references valid for frame Arrow IPC captures

## Validation
- .venv/bin/python -m pytest tests/api/test_frame_routes.py tests/core/test_storage_ipc_hint.py tests/worker/test_cursor_worker_frames.py -q
- python -m compileall noetl/server/api/frames/schema.py

Tracks noetl/noetl#438 and noetl/noetl#440.