### PR TITLE
Route command claim events through outbox

### DIFF
--- a/noetl/server/api/core/commands.py
+++ b/noetl/server/api/core/commands.py
@@ -436,13 +436,16 @@ async def claim_command(event_id: int, req: ClaimRequest):
                 if stale_reclaim:
                     claim_meta.update({"reclaimed": True, "reclaimed_from_worker": reclaimed_from, "reclaimed_reason": reclaimed_reason})
                 
+                from .events import _drain_core_outbox, _enqueue_event_outbox, _event_envelope
+
+                created_at = datetime.now(timezone.utc)
                 res_obj = _build_reference_only_result(payload={"command_id": command_id}, status="RUNNING")
                 await cur.execute("""
                     INSERT INTO noetl.event (event_id, execution_id, catalog_id, event_type, node_id, node_name, status, result, meta, worker_id, created_at)
                     SELECT %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
                     WHERE NOT EXISTS (SELECT 1 FROM noetl.event WHERE execution_id = %s AND event_type = ANY(%s) LIMIT 1)
                     RETURNING event_id
-                """, (claim_evt_id, execution_id, catalog_id, "command.claimed", step, step, "RUNNING", Json(res_obj), Json(claim_meta), req.worker_id, datetime.now(timezone.utc), execution_id, _EXECUTION_TERMINAL_EVENT_TYPES))
+                """, (claim_evt_id, execution_id, catalog_id, "command.claimed", step, step, "RUNNING", Json(res_obj), Json(claim_meta), req.worker_id, created_at, execution_id, _EXECUTION_TERMINAL_EVENT_TYPES))
                 
                 if not await cur.fetchone():
                     _active_claim_cache_invalidate(command_id=command_id, event_id=event_id)
@@ -460,8 +463,24 @@ async def claim_command(event_id: int, req: ClaimRequest):
                     """,
                     (req.worker_id, claim_evt_id, command_id),
                 )
+                await _enqueue_event_outbox(
+                    cur,
+                    _event_envelope(
+                        event_id=claim_evt_id,
+                        execution_id=execution_id,
+                        catalog_id=catalog_id,
+                        event_type="command.claimed",
+                        node_name=step,
+                        status="RUNNING",
+                        result=res_obj,
+                        meta=claim_meta,
+                        command_id=command_id,
+                        event_time=created_at,
+                    ),
+                )
                 
                 await conn.commit()
+                await _drain_core_outbox()
                 _active_claim_cache_set(event_id, command_id, req.worker_id)
                 logger.info(f"[CLAIM] Command {command_id} claimed by {req.worker_id}")
                 return ClaimResponse(status="ok", event_id=event_id, execution_id=execution_id, node_id=step, node_name=step, action=tool_kind, context=context, meta=meta)

--- a/tests/api/test_command_claim_outbox.py
+++ b/tests/api/test_command_claim_outbox.py
@@ -1,0 +1,104 @@
+from datetime import datetime, timezone
+
+import pytest
+
+
+class _FakeCursor:
+    def __init__(self):
+        self.query = ""
+        self.executed = []
+        self.command_row_returned = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, query, params=None):
+        self.query = query
+        self.executed.append((query, params))
+
+    async def fetchone(self):
+        if "FROM noetl.command" in self.query:
+            if self.command_row_returned:
+                return None
+            self.command_row_returned = True
+            return {
+                "command_id": 900,
+                "execution_id": 7,
+                "catalog_id": 5,
+                "step_name": "fetch",
+                "tool_kind": "http",
+                "context": {"url": "https://example.test"},
+                "meta": {"stage_id": "stage-1"},
+                "status": "PENDING",
+                "worker_id": None,
+                "claimed_at": None,
+                "started_at": None,
+                "updated_at": None,
+            }
+        if "pg_try_advisory_xact_lock" in self.query:
+            return {"lock_acquired": True}
+        if "RETURNING event_id" in self.query:
+            return {"event_id": 501}
+        return None
+
+
+class _FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.commits = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self, **_kwargs):
+        return self._cursor
+
+    async def commit(self):
+        self.commits += 1
+
+
+@pytest.mark.asyncio
+async def test_claim_command_enqueues_claimed_event_before_drain(monkeypatch):
+    from noetl.server.api.core import commands, events
+    from noetl.server.api.core.models import ClaimRequest
+
+    cursor = _FakeCursor()
+    conn = _FakeConnection(cursor)
+    enqueued = []
+
+    async def fake_next_snowflake_id(_cur):
+        return 501
+
+    async def fake_enqueue(_cur, event):
+        enqueued.append(event)
+
+    async def fake_drain():
+        assert conn.commits == 1
+
+    monkeypatch.setattr(commands, "get_pool_connection", lambda **_kwargs: conn)
+    monkeypatch.setattr(commands, "_next_snowflake_id", fake_next_snowflake_id)
+    monkeypatch.setattr(commands, "_active_claim_cache_get", lambda _event_id: None)
+    monkeypatch.setattr(commands, "_active_claim_cache_set", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(commands, "_record_db_operation_success", lambda: None)
+    monkeypatch.setattr(events, "_enqueue_event_outbox", fake_enqueue)
+    monkeypatch.setattr(events, "_drain_core_outbox", fake_drain)
+
+    response = await commands.claim_command(100, ClaimRequest(worker_id="worker-1"))
+
+    assert response.status == "ok"
+    assert enqueued[0]["event_id"] == 501
+    assert enqueued[0]["event_type"] == "command.claimed"
+    assert enqueued[0]["execution_id"] == 7
+    assert enqueued[0]["catalog_id"] == 5
+    assert enqueued[0]["command_id"] == 900
+    assert enqueued[0]["node_name"] == "fetch"
+    assert enqueued[0]["status"] == "RUNNING"
+    assert enqueued[0]["meta"]["worker_id"] == "worker-1"
+    assert isinstance(enqueued[0]["created_at"], datetime)
+    assert enqueued[0]["created_at"].tzinfo == timezone.utc


### PR DESCRIPTION
## Summary
- enqueue command.claimed envelopes into noetl.outbox before the claim transaction commits
- drain committed outbox rows after commit without changing claim response semantics
- add focused regression coverage for the command claim outbox boundary

## Tests
- .venv/bin/python -m pytest tests/api/test_command_claim_outbox.py tests/api/test_db_resilience.py tests/core/test_outbox.py tests/core/test_arrow_ipc_serialization.py
- .venv/bin/python -m compileall noetl/server/api/core/commands.py tests/api/test_command_claim_outbox.py

Refs #461
Refs #437