### PR TITLE
Fix DSL step.exit next-arcs scope bug

### DIFF
--- a/noetl/core/dsl/engine/executor/events.py
+++ b/noetl/core/dsl/engine/executor/events.py
@@ -4,6 +4,7 @@ from .common import *
 from .state import ExecutionState
 from .store import PlaybookRepo, StateStore
 from noetl.core.event_store.ports import canonical_event_checksum
+from .transitions import _get_next_arcs, _get_next_mode
 
 class EventHandlingMixin:
     async def _persist_event_compat(self, event: Event, state: ExecutionState, conn=None):
@@ -2253,7 +2254,6 @@ class EventHandlingMixin:
         # whose arcs all raised would appear dead-end-eligible and prematurely fire
         # workflow.completed.
         if not next_any_raised and is_completion_trigger and step_def.next and not is_loop_step:
-            from .transitions import _get_next_arcs  # local import to avoid cycles
             for probe in _get_next_arcs(step_def):
                 probe_when = getattr(probe, "when", None)
                 if not probe_when:


### PR DESCRIPTION
## Summary
- imports _get_next_arcs/_get_next_mode at module scope in the DSL event handler
- removes the later local import that made _get_next_arcs a function-local name and caused step.exit fallback to crash before assignment

## Tests
- .venv/bin/python -m pytest tests/unit/dsl/engine/test_engine.py::test_step_exit_structural_next_does_not_duplicate_pending_step
- .venv/bin/python -m compileall noetl/core/dsl/engine/executor/events.py

Refs #474