### PR TITLE
Fix async mark_step_completed context tests

### DIFF
--- a/noetl/core/dsl/engine/executor/state.py
+++ b/noetl/core/dsl/engine/executor/state.py
@@ -194,15 +194,12 @@ class ExecutionState:
                             result["rows"] = resolved
                     except Exception:
                         pass
-                # Promote context keys to top level
+                # Add a context alias for plain dict results. When the
+                # producer already supplied a context envelope, keep it scoped:
+                # flattening arbitrary context keys changes the public result
+                # shape and can leak nested state into top-level templates.
                 if "context" not in result:
                     result = {**result, "context": dict(result)}
-                context = result.get("context")
-                if isinstance(context, dict):
-                    promoted = dict(result)
-                    for k, v in context.items():
-                        promoted.setdefault(k, v)
-                    result = promoted
 
                 # Preserve row-bearing data from the prior step_result when
                 # the incoming result is compact (e.g. step.exit omits

--- a/tests/unit/dsl/engine/test_task_sequence_loop_completion.py
+++ b/tests/unit/dsl/engine/test_task_sequence_loop_completion.py
@@ -933,7 +933,8 @@ workflow:
     assert state.variables["facility_id"] == 8123
 
 
-def test_mark_step_completed_adds_context_alias_for_plain_dict_results():
+@pytest.mark.asyncio
+async def test_mark_step_completed_adds_context_alias_for_plain_dict_results():
     playbook = Playbook(**yaml.safe_load(
         """
 apiVersion: noetl.io/v2
@@ -951,7 +952,7 @@ workflow:
         """
     ))
     state = ExecutionState("9023", playbook, payload={})
-    state.mark_step_completed(
+    await state.mark_step_completed(
         "compute_report_window",
         {
             "report_start_date": "2026-03-01",
@@ -965,7 +966,8 @@ workflow:
     assert step_result["context"]["report_end_date"] == "2026-03-31"
 
 
-def test_mark_step_completed_does_not_flatten_non_reference_context_payload():
+@pytest.mark.asyncio
+async def test_mark_step_completed_does_not_flatten_non_reference_context_payload():
     playbook = Playbook(**yaml.safe_load(
         """
 apiVersion: noetl.io/v2
@@ -983,7 +985,7 @@ workflow:
         """
     ))
     state = ExecutionState("9024", playbook, payload={})
-    state.mark_step_completed(
+    await state.mark_step_completed(
         "end",
         {
             "status": "COMPLETED",


### PR DESCRIPTION
## Summary
- awaits async mark_step_completed in the two context-shape regression tests
- keeps explicitly supplied result.context scoped instead of promoting arbitrary context keys to the top level
- preserves the plain-dict context alias behavior for results without an explicit context envelope

## Tests
- .venv/bin/python -m pytest tests/unit/dsl/engine/test_task_sequence_loop_completion.py::test_mark_step_completed_adds_context_alias_for_plain_dict_results tests/unit/dsl/engine/test_task_sequence_loop_completion.py::test_mark_step_completed_does_not_flatten_non_reference_context_payload
- .venv/bin/python -m compileall noetl/core/dsl/engine/executor/state.py tests/unit/dsl/engine/test_task_sequence_loop_completion.py

Refs #474