### PR TITLE
Route DSL executor events through outbox

### DIFF
--- a/noetl/core/dsl/engine/executor/events.py
+++ b/noetl/core/dsl/engine/executor/events.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .common import *
+from .outbox import drain_executor_outbox, enqueue_executor_outbox
 from .state import ExecutionState
 from .store import PlaybookRepo, StateStore
 from noetl.core.event_store.ports import canonical_event_checksum
@@ -205,6 +206,20 @@ class EventHandlingMixin:
                     """,
                     (event_id, stage["stage_id"]),
                 )
+                await enqueue_executor_outbox(
+                    cur,
+                    envelope
+                    | {
+                        "event_id": event_id,
+                        "catalog_id": stage.get("catalog_id") or state.catalog_id,
+                        "parent_event_id": parent_event_id,
+                        "node_id": step_name,
+                        "created_at": now,
+                        "ingest_time": now,
+                        "context": {"stage_id": str(stage["stage_id"]), "loop_event_id": str(loop_event_id)},
+                        "stage_id": stage["stage_id"],
+                    },
+                )
                 if owns_transaction:
                     await active_conn.commit()
                 logger.info(
@@ -221,7 +236,10 @@ class EventHandlingMixin:
             if conn is not None:
                 return await _close_with_conn(conn, owns_transaction=False)
             async with get_pool_connection() as owned_conn:
-                return await _close_with_conn(owned_conn, owns_transaction=True)
+                stage_id = await _close_with_conn(owned_conn, owns_transaction=True)
+            if stage_id is not None:
+                await drain_executor_outbox()
+            return stage_id
         except Exception as exc:
             logger.warning(
                 "[CURSOR-LOOP] Failed to close runtime stage for step %s execution=%s loop_event_id=%s: %s",

--- a/noetl/core/dsl/engine/executor/lifecycle.py
+++ b/noetl/core/dsl/engine/executor/lifecycle.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from .common import *
+from .outbox import drain_executor_outbox, enqueue_executor_outbox
 from .state import ExecutionState
 from .store import PlaybookRepo, StateStore
 from noetl.core.dsl.engine.models import Event, Command
@@ -102,6 +103,29 @@ class LifecycleMixin:
                         event.worker_id
                     )
                 )
+                await enqueue_executor_outbox(
+                    cur,
+                    {
+                        "event_id": event_id,
+                        "execution_id": int(event.execution_id),
+                        "catalog_id": catalog_id,
+                        "parent_event_id": parent_event_id,
+                        "parent_execution_id": state.parent_execution_id,
+                        "event_type": event.name,
+                        "node_id": event.step,
+                        "node_name": event.step,
+                        "status": status,
+                        "duration": duration_ms,
+                        "context": context_val,
+                        "result": result_val,
+                        "meta": event.meta or {},
+                        "error": event.payload.get("error") if isinstance(event.payload, dict) else None,
+                        "worker_id": event.worker_id,
+                        "event_time": event_timestamp,
+                        "ingest_time": event_timestamp,
+                        "created_at": event_timestamp,
+                    },
+                )
 
             state.last_event_id = event_id
             if event.step:
@@ -110,6 +134,7 @@ class LifecycleMixin:
         if conn is None:
             async with get_pool_connection() as c:
                 await _do_persist(c)
+            await drain_executor_outbox()
         else:
             await _do_persist(conn)
 

--- a/noetl/core/dsl/engine/executor/outbox.py
+++ b/noetl/core/dsl/engine/executor/outbox.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from noetl.core.logger import setup_logger
+from noetl.core.messaging import NATSEventPublisher
+from noetl.core.outbox import enqueue_outbox, publish_outbox_batch
+
+logger = setup_logger(__name__, include_location=True)
+_executor_event_subject_publisher: NATSEventPublisher | None = None
+
+
+def event_mirror_enabled() -> bool:
+    return os.getenv("NOETL_EVENT_MIRROR_ENABLED", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def executor_event_subject(event: dict[str, Any]) -> str:
+    global _executor_event_subject_publisher
+    if _executor_event_subject_publisher is None:
+        _executor_event_subject_publisher = NATSEventPublisher()
+    return _executor_event_subject_publisher.subject_for_event(event)
+
+
+async def enqueue_executor_outbox(cur: Any, event: dict[str, Any]) -> None:
+    if not event_mirror_enabled():
+        return
+    await enqueue_outbox(cur, event, subject=executor_event_subject(event))
+
+
+async def drain_executor_outbox() -> None:
+    if not event_mirror_enabled():
+        return
+    try:
+        limit = int(os.getenv("NOETL_EXECUTOR_OUTBOX_DRAIN_LIMIT", "100"))
+        await publish_outbox_batch(limit=limit)
+    except Exception as exc:
+        logger.warning("Executor outbox drain failed: %s", exc)

--- a/noetl/core/dsl/engine/executor/transitions.py
+++ b/noetl/core/dsl/engine/executor/transitions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .common import *
+from .outbox import drain_executor_outbox, enqueue_executor_outbox
 from .state import ExecutionState
 from .store import PlaybookRepo, StateStore
 from noetl.core.event_store.ports import canonical_event_checksum
@@ -413,6 +414,22 @@ class TransitionMixin:
                         """,
                         (event_id, stage_id),
                     )
