### PR TITLE
Restore DSL engine regression coverage

### DIFF
--- a/noetl/core/dsl/engine/executor/common.py
+++ b/noetl/core/dsl/engine/executor/common.py
@@ -345,15 +345,20 @@ def _unwrap_event_payload(payload: Any) -> Any:
     return payload
 
 
-def _extract_command_id_from_event_payload(payload: Any, meta: Optional[dict[str, Any]] = None) -> Optional[int]:
-    """Best-effort extraction of command_id (BIGINT snowflake) from worker event payloads.
+def _extract_command_id_from_event_payload(payload: Any, meta: Optional[dict[str, Any]] = None) -> Optional[str]:
+    """Best-effort extraction of command_id from worker event payloads.
 
-    Accepts int (current shape), or numeric str (legacy). Returns int or None.
+    Command ids are numeric in the current projection tables, but older worker
+    paths and event meta can still carry opaque string ids. Keep the extractor
+    lossless and let query paths compare via text.
     """
-    def _coerce(v: Any) -> Optional[int]:
-        if v is None: return None
-        if isinstance(v, int): return v
-        if isinstance(v, str) and v.strip().isdigit(): return int(v.strip())
+    def _coerce(v: Any) -> Optional[str]:
+        if v is None:
+            return None
+        if isinstance(v, int):
+            return str(v)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
         return None
 
     if isinstance(meta, dict) and "command_id" in meta:

--- a/noetl/core/dsl/engine/executor/queries.py
+++ b/noetl/core/dsl/engine/executor/queries.py
@@ -46,6 +46,8 @@ class QueryMixin:
     ) -> int:
         """Count persisted events by command_id for actionable idempotency guards."""
         try:
+            command_id_text = str(command_id)
+            command_id_int = int(command_id_text) if command_id_text.isdigit() else None
             async with get_pool_connection() as conn:
                 async with conn.cursor(row_factory=dict_row) as cur:
                     await cur.execute(
@@ -54,9 +56,18 @@ class QueryMixin:
                         FROM noetl.event
                         WHERE execution_id = %s
                           AND event_type = %s
-                          AND command_id = %s
+                          AND (
+                              (%s AND command_id = %s)
+                              OR meta->>'command_id' = %s
+                          )
                         """,
-                        (int(execution_id), event_type, int(command_id)),
+                        (
+                            int(execution_id),
+                            event_type,
+                            command_id_int is not None,
+                            command_id_int,
+                            command_id_text,
+                        ),
                     )
                     row = await cur.fetchone()
                     return int((row or {}).get("cnt", 0) or 0)
@@ -79,6 +90,8 @@ class QueryMixin:
     ) -> bool:
         """Return True when the provided persisted event_id is the earliest duplicate candidate."""
         try:
