### PR TITLE
Decode Arrow Feather event payloads in projector

### DIFF
--- a/noetl/core/messaging/nats_client.py
+++ b/noetl/core/messaging/nats_client.py
@@ -286,6 +286,7 @@ class NATSCommandSubscriber:
         fetch_timeout: Optional[float] = None,
         fetch_heartbeat: Optional[float] = None,
         callback_timeout_seconds: Optional[float] = None,
+        message_decoder: Optional[Callable[[bytes], dict[str, Any]]] = None,
     ):
         from noetl.core.config import get_worker_settings
         ws = get_worker_settings()
@@ -310,12 +311,17 @@ class NATSCommandSubscriber:
             5.0,
             min(30.0, self.callback_timeout_seconds / 4.0),
         )
+        self._message_decoder = message_decoder or self._decode_json_message
         self._nc: Optional[NATSClient] = None
         self._js: Optional[JetStreamContext] = None
         self._subscription = None
         self._background_tasks: set = set()
         self._inflight_semaphore = asyncio.Semaphore(self.max_inflight)
         self._throttle_hits = 0
+
+    @staticmethod
+    def _decode_json_message(payload: bytes) -> dict[str, Any]:
+        return json.loads(payload.decode("utf-8"))
 
     @staticmethod
     def _effective_ack_wait_seconds() -> float:
@@ -689,8 +695,7 @@ class NATSCommandSubscriber:
 
                     for msg in messages:
                         try:
-                            import json
-                            data = json.loads(msg.data.decode())
+                            data = self._message_decoder(bytes(msg.data))
                             # Process in background and ack/nak based on callback result.
                             create_background_task(process_message(data, msg))
 

--- a/noetl/core/projector/nats_worker.py
+++ b/noetl/core/projector/nats_worker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import re
 from dataclasses import dataclass
@@ -15,6 +16,7 @@ from noetl.core.db.pool import close_pool, init_pool
 from noetl.core.logger import setup_logger
 from noetl.core.messaging import NATSCommandSubscriber
 from noetl.core.projection_store import PostgresProjectionStore, ProjectionStore
+from noetl.core.storage.arrow_ipc import arrow_feather_to_rows
 
 from .metrics import ProjectorMetrics, start_projector_metrics_server
 from .service import ReplayStateProjector
@@ -109,6 +111,7 @@ class NATSProjectorWorker:
             max_ack_pending=self.settings.max_ack_pending,
             fetch_timeout=self.settings.fetch_timeout_seconds,
             fetch_heartbeat=self.settings.fetch_heartbeat_seconds,
+            message_decoder=decode_projector_notification,
         )
         await self._subscriber.connect()
         logger.info(
@@ -216,6 +219,23 @@ def _extract_events(notification: dict[str, Any]) -> list[dict[str, Any]]:
         return [dict(notification)]
 
     return []
+
+
+def decode_projector_notification(payload: bytes) -> dict[str, Any]:
+    """Decode projector notifications from JSON or Arrow Feather outbox payloads."""
+
+    try:
+        decoded = json.loads(payload.decode("utf-8"))
+        if isinstance(decoded, dict):
+            return decoded
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        pass
+
+    rows = arrow_feather_to_rows(payload)
+    events = [dict(row) for row in rows if isinstance(row, dict)]
+    if len(events) == 1:
+        return events[0]
+    return {"events": events}
 
 
 def _parse_shard_index(shard_id: str) -> int:

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -219,6 +219,46 @@ async def test_nats_projector_worker_projects_owned_event_batch():
     assert snapshot["last_projection_source_event_id"] == 20
 
 
+def test_projector_notification_decoder_accepts_json_and_arrow_feather():
+    from noetl.core.projector.nats_worker import decode_projector_notification
+    from noetl.core.storage.arrow_ipc import rows_to_arrow_feather
+
+    json_payload = b'{"event_id": 20, "execution_id": 7, "event_type": "workflow.completed"}'
+    assert decode_projector_notification(json_payload)["event_id"] == 20
+
+    arrow_payload, _schema_digest, row_count = rows_to_arrow_feather(
+        [
+            {
+                "event_id": 21,
+                "execution_id": 7,
+                "event_type": "frame.committed",
+                "status": "COMPLETED",
+            }
+        ]
+    )
+
+    assert row_count == 1
+    decoded = decode_projector_notification(arrow_payload)
+    assert decoded["event_id"] == 21
+    assert decoded["event_type"] == "frame.committed"
+
+
+def test_projector_notification_decoder_wraps_arrow_batches():
+    from noetl.core.projector.nats_worker import decode_projector_notification
+    from noetl.core.storage.arrow_ipc import rows_to_arrow_feather
+
+    arrow_payload, _schema_digest, row_count = rows_to_arrow_feather(
+        [
+            {"event_id": 21, "execution_id": 7, "event_type": "frame.dispatched"},
+            {"event_id": 22, "execution_id": 7, "event_type": "frame.committed"},
+        ]
+    )
+
+    assert row_count == 2
+    decoded = decode_projector_notification(arrow_payload)
+    assert [event["event_id"] for event in decoded["events"]] == [21, 22]
+
+
 @pytest.mark.asyncio
 async def test_nats_projector_worker_acks_empty_or_unowned_notifications():
     from noetl.core.projector.metrics import ProjectorMetrics
@@ -253,6 +293,7 @@ async def test_nats_projector_worker_tolerates_projection_schema_permission(monk
     class FakeSubscriber:
         def __init__(self, **kwargs):
             calls.append(("init", kwargs["consumer_name"]))
+            assert callable(kwargs["message_decoder"])
 
         async def connect(self):
             calls.append(("connect", None))


### PR DESCRIPTION
## Summary
- add a message decoder hook to NATSCommandSubscriber while preserving JSON as the default
- let NATSProjectorWorker decode projector notifications from either JSON envelopes or Arrow Feather outbox payloads
- add projector tests for single-event and batch Arrow Feather payloads

## Tests
- .venv/bin/python -m pytest tests/core/test_replay_state_projector.py tests/core/test_outbox.py tests/core/test_arrow_ipc_serialization.py -q

Tracks noetl/noetl#437.