### PR TITLE
Route frame event mirrors through outbox

### DIFF
--- a/noetl/server/api/frames/endpoint.py
+++ b/noetl/server/api/frames/endpoint.py
@@ -14,6 +14,7 @@ from noetl.core.db.pool import get_pool_connection
 from noetl.core.event_store.ports import canonical_event_checksum
 from noetl.core.logger import setup_logger
 from noetl.core.messaging import NATSEventPublisher
+from noetl.core.outbox import enqueue_outbox, publish_outbox_batch
 
 from noetl.server.api.core.db import _next_snowflake_id
 
@@ -21,7 +22,7 @@ from .schema import FrameClaimRequest, FrameCommitRequest, FrameHeartbeatRequest
 
 logger = setup_logger(__name__, include_location=True)
 router = APIRouter(tags=["frames"])
-_event_mirror_publisher: NATSEventPublisher | None = None
+_event_subject_publisher: NATSEventPublisher | None = None
 
 
 def _event_meta(*, frame: dict[str, Any], worker_id: str, extra: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -348,7 +349,7 @@ async def _insert_frame_event(
             "now": now,
         },
     )
-    return {
+    event = {
         "event_id": int(event_id),
         "execution_id": frame["execution_id"],
         "catalog_id": catalog_id,
@@ -376,6 +377,9 @@ async def _insert_frame_event(
         "payload_ref": payload_ref,
         "envelope_checksum": envelope_checksum,
     }
+    if _event_mirror_enabled():
+        await enqueue_outbox(cur, event, subject=_frame_event_subject(event))
+    return event
 
 
 def _frame_commit_result(
@@ -446,22 +450,20 @@ def _event_mirror_enabled() -> bool:
     return os.getenv("NOETL_EVENT_MIRROR_ENABLED", "").strip().lower() in {"1", "true", "yes", "on"}
 
 
-async def _mirror_frame_events(events: list[dict[str, Any]]) -> None:
-    if not events or not _event_mirror_enabled():
+def _frame_event_subject(event: dict[str, Any]) -> str:
+    global _event_subject_publisher
+    if _event_subject_publisher is None:
+        _event_subject_publisher = NATSEventPublisher()
+    return _event_subject_publisher.subject_for_event(event)
+
+
+async def _drain_frame_outbox() -> None:
+    if not _event_mirror_enabled():
         return
-    global _event_mirror_publisher
-    if _event_mirror_publisher is None:
-        _event_mirror_publisher = NATSEventPublisher()
-    for event in events:
-        try:
-            await _event_mirror_publisher.publish_event(event)
-        except Exception as exc:
-            logger.warning(
-                "Frame event mirror failed event_id=%s event_type=%s: %s",
-                event.get("event_id"),
-                event.get("event_type"),
-                exc,
-            )
+    try:
+        await publish_outbox_batch(limit=int(os.getenv("NOETL_FRAME_OUTBOX_DRAIN_LIMIT", "100")))
+    except Exception as exc:
+        logger.warning("Frame outbox drain failed: %s", exc)
 
 
 def _frame_response(frame: dict[str, Any], event_id: int | None = None) -> dict[str, Any]:
@@ -502,7 +504,6 @@ async def claim_frames(stage_id: int, req: FrameClaimRequest) -> dict[str, Any]:
                     requested_command_id=req.command_id,
                 )
                 claimed: list[dict[str, Any]] = []
-                events_to_mirror: list[dict[str, Any]] = []
                 for _ in range(req.requested_count):
                     frame = await _load_idempotent_claimed_frame(
                         cur,
@@ -613,7 +614,7 @@ async def claim_frames(stage_id: int, req: FrameClaimRequest) -> dict[str, Any]:
                         frame["step_name"] = stage["step_name"]
 
                     if frame.get("expired_lease"):
-                        abandoned = await _insert_frame_event(
+                        await _insert_frame_event(
                             cur,
                             frame={**frame, "catalog_id": stage["catalog_id"]},
                             event_type="frame.abandoned",
@@ -630,7 +631,6 @@ async def claim_frames(stage_id: int, req: FrameClaimRequest) -> dict[str, Any]:
                                 ),
                             },
                         )
-                        events_to_mirror.append(abandoned)
 
                     await cur.execute(
                         """
@@ -671,11 +671,10 @@ async def claim_frames(stage_id: int, req: FrameClaimRequest) -> dict[str, Any]:
                         event_id=updated.get("claimed_event_id"),
                     )
                     updated["claimed_event_id"] = event["event_id"]
-                    events_to_mirror.append(event)
                     claimed.append(_frame_response(updated, event["event_id"]))
 
                 await conn.commit()
-                await _mirror_frame_events(events_to_mirror)
+                await _drain_frame_outbox()
                 return {"status": "ok", "frames": claimed}
     except HTTPException:
         raise
@@ -733,7 +732,7 @@ async def heartbeat_frame(frame_id: int, req: FrameHeartbeatRequest) -> dict[str
                     meta_extra={"lease_until": str(frame.get("lease_until"))},
                 )
                 await conn.commit()
-                await _mirror_frame_events([event])
+                await _drain_frame_outbox()
                 return {"status": "ok", "frame": _frame_response(frame, event["event_id"])}
     except HTTPException:
         raise
@@ -809,7 +808,7 @@ async def commit_frame(frame_id: int, req: FrameCommitRequest) -> dict[str, Any]
                 )
                 frame["terminal_event_id"] = event["event_id"]
                 await conn.commit()
-                await _mirror_frame_events([event])
+                await _drain_frame_outbox()
                 return {"status": "ok", "frame": _frame_response(frame, event["event_id"])}
     except HTTPException:
         raise

--- a/tests/api/test_frame_routes.py
+++ b/tests/api/test_frame_routes.py
@@ -224,19 +224,66 @@ async def test_insert_frame_event_sets_sparse_stream_version_and_checksum(monkey
 
 
 @pytest.mark.asyncio
-async def test_frame_event_mirror_is_opt_in(monkeypatch):
+async def test_insert_frame_event_enqueues_outbox_when_enabled(monkeypatch):
+    from noetl.server.api.frames import endpoint
+
+    class Cursor:
+        def __init__(self):
+            self.calls = []
+
+        async def execute(self, query, params=None):
+            self.calls.append((query, params))
+
+        async def fetchone(self):
+            return {"catalog_id": 6}
+
+    outbox_rows = []
+
+    async def next_event_id(cur):  # noqa: ARG001
+        return 123
+
+    async def enqueue_outbox(cur, event, *, subject=None):  # noqa: ARG001
+        outbox_rows.append((event, subject))
+
+    monkeypatch.setattr(endpoint, "_next_snowflake_id", next_event_id)
+    monkeypatch.setattr(endpoint, "enqueue_outbox", enqueue_outbox)
+    monkeypatch.setattr(endpoint, "_frame_event_subject", lambda event: f"subject.{event['event_id']}")
+    monkeypatch.setenv("NOETL_EVENT_MIRROR_ENABLED", "true")
+
+    await endpoint._insert_frame_event(
+        Cursor(),
+        frame={
+            "frame_id": 9,
+            "stage_id": 8,
+            "execution_id": 7,
+            "tenant_id": "tenant-a",
+            "organization_id": "org-a",
+            "step_name": "fetch_rows",
+        },
+        event_type="frame.dispatched",
+        status="CLAIMED",
+        worker_id="worker-a",
+    )
+
+    assert outbox_rows[0][0]["event_id"] == 123
+    assert outbox_rows[0][0]["event_type"] == "frame.dispatched"
+    assert outbox_rows[0][1] == "subject.123"
+
+
+@pytest.mark.asyncio
+async def test_frame_outbox_drain_is_opt_in(monkeypatch):
     from noetl.server.api.frames import endpoint
 
     calls = []
 
-    class _FakePublisher:
-        async def publish_event(self, event):
-            calls.append(event)
+    async def publish_outbox_batch(*, limit):
+        calls.append(limit)
+        return 1
 
-    monkeypatch.setattr(endpoint, "_event_mirror_publisher", _FakePublisher())
+    monkeypatch.setattr(endpoint, "publish_outbox_batch", publish_outbox_batch)
     monkeypatch.delenv("NOETL_EVENT_MIRROR_ENABLED", raising=False)
 
-    await endpoint._mirror_frame_events([{"event_id": 1, "event_type": "frame.dispatched"}])
+    await endpoint._drain_frame_outbox()
 
     assert calls == []
 
@@ -303,21 +350,22 @@ async def test_load_frame_by_claim_key_matches_pending_frame():
 
 
 @pytest.mark.asyncio
-async def test_frame_event_mirror_publishes_when_enabled(monkeypatch):
+async def test_frame_outbox_drain_publishes_when_enabled(monkeypatch):
     from noetl.server.api.frames import endpoint
 
     calls = []
 
-    class _FakePublisher:
-        async def publish_event(self, event):
-            calls.append(event)
+    async def publish_outbox_batch(*, limit):
+        calls.append(limit)
+        return 1
 
-    monkeypatch.setattr(endpoint, "_event_mirror_publisher", _FakePublisher())
+    monkeypatch.setattr(endpoint, "publish_outbox_batch", publish_outbox_batch)
     monkeypatch.setenv("NOETL_EVENT_MIRROR_ENABLED", "true")
+    monkeypatch.setenv("NOETL_FRAME_OUTBOX_DRAIN_LIMIT", "7")
 
-    await endpoint._mirror_frame_events([{"event_id": 1, "event_type": "frame.dispatched"}])
+    await endpoint._drain_frame_outbox()
 
-    assert calls == [{"event_id": 1, "event_type": "frame.dispatched"}]
+    assert calls == [7]
 
 
 class _CursorCtx:
@@ -455,12 +503,8 @@ async def test_heartbeat_frame_separates_start_from_lease_extension(
         emitted.append(kwargs)
         return {"event_id": 123, "event_type": kwargs["event_type"]}
 
-    async def mirror_frame_events(_events):
-        return None
-
     monkeypatch.setattr(endpoint, "get_pool_connection", lambda: _ConnCtx(conn))
     monkeypatch.setattr(endpoint, "_insert_frame_event", insert_frame_event)
-    monkeypatch.setattr(endpoint, "_mirror_frame_events", mirror_frame_events)
 
     response = await endpoint.heartbeat_frame(
         9,
@@ -574,14 +618,10 @@ async def test_claim_frames_reclaims_expired_frame_with_abandoned_event(monkeypa
         emitted.append(kwargs)
         return {"event_id": 100 + len(emitted), "event_type": kwargs["event_type"]}
 
-    async def mirror_frame_events(_events):
-        return None
-
     monkeypatch.setattr(endpoint, "get_pool_connection", lambda: _ConnCtx(conn))
     monkeypatch.setattr(endpoint, "_load_stage", load_stage)
     monkeypatch.setattr(endpoint, "_resolve_claim_command_id", resolve_command_id)
     monkeypatch.setattr(endpoint, "_insert_frame_event", insert_frame_event)
-    monkeypatch.setattr(endpoint, "_mirror_frame_events", mirror_frame_events)
 
     response = await endpoint.claim_frames(
         8,
@@ -706,15 +746,11 @@ async def test_claim_frames_mints_without_advisory_lock(monkeypatch):
         emitted.append(kwargs)
         return {"event_id": kwargs["event_id"], "event_type": kwargs["event_type"]}
 
-    async def mirror_frame_events(_events):
-        return None
-
     monkeypatch.setattr(endpoint, "get_pool_connection", lambda: _ConnCtx(conn))
     monkeypatch.setattr(endpoint, "_load_stage", load_stage)
     monkeypatch.setattr(endpoint, "_resolve_claim_command_id", resolve_command_id)
     monkeypatch.setattr(endpoint, "_next_snowflake_id", next_snowflake_id)
     monkeypatch.setattr(endpoint, "_insert_frame_event", insert_frame_event)
-    monkeypatch.setattr(endpoint, "_mirror_frame_events", mirror_frame_events)
 
     response = await endpoint.claim_frames(
         8,


### PR DESCRIPTION
## Summary\n- enqueue frame lifecycle mirror envelopes into noetl.outbox inside the canonical noetl.event transaction\n- drain committed outbox rows after frame route commits instead of directly publishing event dicts\n- keep rollout gated by NOETL_EVENT_MIRROR_ENABLED\n- update frame route tests for outbox enqueue/drain behavior\n\n## Validation\n- .venv/bin/python -m pytest tests/api/test_frame_routes.py tests/core/test_outbox.py tests/core/test_arrow_ipc_serialization.py\n- .venv/bin/python -m compileall noetl/server/api/frames/endpoint.py\n- git diff --check\n\nTracks noetl/noetl#461 and noetl/noetl#437