### PR TITLE
Export projector checkpoint lag metrics

### DIFF
--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import time
+from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from threading import Lock, Thread
-from typing import Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 
 class ProjectorMetrics:
@@ -24,6 +25,11 @@ class ProjectorMetrics:
             "last_error_unixtime": 0.0,
             "last_batch_events": 0.0,
             "last_batch_projection_records": 0.0,
+            "last_projection_source_event_id": 0.0,
+            "last_projection_event_time_watermark_unixtime": 0.0,
+            "last_projection_projected_at_unixtime": 0.0,
+            "last_projection_lag_milliseconds": 0.0,
+            "max_projection_lag_milliseconds": 0.0,
         }
 
     def record_notification(
@@ -49,6 +55,31 @@ class ProjectorMetrics:
         with self._lock:
             self._values["errors_total"] += 1.0
             self._values["last_error_unixtime"] = time.time()
+
+    def record_projection_checkpoints(self, records: Iterable[Any]) -> None:
+        with self._lock:
+            for record in records:
+                meta = getattr(record, "meta", None)
+                meta = meta if isinstance(meta, Mapping) else {}
+                source_event_id = _coerce_float(
+                    meta.get("source_event_id") or getattr(record, "source_event_id", None)
+                )
+                event_watermark = _coerce_datetime_unixtime(meta.get("event_time_watermark"))
+                projected_at = _coerce_datetime_unixtime(meta.get("projected_at"))
+                lag_ms = _coerce_float(meta.get("projection_lag_ms"))
+
+                if source_event_id is not None:
+                    self._values["last_projection_source_event_id"] = source_event_id
+                if event_watermark is not None:
+                    self._values["last_projection_event_time_watermark_unixtime"] = event_watermark
+                if projected_at is not None:
+                    self._values["last_projection_projected_at_unixtime"] = projected_at
+                if lag_ms is not None:
+                    self._values["last_projection_lag_milliseconds"] = lag_ms
+                    self._values["max_projection_lag_milliseconds"] = max(
+                        self._values["max_projection_lag_milliseconds"],
+                        lag_ms,
+                    )
 
     def snapshot(self) -> dict[str, float]:
         with self._lock:
@@ -94,6 +125,27 @@ def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapp
         "# HELP noetl_projector_last_batch_projection_records Projection records from the last handled notification.",
         "# TYPE noetl_projector_last_batch_projection_records gauge",
         f"noetl_projector_last_batch_projection_records{label_text} {snapshot['last_batch_projection_records']}",
+        "# HELP noetl_projector_last_projection_source_event_id Last projected source event id.",
+        "# TYPE noetl_projector_last_projection_source_event_id gauge",
+        f"noetl_projector_last_projection_source_event_id{label_text} {snapshot['last_projection_source_event_id']}",
+        "# HELP noetl_projector_last_projection_event_time_watermark_unixtime Last projected event-time watermark.",
+        "# TYPE noetl_projector_last_projection_event_time_watermark_unixtime gauge",
+        (
+            "noetl_projector_last_projection_event_time_watermark_unixtime"
+            f"{label_text} {snapshot['last_projection_event_time_watermark_unixtime']}"
+        ),
+        "# HELP noetl_projector_last_projection_projected_at_unixtime Last projector write timestamp.",
+        "# TYPE noetl_projector_last_projection_projected_at_unixtime gauge",
+        (
+            "noetl_projector_last_projection_projected_at_unixtime"
+            f"{label_text} {snapshot['last_projection_projected_at_unixtime']}"
+        ),
+        "# HELP noetl_projector_last_projection_lag_milliseconds Latest projection lag from event watermark to write time.",
+        "# TYPE noetl_projector_last_projection_lag_milliseconds gauge",
+        f"noetl_projector_last_projection_lag_milliseconds{label_text} {snapshot['last_projection_lag_milliseconds']}",
+        "# HELP noetl_projector_max_projection_lag_milliseconds Max observed projection lag since process start.",
+        "# TYPE noetl_projector_max_projection_lag_milliseconds gauge",
+        f"noetl_projector_max_projection_lag_milliseconds{label_text} {snapshot['max_projection_lag_milliseconds']}",
     ]
     return "\n".join(lines) + "\n"
 
@@ -145,6 +197,35 @@ def _format_labels(labels: Mapping[str, str]) -> str:
 
 def _escape_label(value: str) -> str:
     return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_datetime_unixtime(value: Any) -> Optional[float]:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str):
+        raw = value.strip()
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+    else:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
 
 
 __all__ = [

--- a/noetl/core/projector/nats_worker.py
+++ b/noetl/core/projector/nats_worker.py
@@ -147,6 +147,7 @@ class NATSProjectorWorker:
             owned_events=len(events),
             projection_records=len(written),
         )
+        self.metrics.record_projection_checkpoints(written)
         logger.debug(
             "Projector %s folded %s events into %s projection records",
             self.settings.shard_id,

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from urllib.request import urlopen
 
 
@@ -21,6 +22,34 @@ def test_projector_metrics_render_prometheus_labels():
     assert "noetl_projector_events_owned_total" in body
     assert "noetl_projector_projection_records_total" in body
     assert " 1.0" in body
+
+
+def test_projector_metrics_export_projection_checkpoint_gauges():
+    from noetl.core.projector.metrics import ProjectorMetrics, render_projector_metrics
+
+    metrics = ProjectorMetrics()
+    metrics.record_projection_checkpoints(
+        [
+            SimpleNamespace(
+                source_event_id=31,
+                meta={
+                    "event_time_watermark": "2026-05-18T17:00:00Z",
+                    "projected_at": "2026-05-18T17:00:02Z",
+                    "projection_lag_ms": 2000,
+                },
+            )
+        ]
+    )
+
+    snapshot = metrics.snapshot()
+    assert snapshot["last_projection_source_event_id"] == 31
+    assert snapshot["last_projection_lag_milliseconds"] == 2000
+    assert snapshot["max_projection_lag_milliseconds"] == 2000
+
+    body = render_projector_metrics(metrics)
+    assert "noetl_projector_last_projection_source_event_id 31.0" in body
+    assert "noetl_projector_last_projection_lag_milliseconds 2000.0" in body
+    assert "noetl_projector_max_projection_lag_milliseconds 2000.0" in body
 
 
 def test_projector_metrics_server_exposes_metrics_and_health():

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -216,6 +216,7 @@ async def test_nats_projector_worker_projects_owned_event_batch():
     assert snapshot["events_extracted_total"] == 2
     assert snapshot["events_owned_total"] == 1
     assert snapshot["projection_records_total"] == 1
+    assert snapshot["last_projection_source_event_id"] == 20
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- exports checkpoint/lag gauges from `ProjectionRecord.meta` on the standalone projector metrics endpoint
- tracks last source event id, event-time watermark, projected-at timestamp, latest lag, and max lag since process start
- records checkpoint gauges after successful NATS projector writes

## Validation
- `.venv/bin/python -m pytest tests/core/test_projector_metrics.py tests/core/test_replay_state_projector.py tests/core/test_projection_store_ports.py -q`
- `python -m compileall noetl/core/projector`
- `git diff --check`

Tracks noetl/noetl#437.