### PR TITLE
Add standalone outbox publisher worker

### DIFF
--- a/noetl/outbox/__init__.py
+++ b/noetl/outbox/__init__.py
@@ -1,0 +1,2 @@
+"""NoETL outbox publisher process package."""
+

--- a/noetl/outbox/__main__.py
+++ b/noetl/outbox/__main__.py
@@ -1,0 +1,34 @@
+"""Command-line entrypoint for the NoETL outbox publisher."""
+
+from __future__ import annotations
+
+import argparse
+
+from noetl.outbox.worker import (
+    OutboxPublisherSettings,
+    load_outbox_publisher_settings,
+    run_outbox_publisher_sync,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="NoETL transactional outbox publisher")
+    parser.add_argument("--batch-size", type=int, default=None, help="Rows to claim per publish batch")
+    parser.add_argument("--idle-sleep", type=float, default=None, help="Sleep seconds when no rows are ready")
+    parser.add_argument("--error-sleep", type=float, default=None, help="Sleep seconds after a publish loop error")
+    parser.add_argument("--once", action="store_true", help="Publish one batch and exit")
+    args = parser.parse_args()
+
+    base = load_outbox_publisher_settings()
+    settings = OutboxPublisherSettings(
+        batch_size=args.batch_size if args.batch_size is not None else base.batch_size,
+        idle_sleep_seconds=args.idle_sleep if args.idle_sleep is not None else base.idle_sleep_seconds,
+        error_sleep_seconds=args.error_sleep if args.error_sleep is not None else base.error_sleep_seconds,
+        once=args.once or base.once,
+    )
+    run_outbox_publisher_sync(settings=settings)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/noetl/outbox/worker.py
+++ b/noetl/outbox/worker.py
@@ -1,0 +1,81 @@
+"""Standalone transactional outbox publisher."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from noetl.core.common import get_pgdb_connection
+from noetl.core.db.pool import close_pool, init_pool
+from noetl.core.logger import setup_logger
+from noetl.core.outbox import ensure_outbox_schema, publish_outbox_batch
+
+logger = setup_logger(__name__, include_location=True)
+
+
+@dataclass(frozen=True)
+class OutboxPublisherSettings:
+    batch_size: int = 100
+    idle_sleep_seconds: float = 1.0
+    error_sleep_seconds: float = 5.0
+    once: bool = False
+
+
+def load_outbox_publisher_settings() -> OutboxPublisherSettings:
+    return OutboxPublisherSettings(
+        batch_size=max(1, _int_env("NOETL_OUTBOX_PUBLISHER_BATCH_SIZE", 100)),
+        idle_sleep_seconds=max(0.05, _float_env("NOETL_OUTBOX_PUBLISHER_IDLE_SLEEP_SECONDS", 1.0)),
+        error_sleep_seconds=max(0.05, _float_env("NOETL_OUTBOX_PUBLISHER_ERROR_SLEEP_SECONDS", 5.0)),
+        once=_bool_env("NOETL_OUTBOX_PUBLISHER_ONCE", False),
+    )
+
+
+async def run_outbox_publisher(settings: Optional[OutboxPublisherSettings] = None) -> None:
+    effective_settings = settings or load_outbox_publisher_settings()
+    await init_pool(get_pgdb_connection())
+    try:
+        await ensure_outbox_schema()
+        while True:
+            try:
+                published = await publish_outbox_batch(limit=effective_settings.batch_size)
+                if effective_settings.once:
+                    return
+                if published <= 0:
+                    await asyncio.sleep(effective_settings.idle_sleep_seconds)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("Outbox publisher iteration failed: %s", exc, exc_info=True)
+                if effective_settings.once:
+                    raise
+                await asyncio.sleep(effective_settings.error_sleep_seconds)
+    finally:
+        await close_pool()
+
+
+def run_outbox_publisher_sync(settings: Optional[OutboxPublisherSettings] = None) -> None:
+    asyncio.run(run_outbox_publisher(settings=settings))
+
+
+def _int_env(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    return int(value)
+
+
+def _float_env(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    return float(value)
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+

--- a/tests/core/test_outbox_publisher_worker.py
+++ b/tests/core/test_outbox_publisher_worker.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_load_outbox_publisher_settings_from_env(monkeypatch):
+    from noetl.outbox.worker import load_outbox_publisher_settings
+
+    monkeypatch.setenv("NOETL_OUTBOX_PUBLISHER_BATCH_SIZE", "25")
+    monkeypatch.setenv("NOETL_OUTBOX_PUBLISHER_IDLE_SLEEP_SECONDS", "0.2")
+    monkeypatch.setenv("NOETL_OUTBOX_PUBLISHER_ERROR_SLEEP_SECONDS", "2.5")
+    monkeypatch.setenv("NOETL_OUTBOX_PUBLISHER_ONCE", "true")
+
+    settings = load_outbox_publisher_settings()
+
+    assert settings.batch_size == 25
+    assert settings.idle_sleep_seconds == 0.2
+    assert settings.error_sleep_seconds == 2.5
+    assert settings.once is True
+
+
+@pytest.mark.asyncio
+async def test_run_outbox_publisher_once_initializes_publishes_and_closes(monkeypatch):
+    import noetl.outbox.worker as worker
+
+    calls = []
+
+    async def init_pool(conninfo):
+        calls.append(("init", conninfo))
+
+    async def close_pool():
+        calls.append(("close", None))
+
+    async def ensure_schema():
+        calls.append(("ensure", None))
+
+    async def publish_batch(*, limit):
+        calls.append(("publish", limit))
+        return 3
+
+    monkeypatch.setattr(worker, "get_pgdb_connection", lambda: "dbname=noetl")
+    monkeypatch.setattr(worker, "init_pool", init_pool)
+    monkeypatch.setattr(worker, "close_pool", close_pool)
+    monkeypatch.setattr(worker, "ensure_outbox_schema", ensure_schema)
+    monkeypatch.setattr(worker, "publish_outbox_batch", publish_batch)
+
+    await worker.run_outbox_publisher(
+        worker.OutboxPublisherSettings(batch_size=7, once=True)
+    )
+
+    assert calls == [
+        ("init", "dbname=noetl"),
+        ("ensure", None),
+        ("publish", 7),
+        ("close", None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_outbox_publisher_sleeps_when_idle_then_handles_cancel(monkeypatch):
+    import asyncio
+
+    import noetl.outbox.worker as worker
+
+    calls = []
+
+    async def init_pool(conninfo):  # noqa: ARG001
+        calls.append("init")
+
+    async def close_pool():
+        calls.append("close")
+
+    async def ensure_schema():
+        calls.append("ensure")
+
+    async def publish_batch(*, limit):  # noqa: ARG001
+        calls.append("publish")
+        return 0
+
+    async def sleep(seconds):  # noqa: ARG001
+        calls.append("sleep")
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(worker, "get_pgdb_connection", lambda: "dbname=noetl")
+    monkeypatch.setattr(worker, "init_pool", init_pool)
+    monkeypatch.setattr(worker, "close_pool", close_pool)
+    monkeypatch.setattr(worker, "ensure_outbox_schema", ensure_schema)
+    monkeypatch.setattr(worker, "publish_outbox_batch", publish_batch)
+    monkeypatch.setattr(worker.asyncio, "sleep", sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await worker.run_outbox_publisher(worker.OutboxPublisherSettings())
+
+    assert calls == ["init", "ensure", "publish", "sleep", "close"]
+


### PR DESCRIPTION
## Summary
- add python -m noetl.outbox as a standalone transactional outbox publisher
- support continuous publishing and --once / NOETL_OUTBOX_PUBLISHER_ONCE for jobs and smoke tests
- initialize/close the shared DB pool and ensure the outbox schema before publishing

## Tests
- .venv/bin/python -m pytest tests/core/test_outbox_publisher_worker.py tests/core/test_outbox.py -q

Tracks noetl/noetl#437.