### PR TITLE
Route auto-resume cancellation events through outbox

### DIFF
--- a/noetl/server/auto_resume.py
+++ b/noetl/server/auto_resume.py
@@ -19,8 +19,11 @@ from psycopg.types.json import Json
 
 from noetl.core.db.pool import get_pool_connection, get_snowflake_id
 from noetl.core.logger import setup_logger
+from noetl.core.messaging import NATSEventPublisher
+from noetl.core.outbox import enqueue_outbox, publish_outbox_batch
 
 logger = setup_logger(__name__, include_location=True)
+_auto_resume_event_subject_publisher: NATSEventPublisher | None = None
 
 _AUTO_RESUME_ENABLED = os.getenv("NOETL_AUTO_RESUME_ENABLED", "true").strip().lower() in {
     "1",
@@ -75,6 +78,33 @@ _auto_resume_metrics: dict[str, float] = {
     "recoveries_cancelled_total": 0.0,
     "recoveries_restarted_total": 0.0,
 }
+
+
+def _event_mirror_enabled() -> bool:
+    return os.getenv("NOETL_EVENT_MIRROR_ENABLED", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _auto_resume_event_subject(event: dict[str, Any]) -> str:
+    global _auto_resume_event_subject_publisher
+    if _auto_resume_event_subject_publisher is None:
+        _auto_resume_event_subject_publisher = NATSEventPublisher()
+    return _auto_resume_event_subject_publisher.subject_for_event(event)
+
+
+async def _enqueue_auto_resume_outbox(cur: Any, event: dict[str, Any]) -> None:
+    if not _event_mirror_enabled():
+        return
+    await enqueue_outbox(cur, event, subject=_auto_resume_event_subject(event))
+
+
+async def _drain_auto_resume_outbox() -> None:
+    if not _event_mirror_enabled():
+        return
+    try:
+        limit = int(os.getenv("NOETL_AUTO_RESUME_OUTBOX_DRAIN_LIMIT", "100"))
+        await publish_outbox_batch(limit=limit)
+    except Exception as exc:
+        logger.warning("[AUTO-RESUME] Outbox drain failed: %s", exc)
 
 
 def _inc_metric(name: str, amount: float = 1.0) -> None:
@@ -373,6 +403,8 @@ async def mark_execution_cancelled(
                 }
                 if meta_extra:
                     cancel_meta.update(meta_extra)
+                created_at = datetime.now(timezone.utc)
+                result_obj = {"status": "CANCELLED", "context": cancel_payload}
                 await cur.execute(
                     """
                     INSERT INTO noetl.event (
@@ -380,7 +412,7 @@ async def mark_execution_cancelled(
                         node_id, node_name, status, result, meta, created_at
                     ) VALUES (
                         %s, %s, %s, 'execution.cancelled',
-                        %s, %s, 'CANCELLED', %s, %s, NOW()
+                        %s, %s, 'CANCELLED', %s, %s, %s
                     )
                     """,
                     (
@@ -389,11 +421,30 @@ async def mark_execution_cancelled(
                         int(event_id),
                         "workflow",
                         "workflow",
-                        Json({"status": "CANCELLED", "context": cancel_payload}),
+                        Json(result_obj),
                         Json(cancel_meta),
+                        created_at,
                     ),
                 )
+                await _enqueue_auto_resume_outbox(
+                    cur,
+                    {
+                        "event_id": int(event_id),
+                        "execution_id": int(execution_id),
+                        "catalog_id": row["catalog_id"],
+                        "event_type": "execution.cancelled",
+                        "node_id": "workflow",
+                        "node_name": "workflow",
+                        "status": "CANCELLED",
+                        "result": result_obj,
+                        "meta": cancel_meta,
+                        "event_time": created_at,
+                        "ingest_time": created_at,
+                        "created_at": created_at,
+                    },
+                )
                 await conn.commit()
+        await _drain_auto_resume_outbox()
 
         _inc_metric("recoveries_cancelled_total")
         logger.info("[AUTO-RESUME] Marked execution %s as CANCELLED", execution_id)

--- a/tests/test_auto_resume.py
+++ b/tests/test_auto_resume.py
@@ -234,6 +234,80 @@ class _FakeConnCtx:
         return False
 
 
+class _CancelCursor:
+    def __init__(self):
+        self.query = ""
+        self.executed = []
+
+    async def execute(self, query, params=None):
+        self.query = query
+        self.executed.append((query, params))
+
+    async def fetchone(self):
+        if "SELECT catalog_id" in self.query:
+            return {"catalog_id": 5}
+        return None
+
+
+class _CancelConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.commits = 0
+
+    def cursor(self, row_factory=None):
+        return _FakeCursorCtx(self._cursor)
+
+    async def commit(self):
+        self.commits += 1
+
+
+class _CancelConnCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_mark_execution_cancelled_enqueues_outbox_before_drain(monkeypatch):
+    cursor = _CancelCursor()
+    conn = _CancelConn(cursor)
+    enqueued = []
+
+    async def fake_enqueue(_cur, event):
+        enqueued.append(event)
+
+    async def fake_drain():
+        assert conn.commits == 1
+
+    async def fake_snowflake_id():
+        return 9001
+
+    monkeypatch.setattr(auto_resume, "get_pool_connection", lambda *args, **kwargs: _CancelConnCtx(conn))
+    monkeypatch.setattr(auto_resume, "get_snowflake_id", fake_snowflake_id)
+    monkeypatch.setattr(auto_resume, "_enqueue_auto_resume_outbox", fake_enqueue)
+    monkeypatch.setattr(auto_resume, "_drain_auto_resume_outbox", fake_drain)
+
+    ok = await auto_resume.mark_execution_cancelled(
+        7,
+        "restart replacement created",
+        meta_extra={"restarted_execution_id": "8"},
+        payload_extra={"restarted_execution_id": "8"},
+    )
+
+    assert ok is True
+    assert enqueued[0]["event_id"] == 9001
+    assert enqueued[0]["event_type"] == "execution.cancelled"
+    assert enqueued[0]["execution_id"] == 7
+    assert enqueued[0]["catalog_id"] == 5
+    assert enqueued[0]["result"]["context"]["restarted_execution_id"] == "8"
+    assert enqueued[0]["meta"]["auto_resume"] is True
+
+
 @pytest.mark.asyncio
 async def test_get_execution_status_treats_workflow_completed_as_completed(monkeypatch):
     row = {"event_type": "workflow.completed", "status": "COMPLETED"}


### PR DESCRIPTION
## Summary
- enqueue auto-resume execution.cancelled envelopes into noetl.outbox inside the cancellation transaction
- drain committed outbox rows after commit without changing recovery mode behavior
- add focused regression coverage for the outbox enqueue/drain boundary

## Tests
- .venv/bin/python -m pytest tests/test_auto_resume.py tests/core/test_outbox.py tests/core/test_arrow_ipc_serialization.py
- .venv/bin/python -m compileall noetl/server/auto_resume.py tests/test_auto_resume.py

Refs #461
Refs #437