### PR TITLE
Add transactional outbox for event distribution

### DIFF
--- a/noetl/core/outbox.py
+++ b/noetl/core/outbox.py
@@ -1,0 +1,199 @@
+"""Transactional outbox for mirrored event distribution."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from psycopg.rows import dict_row
+from psycopg.types.json import Json
+
+from noetl.core.db.pool import get_pool_connection
+from noetl.core.logger import setup_logger
+from noetl.core.messaging import NATSEventPublisher
+from noetl.core.storage.arrow_ipc import rows_to_arrow_feather
+
+logger = setup_logger(__name__, include_location=True)
+
+OUTBOX_DDL = """
+CREATE TABLE IF NOT EXISTS noetl.outbox (
+    outbox_id BIGSERIAL PRIMARY KEY,
+    execution_id BIGINT,
+    event_id BIGINT NOT NULL,
+    subject TEXT,
+    payload JSONB NOT NULL,
+    payload_bytes BYTEA,
+    payload_codec TEXT NOT NULL DEFAULT 'arrow-feather',
+    status TEXT NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'IN_FLIGHT', 'PUBLISHED', 'FAILED')),
+    attempts INTEGER NOT NULL DEFAULT 0,
+    available_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    locked_at TIMESTAMPTZ,
+    published_at TIMESTAMPTZ,
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (execution_id, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_ready
+    ON noetl.outbox (status, available_at, outbox_id)
+    WHERE status IN ('PENDING', 'FAILED');
+
+CREATE INDEX IF NOT EXISTS idx_outbox_execution_event
+    ON noetl.outbox (execution_id, event_id);
+"""
+
+
+def normalize_outbox_payload(event: dict[str, Any]) -> dict[str, Any]:
+    """Return a JSONB-safe event envelope without changing semantic fields."""
+
+    return json.loads(json.dumps(event, default=str, sort_keys=True))
+
+
+async def ensure_outbox_schema() -> None:
+    async with get_pool_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(OUTBOX_DDL)
+        await conn.commit()
+
+
+async def enqueue_outbox(cur: Any, event: dict[str, Any], *, subject: str | None = None) -> None:
+    """Enqueue a mirrored event in the caller's current database transaction."""
+
+    event_id = event.get("event_id")
+    if event_id is None:
+        raise ValueError("outbox requires event_id")
+    payload = normalize_outbox_payload(event)
+    payload_bytes, _schema_digest, _row_count = rows_to_arrow_feather([payload])
+    execution_id = payload.get("execution_id")
+    await cur.execute(
+        """
+        INSERT INTO noetl.outbox (execution_id, event_id, subject, payload, payload_bytes, payload_codec)
+        VALUES (%s, %s, %s, %s, %s, 'arrow-feather')
+        ON CONFLICT (execution_id, event_id) DO NOTHING
+        """,
+        (
+            int(execution_id) if execution_id is not None else None,
+            int(event_id),
+            subject,
+            Json(payload),
+            payload_bytes,
+        ),
+    )
+
+
+async def claim_outbox_batch(*, limit: int = 100) -> list[dict[str, Any]]:
+    async with get_pool_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                WITH ready AS (
+                    SELECT outbox_id
+                    FROM noetl.outbox
+                    WHERE status IN ('PENDING', 'FAILED')
+                      AND available_at <= now()
+                    ORDER BY outbox_id
+                    LIMIT %s
+                    FOR UPDATE SKIP LOCKED
+                )
+                UPDATE noetl.outbox o
+                SET status = 'IN_FLIGHT',
+                    attempts = attempts + 1,
+                    locked_at = now(),
+                    updated_at = now()
+                FROM ready
+                WHERE o.outbox_id = ready.outbox_id
+                RETURNING o.outbox_id, o.event_id, o.execution_id, o.subject,
+                          o.payload, o.payload_bytes, o.payload_codec, o.attempts
+                """,
+                (max(1, int(limit)),),
+            )
+            rows = await cur.fetchall()
+        await conn.commit()
+    return [dict(row) for row in rows]
+
+
+async def mark_outbox_published(outbox_id: int) -> None:
+    async with get_pool_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                UPDATE noetl.outbox
+                SET status = 'PUBLISHED',
+                    published_at = now(),
+                    updated_at = now(),
+                    last_error = NULL
+                WHERE outbox_id = %s
+                """,
+                (int(outbox_id),),
+            )
+        await conn.commit()
+
+
+async def mark_outbox_failed(
+    outbox_id: int,
+    error: Exception,
+    *,
+    attempts: int = 1,
+    max_delay_seconds: int = 300,
+) -> None:
+    delay_seconds = min(max_delay_seconds, 2 ** min(8, max(0, int(attempts) - 1)))
+    async with get_pool_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                UPDATE noetl.outbox
+                SET status = 'FAILED',
+                    available_at = now() + (%s || ' seconds')::interval,
+                    last_error = %s,
+                    updated_at = now()
+                WHERE outbox_id = %s
+                """,
+                (delay_seconds, str(error)[:2000], int(outbox_id)),
+            )
+        await conn.commit()
+
+
+async def publish_outbox_batch(
+    *,
+    limit: int = 100,
+    publisher: NATSEventPublisher | None = None,
+) -> int:
+    """Publish one claimed outbox batch to the configured event distribution stream."""
+
+    rows = await claim_outbox_batch(limit=limit)
+    if not rows:
+        return 0
+    event_publisher = publisher or NATSEventPublisher()
+    published = 0
+    for row in rows:
+        try:
+            payload = row.get("payload") or {}
+            subject = row.get("subject")
+            payload_bytes = row.get("payload_bytes")
+            if subject and payload_bytes:
+                await event_publisher.ensure_connected()
+                await event_publisher._publish_event_payload(subject, bytes(payload_bytes))
+            else:
+                await event_publisher.publish_event(payload)
+            await mark_outbox_published(int(row["outbox_id"]))
+            published += 1
+        except Exception as exc:
+            logger.warning(
+                "Outbox publish failed outbox_id=%s event_id=%s: %s",
+                row.get("outbox_id"),
+                row.get("event_id"),
+                exc,
+            )
+            await mark_outbox_failed(
+                int(row["outbox_id"]),
+                exc,
+                attempts=int(row.get("attempts") or 1),
+            )
+    return published
+
+
+async def run_outbox_publisher_once(*, limit: int = 100) -> int:
+    await ensure_outbox_schema()
+    return await publish_outbox_batch(limit=limit)

--- a/noetl/core/storage/__init__.py
+++ b/noetl/core/storage/__init__.py
@@ -61,9 +61,12 @@ from noetl.core.storage.ipc_cache import (
 )
 
 from noetl.core.storage.arrow_ipc import (
+    ARROW_FEATHER_MEDIA_TYPE,
     ARROW_STREAM_MEDIA_TYPE,
+    arrow_feather_to_rows,
     rows_to_arrow_ipc,
     arrow_ipc_to_rows,
+    rows_to_arrow_feather,
 )
 
 from noetl.core.storage.scope_tracker import (
@@ -125,8 +128,11 @@ __all__ = [
     'ArrowIpcSharedMemoryCache',
     'IpcCacheEntry',
     'ARROW_STREAM_MEDIA_TYPE',
+    'ARROW_FEATHER_MEDIA_TYPE',
     'rows_to_arrow_ipc',
     'arrow_ipc_to_rows',
+    'rows_to_arrow_feather',
+    'arrow_feather_to_rows',
     # Scope Tracker
     'ScopeContext',
     'ScopeTracker',

--- a/noetl/core/storage/arrow_ipc.py
+++ b/noetl/core/storage/arrow_ipc.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable, Mapping, Optional
 
 
 ARROW_STREAM_MEDIA_TYPE = "application/vnd.apache.arrow.stream"
+ARROW_FEATHER_MEDIA_TYPE = "application/vnd.apache.arrow.file"
 
 
 def rows_to_arrow_ipc(
@@ -64,4 +65,58 @@ def arrow_ipc_to_rows(payload: bytes) -> list[dict[str, Any]]:
     return table.to_pylist()
 
 
-__all__ = ["ARROW_STREAM_MEDIA_TYPE", "rows_to_arrow_ipc", "arrow_ipc_to_rows"]
+def rows_to_arrow_feather(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    columns: Optional[list[str]] = None,
+) -> tuple[bytes, str, int]:
+    """Serialize row dictionaries to Arrow Feather/file bytes."""
+    try:
+        import pyarrow as pa
+        import pyarrow.feather as feather
+    except Exception as exc:  # pragma: no cover - exercised when optional dep missing
+        raise RuntimeError("pyarrow is required for Arrow Feather serialization") from exc
+
+    materialized_rows = [dict(row) for row in rows]
+    if columns is None:
+        seen: list[str] = []
+        for row in materialized_rows:
+            for key in row.keys():
+                key_str = str(key)
+                if key_str not in seen:
+                    seen.append(key_str)
+        columns = seen
+
+    normalized_rows = [
+        {column: row.get(column) for column in columns}
+        for row in materialized_rows
+    ]
+    table = pa.Table.from_pylist(normalized_rows, schema=None)
+    if columns:
+        table = table.select([column for column in columns if column in table.column_names])
+
+    sink = BytesIO()
+    feather.write_feather(table, sink)
+    payload = sink.getvalue()
+    schema_digest = hashlib.sha256(table.schema.serialize().to_pybytes()).hexdigest()
+    return payload, schema_digest, len(materialized_rows)
+
+
+def arrow_feather_to_rows(payload: bytes) -> list[dict[str, Any]]:
+    """Decode Arrow Feather/file bytes back into Python row dictionaries."""
+    try:
+        import pyarrow.feather as feather
+    except Exception as exc:  # pragma: no cover - exercised when optional dep missing
+        raise RuntimeError("pyarrow is required for Arrow Feather deserialization") from exc
+
+    return feather.read_table(BytesIO(payload)).to_pylist()
+
+
+__all__ = [
+    "ARROW_FEATHER_MEDIA_TYPE",
+    "ARROW_STREAM_MEDIA_TYPE",
+    "arrow_feather_to_rows",
+    "arrow_ipc_to_rows",
+    "rows_to_arrow_feather",
+    "rows_to_arrow_ipc",
+]

--- a/noetl/database/ddl/postgres/schema_ddl.sql
+++ b/noetl/database/ddl/postgres/schema_ddl.sql
@@ -338,6 +338,35 @@ CREATE INDEX IF NOT EXISTS idx_event_idempotency_key_column
     ON noetl.event (tenant_id, organization_id, idempotency_key)
     WHERE idempotency_key IS NOT NULL;
 
+-- Transactional outbox for event distribution. Writers insert here in the same
+-- transaction as noetl.event, and a publisher drains committed rows to NATS.
+CREATE TABLE IF NOT EXISTS noetl.outbox (
+    outbox_id BIGSERIAL PRIMARY KEY,
+    execution_id BIGINT,
+    event_id BIGINT NOT NULL,
+    subject TEXT,
+    payload JSONB NOT NULL,
+    payload_bytes BYTEA,
+    payload_codec TEXT NOT NULL DEFAULT 'arrow-feather',
+    status TEXT NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'IN_FLIGHT', 'PUBLISHED', 'FAILED')),
+    attempts INTEGER NOT NULL DEFAULT 0,
+    available_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    locked_at TIMESTAMPTZ,
+    published_at TIMESTAMPTZ,
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (execution_id, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_ready
+    ON noetl.outbox (status, available_at, outbox_id)
+    WHERE status IN ('PENDING', 'FAILED');
+
+CREATE INDEX IF NOT EXISTS idx_outbox_execution_event
+    ON noetl.outbox (execution_id, event_id);
+
 -- Legacy compatibility view for event_log. Keep this after additive event
 -- columns so SELECT * expands to the migrated event envelope.
 CREATE OR REPLACE VIEW noetl.event_log AS SELECT * FROM noetl.event;

--- a/tests/core/test_arrow_ipc_serialization.py
+++ b/tests/core/test_arrow_ipc_serialization.py
@@ -24,3 +24,16 @@ def test_rows_to_arrow_ipc_digest_is_schema_based_not_value_based():
     _, right_digest, _ = rows_to_arrow_ipc([{"id": 2, "name": "Grace"}])
 
     assert left_digest == right_digest
+
+
+def test_rows_to_arrow_feather_round_trips_rows_and_schema_digest():
+    from noetl.core.storage import arrow_feather_to_rows, rows_to_arrow_feather
+
+    rows = [{"event_id": 1, "event_type": "workflow.completed", "status": "COMPLETED"}]
+
+    payload, schema_digest, row_count = rows_to_arrow_feather(rows)
+
+    assert payload
+    assert len(schema_digest) == 64
+    assert row_count == 1
+    assert arrow_feather_to_rows(payload) == rows

--- a/tests/core/test_outbox.py
+++ b/tests/core/test_outbox.py
@@ -1,0 +1,188 @@
+from datetime import datetime, timezone
+
+import pytest
+
+
+class _Cursor:
+    def __init__(self, rows=None):
+        self.rows = list(rows or [])
+        self.executed = []
+
+    async def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    async def fetchall(self):
+        return self.rows
+
+
+class _CursorCtx:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    async def __aenter__(self):
+        return self._cursor
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _Conn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.commits = 0
+
+    def cursor(self, **_kwargs):
+        return _CursorCtx(self._cursor)
+
+    async def commit(self):
+        self.commits += 1
+
+
+class _ConnCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_normalize_outbox_payload_serializes_datetimes():
+    from noetl.core.outbox import normalize_outbox_payload
+
+    payload = normalize_outbox_payload(
+        {
+            "event_id": 1,
+            "execution_id": 7,
+            "event_time": datetime(2026, 5, 18, 20, 0, tzinfo=timezone.utc),
+        }
+    )
+
+    assert payload["event_time"] == "2026-05-18 20:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_outbox_uses_caller_transaction_cursor():
+    from psycopg.types.json import Json
+
+    from noetl.core.outbox import enqueue_outbox
+
+    cursor = _Cursor()
+
+    await enqueue_outbox(
+        cursor,
+        {
+            "event_id": 101,
+            "execution_id": 7,
+            "event_type": "workflow.completed",
+        },
+        subject="noetl.events.default.default.7.0",
+    )
+
+    query, params = cursor.executed[0]
+    assert "INSERT INTO noetl.outbox" in query
+    assert params[:3] == (7, 101, "noetl.events.default.default.7.0")
+    assert isinstance(params[3], Json)
+    assert bytes(params[4]).startswith(b"ARROW1")
+
+
+@pytest.mark.asyncio
+async def test_publish_outbox_batch_publishes_and_marks(monkeypatch):
+    import noetl.core.outbox as outbox
+
+    claim_rows = [
+        {
+            "outbox_id": 1,
+            "event_id": 101,
+            "execution_id": 7,
+            "payload": {"event_id": 101, "execution_id": 7, "event_type": "workflow.completed"},
+            "attempts": 1,
+        }
+    ]
+    published = []
+    marked = []
+
+    class Publisher:
+        async def publish_event(self, event):
+            published.append(event)
+
+    async def fake_claim(*, limit):
+        assert limit == 10
+        return claim_rows
+
+    async def fake_mark(outbox_id):
+        marked.append(outbox_id)
+
+    monkeypatch.setattr(outbox, "claim_outbox_batch", fake_claim)
+    monkeypatch.setattr(outbox, "mark_outbox_published", fake_mark)
+
+    count = await outbox.publish_outbox_batch(limit=10, publisher=Publisher())
+
+    assert count == 1
+    assert published == [claim_rows[0]["payload"]]
+    assert marked == [1]
+
+
+@pytest.mark.asyncio
+async def test_publish_outbox_batch_uses_preencoded_bytes_when_subject_exists(monkeypatch):
+    import noetl.core.outbox as outbox
+
+    claim_rows = [
+        {
+            "outbox_id": 1,
+            "event_id": 101,
+            "execution_id": 7,
+            "subject": "noetl.events.default.default.7.0",
+            "payload": {"event_id": 101},
+            "payload_bytes": b"ARROW1...",
+            "attempts": 1,
+        }
+    ]
+    sent = []
+    marked = []
+
+    class Publisher:
+        async def ensure_connected(self):
+            sent.append(("connected", None))
+
+        async def _publish_event_payload(self, subject, payload):
+            sent.append((subject, payload))
+
+        async def publish_event(self, event):  # pragma: no cover - fallback must not run
+            raise AssertionError(f"unexpected fallback publish: {event}")
+
+    async def fake_claim(*, limit):
+        return claim_rows
+
+    async def fake_mark(outbox_id):
+        marked.append(outbox_id)
+
+    monkeypatch.setattr(outbox, "claim_outbox_batch", fake_claim)
+    monkeypatch.setattr(outbox, "mark_outbox_published", fake_mark)
+
+    count = await outbox.publish_outbox_batch(limit=10, publisher=Publisher())
+
+    assert count == 1
+    assert sent == [
+        ("connected", None),
+        ("noetl.events.default.default.7.0", b"ARROW1..."),
+    ]
+    assert marked == [1]
+
+
+@pytest.mark.asyncio
+async def test_claim_outbox_batch_marks_rows_in_flight(monkeypatch):
+    import noetl.core.outbox as outbox
+
+    cursor = _Cursor(rows=[{"outbox_id": 1, "event_id": 101, "payload": {"event_id": 101}}])
+    conn = _Conn(cursor)
+
+    monkeypatch.setattr(outbox, "get_pool_connection", lambda: _ConnCtx(conn))
+
+    rows = await outbox.claim_outbox_batch(limit=5)
+
+    assert rows == [{"outbox_id": 1, "event_id": 101, "payload": {"event_id": 101}}]
+    assert conn.commits == 1
+    assert "FOR UPDATE SKIP LOCKED" in cursor.executed[0][0]

--- a/tests/database/test_distributed_runtime_schema.py
+++ b/tests/database/test_distributed_runtime_schema.py
@@ -9,6 +9,7 @@ def test_distributed_runtime_schema_contract_is_present():
 
     assert "CREATE TABLE IF NOT EXISTS noetl.stage" in ddl
     assert "CREATE TABLE IF NOT EXISTS noetl.frame" in ddl
+    assert "CREATE TABLE IF NOT EXISTS noetl.outbox" in ddl
     assert "CREATE TABLE IF NOT EXISTS noetl.projection" in ddl
     assert "CREATE TABLE IF NOT EXISTS noetl.projection_snapshot" in ddl
     assert "CREATE INDEX IF NOT EXISTS frame_open_idx" in ddl
@@ -40,3 +41,4 @@ def test_distributed_runtime_schema_contract_is_present():
     assert "idx_event_tenant_org_execution_event_id" in ddl
     assert "idx_event_stream_version" in ddl
     assert "idx_event_aggregate_event_id" in ddl
+    assert "idx_outbox_ready" in ddl


### PR DESCRIPTION
## Summary\n- add canonical noetl.outbox table for transactional event distribution\n- add noetl.core.outbox helpers to enqueue, claim, publish, and mark outbox rows\n- store JSONB payloads for operator/debug visibility plus Arrow Feather payload_bytes with payload_codec='arrow-feather' so NATS drain can publish bytes without reserializing when a subject is present\n- add Arrow Feather serialization helpers alongside the existing Arrow stream helpers\n- use FOR UPDATE SKIP LOCKED claiming and UNIQUE (execution_id, event_id) idempotency\n\n## Why\nThis moves Phase 2 mirroring away from fragile direct publisher calls and caller-owned after-commit hooks. Writers can enqueue in the same transaction as noetl.event, and the publisher drains only committed rows. Feather is the default persisted byte codec for the outbox hot path.\n\n## Validation\n- .venv/bin/python -m pytest tests/core/test_outbox.py tests/core/test_arrow_ipc_serialization.py tests/database/test_distributed_runtime_schema.py tests/core/test_nats_command_publisher.py tests/api/test_core_event_mirror.py\n- .venv/bin/python -m compileall noetl/core/outbox.py noetl/core/storage/arrow_ipc.py\n- git diff --check\n\nTracks noetl/noetl#461 and noetl/noetl#437