### PR TITLE
Mirror engine-owned DSL events

### DIFF
--- a/noetl/core/dsl/engine/executor/common.py
+++ b/noetl/core/dsl/engine/executor/common.py
@@ -59,6 +59,13 @@ def get_snowflake_id():
     return db_pool.get_snowflake_id()
 
 
+async def _mirror_engine_events(events: list[dict[str, Any]]) -> None:
+    """Mirror engine-owned event appends after their DB transaction commits."""
+    from noetl.server.api.core.events import _mirror_events
+
+    await _mirror_events(events)
+
+
 def get_nats_cache():
     """Resolve the shared NATS cache lazily.
 

--- a/noetl/core/dsl/engine/executor/events.py
+++ b/noetl/core/dsl/engine/executor/events.py
@@ -207,6 +207,21 @@ class EventHandlingMixin:
                 )
                 if owns_transaction:
                     await active_conn.commit()
+                    await _mirror_engine_events([
+                        envelope | {
+                            "event_id": event_id,
+                            "catalog_id": stage.get("catalog_id") or state.catalog_id,
+                            "node_id": step_name,
+                            "context": {
+                                "stage_id": str(stage["stage_id"]),
+                                "loop_event_id": str(loop_event_id),
+                            },
+                            "parent_event_id": parent_event_id,
+                            "stage_id": str(stage["stage_id"]),
+                            "ingest_time": now,
+                            "created_at": now,
+                        }
+                    ])
                 logger.info(
                     "[CURSOR-LOOP] Closed runtime stage %s for step %s execution=%s frames=%s rows=%s",
                     stage["stage_id"],

--- a/noetl/core/dsl/engine/executor/lifecycle.py
+++ b/noetl/core/dsl/engine/executor/lifecycle.py
@@ -106,10 +106,33 @@ class LifecycleMixin:
             state.last_event_id = event_id
             if event.step:
                 state.step_event_ids[event.step] = event_id
+            return {
+                "event_id": event_id,
+                "execution_id": int(event.execution_id),
+                "catalog_id": catalog_id,
+                "event_type": event.name,
+                "node_id": event.step,
+                "node_name": event.step,
+                "status": status,
+                "context": context_val,
+                "result": result_val or {"status": status},
+                "meta": event.meta or {},
+                "worker_id": event.worker_id,
+                "parent_event_id": parent_event_id,
+                "parent_execution_id": state.parent_execution_id,
+                "command_id": (event.meta or {}).get("command_id") if isinstance(event.meta, dict) else None,
+                "stage_id": (event.meta or {}).get("stage_id") if isinstance(event.meta, dict) else None,
+                "frame_id": (event.meta or {}).get("frame_id") if isinstance(event.meta, dict) else None,
+                "event_time": event_timestamp,
+                "ingest_time": event_timestamp,
+                "created_at": event_timestamp,
+            }
 
         if conn is None:
             async with get_pool_connection() as c:
-                await _do_persist(c)
+                mirrored_event = await _do_persist(c)
+            if mirrored_event:
+                await _mirror_engine_events([mirrored_event])
         else:
             await _do_persist(conn)
 

--- a/noetl/core/dsl/engine/executor/transitions.py
+++ b/noetl/core/dsl/engine/executor/transitions.py
@@ -417,6 +417,19 @@ class TransitionMixin:
                         await cur.execute(f"RELEASE SAVEPOINT {savepoint_name}")
                     if owns_transaction:
                         await active_conn.commit()
+                        await _mirror_engine_events([
+                            envelope | {
+                                "event_id": event_id,
+                                "catalog_id": catalog_id,
+                                "node_id": step_def.step,
+                                "node_name": step_def.step,
+                                "status": "OPEN",
+                                "context": {"stage_id": str(stage_id), "loop_event_id": loop_event_id},
+                                "parent_event_id": parent_event_id,
+                                "stage_id": str(stage_id),
+                                "created_at": event_time,
+                            }
+                        ])
                 except Exception as event_exc:
                     if owns_transaction:
                         await active_conn.rollback()

--- a/tests/unit/dsl/engine/test_engine_event_mirror.py
+++ b/tests/unit/dsl/engine/test_engine_event_mirror.py
@@ -1,0 +1,136 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from noetl.core.dsl.engine.models import Event
+
+
+class _CursorCtx:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    async def __aenter__(self):
+        return self._cursor
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _ConnCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _Cursor:
+    def __init__(self):
+        self.query = ""
+        self.inserts = []
+
+    async def execute(self, query, params=None):
+        self.query = query
+        if "INSERT INTO noetl.event" in query:
+            self.inserts.append(params)
+
+    async def fetchone(self):
+        if "noetl.snowflake_id()" in self.query:
+            return {"snowflake_id": 101}
+        return None
+
+
+class _Conn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self, **_kwargs):
+        return _CursorCtx(self._cursor)
+
+
+class _Engine:
+    from noetl.core.dsl.engine.executor.lifecycle import LifecycleMixin
+
+    _persist_event = LifecycleMixin._persist_event
+
+
+@pytest.mark.asyncio
+async def test_engine_owned_persist_event_mirrors_after_connection_context(monkeypatch):
+    import noetl.core.dsl.engine.executor.lifecycle as lifecycle
+
+    cursor = _Cursor()
+    mirrored = []
+
+    async def fake_mirror(events):
+        mirrored.extend(events)
+
+    monkeypatch.setattr(lifecycle, "get_pool_connection", lambda: _ConnCtx(_Conn(cursor)))
+    monkeypatch.setattr(lifecycle, "_mirror_engine_events", fake_mirror)
+
+    state = SimpleNamespace(
+        catalog_id=5,
+        parent_execution_id=None,
+        step_event_ids={},
+        last_event_id=77,
+        loop_state={},
+    )
+    event_time = datetime(2026, 5, 18, 20, 0, tzinfo=timezone.utc)
+
+    await _Engine()._persist_event(
+        Event(
+            execution_id="7",
+            step="workflow",
+            name="workflow.initialized",
+            payload={"status": "initialized", "result": {"status": "RUNNING"}},
+            meta={"stage_id": "stage-1"},
+            timestamp=event_time,
+        ),
+        state,
+    )
+
+    assert cursor.inserts
+    assert state.last_event_id == 101
+    assert mirrored[0]["event_id"] == 101
+    assert mirrored[0]["event_type"] == "workflow.initialized"
+    assert mirrored[0]["execution_id"] == 7
+    assert mirrored[0]["catalog_id"] == 5
+    assert mirrored[0]["parent_event_id"] == 77
+    assert mirrored[0]["stage_id"] == "stage-1"
+    assert mirrored[0]["event_time"] == event_time
+
+
+@pytest.mark.asyncio
+async def test_engine_caller_owned_persist_event_does_not_mirror_before_external_commit(monkeypatch):
+    import noetl.core.dsl.engine.executor.lifecycle as lifecycle
+
+    mirrored = []
+
+    async def fake_mirror(events):
+        mirrored.extend(events)
+
+    monkeypatch.setattr(lifecycle, "_mirror_engine_events", fake_mirror)
+
+    state = SimpleNamespace(
+        catalog_id=5,
+        parent_execution_id=None,
+        step_event_ids={},
+        last_event_id=None,
+        loop_state={},
+    )
+
+    await _Engine()._persist_event(
+        Event(
+            execution_id="7",
+            step="workflow",
+            name="workflow.initialized",
+            payload={"status": "initialized"},
+        ),
+        state,
+        conn=_Conn(_Cursor()),
+    )
+
+    assert mirrored == []


### PR DESCRIPTION
## Summary\n- add a shared engine event mirror helper that reuses the opt-in core event mirror\n- mirror engine-owned lifecycle appends after the connection context exits\n- mirror owned-transaction stage.opened and stage.closed events after commit\n- deliberately avoid mirroring caller-owned transaction paths before their external commit boundary\n\n## Validation\n- .venv/bin/python -m pytest tests/unit/dsl/engine/test_engine_event_mirror.py tests/core/test_replay_state_projector.py tests/api/test_core_event_mirror.py\n- .venv/bin/python -m compileall noetl/core/dsl/engine/executor/common.py noetl/core/dsl/engine/executor/lifecycle.py noetl/core/dsl/engine/executor/transitions.py noetl/core/dsl/engine/executor/events.py\n- git diff --check\n\nTracks noetl/noetl#461 and noetl/noetl#437