+            command_id_text = str(command_id)
+            command_id_int = int(command_id_text) if command_id_text.isdigit() else None
             async with get_pool_connection() as conn:
                 async with conn.cursor(row_factory=dict_row) as cur:
                     await cur.execute(
@@ -87,9 +100,18 @@ class QueryMixin:
                         FROM noetl.event
                         WHERE execution_id = %s
                           AND event_type = %s
-                          AND command_id = %s
+                          AND (
+                              (%s AND command_id = %s)
+                              OR meta->>'command_id' = %s
+                          )
                         """,
-                        (int(execution_id), event_type, int(command_id)),
+                        (
+                            int(execution_id),
+                            event_type,
+                            command_id_int is not None,
+                            command_id_int,
+                            command_id_text,
+                        ),
                     )
                     row = await cur.fetchone()
                     first_event_id = int((row or {}).get("first_event_id", 0) or 0)

--- a/tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step/README.md
+++ b/tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step/README.md
@@ -1,0 +1,226 @@
+# heavy_payload_pipeline_in_step
+
+This fixture simulates large per-item payload processing in a looped `task_sequence` pipeline.
+
+It is built to reproduce and analyze behavior where execution slows down or stalls around ~100 items when each iteration handles 200-300 KB payloads.
+
+## What this fixture gives you
+
+- `direct_stress` mode:
+  - One large loop over all items.
+  - Per-item pipeline: `python -> http -> python -> postgres`.
+  - Highest pressure on loop state, worker memory, and event throughput.
+- `chunked_optimal` mode (default):
+  - Parent orchestrates bounded chunk windows.
+  - Child worker processes each chunk with parallel per-item pipeline.
+  - Better control over server and worker resource usage.
+
+## Fixture files
+
+- Parent playbook:
+  `tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step/heavy_payload_pipeline_in_step.yaml`
+- Chunk worker playbook:
+  `tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_chunk_worker/heavy_payload_pipeline_chunk_worker.yaml`
+
+## Prerequisites
+
+- NoETL server and workers running in distributed mode.
+- Postgres credential available (default `pg_k8s`).
+- `noetl`, `kubectl`, and `jq` installed.
+- API reachable directly or via port-forward.
+
+If needed, port-forward in terminal A:
+
+```bash
+kubectl -n noetl port-forward svc/noetl 8082:8082
+```
+
+Terminal B defaults:
+
+```bash
+export NOETL_HOST=localhost
+export NOETL_PORT=8082
+```
+
+## Register playbooks
+
+Register worker first, then parent:
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" catalog register \
+  tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_chunk_worker/heavy_payload_pipeline_chunk_worker.yaml
+
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" catalog register \
+  tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step/heavy_payload_pipeline_in_step.yaml
+```
+
+## Dry-run
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" exec \
+  catalog://tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step \
+  -r distributed \
+  --dry-run
+```
+
+## Smoke test (recommended first)
+
+This is a quick verification with bounded data.
+
+```bash
+RUN_JSON="$(curl -sS -X POST "http://$NOETL_HOST:$NOETL_PORT/api/execute" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "path": "tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step",
+    "payload": {
+      "execution_mode": "chunked_optimal",
+      "seed_rows": 120,
+      "batch_size": 30,
+      "max_batches": 4,
+      "payload_kb_per_item": 220,
+      "details_api_url": "https://httpbin.org/anything/heavy-item-detail"
+    }
+  }')"
+
+echo "$RUN_JSON" | jq .
+export EXECUTION_ID="$(echo "$RUN_JSON" | jq -r '.execution_id')"
+echo "EXECUTION_ID=$EXECUTION_ID"
+```
+
+Wait for completion:
+
+```bash
+while true; do
+  STATUS_JSON="$(noetl --host "$NOETL_HOST" --port "$NOETL_PORT" status "$EXECUTION_ID" --json)"
+  echo "$STATUS_JSON" | jq '{execution_id, completed, failed, current_step}'
+
+  COMPLETED="$(echo "$STATUS_JSON" | jq -r '.completed')"
+  FAILED="$(echo "$STATUS_JSON" | jq -r '.failed')"
+  if [ "$COMPLETED" = "true" ] || [ "$FAILED" = "true" ]; then
+    break
+  fi
+  sleep 5
+done
+```
+
+## Stress test (simulate >100 heavy items)
+
+Use `direct_stress` with a larger row count.
+
+```bash
+RUN_JSON="$(curl -sS -X POST "http://$NOETL_HOST:$NOETL_PORT/api/execute" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "path": "tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step",
+    "payload": {
+      "execution_mode": "direct_stress",
+      "seed_rows": 220,
+      "payload_kb_per_item": 256,
+      "details_api_url": "https://httpbin.org/anything/heavy-item-detail"
+    }
+  }')"
+
+echo "$RUN_JSON" | jq .
+export EXECUTION_ID="$(echo "$RUN_JSON" | jq -r '.execution_id')"
+echo "EXECUTION_ID=$EXECUTION_ID"
+```
+
+## Validation queries
+
+Execution summary from final step:
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "SELECT result
+   FROM noetl.event
+   WHERE execution_id = $EXECUTION_ID
+     AND event_type = 'step.exit'
+     AND node_name = 'summarize'
+   ORDER BY event_id DESC
+   LIMIT 1;" \
+  --schema noetl --format json
+```
+
+Row-level completeness and byte profile:
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "SELECT
+     COUNT(*) AS stored_rows,
+     COUNT(*) FILTER (WHERE http_status = 200) AS ok_rows,
+     MIN(item_id) AS min_item_id,
+     MAX(item_id) AS max_item_id,
+     AVG(request_bytes)::bigint AS avg_request_bytes,
+     AVG(response_bytes)::bigint AS avg_response_bytes
+   FROM public.heavy_payload_results
+   WHERE execution_id = '$EXECUTION_ID';" \
+  --schema public --format table
+```
+
+Missing rows check:
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "SELECT COUNT(*) AS missing_rows
+   FROM public.heavy_payload_source src
+   LEFT JOIN public.heavy_payload_results tgt
+     ON src.execution_id = tgt.execution_id
+    AND src.item_id = tgt.item_id
+   WHERE src.execution_id = '$EXECUTION_ID'
+     AND tgt.item_id IS NULL;" \
+  --schema public --format table
+```
+
+Event trace around failures/retries:
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "SELECT event_id, event_type, node_name, status, error, created_at
+   FROM noetl.event
+   WHERE execution_id = $EXECUTION_ID
+   ORDER BY event_id DESC
+   LIMIT 120;" \
+  --schema noetl --format table
+```
+
+## GKE runtime observation commands
+
+Watch pod CPU/memory while stress run is active:
+
+```bash
+kubectl -n noetl top pod
+```
+
+Check server and worker logs for retries/failures:
+
+```bash
+kubectl -n noetl logs deploy/noetl --tail=200
+kubectl -n noetl logs deploy/noetl-worker --tail=200
+```
+
+## Resource control guidance
+
+Use these controls to keep streaming batch runs stable:
+
+1. Prefer `chunked_optimal` for production runs.
+2. Keep `batch_size` bounded (for example 20-60 for 200-300 KB payloads).
+3. Keep worker loop `max_in_flight` moderate (`15` in chunk worker by default).
+4. Keep large results reference-first (default `NOETL_INLINE_MAX_BYTES=65536`).
+5. Tune HTTP pool reuse if needed:
+   - `NOETL_HTTP_MAX_CONNECTIONS`
+   - `NOETL_HTTP_MAX_KEEPALIVE_CONNECTIONS`
+   - `NOETL_HTTP_KEEPALIVE_EXPIRY_SECONDS`
+6. If a run stalls around ~100 items, compare `direct_stress` vs `chunked_optimal` on identical payload size and inspect:
+   - retries per node,
+   - missing terminal events,
+   - pod memory growth,
+   - max persisted `item_id` in `heavy_payload_results`.
+
+## Cleanup for one execution (optional)
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "DELETE FROM public.heavy_payload_results WHERE execution_id = '$EXECUTION_ID';
+   DELETE FROM public.heavy_payload_source WHERE execution_id = '$EXECUTION_ID';" \
+  --schema public --format table
+```

--- a/tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step/heavy_payload_pipeline_in_step.yaml
+++ b/tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step/heavy_payload_pipeline_in_step.yaml
@@ -1,0 +1,439 @@
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: heavy_payload_pipeline_in_step
+  path: tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step
+  description: Simulate large per-item pipeline payloads and compare direct stress vs chunked processing.
+
+workload:
+  pg_auth: pg_k8s
+  seed_rows: 240
+  payload_kb_per_item: 256
+  batch_size: 40
+  max_batches: 6
+  execution_mode: chunked_optimal
+  details_api_url: https://httpbin.org/anything/heavy-item-detail
+  batch_worker_path: tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_chunk_worker
+
+workflow:
+  - step: start
+    desc: Initialize heavy payload simulation
+    tool:
+      kind: python
+      code: |
+        result = {
+          "status": "initialized",
+          "modes": ["direct_stress", "chunked_optimal"],
+          "goal": "simulate_large_pipeline_payloads"
+        }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: prepare_source_and_target
+
+  - step: prepare_source_and_target
+    desc: Prepare source and result tables and seed source IDs
+    tool:
+      kind: postgres
+      auth: '{{ pg_auth }}'
+      query: |
+        CREATE TABLE IF NOT EXISTS public.heavy_payload_source (
+          execution_id TEXT NOT NULL,
+          item_id INTEGER NOT NULL,
+          item_key TEXT NOT NULL,
+          PRIMARY KEY (execution_id, item_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS public.heavy_payload_results (
+          execution_id TEXT NOT NULL,
+          item_id INTEGER NOT NULL,
+          item_key TEXT NOT NULL,
+          mode TEXT NOT NULL,
+          batch_number INTEGER NOT NULL DEFAULT 0,
+          http_status INTEGER,
+          request_bytes INTEGER NOT NULL DEFAULT 0,
+          response_bytes INTEGER NOT NULL DEFAULT 0,
+          has_response BOOLEAN NOT NULL DEFAULT FALSE,
+          response_meta JSONB,
+          error_message TEXT,
+          processed_at TIMESTAMPTZ DEFAULT NOW(),
+          PRIMARY KEY (execution_id, item_id)
+        );
+
+        DELETE FROM public.heavy_payload_source
+        WHERE execution_id = '{{ execution_id }}';
+
+        DELETE FROM public.heavy_payload_results
+        WHERE execution_id = '{{ execution_id }}';
+
+        INSERT INTO public.heavy_payload_source (execution_id, item_id, item_key)
+        SELECT
+          '{{ execution_id }}',
+          gs,
+          'Item-' || gs
+        FROM generate_series(1, {{ seed_rows | int }}) AS gs;
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: load_items_for_execution
+
+  - step: load_items_for_execution
+    desc: Load lightweight item list (IDs only) for loop routing
+    tool:
+      kind: postgres
+      auth: '{{ pg_auth }}'
+      query: |
+        SELECT item_id, item_key
+        FROM public.heavy_payload_source
+        WHERE execution_id = '{{ execution_id }}'
+        ORDER BY item_id ASC;
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: resolve_mode
+
+  - step: resolve_mode
+    desc: Resolve mode for this run
+    tool:
+      kind: python
+      input:
+        execution_mode: '{{ execution_mode }}'
+      code: |
+        mode = str(execution_mode or "chunked_optimal").strip().lower()
+        if mode not in ("direct_stress", "chunked_optimal"):
+            mode = "chunked_optimal"
+
+        result = {
+            "mode": mode,
+            "is_direct": mode == "direct_stress",
+        }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: run_direct_stress
+          when: '{{ resolve_mode.mode == "direct_stress" }}'
+        - step: build_batch_plan
+          when: '{{ resolve_mode.mode != "direct_stress" }}'
+
+  - step: run_direct_stress
+    desc: Direct loop over all items using heavy pipeline per item
+    loop:
+      in: '{{ load_items_for_execution.command_0.rows }}'
+      iterator: item
+      spec:
+        mode: parallel
+        max_in_flight: 20
+        policy:
+          exec: distributed
+    tool:
+      - name: build_large_request
+        kind: python
+        input:
+          item: '{{ iter.item }}'
+          payload_kb_per_item: '{{ payload_kb_per_item }}'
+        code: |
+          import hashlib
+
+          size_kb = int(payload_kb_per_item or 256)
+          size_bytes = max(1024, size_kb * 1024)
+
+          item_id = int(item.get("item_id", 0) or 0) if isinstance(item, dict) else 0
+          item_key = str(item.get("item_key", "") or "") if isinstance(item, dict) else ""
+
+          seed = f"{item_id}:{item_key}".encode("utf-8")
+          block = hashlib.sha256(seed).hexdigest()
+          repeat_count = (size_bytes // len(block)) + 2
+          request_blob = (block * repeat_count)[:size_bytes]
+
+          result = {
+              "item_id": item_id,
+              "item_key": item_key,
+              "request_blob": request_blob,
+              "request_bytes": len(request_blob.encode("utf-8")),
+          }
+      - name: fetch_detail
+        kind: http
+        method: POST
+        url: '{{ details_api_url }}'
+        headers:
+          Content-Type: application/json
+          Accept: application/json
+        payload:
+          item_id: '{{ build_large_request.item_id }}'
+          item_key: '{{ build_large_request.item_key }}'
+          request_blob: '{{ build_large_request.request_blob }}'
+        spec:
+          policy:
+            rules:
+              - when: '{{ output.status == "error" and (output.http.status in [429, 500, 502, 503, 504]) }}'
+                then: { do: retry, attempts: 4, backoff: exponential, delay: 1.0 }
+              - when: '{{ output.status == "error" }}'
+                then: { do: fail }
+              - else:
+                  then: { do: continue }
+      - name: project_result
+        kind: python
+        libs:
+          json: json
+        input:
+          request_payload: '{{ build_large_request }}'
+          http_result: '{{ fetch_detail }}'
+          mode: direct_stress
+          batch_number: 0
+        code: |
+          status_code = int(http_result.get("status_code", 0) or 0) if isinstance(http_result, dict) else 0
+          response_headers = http_result.get("headers", {}) if isinstance(http_result, dict) else {}
+
+          content_length = response_headers.get("content-length") or response_headers.get("Content-Length")
+          if isinstance(content_length, str) and content_length.isdigit():
+              response_bytes = int(content_length)
+          else:
+              response_bytes = len(json.dumps(http_result.get("data", {}), separators=(",", ":"))) if isinstance(http_result, dict) else 0
+
+          result = {
+              "item_id": int(request_payload.get("item_id", 0) or 0),
+              "item_key": str(request_payload.get("item_key", "") or ""),
+              "mode": str(mode),
+              "batch_number": int(batch_number or 0),
+              "http_status": status_code,
+              "request_bytes": int(request_payload.get("request_bytes", 0) or 0),
+              "response_bytes": int(response_bytes or 0),
+              "has_response": status_code > 0,
+              "response_meta": {
+                  "url": http_result.get("url") if isinstance(http_result, dict) else None,
+                  "elapsed": http_result.get("elapsed") if isinstance(http_result, dict) else None,
+              },
+              "error_message": "",
+          }
+      - name: persist_result
+        kind: postgres
+        auth: '{{ pg_auth }}'
+        command: |
+          INSERT INTO public.heavy_payload_results (
+            execution_id,
+            item_id,
+            item_key,
+            mode,
+            batch_number,
+            http_status,
+            request_bytes,
+            response_bytes,
+            has_response,
+            response_meta,
+            error_message
+          )
+          VALUES (
+            '{{ execution_id }}',
+            {{ project_result.item_id }},
+            '{{ project_result.item_key | replace("'", "''") }}',
+            '{{ project_result.mode }}',
+            {{ project_result.batch_number }},
+            {{ project_result.http_status }},
+            {{ project_result.request_bytes }},
+            {{ project_result.response_bytes }},
+            {{ 'true' if project_result.has_response else 'false' }},
+            '{{ project_result.response_meta | tojson | replace("'", "''") }}'::jsonb,
+            NULLIF('{{ project_result.error_message | replace("'", "''") }}', '')
+          )
+          ON CONFLICT (execution_id, item_id)
+          DO UPDATE SET
+            item_key = EXCLUDED.item_key,
+            mode = EXCLUDED.mode,
+            batch_number = EXCLUDED.batch_number,
+            http_status = EXCLUDED.http_status,
+            request_bytes = EXCLUDED.request_bytes,
+            response_bytes = EXCLUDED.response_bytes,
+            has_response = EXCLUDED.has_response,
+            response_meta = EXCLUDED.response_meta,
+            error_message = EXCLUDED.error_message,
+            processed_at = NOW();
+      - name: finalize
+        kind: python
+        input:
+          projected: '{{ project_result }}'
+        code: |
+          result = projected
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: validate_persisted_results
+          when: '{{ event.name == ''loop.done'' }}'
+
+  - step: build_batch_plan
+    desc: Build chunk windows for bounded-memory batch execution
+    tool:
+      kind: python
+      input:
+        batch_size: '{{ batch_size }}'
+        max_batches: '{{ max_batches }}'
+      code: |
+        size = int(batch_size or 40)
+        total = int(max_batches or 1)
+
+        batches = []
+        for idx in range(total):
+            batch_number = idx + 1
+            offset = idx * size
+            batches.append(
+                {
+                    "batch_number": batch_number,
+                    "offset": offset,
+                    "limit": size,
+                }
+            )
+
+        result = {
+            "batch_size": size,
+            "max_batches": total,
+            "batches": batches,
+        }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: run_batch_workers
+
+  - step: run_batch_workers
+    desc: Execute chunk worker playbook sequentially across planned windows
+    loop:
+      in: '{{ build_batch_plan.batches }}'
+      iterator: batch
+      spec:
+        mode: sequential
+        policy:
+          exec: distributed
+    tool:
+      kind: playbook
+      path: '{{ batch_worker_path }}'
+      return_step: end
+      timeout: 1200
+      input:
+        pg_auth: '{{ pg_auth }}'
+        parent_execution_id: '{{ job.execution_id }}'
+        batch_number: '{{ iter.batch.batch_number }}'
+        offset: '{{ iter.batch.offset }}'
+        batch_size: '{{ iter.batch.limit }}'
+        payload_kb_per_item: '{{ payload_kb_per_item }}'
+        details_api_url: '{{ details_api_url }}'
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: validate_persisted_results
+          when: '{{ event.name == ''loop.done'' }}'
+
+  - step: validate_persisted_results
+    desc: Validate persisted data volume and completeness
+    tool:
+      kind: postgres
+      auth: '{{ pg_auth }}'
+      query: |
+        SELECT
+          (SELECT COUNT(*)
+           FROM public.heavy_payload_source
+           WHERE execution_id = '{{ execution_id }}') AS source_rows,
+          (SELECT COUNT(*)
+           FROM public.heavy_payload_results
+           WHERE execution_id = '{{ execution_id }}') AS stored_rows,
+          (SELECT COUNT(*)
+           FROM public.heavy_payload_results
+           WHERE execution_id = '{{ execution_id }}' AND http_status = 200) AS successful_http_calls,
+          (SELECT COUNT(*)
+           FROM public.heavy_payload_results
+           WHERE execution_id = '{{ execution_id }}' AND mode = 'direct_stress') AS direct_mode_rows,
+          (SELECT COUNT(*)
+           FROM public.heavy_payload_results
+           WHERE execution_id = '{{ execution_id }}' AND mode = 'chunked_optimal') AS chunked_mode_rows,
+          (SELECT COALESCE(MAX(batch_number), 0)
+           FROM public.heavy_payload_results
+           WHERE execution_id = '{{ execution_id }}') AS max_batch_number,
+          CASE
+            WHEN '{{ resolve_mode.mode }}' = 'direct_stress'
+              THEN {{ seed_rows | int }}
+            ELSE LEAST({{ seed_rows | int }}, {{ batch_size | int }} * {{ max_batches | int }})
+          END AS expected_rows;
+
+        SELECT COUNT(*) AS missing_rows
+        FROM public.heavy_payload_source src
+        LEFT JOIN public.heavy_payload_results tgt
+          ON src.execution_id = tgt.execution_id
+         AND src.item_id = tgt.item_id
+        WHERE src.execution_id = '{{ execution_id }}'
+          AND src.item_id <= CASE
+            WHEN '{{ resolve_mode.mode }}' = 'direct_stress'
+              THEN {{ seed_rows | int }}
+            ELSE LEAST({{ seed_rows | int }}, {{ batch_size | int }} * {{ max_batches | int }})
+          END
+          AND tgt.item_id IS NULL;
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: summarize
+
+  - step: summarize
+    desc: Summarize execution for mode and data checks
+    tool:
+      kind: python
+      input:
+        mode: '{{ resolve_mode.mode }}'
+        validation: '{{ validate_persisted_results }}'
+        direct_loop: '{{ run_direct_stress | default({}) }}'
+        worker_loop: '{{ run_batch_workers | default({}) }}'
+        payload_kb_per_item: '{{ payload_kb_per_item }}'
+        seed_rows: '{{ seed_rows }}'
+        batch_size: '{{ batch_size }}'
+        max_batches: '{{ max_batches }}'
+      code: |
+        stats = validation.get("command_0", {}).get("rows", [{}])[0] if isinstance(validation, dict) else {}
+        gaps = validation.get("command_1", {}).get("rows", [{}])[0] if isinstance(validation, dict) else {}
+
+        chosen_mode = str(mode or "chunked_optimal")
+        loop_data = direct_loop if chosen_mode == "direct_stress" else worker_loop
+        loop_stats = loop_data.get("stats", {}) if isinstance(loop_data, dict) else {}
+
+        configured_seed = int(seed_rows or 0)
+        configured_batch_size = int(batch_size or 0)
+        configured_max_batches = int(max_batches or 0)
+
+        result = {
+            "status": "completed",
+            "mode": chosen_mode,
+            "configured": {
+                "seed_rows": configured_seed,
+                "payload_kb_per_item": int(payload_kb_per_item or 0),
+                "batch_size": configured_batch_size,
+                "max_batches": configured_max_batches,
+            },
+            "execution": {
+                "loop_iterations": int(loop_stats.get("total", 0) or 0),
+                "failed_iterations": int(loop_stats.get("failed", 0) or 0),
+            },
+            "data": {
+                "source_rows": int(stats.get("source_rows", 0) or 0),
+                "expected_rows": int(stats.get("expected_rows", 0) or 0),
+                "stored_rows": int(stats.get("stored_rows", 0) or 0),
+                "missing_rows": int(gaps.get("missing_rows", 0) or 0),
+                "successful_http_calls": int(stats.get("successful_http_calls", 0) or 0),
+                "direct_mode_rows": int(stats.get("direct_mode_rows", 0) or 0),
+                "chunked_mode_rows": int(stats.get("chunked_mode_rows", 0) or 0),
+                "max_batch_number": int(stats.get("max_batch_number", 0) or 0),
+            },
+        }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: end
+
+  - step: end
+    desc: End workflow
+    tool:
+      kind: python
+      code: |
+        result = {"status": "completed"}

--- a/tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel/README.md
+++ b/tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel/README.md
@@ -1,0 +1,228 @@
+# heavy_payload_pipeline_in_step_parallel
+
+This fixture simulates large per-item payload processing in a looped `task_sequence` pipeline.
+
+It is built to reproduce and analyze behavior where execution slows down or stalls around ~100 items when each iteration handles 200-300 KB payloads.
+
+## What this fixture gives you
+
+- `direct_stress` mode:
+  - One large loop over all items.
+  - Per-item pipeline: `python -> http -> python -> postgres`.
+  - Highest pressure on loop state, worker memory, and event throughput.
+- `chunked_optimal` mode (default):
+  - Parent orchestrates bounded chunk windows.
+  - Parent dispatches chunk workers in parallel (`max_in_flight: 3`).
+  - Child worker processes each chunk with parallel per-item pipeline.
+  - Better control over server and worker resource usage while increasing throughput.
+
+## Fixture files
+
+- Parent playbook:
+  `tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel/heavy_payload_pipeline_in_step_parallel.yaml`
+- Chunk worker playbook:
+  `tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_chunk_worker/heavy_payload_pipeline_chunk_worker.yaml`
+
+## Prerequisites
+
+- NoETL server and workers running in distributed mode.
+- Postgres credential available (default `pg_k8s`).
+- `noetl`, `kubectl`, and `jq` installed.
+- API reachable directly or via port-forward.
+
+If needed, port-forward in terminal A:
+
+```bash
+kubectl -n noetl port-forward svc/noetl 8082:8082
+```
+
+Terminal B defaults:
+
+```bash
+export NOETL_HOST=localhost
+export NOETL_PORT=8082
+```
+
+## Register playbooks
+
+Register worker first, then parent:
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" catalog register \
+  tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_chunk_worker/heavy_payload_pipeline_chunk_worker.yaml
+
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" catalog register \
+  tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel/heavy_payload_pipeline_in_step_parallel.yaml
+```
+
+## Dry-run
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" exec \
+  catalog://tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel \
+  -r distributed \
+  --dry-run
+```
+
+## Smoke test (recommended first)
+
+This is a quick verification with bounded data and parallel chunk-worker orchestration.
+
+```bash
+RUN_JSON="$(curl -sS -X POST "http://$NOETL_HOST:$NOETL_PORT/api/execute" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "path": "tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel",
+    "payload": {
+      "execution_mode": "chunked_optimal",
+      "seed_rows": 120,
+      "batch_size": 30,
+      "max_batches": 4,
+      "payload_kb_per_item": 220,
+      "details_api_url": "https://httpbin.org/anything/heavy-item-detail"
+    }
+  }')"
+
+echo "$RUN_JSON" | jq .
+export EXECUTION_ID="$(echo "$RUN_JSON" | jq -r '.execution_id')"
+echo "EXECUTION_ID=$EXECUTION_ID"
+```
+
+Wait for completion:
+
+```bash
+while true; do
+  STATUS_JSON="$(noetl --host "$NOETL_HOST" --port "$NOETL_PORT" status "$EXECUTION_ID" --json)"
+  echo "$STATUS_JSON" | jq '{execution_id, completed, failed, current_step}'
+
+  COMPLETED="$(echo "$STATUS_JSON" | jq -r '.completed')"
+  FAILED="$(echo "$STATUS_JSON" | jq -r '.failed')"
+  if [ "$COMPLETED" = "true" ] || [ "$FAILED" = "true" ]; then
+    break
+  fi
+  sleep 5
+done
+```
+
+## Stress test (simulate >100 heavy items)
+
+Use `direct_stress` with a larger row count.
+
+```bash
+RUN_JSON="$(curl -sS -X POST "http://$NOETL_HOST:$NOETL_PORT/api/execute" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "path": "tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel",
+    "payload": {
+      "execution_mode": "direct_stress",
+      "seed_rows": 220,
+      "payload_kb_per_item": 256,
+      "details_api_url": "https://httpbin.org/anything/heavy-item-detail"
+    }
+  }')"
+
+echo "$RUN_JSON" | jq .
+export EXECUTION_ID="$(echo "$RUN_JSON" | jq -r '.execution_id')"
+echo "EXECUTION_ID=$EXECUTION_ID"
+```
+
+## Validation queries
+
+Execution summary from final step:
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "SELECT result
+   FROM noetl.event
+   WHERE execution_id = $EXECUTION_ID
+     AND event_type = 'step.exit'
+     AND node_name = 'summarize'
+   ORDER BY event_id DESC
+   LIMIT 1;" \
+  --schema noetl --format json
+```
+
+Row-level completeness and byte profile:
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "SELECT
+     COUNT(*) AS stored_rows,
+     COUNT(*) FILTER (WHERE http_status = 200) AS ok_rows,
+     MIN(item_id) AS min_item_id,
+     MAX(item_id) AS max_item_id,
+     AVG(request_bytes)::bigint AS avg_request_bytes,
+     AVG(response_bytes)::bigint AS avg_response_bytes
+   FROM public.heavy_payload_results
+   WHERE execution_id = '$EXECUTION_ID';" \
+  --schema public --format table
+```
+
+Missing rows check:
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "SELECT COUNT(*) AS missing_rows
+   FROM public.heavy_payload_source src
+   LEFT JOIN public.heavy_payload_results tgt
+     ON src.execution_id = tgt.execution_id
+    AND src.item_id = tgt.item_id
+   WHERE src.execution_id = '$EXECUTION_ID'
+     AND tgt.item_id IS NULL;" \
+  --schema public --format table
+```
+
+Event trace around failures/retries:
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "SELECT event_id, event_type, node_name, status, error, created_at
+   FROM noetl.event
+   WHERE execution_id = $EXECUTION_ID
+   ORDER BY event_id DESC
+   LIMIT 120;" \
+  --schema noetl --format table
+```
+
+## GKE runtime observation commands
+
+Watch pod CPU/memory while stress run is active:
+
+```bash
+kubectl -n noetl top pod
+```
+
+Check server and worker logs for retries/failures:
+
+```bash
+kubectl -n noetl logs deploy/noetl --tail=200
+kubectl -n noetl logs deploy/noetl-worker --tail=200
+```
+
+## Resource control guidance
+
+Use these controls to keep streaming batch runs stable:
+
+1. Prefer `chunked_optimal` for production runs.
+2. Keep `batch_size` bounded (for example 20-60 for 200-300 KB payloads).
+3. Keep parent chunk-worker parallelism bounded (`max_in_flight: 3` in this fixture).
+4. Keep worker loop `max_in_flight` moderate (`15` in chunk worker by default).
+5. Keep large results reference-first (default `NOETL_INLINE_MAX_BYTES=65536`).
+6. Tune HTTP pool reuse if needed:
+   - `NOETL_HTTP_MAX_CONNECTIONS`
+   - `NOETL_HTTP_MAX_KEEPALIVE_CONNECTIONS`
+   - `NOETL_HTTP_KEEPALIVE_EXPIRY_SECONDS`
+7. If a run stalls around ~100 items, compare `direct_stress` vs `chunked_optimal` on identical payload size and inspect:
+   - retries per node,
+   - missing terminal events,
+   - pod memory growth,
+   - max persisted `item_id` in `heavy_payload_results`.
+
+## Cleanup for one execution (optional)
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "DELETE FROM public.heavy_payload_results WHERE execution_id = '$EXECUTION_ID';
+   DELETE FROM public.heavy_payload_source WHERE execution_id = '$EXECUTION_ID';" \
+  --schema public --format table
+```

--- a/tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel/heavy_payload_pipeline_in_step_parallel.yaml
+++ b/tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel/heavy_payload_pipeline_in_step_parallel.yaml
@@ -1,0 +1,440 @@
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: heavy_payload_pipeline_in_step_parallel
+  path: tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_in_step_parallel
+  description: Simulate large per-item pipeline payloads with parallel chunk-worker orchestration.
+
+workload:
+  pg_auth: pg_k8s
+  seed_rows: 240
+  payload_kb_per_item: 256
+  batch_size: 40
+  max_batches: 6
+  execution_mode: chunked_optimal
+  details_api_url: https://httpbin.org/anything/heavy-item-detail
+  batch_worker_path: tests/fixtures/playbooks/batch_execution/heavy_payload_pipeline_chunk_worker
+
+workflow:
+  - step: start
+    desc: Initialize heavy payload simulation
+    tool:
+      kind: python
+      code: |
+        result = {
+          "status": "initialized",
+          "modes": ["direct_stress", "chunked_optimal"],
+          "goal": "simulate_large_pipeline_payloads"
+        }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: prepare_source_and_target
+
+  - step: prepare_source_and_target
+    desc: Prepare source and result tables and seed source IDs
+    tool:
+      kind: postgres
+      auth: '{{ pg_auth }}'
+      query: |
+        CREATE TABLE IF NOT EXISTS public.heavy_payload_source (
+          execution_id TEXT NOT NULL,
+          item_id INTEGER NOT NULL,
+          item_key TEXT NOT NULL,
+          PRIMARY KEY (execution_id, item_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS public.heavy_payload_results (
+          execution_id TEXT NOT NULL,
+          item_id INTEGER NOT NULL,
+          item_key TEXT NOT NULL,
+          mode TEXT NOT NULL,
+          batch_number INTEGER NOT NULL DEFAULT 0,
+          http_status INTEGER,
+          request_bytes INTEGER NOT NULL DEFAULT 0,
+          response_bytes INTEGER NOT NULL DEFAULT 0,
+          has_response BOOLEAN NOT NULL DEFAULT FALSE,
+          response_meta JSONB,
+          error_message TEXT,
+          processed_at TIMESTAMPTZ DEFAULT NOW(),
+          PRIMARY KEY (execution_id, item_id)
+        );
+
+        DELETE FROM public.heavy_payload_source
+        WHERE execution_id = '{{ execution_id }}';
+
+        DELETE FROM public.heavy_payload_results
+        WHERE execution_id = '{{ execution_id }}';
+
+        INSERT INTO public.heavy_payload_source (execution_id, item_id, item_key)
+        SELECT
+          '{{ execution_id }}',
+          gs,
+          'Item-' || gs
+        FROM generate_series(1, {{ seed_rows | int }}) AS gs;
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: load_items_for_execution
+
+  - step: load_items_for_execution
+    desc: Load lightweight item list (IDs only) for loop routing
+    tool:
+      kind: postgres
+      auth: '{{ pg_auth }}'
+      query: |
+        SELECT item_id, item_key
+        FROM public.heavy_payload_source
+        WHERE execution_id = '{{ execution_id }}'
+        ORDER BY item_id ASC;
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: resolve_mode
+
+  - step: resolve_mode
+    desc: Resolve mode for this run
+    tool:
+      kind: python
+      input:
+        execution_mode: '{{ execution_mode }}'
+      code: |
+        mode = str(execution_mode or "chunked_optimal").strip().lower()
+        if mode not in ("direct_stress", "chunked_optimal"):
+            mode = "chunked_optimal"
+
+        result = {
+            "mode": mode,
+            "is_direct": mode == "direct_stress",
+        }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: run_direct_stress
+          when: '{{ resolve_mode.mode == "direct_stress" }}'
+        - step: build_batch_plan
+          when: '{{ resolve_mode.mode != "direct_stress" }}'
+
+  - step: run_direct_stress
+    desc: Direct loop over all items using heavy pipeline per item
+    loop:
+      in: '{{ load_items_for_execution.command_0.rows }}'
+      iterator: item
+      spec:
+        mode: parallel
+        max_in_flight: 20
+        policy:
+          exec: distributed
+    tool:
+      - name: build_large_request
+        kind: python
+        input:
+          item: '{{ iter.item }}'
+          payload_kb_per_item: '{{ payload_kb_per_item }}'
+        code: |
+          import hashlib
+
+          size_kb = int(payload_kb_per_item or 256)
+          size_bytes = max(1024, size_kb * 1024)
+
+          item_id = int(item.get("item_id", 0) or 0) if isinstance(item, dict) else 0
+          item_key = str(item.get("item_key", "") or "") if isinstance(item, dict) else ""
+
+          seed = f"{item_id}:{item_key}".encode("utf-8")
+          block = hashlib.sha256(seed).hexdigest()
+          repeat_count = (size_bytes // len(block)) + 2
+          request_blob = (block * repeat_count)[:size_bytes]
+
+          result = {
+              "item_id": item_id,
+              "item_key": item_key,
+              "request_blob": request_blob,
+              "request_bytes": len(request_blob.encode("utf-8")),
+          }
+      - name: fetch_detail
+        kind: http
+        method: POST
+        url: '{{ details_api_url }}'
+        headers:
+          Content-Type: application/json
+          Accept: application/json
+        payload:
+          item_id: '{{ build_large_request.item_id }}'
+          item_key: '{{ build_large_request.item_key }}'
+          request_blob: '{{ build_large_request.request_blob }}'
+        spec:
+          policy:
+            rules:
+              - when: '{{ output.status == "error" and (output.http.status in [429, 500, 502, 503, 504]) }}'
+                then: { do: retry, attempts: 4, backoff: exponential, delay: 1.0 }
+              - when: '{{ output.status == "error" }}'
+                then: { do: fail }
+              - else:
+                  then: { do: continue }
+      - name: project_result
+        kind: python
+        libs:
+          json: json
+        input:
+          request_payload: '{{ build_large_request }}'
+          http_result: '{{ fetch_detail }}'
+          mode: direct_stress
+          batch_number: 0
+        code: |
+          status_code = int(http_result.get("status_code", 0) or 0) if isinstance(http_result, dict) else 0
+          response_headers = http_result.get("headers", {}) if isinstance(http_result, dict) else {}
+
+          content_length = response_headers.get("content-length") or response_headers.get("Content-Length")
+          if isinstance(content_length, str) and content_length.isdigit():
+              response_bytes = int(content_length)
+          else:
+              response_bytes = len(json.dumps(http_result.get("data", {}), separators=(",", ":"))) if isinstance(http_result, dict) else 0
+
+          result = {
+              "item_id": int(request_payload.get("item_id", 0) or 0),
+              "item_key": str(request_payload.get("item_key", "") or ""),
+              "mode": str(mode),
+              "batch_number": int(batch_number or 0),
+              "http_status": status_code,
+              "request_bytes": int(request_payload.get("request_bytes", 0) or 0),
+              "response_bytes": int(response_bytes or 0),
+              "has_response": status_code > 0,
+              "response_meta": {
+                  "url": http_result.get("url") if isinstance(http_result, dict) else None,
+                  "elapsed": http_result.get("elapsed") if isinstance(http_result, dict) else None,
+              },
+              "error_message": "",
+          }
+      - name: persist_result
+        kind: postgres
+        auth: '{{ pg_auth }}'
+        command: |
+          INSERT INTO public.heavy_payload_results (
+            execution_id,
+            item_id,
+            item_key,
+            mode,
+            batch_number,
+            http_status,
+            request_bytes,
+            response_bytes,
+            has_response,
+            response_meta,
+            error_message
+          )
+          VALUES (
+            '{{ execution_id }}',
+            {{ project_result.item_id }},
+            '{{ project_result.item_key | replace("'", "''") }}',
+            '{{ project_result.mode }}',
+            {{ project_result.batch_number }},
+            {{ project_result.http_status }},
+            {{ project_result.request_bytes }},
+            {{ project_result.response_bytes }},
+            {{ 'true' if project_result.has_response else 'false' }},
+            '{{ project_result.response_meta | tojson | replace("'", "''") }}'::jsonb,
+            NULLIF('{{ project_result.error_message | replace("'", "''") }}', '')
+          )
+          ON CONFLICT (execution_id, item_id)
+          DO UPDATE SET
+            item_key = EXCLUDED.item_key,
+            mode = EXCLUDED.mode,
+            batch_number = EXCLUDED.batch_number,
+            http_status = EXCLUDED.http_status,
+            request_bytes = EXCLUDED.request_bytes,
+            response_bytes = EXCLUDED.response_bytes,
+            has_response = EXCLUDED.has_response,
+            response_meta = EXCLUDED.response_meta,
+            error_message = EXCLUDED.error_message,
+            processed_at = NOW();
+      - name: finalize
+        kind: python
+        input:
+          projected: '{{ project_result }}'
+        code: |
+          result = projected
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: validate_persisted_results
+          when: '{{ event.name == ''loop.done'' }}'
+
+  - step: build_batch_plan
+    desc: Build chunk windows for bounded-memory batch execution
+    tool:
+      kind: python
+      input:
+        batch_size: '{{ batch_size }}'
+        max_batches: '{{ max_batches }}'
+      code: |
+        size = int(batch_size or 40)
+        total = int(max_batches or 1)
+
+        batches = []
+        for idx in range(total):
+            batch_number = idx + 1
+            offset = idx * size
+            batches.append(
+                {
+                    "batch_number": batch_number,
+                    "offset": offset,
+                    "limit": size,
+                }
+            )
+
+        result = {
+            "batch_size": size,
+            "max_batches": total,
+            "batches": batches,
+        }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: run_batch_workers
+
+  - step: run_batch_workers
+    desc: Execute chunk worker playbook in parallel across planned windows
+    loop:
+      in: '{{ build_batch_plan.batches }}'
+      iterator: batch
+      spec:
+        mode: parallel
+        max_in_flight: 3
+        policy:
+          exec: distributed
+    tool:
+      kind: playbook
+      path: '{{ batch_worker_path }}'
+      return_step: end
+      timeout: 1200
+      input:
+        pg_auth: '{{ pg_auth }}'
+        parent_execution_id: '{{ job.execution_id }}'
+        batch_number: '{{ iter.batch.batch_number }}'
+        offset: '{{ iter.batch.offset }}'
+        batch_size: '{{ iter.batch.limit }}'
+        payload_kb_per_item: '{{ payload_kb_per_item }}'
+        details_api_url: '{{ details_api_url }}'
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: validate_persisted_results
+          when: '{{ event.name == ''loop.done'' }}'
+
+  - step: validate_persisted_results
+    desc: Validate persisted data volume and completeness
+    tool:
+      kind: postgres
+      auth: '{{ pg_auth }}'
+      query: |
+        SELECT
+          (SELECT COUNT(*)
+           FROM public.heavy_payload_source
+           WHERE execution_id = '{{ execution_id }}') AS source_rows,
+          (SELECT COUNT(*)
+           FROM public.heavy_payload_results
+           WHERE execution_id = '{{ execution_id }}') AS stored_rows,
+          (SELECT COUNT(*)
+           FROM public.heavy_payload_results
+           WHERE execution_id = '{{ execution_id }}' AND http_status = 200) AS successful_http_calls,
+          (SELECT COUNT(*)
+           FROM public.heavy_payload_results
+           WHERE execution_id = '{{ execution_id }}' AND mode = 'direct_stress') AS direct_mode_rows,
+          (SELECT COUNT(*)
+           FROM public.heavy_payload_results
+           WHERE execution_id = '{{ execution_id }}' AND mode = 'chunked_optimal') AS chunked_mode_rows,
+          (SELECT COALESCE(MAX(batch_number), 0)
+           FROM public.heavy_payload_results
+           WHERE execution_id = '{{ execution_id }}') AS max_batch_number,
+          CASE
+            WHEN '{{ resolve_mode.mode }}' = 'direct_stress'
+              THEN {{ seed_rows | int }}
+            ELSE LEAST({{ seed_rows | int }}, {{ batch_size | int }} * {{ max_batches | int }})
+          END AS expected_rows;
+
+        SELECT COUNT(*) AS missing_rows
+        FROM public.heavy_payload_source src
+        LEFT JOIN public.heavy_payload_results tgt
+          ON src.execution_id = tgt.execution_id
+         AND src.item_id = tgt.item_id
+        WHERE src.execution_id = '{{ execution_id }}'
+          AND src.item_id <= CASE
+            WHEN '{{ resolve_mode.mode }}' = 'direct_stress'
+              THEN {{ seed_rows | int }}
+            ELSE LEAST({{ seed_rows | int }}, {{ batch_size | int }} * {{ max_batches | int }})
+          END
+          AND tgt.item_id IS NULL;
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: summarize
+
+  - step: summarize
+    desc: Summarize execution for mode and data checks
+    tool:
+      kind: python
+      input:
+        mode: '{{ resolve_mode.mode }}'
+        validation: '{{ validate_persisted_results }}'
+        direct_loop: '{{ run_direct_stress | default({}) }}'
+        worker_loop: '{{ run_batch_workers | default({}) }}'
+        payload_kb_per_item: '{{ payload_kb_per_item }}'
+        seed_rows: '{{ seed_rows }}'
+        batch_size: '{{ batch_size }}'
+        max_batches: '{{ max_batches }}'
+      code: |
+        stats = validation.get("command_0", {}).get("rows", [{}])[0] if isinstance(validation, dict) else {}
+        gaps = validation.get("command_1", {}).get("rows", [{}])[0] if isinstance(validation, dict) else {}
+
+        chosen_mode = str(mode or "chunked_optimal")
+        loop_data = direct_loop if chosen_mode == "direct_stress" else worker_loop
+        loop_stats = loop_data.get("stats", {}) if isinstance(loop_data, dict) else {}
+
+        configured_seed = int(seed_rows or 0)
+        configured_batch_size = int(batch_size or 0)
+        configured_max_batches = int(max_batches or 0)
+
+        result = {
+            "status": "completed",
+            "mode": chosen_mode,
+            "configured": {
+                "seed_rows": configured_seed,
+                "payload_kb_per_item": int(payload_kb_per_item or 0),
+                "batch_size": configured_batch_size,
+                "max_batches": configured_max_batches,
+            },
+            "execution": {
+                "loop_iterations": int(loop_stats.get("total", 0) or 0),
+                "failed_iterations": int(loop_stats.get("failed", 0) or 0),
+            },
+            "data": {
+                "source_rows": int(stats.get("source_rows", 0) or 0),
+                "expected_rows": int(stats.get("expected_rows", 0) or 0),
+                "stored_rows": int(stats.get("stored_rows", 0) or 0),
+                "missing_rows": int(gaps.get("missing_rows", 0) or 0),
+                "successful_http_calls": int(stats.get("successful_http_calls", 0) or 0),
+                "direct_mode_rows": int(stats.get("direct_mode_rows", 0) or 0),
+                "chunked_mode_rows": int(stats.get("chunked_mode_rows", 0) or 0),
+                "max_batch_number": int(stats.get("max_batch_number", 0) or 0),
+            },
+        }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: end
+
+  - step: end
+    desc: End workflow
+    tool:
+      kind: python
+      code: |
+        result = {"status": "completed"}

--- a/tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step/README.md
+++ b/tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step/README.md
@@ -1,0 +1,270 @@
+# traveler_batch_enrichment_in_step
+
+This fixture validates a full batched enrichment pattern:
+
+1. Parent playbook seeds traveler source rows.
+2. Parent creates fixed batch windows.
+3. Parent runs one worker playbook per batch window.
+4. Worker fetches one batch (`OFFSET/LIMIT`), runs parallel HTTP (`loop.spec.mode: parallel`), transforms, and persists.
+5. Parent waits on `loop.done`, validates persisted rows, and returns a summary.
+
+## What this test is for
+
+- Parent loop orchestration over child playbook calls (`kind: playbook`).
+- Parallel HTTP execution inside each worker batch.
+- Correct aggregation/continuation behavior for `loop.done`.
+- End-to-end row persistence and data completeness checks.
+
+## Fixture files
+
+- Parent playbook:
+  `tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step/traveler_batch_enrichment_in_step.yaml`
+- Worker playbook:
+  `tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_chunk_worker/traveler_batch_enrichment_chunk_worker.yaml`
+
+## Prerequisites
+
+- NoETL server + worker are running (distributed runtime).
+- A usable Postgres credential exists for `pg_auth` (default: `pg_k8s` in this fixture).
+- You can reach the NoETL API (either direct host/port or `kubectl port-forward`).
+- Tools: `noetl`, `kubectl`, `jq`.
+
+If NoETL API is only internal, start a port-forward in a separate terminal:
+
+```bash
+kubectl -n noetl port-forward svc/noetl 8082:8082
+```
+
+All commands below assume:
+
+```bash
+NOETL_HOST=localhost
+NOETL_PORT=8082
+```
+
+## Register both playbooks
+
+Register worker first, then parent:
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" catalog register \
+  tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_chunk_worker/traveler_batch_enrichment_chunk_worker.yaml
+
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" catalog register \
+  tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step/traveler_batch_enrichment_in_step.yaml
+```
+
+## Dry-run validation
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" exec \
+  catalog://tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step \
+  -r distributed \
+  --dry-run
+```
+
+## Smoke test (recommended first)
+
+Use smaller workload for fast verification:
+
+- `seed_rows=200`
+- `batch_size=50`
+- `max_batches=4`
+- expected processed rows = `LEAST(200, 50*4) = 200`
+
+### Smoke test quick commands (copy/paste)
+
+```bash
+export NOETL_HOST=localhost
+export NOETL_PORT=8082
+
+# Terminal A: expose NoETL API locally
+kubectl -n noetl port-forward svc/noetl 8082:8082
+```
+
+```bash
+# Terminal B: register worker + parent playbooks
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" catalog register \
+  tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_chunk_worker/traveler_batch_enrichment_chunk_worker.yaml
+
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" catalog register \
+  tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step/traveler_batch_enrichment_in_step.yaml
+```
+
+```bash
+# Terminal B: run smoke workload and capture execution id
+RUN_JSON="$(curl -sS -X POST "http://$NOETL_HOST:$NOETL_PORT/api/execute" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "path": "tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step",
+    "payload": {
+      "seed_rows": 200,
+      "batch_size": 50,
+      "max_batches": 4,
+      "profile_api_url": "https://httpbin.org/anything/traveler-profile"
+    }
+  }')"
+
+echo "$RUN_JSON" | jq .
+export EXECUTION_ID="$(echo "$RUN_JSON" | jq -r '.execution_id')"
+echo "EXECUTION_ID=$EXECUTION_ID"
+```
+
+```bash
+# Terminal B: wait until execution completes or fails
+while true; do
+  STATUS_JSON="$(noetl --host "$NOETL_HOST" --port "$NOETL_PORT" status "$EXECUTION_ID" --json)"
+  echo "$STATUS_JSON" | jq '{execution_id, completed, failed, current_step}'
+
+  COMPLETED="$(echo "$STATUS_JSON" | jq -r '.completed')"
+  FAILED="$(echo "$STATUS_JSON" | jq -r '.failed')"
+  if [ "$COMPLETED" = "true" ] || [ "$FAILED" = "true" ]; then
+    break
+  fi
+  sleep 5
+done
+```
+
+Optional event tail:
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "SELECT event_id, event_type, node_name, status, created_at
+   FROM noetl.event
+   WHERE execution_id = $EXECUTION_ID
+   ORDER BY event_id DESC
+   LIMIT 40;" \
+  --schema noetl --format table
+```
+
+## Data validation SQL
+
+### 1) Validate persisted counts
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "SELECT
+     COUNT(*) AS stored_rows,
+     COUNT(*) FILTER (WHERE profile_status = 200) AS successful_http_calls,
+     COUNT(*) FILTER (WHERE is_valid = TRUE) AS valid_rows,
+     COUNT(*) FILTER (WHERE is_valid = FALSE) AS invalid_rows,
+     COUNT(DISTINCT batch_number) AS batches_with_rows,
+     MAX(batch_number) AS max_batch_number
+   FROM public.traveler_batch_results
+   WHERE execution_id = '$EXECUTION_ID';" \
+  --schema public --format table
+```
+
+Expected for smoke test:
+
+- `stored_rows = 200`
+- `max_batch_number <= 4`
+- `invalid_rows = 0` (normally)
+
+### 2) Validate no missing rows in expected range
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "SELECT COUNT(*) AS missing_rows
+   FROM public.traveler_batch_source src
+   LEFT JOIN public.traveler_batch_results tgt
+     ON src.execution_id = tgt.execution_id
+    AND src.traveler_id = tgt.traveler_id
+   WHERE src.execution_id = '$EXECUTION_ID'
+     AND src.traveler_id <= LEAST(200, 50 * 4)
+     AND tgt.traveler_id IS NULL;" \
+  --schema public --format table
+```
+
+Expected: `missing_rows = 0`
+
+### 3) Validate parent transitioned after loop (loop completion path)
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "SELECT COUNT(*) AS validate_step_enters
+   FROM noetl.event
+   WHERE execution_id = $EXECUTION_ID
+     AND event_type = 'step.enter'
+     AND node_name = 'validate_persisted_results';" \
+  --schema noetl --format table
+```
+
+Expected: `validate_step_enters = 1`
+
+### 4) Validate summarize output payload
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "SELECT result
+   FROM noetl.event
+   WHERE execution_id = $EXECUTION_ID
+     AND node_name = 'summarize'
+     AND event_type = 'step.exit'
+   ORDER BY event_id DESC
+   LIMIT 1;" \
+  --schema noetl --format json
+```
+
+Check fields in `result`:
+
+- `status = completed`
+- `execution.batch_worker_iterations` matches expected batch rounds
+- `data.expected_rows` and `data.stored_rows` are equal
+- `data.missing_rows = 0`
+
+## Full-scale run (fixture defaults)
+
+Default profile in the playbook:
+
+- `seed_rows=2000`
+- `batch_size=100`
+- `max_batches=20`
+- expected processed rows = `LEAST(2000, 100*20) = 2000`
+
+Run:
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" exec \
+  catalog://tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step \
+  -r distributed
+```
+
+For this run, use the same validation queries as above, replacing expected range with:
+
+```sql
+LEAST(2000, 100 * 20)
+```
+
+## Cleanup for one execution (optional)
+
+```bash
+noetl --host "$NOETL_HOST" --port "$NOETL_PORT" query \
+  "DELETE FROM public.traveler_batch_results WHERE execution_id = '$EXECUTION_ID';
+   DELETE FROM public.traveler_batch_source WHERE execution_id = '$EXECUTION_ID';" \
+  --schema public --format table
+```
+
+## Troubleshooting
+
+- `Connection refused` on `localhost:8082`:
+  - Start `kubectl -n noetl port-forward svc/noetl 8082:8082`
+  - Or use reachable `--host/--port`.
+- `Credential not found` (`pg_k8s`):
+  - Provide `--set pg_auth=<your_credential_name>`
+  - Or register/update the expected credential.
+- High latency/timeouts to external HTTP endpoint:
+  - Override `profile_api_url` with low-latency endpoint.
+- Fewer rows than expected:
+  - Check `summarize.result.data.missing_rows`
+  - Check recent `step.exit` and `call.error` events for worker steps.
+
+## Performance notes
+
+- `profile_api_url` defaults to a public endpoint. Throughput is network-bound.
+- Worker HTTP parallelism is controlled by `loop.spec.max_in_flight` in worker playbook (`25` by default).
+- HTTP pooling knobs (worker env):
+  - `NOETL_HTTP_MAX_CONNECTIONS` (default `200`)
+  - `NOETL_HTTP_MAX_KEEPALIVE_CONNECTIONS` (default `50`)
+  - `NOETL_HTTP_KEEPALIVE_EXPIRY_SECONDS` (default `30`)
+  - `NOETL_HTTP_ENABLE_HTTP2` (default `true`)

--- a/tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step/traveler_batch_enrichment_in_step.yaml
+++ b/tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step/traveler_batch_enrichment_in_step.yaml
@@ -1,0 +1,227 @@
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: traveler_batch_enrichment_in_step
+  path: tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_in_step
+  description: Query travelers in 100-row batches and process each batch with parallel HTTP enrichment.
+
+workload:
+  pg_auth: pg_k8s
+  seed_rows: 120
+  batch_size: 30
+  max_batches: 4
+  profile_api_url: https://httpbin.org/anything/traveler-profile
+  batch_worker_path: tests/fixtures/playbooks/batch_execution/traveler_batch_enrichment_chunk_worker
+
+workflow:
+  - step: start
+    desc: Initialize execution
+    tool:
+      kind: python
+      code: |
+        result = {
+          "status": "initialized",
+          "pattern": "query_100_then_parallel_http_then_next_batch"
+        }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: prepare_source_and_target
+
+  - step: prepare_source_and_target
+    desc: Prepare source/target tables and seed traveler source rows
+    tool:
+      kind: postgres
+      auth: '{{ pg_auth }}'
+      query: |
+        CREATE TABLE IF NOT EXISTS public.traveler_batch_source (
+          execution_id TEXT NOT NULL,
+          traveler_id INTEGER NOT NULL,
+          traveler_name TEXT NOT NULL,
+          PRIMARY KEY (execution_id, traveler_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS public.traveler_batch_results (
+          execution_id TEXT NOT NULL,
+          traveler_id INTEGER NOT NULL,
+          traveler_name TEXT NOT NULL,
+          normalized_name TEXT NOT NULL,
+          profile_status INTEGER NOT NULL,
+          profile_hash TEXT NOT NULL,
+          profile_payload JSONB NOT NULL,
+          is_valid BOOLEAN NOT NULL DEFAULT TRUE,
+          validation_error TEXT,
+          batch_number INTEGER NOT NULL,
+          processed_at TIMESTAMPTZ DEFAULT NOW(),
+          PRIMARY KEY (execution_id, traveler_id)
+        );
+
+        DELETE FROM public.traveler_batch_source
+        WHERE execution_id = '{{ execution_id }}';
+
+        DELETE FROM public.traveler_batch_results
+        WHERE execution_id = '{{ execution_id }}';
+
+        INSERT INTO public.traveler_batch_source (execution_id, traveler_id, traveler_name)
+        SELECT
+          '{{ execution_id }}',
+          gs,
+          'Traveler ' || gs
+        FROM generate_series(1, {{ seed_rows }}) AS gs;
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: build_batch_plan
+
+  - step: build_batch_plan
+    desc: Build configurable batch windows for traveler processing
+    tool:
+      kind: python
+      input:
+        batch_size: '{{ batch_size }}'
+        max_batches: '{{ max_batches }}'
+      code: |
+        size = int(batch_size or 30)
+        total = int(max_batches or 4)
+
+        batches = []
+        for idx in range(total):
+            batch_number = idx + 1
+            offset = idx * size
+            batches.append(
+                {
+                    "batch_number": batch_number,
+                    "offset": offset,
+                    "limit": size,
+                }
+            )
+
+        result = {
+            "batch_size": size,
+            "max_batches": total,
+            "batches": batches,
+        }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: run_batch_workers
+
+  - step: run_batch_workers
+    desc: For each planned batch, execute worker playbook that runs parallel HTTP per traveler
+    loop:
+      in: '{{ build_batch_plan.batches }}'
+      iterator: batch
+      spec:
+        mode: sequential
+        policy:
+          exec: distributed
+    tool:
+      kind: playbook
+      path: '{{ batch_worker_path }}'
+      return_step: end
+      timeout: 900
+      input:
+        pg_auth: '{{ pg_auth }}'
+        parent_execution_id: '{{ job.execution_id }}'
+        batch_number: '{{ iter.batch.batch_number }}'
+        offset: '{{ iter.batch.offset }}'
+        batch_size: '{{ iter.batch.limit }}'
+        profile_api_url: '{{ profile_api_url }}'
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: validate_persisted_results
+          when: '{{ event.name == ''loop.done'' }}'
+
+  - step: validate_persisted_results
+    desc: Validate persisted rows for processed batch range
+    tool:
+      kind: postgres
+      auth: '{{ pg_auth }}'
+      query: |
+        SELECT
+          (SELECT COUNT(*)
+           FROM public.traveler_batch_source
+           WHERE execution_id = '{{ execution_id }}') AS source_rows,
+          (SELECT COUNT(*)
+           FROM public.traveler_batch_results
+           WHERE execution_id = '{{ execution_id }}') AS stored_rows,
+          (SELECT COUNT(*)
+           FROM public.traveler_batch_results
+           WHERE execution_id = '{{ execution_id }}' AND profile_status = 200) AS successful_http_calls,
+          (SELECT COUNT(*)
+           FROM public.traveler_batch_results
+           WHERE execution_id = '{{ execution_id }}' AND is_valid = TRUE) AS valid_rows,
+          (SELECT COUNT(*)
+           FROM public.traveler_batch_results
+           WHERE execution_id = '{{ execution_id }}' AND is_valid = FALSE) AS invalid_rows,
+          (SELECT COALESCE(MAX(batch_number), 0)
+           FROM public.traveler_batch_results
+           WHERE execution_id = '{{ execution_id }}') AS max_batch_number,
+          LEAST({{ seed_rows | int }}, {{ batch_size | int }} * {{ max_batches | int }}) AS expected_rows;
+
+        SELECT COUNT(*) AS missing_rows
+        FROM public.traveler_batch_source src
+        LEFT JOIN public.traveler_batch_results tgt
+          ON src.execution_id = tgt.execution_id
+         AND src.traveler_id = tgt.traveler_id
+        WHERE src.execution_id = '{{ execution_id }}'
+          AND src.traveler_id <= LEAST({{ seed_rows | int }}, {{ batch_size | int }} * {{ max_batches | int }})
+          AND tgt.traveler_id IS NULL;
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: summarize
+
+  - step: summarize
+    desc: Summarize batch worker execution and persistence checks
+    tool:
+      kind: python
+      input:
+        validation: '{{ validate_persisted_results }}'
+        worker_loop: '{{ run_batch_workers }}'
+        batch_size: '{{ batch_size }}'
+        max_batches: '{{ max_batches }}'
+      code: |
+        stats = validation.get("command_0", {}).get("rows", [{}])[0] if isinstance(validation, dict) else {}
+        gaps = validation.get("command_1", {}).get("rows", [{}])[0] if isinstance(validation, dict) else {}
+        loop_stats = worker_loop.get("stats", {}) if isinstance(worker_loop, dict) else {}
+
+        result = {
+            "status": "completed",
+            "configured": {
+                "batch_size": int(batch_size or 30),
+                "max_batches": int(max_batches or 4),
+            },
+            "execution": {
+                "batch_worker_iterations": int(loop_stats.get("total", 0) or 0),
+                "batch_worker_failed_iterations": int(loop_stats.get("failed", 0) or 0),
+            },
+            "data": {
+                "source_rows": int(stats.get("source_rows", 0) or 0),
+                "expected_rows": int(stats.get("expected_rows", 0) or 0),
+                "stored_rows": int(stats.get("stored_rows", 0) or 0),
+                "missing_rows": int(gaps.get("missing_rows", 0) or 0),
+                "successful_http_calls": int(stats.get("successful_http_calls", 0) or 0),
+                "valid_rows": int(stats.get("valid_rows", 0) or 0),
+                "invalid_rows": int(stats.get("invalid_rows", 0) or 0),
+                "max_batch_number": int(stats.get("max_batch_number", 0) or 0),
+            },
+        }
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: end
+
+  - step: end
+    desc: End workflow
+    tool:
+      kind: python
+      code: |
+        result = {"status": "completed"}

--- a/tests/unit/dsl/engine/test_loop_parallel_dispatch.py
+++ b/tests/unit/dsl/engine/test_loop_parallel_dispatch.py
@@ -62,6 +62,29 @@ class ClaimingNATSCache:
         self._state[key] = state
         return claim_index
 
+    async def claim_next_loop_indices(
+        self,
+        execution_id,
+        step_name,
+        collection_size,
+        max_in_flight,
+        requested_count=1,
+        event_id=None,
+    ):
+        claimed = []
+        for _ in range(int(requested_count or 1)):
+            claim_index = await self.claim_next_loop_index(
+                execution_id,
+                step_name,
+                collection_size,
+                max_in_flight,
+                event_id=event_id,
+            )
+            if claim_index is None:
+                break
+            claimed.append(claim_index)
+        return claimed
+
 
 class RepairingNATSCache:
     def __init__(self, initial_state):
@@ -115,6 +138,29 @@ class RepairingNATSCache:
         self.state["collection_size"] = effective_size
         self.state["event_id"] = event_id
         return claim_index
+
+    async def claim_next_loop_indices(
+        self,
+        execution_id,
+        step_name,
+        collection_size,
+        max_in_flight,
+        requested_count=1,
+        event_id=None,
+    ):
+        claimed = []
+        for _ in range(int(requested_count or 1)):
+            claim_index = await self.claim_next_loop_index(
+                execution_id,
+                step_name,
+                collection_size,
+                max_in_flight,
+                event_id=event_id,
+            )
+            if claim_index is None:
+                break
+            claimed.append(claim_index)
+        return claimed
 
     async def count_observed_loop_iteration_terminals(
         self,

--- a/tests/unit/dsl/engine/test_task_sequence_loop_completion.py
+++ b/tests/unit/dsl/engine/test_task_sequence_loop_completion.py
@@ -29,14 +29,32 @@ class FakeNATSCache:
     async def get_loop_state(self, execution_id, step_name, event_id=None):
         self.get_state_calls.append((execution_id, step_name, event_id))
         return {
-            "collection_size": 20,
+            "collection_size": 220,
             "completed_count": 1,
+            "scheduled_count": 1,
             "event_id": event_id,
         }
 
     async def set_loop_state(self, execution_id, step_name, state, event_id=None):
         self.set_state_calls.append((execution_id, step_name, state, event_id))
         return True
+
+    async def claim_next_loop_indices(
+        self,
+        execution_id,
+        step_name,
+        collection_size,
+        max_in_flight,
+        requested_count=1,
+        event_id=None,
+    ):
+        completed_count = 1
+        scheduled_count = 1
+        collection_size = int(collection_size or 220)
+        if scheduled_count >= collection_size:
+            return []
+        claim_count = min(int(requested_count or 1), int(max_in_flight or 1), collection_size - scheduled_count)
+        return list(range(scheduled_count, scheduled_count + claim_count))
 
     async def try_claim_loop_done(self, execution_id, step_name, event_id=None):
         return True  # always grants by default in existing tests
@@ -59,9 +77,26 @@ class EventAwareNATSCache(FakeNATSCache):
             return {
                 "collection_size": 220,
                 "completed_count": 6,
+                "scheduled_count": 6,
                 "event_id": event_id,
             }
         return None
+
+    async def claim_next_loop_indices(
+        self,
+        execution_id,
+        step_name,
+        collection_size,
+        max_in_flight,
+        requested_count=1,
+        event_id=None,
+    ):
+        if event_id != self.exec_event_id:
+            return []
+        scheduled_count = 6
+        collection_size = int(collection_size or 220)
+        claim_count = min(int(requested_count or 1), int(max_in_flight or 1), collection_size - scheduled_count)
+        return list(range(scheduled_count, scheduled_count + claim_count))
 
 
 class ClaimAwareNATSCache(FakeNATSCache):


### PR DESCRIPTION
## Summary
- restore the batch_execution fixture playbooks still referenced by DSL engine unit tests
- keep command_id extraction lossless for older string command ids while duplicate guards still use numeric projection columns when possible
- update unit fake NATS caches to support batched loop index claims

## Tests
- .venv/bin/python -m pytest tests/unit/dsl/engine -q
- .venv/bin/python -m pytest tests/unit/dsl/engine/test_loop_parallel_dispatch.py::test_extract_command_id_from_event_payload_supports_reference_only_shapes tests/unit/dsl/engine/test_loop_parallel_dispatch.py::test_handle_event_skips_duplicate_persisted_call_done tests/unit/dsl/engine/test_task_sequence_loop_completion.py::test_task_sequence_loop_uses_nats_collection_size_when_local_collection_missing tests/unit/dsl/engine/test_task_sequence_loop_completion.py::test_task_sequence_loop_prefers_execution_loop_key_when_step_event_id_present tests/unit/dsl/engine/test_task_sequence_loop_completion.py::test_task_sequence_loop_persists_issued_steps_before_return tests/unit/dsl/engine/test_task_sequence_loop_completion.py::test_task_sequence_loop_persists_event_before_early_return_when_needed -q

Tracks noetl/noetl#474.