### PR TITLE
Route execution event mirrors through outbox

### DIFF
--- a/noetl/server/api/core/execution.py
+++ b/noetl/server/api/core/execution.py
@@ -5,6 +5,8 @@ from fastapi import APIRouter, HTTPException
 from psycopg.rows import dict_row
 from psycopg.types.json import Json
 from noetl.core.db.pool import get_pool_connection
+from noetl.core.messaging import NATSEventPublisher
+from noetl.core.outbox import enqueue_outbox, publish_outbox_batch
 from noetl.server.api.supervision import supervise_command_issued
 from noetl.server.api.event_queries import PENDING_COMMAND_COUNT_SQL
 from .core import logger, get_engine
@@ -16,6 +18,7 @@ from .db import _next_snowflake_id
 from .recovery import _publish_commands_with_recovery
 
 router = APIRouter()
+_execution_event_subject_publisher: NATSEventPublisher | None = None
 _STATUS_TERMINAL_EVENT_TYPES = (
     "playbook.completed",
     "workflow.completed",
@@ -31,6 +34,33 @@ async def _mirror_execution_events(events: list[dict[str, Any]]) -> None:
     from .events import _mirror_events
 
     await _mirror_events(events)
+
+
+def _execution_event_mirror_enabled() -> bool:
+    return os.getenv("NOETL_EVENT_MIRROR_ENABLED", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _execution_event_subject(event: dict[str, Any]) -> str:
+    global _execution_event_subject_publisher
+    if _execution_event_subject_publisher is None:
+        _execution_event_subject_publisher = NATSEventPublisher()
+    return _execution_event_subject_publisher.subject_for_event(event)
+
+
+async def _enqueue_execution_outbox(cur: Any, event: dict[str, Any]) -> None:
+    if not _execution_event_mirror_enabled():
+        return
+    await enqueue_outbox(cur, event, subject=_execution_event_subject(event))
+
+
+async def _drain_execution_outbox() -> None:
+    if not _execution_event_mirror_enabled():
+        return
+    try:
+        limit = int(os.getenv("NOETL_EXECUTION_OUTBOX_DRAIN_LIMIT", "100"))
+        await publish_outbox_batch(limit=limit)
+    except Exception as exc:
+        logger.warning("Execution outbox drain failed: %s", exc)
 
 
 def _normalize_catalog_kind(value: Optional[str]) -> Optional[str]:
@@ -110,7 +140,6 @@ async def execute(req: ExecuteRequest) -> ExecuteResponse:
                     catalog_id, path = row['catalog_id'], row['path']
         
         execution_id, commands = await engine.start_execution(path, req.payload, catalog_id, req.parent_execution_id)
-        mirrored_command_events = []
         async with get_pool_connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cur:
                 await cur.execute("SELECT event_id FROM noetl.event WHERE execution_id = %s AND event_type = 'playbook.initialized' LIMIT 1", (int(execution_id),))
@@ -157,24 +186,27 @@ async def execute(req: ExecuteRequest) -> ExecuteResponse:
                         "created_at": now,
                     })
                     command_events.append((int(execution_id), evt_id, cmd_id, cmd.step))
-                    mirrored_command_events.append(_command_issued_envelope(
-                        event_id=evt_id,
-                        execution_id=int(execution_id),
-                        catalog_id=catalog_id,
-                        command_id=cmd_id,
-                        step=cmd.step,
-                        tool_kind=cmd.tool.kind,
-                        context=ctx,
-                        meta=meta,
-                        parent_event_id=root_evt_id,
-                        parent_execution_id=req.parent_execution_id,
-                        stage_id=stage_id,
-                        frame_id=frame_id,
-                        created_at=now,
-                    ))
+                    await _enqueue_execution_outbox(
+                        cur,
+                        _command_issued_envelope(
+                            event_id=evt_id,
+                            execution_id=int(execution_id),
+                            catalog_id=catalog_id,
+                            command_id=cmd_id,
+                            step=cmd.step,
+                            tool_kind=cmd.tool.kind,
+                            context=ctx,
+                            meta=meta,
+                            parent_event_id=root_evt_id,
+                            parent_execution_id=req.parent_execution_id,
+                            stage_id=stage_id,
+                            frame_id=frame_id,
+                            created_at=now,
+                        ),
+                    )
                     supervisor_commands.append((str(execution_id), cmd_id, cmd.step, int(evt_id), dict(meta)))
                 await conn.commit()
