### PR TITLE
Route Postgres event-store appends through outbox

### DIFF
--- a/noetl/core/event_store/postgres.py
+++ b/noetl/core/event_store/postgres.py
@@ -1,13 +1,47 @@
 from __future__ import annotations
 
+import os
 from typing import Any, Optional
 
 from psycopg.rows import dict_row
 from psycopg.types.json import Json
 
 from noetl.core.db.pool import get_pool_connection
+from noetl.core.logger import setup_logger
+from noetl.core.messaging import NATSEventPublisher
+from noetl.core.outbox import enqueue_outbox, publish_outbox_batch
 
 from .ports import EventRecord, ExpectedVersionConflict
+
+logger = setup_logger(__name__, include_location=True)
+_event_store_subject_publisher: NATSEventPublisher | None = None
+
+
+def _event_mirror_enabled() -> bool:
+    return os.getenv("NOETL_EVENT_MIRROR_ENABLED", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _event_store_subject(event: dict[str, Any]) -> str:
+    global _event_store_subject_publisher
+    if _event_store_subject_publisher is None:
+        _event_store_subject_publisher = NATSEventPublisher()
+    return _event_store_subject_publisher.subject_for_event(event)
+
+
+async def _enqueue_event_store_outbox(cur: Any, event: dict[str, Any]) -> None:
+    if not _event_mirror_enabled():
+        return
+    await enqueue_outbox(cur, event, subject=_event_store_subject(event))
+
+
+async def _drain_event_store_outbox() -> None:
+    if not _event_mirror_enabled():
+        return
+    try:
+        limit = int(os.getenv("NOETL_EVENT_STORE_OUTBOX_DRAIN_LIMIT", "100"))
+        await publish_outbox_batch(limit=limit)
+    except Exception as exc:
+        logger.warning("Event-store outbox drain failed: %s", exc)
 
 
 class PostgresEventStore:
@@ -82,8 +116,10 @@ class PostgresEventStore:
                             "payload_ref": Json(envelope["payload_ref"]) if envelope.get("payload_ref") else None,
                         },
                     )
+                    await _enqueue_event_store_outbox(cur, envelope)
 
                 await conn.commit()
+                await _drain_event_store_outbox()
                 return next_version
 
     async def read(

--- a/tests/core/test_event_store_ports.py
+++ b/tests/core/test_event_store_ports.py
@@ -84,3 +84,89 @@ async def test_postgres_event_store_append_rejects_expected_version_conflict(mon
             [EventRecord(event_type="test.event", stream_id="execution/1")],
             expected_version=2,
         )
+
+
+@pytest.mark.asyncio
+async def test_postgres_event_store_append_enqueues_outbox_before_drain(monkeypatch):
+    from noetl.core.event_store import EventRecord, PostgresEventStore
+    import noetl.core.event_store.postgres as postgres_module
+
+    enqueued = []
+
+    class Cursor:
+        def __init__(self):
+            self.query = ""
+            self.executed = []
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, query, params=None):
+            self.query = query
+            self.executed.append((query, params))
+
+        async def fetchone(self):
+            if "max(stream_version)" in self.query:
+                return {"version": 0}
+            if "snowflake_id" in self.query:
+                return {"snowflake_id": 9001}
+            return None
+
+    class Conn:
+        def __init__(self, cursor):
+            self.cursor_obj = cursor
+            self.commits = 0
+
+        def cursor(self, row_factory=None):  # noqa: ARG002
+            return self.cursor_obj
+
+        async def commit(self):
+            self.commits += 1
+
+    cursor = Cursor()
+    conn = Conn(cursor)
+
+    class Ctx:
+        async def __aenter__(self):
+            return conn
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    async def fake_enqueue(_cur, event):
+        enqueued.append(event)
+
+    async def fake_drain():
+        assert conn.commits == 1
+
+    monkeypatch.setattr(postgres_module, "get_pool_connection", lambda: Ctx())
+    monkeypatch.setattr(postgres_module, "_enqueue_event_store_outbox", fake_enqueue)
+    monkeypatch.setattr(postgres_module, "_drain_event_store_outbox", fake_drain)
+
+    store = PostgresEventStore()
+    version = await store.append(
+        "execution/7",
+        [
+            EventRecord(
+                event_type="test.event",
+                stream_id="execution/7",
+                execution_id=7,
+                tenant_id="tenant-a",
+                organization_id="org-a",
+                result={"status": "OK"},
+            )
+        ],
+        expected_version=0,
+    )
+
+    assert version == 1
+    assert enqueued[0]["event_id"] == 9001
+    assert enqueued[0]["execution_id"] == 7
+    assert enqueued[0]["event_type"] == "test.event"
+    assert enqueued[0]["stream_id"] == "execution/7"
+    assert enqueued[0]["stream_version"] == 1
+    assert enqueued[0]["tenant_id"] == "tenant-a"
+    assert enqueued[0]["organization_id"] == "org-a"


### PR DESCRIPTION
## Summary
- enqueue PostgresEventStore.append envelopes into noetl.outbox inside the append transaction
- drain committed outbox rows after commit while keeping canonical append success independent from fan-out availability
- add regression coverage for expected-version append plus outbox enqueue/drain ordering

## Tests
- .venv/bin/python -m pytest tests/core/test_event_store_ports.py tests/core/test_outbox.py tests/core/test_arrow_ipc_serialization.py
- .venv/bin/python -m compileall noetl/core/event_store/postgres.py tests/core/test_event_store_ports.py

Refs #461
Refs #437