### PR TITLE
Expose scrapeable projector worker metrics

### DIFF
--- a/noetl/core/projector/__init__.py
+++ b/noetl/core/projector/__init__.py
@@ -1,5 +1,11 @@
 """Deterministic projection helpers for decentralized projectors."""
 
+from .metrics import ProjectorMetrics, render_projector_metrics, start_projector_metrics_server
 from .service import ReplayStateProjector
 
-__all__ = ["ReplayStateProjector"]
+__all__ = [
+    "ProjectorMetrics",
+    "ReplayStateProjector",
+    "render_projector_metrics",
+    "start_projector_metrics_server",
+]

--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -1,0 +1,154 @@
+"""Metrics helpers for standalone projector workers."""
+
+from __future__ import annotations
+
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Lock, Thread
+from typing import Mapping, Optional
+
+
+class ProjectorMetrics:
+    """Thread-safe counters for projector worker scrape output."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._values: dict[str, float] = {
+            "notifications_total": 0.0,
+            "events_extracted_total": 0.0,
+            "events_owned_total": 0.0,
+            "projection_records_total": 0.0,
+            "empty_or_unowned_notifications_total": 0.0,
+            "errors_total": 0.0,
+            "last_success_unixtime": 0.0,
+            "last_error_unixtime": 0.0,
+            "last_batch_events": 0.0,
+            "last_batch_projection_records": 0.0,
+        }
+
+    def record_notification(
+        self,
+        *,
+        extracted_events: int,
+        owned_events: int,
+        projection_records: int,
+    ) -> None:
+        now = time.time()
+        with self._lock:
+            self._values["notifications_total"] += 1.0
+            self._values["events_extracted_total"] += float(max(0, extracted_events))
+            self._values["events_owned_total"] += float(max(0, owned_events))
+            self._values["projection_records_total"] += float(max(0, projection_records))
+            self._values["last_success_unixtime"] = now
+            self._values["last_batch_events"] = float(max(0, owned_events))
+            self._values["last_batch_projection_records"] = float(max(0, projection_records))
+            if owned_events <= 0:
+                self._values["empty_or_unowned_notifications_total"] += 1.0
+
+    def record_error(self) -> None:
+        with self._lock:
+            self._values["errors_total"] += 1.0
+            self._values["last_error_unixtime"] = time.time()
+
+    def snapshot(self) -> dict[str, float]:
+        with self._lock:
+            return dict(self._values)
+
+
+def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapping[str, str]] = None) -> str:
+    """Render projector metrics using Prometheus text exposition."""
+
+    label_text = _format_labels(labels or {})
+    snapshot = metrics.snapshot()
+    lines = [
+        "# HELP noetl_projector_notifications_total NATS notifications handled by this projector.",
+        "# TYPE noetl_projector_notifications_total counter",
+        f"noetl_projector_notifications_total{label_text} {snapshot['notifications_total']}",
+        "# HELP noetl_projector_events_extracted_total Events extracted from projector notifications.",
+        "# TYPE noetl_projector_events_extracted_total counter",
+        f"noetl_projector_events_extracted_total{label_text} {snapshot['events_extracted_total']}",
+        "# HELP noetl_projector_events_owned_total Events owned by this projector shard.",
+        "# TYPE noetl_projector_events_owned_total counter",
+        f"noetl_projector_events_owned_total{label_text} {snapshot['events_owned_total']}",
+        "# HELP noetl_projector_projection_records_total Projection records written by this projector.",
+        "# TYPE noetl_projector_projection_records_total counter",
+        f"noetl_projector_projection_records_total{label_text} {snapshot['projection_records_total']}",
+        "# HELP noetl_projector_empty_or_unowned_notifications_total Notifications with no owned events.",
+        "# TYPE noetl_projector_empty_or_unowned_notifications_total counter",
+        (
+            "noetl_projector_empty_or_unowned_notifications_total"
+            f"{label_text} {snapshot['empty_or_unowned_notifications_total']}"
+        ),
+        "# HELP noetl_projector_errors_total Projector notification handling failures.",
+        "# TYPE noetl_projector_errors_total counter",
+        f"noetl_projector_errors_total{label_text} {snapshot['errors_total']}",
+        "# HELP noetl_projector_last_success_unixtime Last successful notification handling time.",
+        "# TYPE noetl_projector_last_success_unixtime gauge",
+        f"noetl_projector_last_success_unixtime{label_text} {snapshot['last_success_unixtime']}",
+        "# HELP noetl_projector_last_error_unixtime Last failed notification handling time.",
+        "# TYPE noetl_projector_last_error_unixtime gauge",
+        f"noetl_projector_last_error_unixtime{label_text} {snapshot['last_error_unixtime']}",
+        "# HELP noetl_projector_last_batch_events Owned events in the last handled notification.",
+        "# TYPE noetl_projector_last_batch_events gauge",
+        f"noetl_projector_last_batch_events{label_text} {snapshot['last_batch_events']}",
+        "# HELP noetl_projector_last_batch_projection_records Projection records from the last handled notification.",
+        "# TYPE noetl_projector_last_batch_projection_records gauge",
+        f"noetl_projector_last_batch_projection_records{label_text} {snapshot['last_batch_projection_records']}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def start_projector_metrics_server(
+    metrics: ProjectorMetrics,
+    *,
+    host: str,
+    port: int,
+    labels: Optional[Mapping[str, str]] = None,
+) -> ThreadingHTTPServer:
+    """Start a lightweight `/metrics` HTTP server in a daemon thread."""
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+            if self.path == "/health":
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(b"ok\n")
+                return
+            if self.path != "/metrics":
+                self.send_response(404)
+                self.end_headers()
+                return
+            body = render_projector_metrics(metrics, labels=labels).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer((host, port), _Handler)
+    thread = Thread(target=server.serve_forever, name="noetl-projector-metrics", daemon=True)
+    thread.start()
+    return server
+
+
+def _format_labels(labels: Mapping[str, str]) -> str:
+    filtered = {key: value for key, value in labels.items() if value}
+    if not filtered:
+        return ""
+    body = ",".join(f'{key}="{_escape_label(value)}"' for key, value in sorted(filtered.items()))
+    return "{" + body + "}"
+
+
+def _escape_label(value: str) -> str:
+    return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+__all__ = [
+    "ProjectorMetrics",
+    "render_projector_metrics",
+    "start_projector_metrics_server",
+]

--- a/noetl/core/projector/nats_worker.py
+++ b/noetl/core/projector/nats_worker.py
@@ -8,6 +8,8 @@ import re
 from dataclasses import dataclass
 from typing import Any, Iterable, Optional
 
+from noetl.core.common import get_pgdb_connection
+from noetl.core.db.pool import close_pool, init_pool
 from noetl.core.logger import setup_logger
 from noetl.core.messaging import NATSCommandSubscriber
 from noetl.core.projection_store import PostgresProjectionStore, ProjectionStore
@@ -159,6 +161,7 @@ class NATSProjectorWorker:
 
 async def run_projector_worker(settings: Optional[ProjectorWorkerSettings] = None) -> None:
     effective_settings = settings or load_projector_worker_settings()
+    await init_pool(get_pgdb_connection())
     worker = NATSProjectorWorker(settings=effective_settings)
     metrics_server = None
     if effective_settings.metrics_port:
@@ -184,6 +187,7 @@ async def run_projector_worker(settings: Optional[ProjectorWorkerSettings] = Non
             metrics_server.shutdown()
             metrics_server.server_close()
         await worker.close()
+        await close_pool()
 
 
 def run_projector_worker_sync(settings: Optional[ProjectorWorkerSettings] = None) -> None:

--- a/noetl/core/projector/nats_worker.py
+++ b/noetl/core/projector/nats_worker.py
@@ -8,6 +8,8 @@ import re
 from dataclasses import dataclass
 from typing import Any, Iterable, Optional
 
+from psycopg import errors as pg_errors
+
 from noetl.core.common import get_pgdb_connection
 from noetl.core.db.pool import close_pool, init_pool
 from noetl.core.logger import setup_logger
@@ -90,7 +92,13 @@ class NATSProjectorWorker:
 
         ensure_schema = getattr(self.projection_store, "ensure_schema", None)
         if callable(ensure_schema):
-            await ensure_schema()
+            try:
+                await ensure_schema()
+            except pg_errors.InsufficientPrivilege:
+                logger.warning(
+                    "Projector %s cannot run projection DDL; continuing with existing schema",
+                    self.settings.shard_id,
+                )
 
         self._subscriber = NATSCommandSubscriber(
             nats_url=self.settings.nats_url,

--- a/noetl/core/projector/nats_worker.py
+++ b/noetl/core/projector/nats_worker.py
@@ -12,6 +12,7 @@ from noetl.core.logger import setup_logger
 from noetl.core.messaging import NATSCommandSubscriber
 from noetl.core.projection_store import PostgresProjectionStore, ProjectionStore
 
+from .metrics import ProjectorMetrics, start_projector_metrics_server
 from .service import ReplayStateProjector
 
 logger = setup_logger(__name__, include_location=True)
@@ -31,6 +32,8 @@ class ProjectorWorkerSettings:
     max_ack_pending: int = 64
     fetch_timeout_seconds: float = 30.0
     fetch_heartbeat_seconds: float = 5.0
+    metrics_host: str = "0.0.0.0"
+    metrics_port: Optional[int] = None
 
     @property
     def shard_index(self) -> int:
@@ -58,6 +61,8 @@ def load_projector_worker_settings() -> ProjectorWorkerSettings:
         max_ack_pending=max(1, _int_env("NOETL_PROJECTOR_NATS_MAX_ACK_PENDING", 64)),
         fetch_timeout_seconds=max(0.1, _float_env("NOETL_PROJECTOR_NATS_FETCH_TIMEOUT_SECONDS", 30.0)),
         fetch_heartbeat_seconds=max(0.1, _float_env("NOETL_PROJECTOR_NATS_FETCH_HEARTBEAT_SECONDS", 5.0)),
+        metrics_host=os.getenv("NOETL_PROJECTOR_METRICS_HOST") or "0.0.0.0",
+        metrics_port=_optional_int_env("NOETL_PROJECTOR_METRICS_PORT"),
     )
 
 
@@ -70,10 +75,12 @@ class NATSProjectorWorker:
         projection_store: Optional[ProjectionStore] = None,
         settings: Optional[ProjectorWorkerSettings] = None,
         projection: str = "all",
+        metrics: Optional[ProjectorMetrics] = None,
     ) -> None:
         self.settings = settings or load_projector_worker_settings()
         self.projection_store = projection_store or PostgresProjectionStore()
         self.projector = ReplayStateProjector(self.projection_store, projection=projection)
+        self.metrics = metrics or ProjectorMetrics()
         self._subscriber: Optional[NATSCommandSubscriber] = None
 
     async def start(self) -> None:
@@ -110,15 +117,26 @@ class NATSProjectorWorker:
     async def handle_notification(self, notification: dict[str, Any]) -> str:
         """Project one NATS notification and return an ack action."""
 
-        events = [
-            event
-            for event in _extract_events(notification)
-            if self._owns_event(event)
-        ]
+        extracted_events = _extract_events(notification)
+        events = [event for event in extracted_events if self._owns_event(event)]
         if not events:
+            self.metrics.record_notification(
+                extracted_events=len(extracted_events),
+                owned_events=0,
+                projection_records=0,
+            )
             return "ack"
 
-        written = await self.projector.project(events)
+        try:
+            written = await self.projector.project(events)
+        except Exception:
+            self.metrics.record_error()
+            raise
+        self.metrics.record_notification(
+            extracted_events=len(extracted_events),
+            owned_events=len(events),
+            projection_records=len(written),
+        )
         logger.debug(
             "Projector %s folded %s events into %s projection records",
             self.settings.shard_id,
@@ -140,10 +158,31 @@ class NATSProjectorWorker:
 
 
 async def run_projector_worker(settings: Optional[ProjectorWorkerSettings] = None) -> None:
-    worker = NATSProjectorWorker(settings=settings)
+    effective_settings = settings or load_projector_worker_settings()
+    worker = NATSProjectorWorker(settings=effective_settings)
+    metrics_server = None
+    if effective_settings.metrics_port:
+        metrics_server = start_projector_metrics_server(
+            worker.metrics,
+            host=effective_settings.metrics_host,
+            port=effective_settings.metrics_port,
+            labels={
+                "shard_id": effective_settings.shard_id,
+                "consumer": effective_settings.consumer_name,
+            },
+        )
+        logger.info(
+            "Projector %s exposing metrics on %s:%s",
+            effective_settings.shard_id,
+            effective_settings.metrics_host,
+            effective_settings.metrics_port,
+        )
     try:
         await worker.start()
     finally:
+        if metrics_server is not None:
+            metrics_server.shutdown()
+            metrics_server.server_close()
         await worker.close()
 
 
@@ -176,6 +215,14 @@ def _int_env(name: str, default: int) -> int:
     if value is None or value.strip() == "":
         return default
     return int(value)
+
+
+def _optional_int_env(name: str) -> Optional[int]:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return None
+    parsed = int(value)
+    return parsed if parsed > 0 else None
 
 
 def _float_env(name: str, default: float) -> float:

--- a/noetl/projector/__main__.py
+++ b/noetl/projector/__main__.py
@@ -19,6 +19,8 @@ def main() -> None:
     parser.add_argument("--consumer", default=None, help="Durable consumer name")
     parser.add_argument("--shard-id", default=None, help="Stable projector shard id")
     parser.add_argument("--shard-count", type=int, default=None, help="Total projector shard count")
+    parser.add_argument("--metrics-host", default=None, help="Metrics bind host")
+    parser.add_argument("--metrics-port", type=int, default=None, help="Metrics bind port; disabled when omitted")
     args = parser.parse_args()
 
     try:
@@ -36,6 +38,8 @@ def main() -> None:
             max_ack_pending=base.max_ack_pending,
             fetch_timeout_seconds=base.fetch_timeout_seconds,
             fetch_heartbeat_seconds=base.fetch_heartbeat_seconds,
+            metrics_host=args.metrics_host or base.metrics_host,
+            metrics_port=args.metrics_port if args.metrics_port is not None else base.metrics_port,
         )
         run_projector_worker_sync(settings=settings)
     except KeyboardInterrupt:

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from urllib.request import urlopen
+
+
+def test_projector_metrics_render_prometheus_labels():
+    from noetl.core.projector.metrics import ProjectorMetrics, render_projector_metrics
+
+    metrics = ProjectorMetrics()
+    metrics.record_notification(extracted_events=3, owned_events=2, projection_records=1)
+
+    body = render_projector_metrics(
+        metrics,
+        labels={"shard_id": "noetl-projector-0", "consumer": "consumer-a"},
+    )
+
+    assert 'consumer="consumer-a"' in body
+    assert 'shard_id="noetl-projector-0"' in body
+    assert "noetl_projector_notifications_total" in body
+    assert "noetl_projector_events_extracted_total" in body
+    assert "noetl_projector_events_owned_total" in body
+    assert "noetl_projector_projection_records_total" in body
+    assert " 1.0" in body
+
+
+def test_projector_metrics_server_exposes_metrics_and_health():
+    from noetl.core.projector.metrics import ProjectorMetrics, start_projector_metrics_server
+
+    metrics = ProjectorMetrics()
+    metrics.record_notification(extracted_events=1, owned_events=0, projection_records=0)
+    server = start_projector_metrics_server(
+        metrics,
+        host="127.0.0.1",
+        port=0,
+        labels={"shard_id": "test-shard"},
+    )
+    host, port = server.server_address
+    try:
+        with urlopen(f"http://{host}:{port}/health", timeout=2) as response:
+            assert response.read() == b"ok\n"
+        with urlopen(f"http://{host}:{port}/metrics", timeout=2) as response:
+            body = response.read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert "noetl_projector_empty_or_unowned_notifications_total" in body
+    assert 'shard_id="test-shard"' in body

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -24,6 +24,13 @@ class _MemoryProjectionStore:
         return None
 
 
+class _SchemaLimitedProjectionStore(_MemoryProjectionStore):
+    async def ensure_schema(self):
+        from psycopg import errors as pg_errors
+
+        raise pg_errors.InsufficientPrivilege("must be owner of table projection")
+
+
 @pytest.mark.asyncio
 async def test_replay_state_projector_writes_grouped_projection_records():
     from noetl.core.projector import ReplayStateProjector
@@ -190,6 +197,37 @@ async def test_nats_projector_worker_acks_empty_or_unowned_notifications():
     snapshot = metrics.snapshot()
     assert snapshot["notifications_total"] == 2
     assert snapshot["empty_or_unowned_notifications_total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_nats_projector_worker_tolerates_projection_schema_permission(monkeypatch):
+    from noetl.core.projector.nats_worker import NATSProjectorWorker, ProjectorWorkerSettings
+
+    calls = []
+
+    class FakeSubscriber:
+        def __init__(self, **kwargs):
+            calls.append(("init", kwargs["consumer_name"]))
+
+        async def connect(self):
+            calls.append(("connect", None))
+
+        async def subscribe(self, handler):
+            calls.append(("subscribe", handler.__name__))
+
+    monkeypatch.setattr("noetl.core.projector.nats_worker.NATSCommandSubscriber", FakeSubscriber)
+    worker = NATSProjectorWorker(
+        projection_store=_SchemaLimitedProjectionStore(),
+        settings=ProjectorWorkerSettings(consumer_name="noetl-projector-0"),
+    )
+
+    await worker.start()
+
+    assert calls == [
+        ("init", "noetl-projector-0"),
+        ("connect", None),
+        ("subscribe", "handle_notification"),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -119,8 +119,10 @@ async def test_replay_state_projector_respects_version_monotonic_store_writes():
 
 @pytest.mark.asyncio
 async def test_nats_projector_worker_projects_owned_event_batch():
+    from noetl.core.projector.metrics import ProjectorMetrics
     from noetl.core.projector.nats_worker import NATSProjectorWorker, ProjectorWorkerSettings
 
+    metrics = ProjectorMetrics()
     store = _MemoryProjectionStore()
     worker = NATSProjectorWorker(
         projection_store=store,
@@ -129,6 +131,7 @@ async def test_nats_projector_worker_projects_owned_event_batch():
             consumer_name="noetl-projector-1",
             shard_count=2,
         ),
+        metrics=metrics,
     )
 
     action = await worker.handle_notification(
@@ -157,12 +160,19 @@ async def test_nats_projector_worker_projects_owned_event_batch():
     assert action == "ack"
     assert set(store.records) == {"execution/7/all"}
     assert store.records["execution/7/all"].state["execution"]["status"] == "COMPLETED"
+    snapshot = metrics.snapshot()
+    assert snapshot["notifications_total"] == 1
+    assert snapshot["events_extracted_total"] == 2
+    assert snapshot["events_owned_total"] == 1
+    assert snapshot["projection_records_total"] == 1
 
 
 @pytest.mark.asyncio
 async def test_nats_projector_worker_acks_empty_or_unowned_notifications():
+    from noetl.core.projector.metrics import ProjectorMetrics
     from noetl.core.projector.nats_worker import NATSProjectorWorker, ProjectorWorkerSettings
 
+    metrics = ProjectorMetrics()
     store = _MemoryProjectionStore()
     worker = NATSProjectorWorker(
         projection_store=store,
@@ -171,8 +181,12 @@ async def test_nats_projector_worker_acks_empty_or_unowned_notifications():
             consumer_name="noetl-projector-0",
             shard_count=2,
         ),
+        metrics=metrics,
     )
 
     assert await worker.handle_notification({"event": {"execution_id": 7, "event_type": "workflow.completed"}}) == "ack"
     assert await worker.handle_notification({"event_id": 99}) == "ack"
     assert store.records == {}
+    snapshot = metrics.snapshot()
+    assert snapshot["notifications_total"] == 2
+    assert snapshot["empty_or_unowned_notifications_total"] == 2

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -190,3 +190,47 @@ async def test_nats_projector_worker_acks_empty_or_unowned_notifications():
     snapshot = metrics.snapshot()
     assert snapshot["notifications_total"] == 2
     assert snapshot["empty_or_unowned_notifications_total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_run_projector_worker_initializes_and_closes_db_pool(monkeypatch):
+    import noetl.core.projector.nats_worker as module
+
+    calls = []
+
+    async def fake_init_pool(conninfo):
+        calls.append(("init", conninfo))
+
+    async def fake_close_pool():
+        calls.append(("close", None))
+
+    class FakeWorker:
+        def __init__(self, *, settings):
+            self.settings = settings
+            from noetl.core.projector.metrics import ProjectorMetrics
+
+            self.metrics = ProjectorMetrics()
+
+        async def start(self):
+            calls.append(("start", self.settings.shard_id))
+            raise RuntimeError("stop projector test")
+
+        async def close(self):
+            calls.append(("worker_close", None))
+
+    monkeypatch.setattr(module, "get_pgdb_connection", lambda: "dbname=noetl")
+    monkeypatch.setattr(module, "init_pool", fake_init_pool)
+    monkeypatch.setattr(module, "close_pool", fake_close_pool)
+    monkeypatch.setattr(module, "NATSProjectorWorker", FakeWorker)
+
+    with pytest.raises(RuntimeError, match="stop projector test"):
+        await module.run_projector_worker(
+            module.ProjectorWorkerSettings(shard_id="noetl-projector-0")
+        )
+
+    assert calls == [
+        ("init", "dbname=noetl"),
+        ("start", "noetl-projector-0"),
+        ("worker_close", None),
+        ("close", None),
+    ]


### PR DESCRIPTION
## Summary
- adds a thread-safe projector metrics surface for notifications, event ownership, projection records, and errors
- exposes optional `/metrics` and `/health` endpoints from `python -m noetl.projector` via `NOETL_PROJECTOR_METRICS_PORT` or `--metrics-port`
- records NATS projector worker metrics without noisy access logs

## Validation
- .venv/bin/python -m pytest tests/core/test_projector_metrics.py tests/core/test_replay_state_projector.py tests/core/test_projection_store_ports.py tests/api/test_replay_routes.py tests/core/test_replay_golden_corpus.py tests/server/test_metrics.py -q
- .venv/bin/python -m noetl.projector --help
- python -m compileall noetl/core/projector noetl/projector
- git diff --check

Tracks noetl/noetl#437.