-        await _mirror_execution_events(mirrored_command_events)
+        await _drain_execution_outbox()
         for s_exec, s_cmd, s_step, s_evt, s_meta in supervisor_commands:
             await supervise_command_issued(s_exec, s_cmd, s_step, event_id=s_evt, meta=s_meta)
         await _publish_commands_with_recovery(command_events, server_url=server_url)

--- a/noetl/server/api/execution/endpoint.py
+++ b/noetl/server/api/execution/endpoint.py
@@ -13,6 +13,8 @@ from psycopg.types.json import Json
 from noetl.core.db.pool import get_pool_connection, get_snowflake_id
 from noetl.core.logger import setup_logger
 from noetl.core.common import convert_snowflake_ids_for_api, normalize_execution_id_for_db
+from noetl.core.messaging import NATSEventPublisher
+from noetl.core.outbox import enqueue_outbox, publish_outbox_batch
 from noetl.server.api.event_queries import PENDING_COMMAND_COUNT_SQL
 from .schema import (
     ExecutionEntryResponse,
@@ -39,6 +41,7 @@ except Exception:  # pragma: no cover
 
 logger = setup_logger(__name__, include_location=True)
 router = APIRouter(tags=["executions"])
+_execution_route_subject_publisher: NATSEventPublisher | None = None
 
 DEFAULT_EXECUTIONS_PAGE_SIZE = 100
 MAX_EXECUTIONS_PAGE_SIZE = 200
@@ -49,6 +52,33 @@ async def _mirror_execution_route_events(events: list[dict[str, Any]]) -> None:
     from noetl.server.api.core.events import _mirror_events
 
     await _mirror_events(events)
+
+
+def _execution_route_mirror_enabled() -> bool:
+    return os.getenv("NOETL_EVENT_MIRROR_ENABLED", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _execution_route_event_subject(event: dict[str, Any]) -> str:
+    global _execution_route_subject_publisher
+    if _execution_route_subject_publisher is None:
+        _execution_route_subject_publisher = NATSEventPublisher()
+    return _execution_route_subject_publisher.subject_for_event(event)
+
+
+async def _enqueue_execution_route_outbox(cur: Any, event: dict[str, Any]) -> None:
+    if not _execution_route_mirror_enabled():
+        return
+    await enqueue_outbox(cur, event, subject=_execution_route_event_subject(event))
+
+
+async def _drain_execution_route_outbox() -> None:
+    if not _execution_route_mirror_enabled():
+        return
+    try:
+        limit = int(os.getenv("NOETL_EXECUTION_ROUTE_OUTBOX_DRAIN_LIMIT", "100"))
+        await publish_outbox_batch(limit=limit)
+    except Exception as exc:
+        logger.warning("Execution route outbox drain failed: %s", exc)
 
 
 def _as_iso(value: Optional[datetime]) -> Optional[str]:
@@ -968,8 +998,6 @@ async def cancel_execution(execution_id: str, request: CancelExecutionRequest = 
         request = CancelExecutionRequest()
     
     cancelled_ids = []
-    mirrored_events = []
-    
     async with get_pool_connection() as conn:
         async with conn.cursor(row_factory=dict_row) as cur:
             # Check if execution exists and get its current state
@@ -1056,26 +1084,29 @@ async def cancel_execution(execution_id: str, request: CancelExecutionRequest = 
                     "cancel", "cancel", "CANCELLED",
                     Json(meta), now
                 ))
-                mirrored_events.append({
-                    "event_id": int(event_id),
-                    "execution_id": int(exec_id),
-                    "catalog_id": catalog_id,
-                    "event_type": "execution.cancelled",
-                    "node_id": "cancel",
-                    "node_name": "cancel",
-                    "status": "CANCELLED",
-                    "result": {"status": "CANCELLED"},
-                    "meta": meta,
-                    "event_time": now,
-                    "ingest_time": now,
-                    "created_at": now,
-                })
+                await _enqueue_execution_route_outbox(
+                    cur,
+                    {
+                        "event_id": int(event_id),
+                        "execution_id": int(exec_id),
+                        "catalog_id": catalog_id,
+                        "event_type": "execution.cancelled",
+                        "node_id": "cancel",
+                        "node_name": "cancel",
+                        "status": "CANCELLED",
+                        "result": {"status": "CANCELLED"},
+                        "meta": meta,
+                        "event_time": now,
+                        "ingest_time": now,
+                        "created_at": now,
+                    },
+                )
                 
                 cancelled_ids.append(str(exec_id))
                 logger.info(f"Cancelled execution {exec_id} - reason: {request.reason}")
             
             await conn.commit()
-    await _mirror_execution_route_events(mirrored_events)
+    await _drain_execution_route_outbox()
     
     return CancelExecutionResponse(
         status="cancelled",

--- a/noetl/server/api/execution/endpoint.py
+++ b/noetl/server/api/execution/endpoint.py
@@ -1958,26 +1958,48 @@ async def cleanup_stuck_executions(request: CleanupStuckExecutionsRequest = Body
                 
                 result = await cursor.fetchone()
                 next_event_id = result['next_event_id']
+                now = datetime.now(timezone.utc)
+                meta = {
+                    "reason": f"Cleaned up stuck execution (older than {request.older_than_minutes} minutes)",
+                    "auto_cancelled": True,
+                    "cleanup_api": True,
+                    "actionable": True,
+                }
                 
                 # Insert cancellation event
                 await cursor.execute("""
                     INSERT INTO event (
                         execution_id, catalog_id, event_id, event_type, status, context, created_at
                     ) VALUES (
-                        %s, %s, %s, 'execution.cancelled', 'CANCELLED', %s, NOW()
+                        %s, %s, %s, 'execution.cancelled', 'CANCELLED', %s, %s
                     )
                 """, (
                     execution_id,
                     catalog_id,
                     next_event_id,
-                    Json({
-                        "reason": f"Cleaned up stuck execution (older than {request.older_than_minutes} minutes)",
-                        "auto_cancelled": True,
-                        "cleanup_api": True
-                    })
+                    Json(meta),
+                    now,
                 ))
+                await _enqueue_execution_route_outbox(
+                    cursor,
+                    {
+                        "event_id": int(next_event_id),
+                        "execution_id": int(execution_id),
+                        "catalog_id": catalog_id,
+                        "event_type": "execution.cancelled",
+                        "node_id": "cleanup",
+                        "node_name": "cleanup",
+                        "status": "CANCELLED",
+                        "result": {"status": "CANCELLED"},
+                        "meta": meta,
+                        "event_time": now,
+                        "ingest_time": now,
+                        "created_at": now,
+                    },
+                )
             
             await conn.commit()
+            await _drain_execution_route_outbox()
             
             logger.info(f"Cancelled {len(execution_ids)} stuck executions")
             

--- a/tests/api/execution/test_execution_event_mirror.py
+++ b/tests/api/execution/test_execution_event_mirror.py
@@ -119,9 +119,11 @@ async def test_execute_mirrors_initial_command_issued_after_commit(monkeypatch):
     async def fake_store_context_if_needed(**kwargs):
         return kwargs["context"]
 
-    async def fake_mirror(events):
+    async def fake_enqueue(_cur, event):
+        mirrored.append(event)
+
+    async def fake_drain():
         assert conn.commits == 1
-        mirrored.extend(events)
 
     async def fake_publish(items, *, server_url):
         published.extend(items)
@@ -132,7 +134,8 @@ async def test_execute_mirrors_initial_command_issued_after_commit(monkeypatch):
     monkeypatch.setattr(execution_module, "get_engine", lambda: FakeEngine())
     monkeypatch.setattr(execution_module, "get_pool_connection", lambda: _ConnCtx(conn))
     monkeypatch.setattr(execution_module, "_next_snowflake_id", fake_next_snowflake_id)
-    monkeypatch.setattr(execution_module, "_mirror_execution_events", fake_mirror)
+    monkeypatch.setattr(execution_module, "_enqueue_execution_outbox", fake_enqueue)
+    monkeypatch.setattr(execution_module, "_drain_execution_outbox", fake_drain)
     monkeypatch.setattr(execution_module, "_publish_commands_with_recovery", fake_publish)
     monkeypatch.setattr(execution_module, "supervise_command_issued", fake_supervise)
     monkeypatch.setattr(commands_module, "_build_command_context", lambda _cmd: {"url": "https://example.test"})
@@ -163,16 +166,19 @@ async def test_cancel_execution_mirrors_cancelled_event_after_commit(monkeypatch
     conn = _FakeConn(cursor)
     mirrored = []
 
-    async def fake_mirror(events):
+    async def fake_enqueue(_cur, event):
+        mirrored.append(event)
+
+    async def fake_drain():
         assert conn.commits == 1
-        mirrored.extend(events)
 
     monkeypatch.setattr(endpoint, "get_pool_connection", lambda: _ConnCtx(conn))
     async def fake_snowflake_id():
         return 9001
 
     monkeypatch.setattr(endpoint, "get_snowflake_id", fake_snowflake_id)
-    monkeypatch.setattr(endpoint, "_mirror_execution_route_events", fake_mirror)
+    monkeypatch.setattr(endpoint, "_enqueue_execution_route_outbox", fake_enqueue)
+    monkeypatch.setattr(endpoint, "_drain_execution_route_outbox", fake_drain)
 
     result = await endpoint.cancel_execution(
         "7",

--- a/tests/api/execution/test_execution_event_mirror.py
+++ b/tests/api/execution/test_execution_event_mirror.py
@@ -85,6 +85,28 @@ class _CancelCursor:
         return []
 
 
+class _CleanupCursor:
+    def __init__(self):
+        self.query = ""
+        self.params = None
+        self.executed = []
+
+    async def execute(self, query, params=None):
+        self.query = query
+        self.params = params
+        self.executed.append((query, params))
+
+    async def fetchall(self):
+        if "SELECT DISTINCT" in self.query:
+            return [{"execution_id": 7, "catalog_id": 5}]
+        return []
+
+    async def fetchone(self):
+        if "next_event_id" in self.query:
+            return {"next_event_id": 9002}
+        return None
+
+
 @pytest.mark.asyncio
 async def test_execute_mirrors_initial_command_issued_after_commit(monkeypatch):
     import noetl.server.api.core.commands as commands_module
@@ -191,3 +213,34 @@ async def test_cancel_execution_mirrors_cancelled_event_after_commit(monkeypatch
     assert mirrored[0]["execution_id"] == 7
     assert mirrored[0]["status"] == "CANCELLED"
     assert mirrored[0]["meta"]["reason"] == "operator requested"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_stuck_execution_enqueues_cancelled_event_before_drain(monkeypatch):
+    import noetl.server.api.execution.endpoint as endpoint
+    from noetl.server.api.execution.schema import CleanupStuckExecutionsRequest
+
+    cursor = _CleanupCursor()
+    conn = _FakeConn(cursor)
+    mirrored = []
+
+    async def fake_enqueue(_cur, event):
+        mirrored.append(event)
+
+    async def fake_drain():
+        assert conn.commits == 1
+
+    monkeypatch.setattr(endpoint, "get_pool_connection", lambda: _ConnCtx(conn))
+    monkeypatch.setattr(endpoint, "_enqueue_execution_route_outbox", fake_enqueue)
+    monkeypatch.setattr(endpoint, "_drain_execution_route_outbox", fake_drain)
+
+    result = await endpoint.cleanup_stuck_executions(
+        CleanupStuckExecutionsRequest(older_than_minutes=5, dry_run=False)
+    )
+
+    assert result.cancelled_count == 1
+    assert mirrored[0]["event_id"] == 9002
+    assert mirrored[0]["event_type"] == "execution.cancelled"
+    assert mirrored[0]["execution_id"] == 7
+    assert mirrored[0]["node_name"] == "cleanup"
+    assert mirrored[0]["meta"]["cleanup_api"] is True


### PR DESCRIPTION
## Summary
- enqueue /api/execute generated command.issued mirror envelopes into noetl.outbox before commit
- enqueue execution.cancelled route envelopes into noetl.outbox before commit
- drain committed outbox rows after commit while preserving command publish/recovery behavior

## Tests
- .venv/bin/python -m pytest tests/api/execution/test_execution_event_mirror.py tests/core/test_outbox.py tests/core/test_arrow_ipc_serialization.py
- .venv/bin/python -m compileall noetl/server/api/core/execution.py noetl/server/api/execution/endpoint.py tests/api/execution/test_execution_event_mirror.py

Refs #461
Refs #437