### PR TITLE
Add replay and serialization release gate script

### DIFF
--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+PYTHON_BIN="${PYTHON_BIN:-.venv/bin/python}"
+
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  PYTHON_BIN="${PYTHON_BIN_FALLBACK:-python}"
+fi
+
+"$PYTHON_BIN" -m pytest -q \
+  tests/core/test_replay_golden_corpus.py \
+  tests/api/test_replay_routes.py \
+  tests/core/test_replay_upcasters.py \
+  tests/core/test_replay_state_projector.py \
+  tests/core/test_projector_metrics.py \
+  tests/core/test_outbox.py \
+  tests/core/test_outbox_publisher_worker.py \
+  tests/api/test_command_claim_outbox.py \
+  tests/api/test_broker_event_outbox.py \
+  tests/unit/dsl/engine/test_executor_outbox.py \
+  tests/api/test_frame_routes.py \
+  tests/core/test_arrow_ipc_serialization.py \
+  tests/core/test_storage_ipc_hint.py \
+  tests/core/test_storage_ipc_cache.py


### PR DESCRIPTION
## Summary
- add scripts/check_replay_release_gate.sh as the local release gate for replay checksums, upcasters, projector folding, outbox publishing, frame event serialization, and Arrow/IPC durability behavior
- use .venv/bin/python by default with PYTHON_BIN override for CI or alternate environments

## Tests
- scripts/check_replay_release_gate.sh => 63 passed

Tracks noetl/noetl#440.