+                    await enqueue_executor_outbox(
+                        cur,
+                        envelope
+                        | {
+                            "event_id": event_id,
+                            "catalog_id": catalog_id,
+                            "parent_event_id": parent_event_id,
+                            "node_id": step_def.step,
+                            "node_name": step_def.step,
+                            "status": "OPEN",
+                            "context": {"stage_id": str(stage_id), "loop_event_id": loop_event_id},
+                            "created_at": event_time,
+                            "ingest_time": event_time,
+                            "stage_id": stage_id,
+                        },
+                    )
                     if not owns_transaction:
                         await cur.execute(f"RELEASE SAVEPOINT {savepoint_name}")
                     if owns_transaction:
@@ -441,7 +458,10 @@ class TransitionMixin:
             if conn is not None:
                 return await _open_with_conn(conn, owns_transaction=False)
             async with get_pool_connection() as owned_conn:
-                return await _open_with_conn(owned_conn, owns_transaction=True)
+                stage_id = await _open_with_conn(owned_conn, owns_transaction=True)
+            if stage_id is not None:
+                await drain_executor_outbox()
+            return stage_id
         except Exception as exc:
             logger.warning(
                 "[CURSOR-LOOP] Failed to open runtime stage for step %s execution=%s: %s",

--- a/tests/unit/dsl/engine/test_executor_outbox.py
+++ b/tests/unit/dsl/engine/test_executor_outbox.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+
+class _FakeCursor:
+    def __init__(self):
+        self.query = ""
+        self.executed = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, query, params=None):
+        self.query = query
+        self.executed.append((query, params))
+
+    async def fetchone(self):
+        if "snowflake_id" in self.query:
+            return {"snowflake_id": 7001}
+        return None
+
+
+class _FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self, **_kwargs):
+        return self._cursor
+
+
+@pytest.mark.asyncio
+async def test_persist_event_enqueues_outbox_inside_caller_transaction(monkeypatch):
+    from noetl.core.dsl.engine.executor import lifecycle
+    from noetl.core.dsl.engine.executor.lifecycle import LifecycleMixin
+
+    enqueued = []
+    drained = {"called": 0}
+    cursor = _FakeCursor()
+
+    async def fake_enqueue(_cur, event):
+        enqueued.append(event)
+
+    async def fake_drain():
+        drained["called"] += 1
+
+    monkeypatch.setattr(lifecycle, "enqueue_executor_outbox", fake_enqueue)
+    monkeypatch.setattr(lifecycle, "drain_executor_outbox", fake_drain)
+
+    event_time = datetime(2026, 5, 19, tzinfo=timezone.utc)
+    event = SimpleNamespace(
+        execution_id="7",
+        step="fetch",
+        name="command.started",
+        payload={"command_id": 900},
+        meta={"stage_id": "stage-1"},
+        timestamp=event_time,
+        parent_event_id=None,
+        worker_id="worker-1",
+    )
+    state = SimpleNamespace(
+        catalog_id=5,
+        parent_execution_id=None,
+        step_event_ids={},
+        last_event_id=99,
+    )
+
+    await LifecycleMixin()._persist_event(event, state, conn=_FakeConnection(cursor))
+
+    assert drained["called"] == 0
+    assert state.last_event_id == 7001
+    assert state.step_event_ids["fetch"] == 7001
+    assert enqueued[0]["event_id"] == 7001
+    assert enqueued[0]["event_type"] == "command.started"
+    assert enqueued[0]["execution_id"] == 7
+    assert enqueued[0]["catalog_id"] == 5
+    assert enqueued[0]["parent_event_id"] == 99
+    assert enqueued[0]["node_name"] == "fetch"
+    assert enqueued[0]["context"] == {"command_id": 900}
+    assert enqueued[0]["meta"] == {"stage_id": "stage-1"}


### PR DESCRIPTION
## Summary
- add executor outbox helpers for DSL engine-owned event distribution
- enqueue lifecycle events, stage.opened, and stage.closed envelopes in the same transaction as their noetl.event writes
- drain outbox only when the executor owns the DB connection, preserving caller-owned transaction boundaries
- add focused regression coverage for caller-owned _persist_event behavior

## Tests
- .venv/bin/python -m pytest tests/unit/dsl/engine/test_executor_outbox.py tests/core/test_outbox.py tests/core/test_arrow_ipc_serialization.py
- .venv/bin/python -m compileall noetl/core/dsl/engine/executor/lifecycle.py noetl/core/dsl/engine/executor/transitions.py noetl/core/dsl/engine/executor/events.py noetl/core/dsl/engine/executor/outbox.py tests/unit/dsl/engine/test_executor_outbox.py

## Notes
- Broader tests/unit/dsl/engine currently has pre-existing failures unrelated to this branch: missing batch_execution fixture YAML files, async mark_step_completed tests that are not awaited, and an existing UnboundLocalError for _get_next_arcs in test_engine.py::test_step_exit_structural_next_does_not_duplicate_pending_step.

Refs #461
Refs #437