### PR TITLE
Add projection store query port

### DIFF
--- a/noetl/core/projection_store/__init__.py
+++ b/noetl/core/projection_store/__init__.py
@@ -2,6 +2,7 @@
 
 from .ports import (
     ProjectionConflict,
+    ProjectionQuery,
     ProjectionRecord,
     ProjectionSnapshot,
     ProjectionStore,
@@ -11,6 +12,7 @@ from .postgres import PostgresProjectionStore
 
 __all__ = [
     "ProjectionConflict",
+    "ProjectionQuery",
     "ProjectionRecord",
     "ProjectionSnapshot",
     "ProjectionStore",

--- a/noetl/core/projection_store/ports.py
+++ b/noetl/core/projection_store/ports.py
@@ -61,12 +61,24 @@ class ProjectionSnapshot:
         return self.checksum or projection_checksum(self.snapshot)
 
 
+@dataclass(frozen=True)
+class ProjectionQuery:
+    tenant_id: Optional[str] = None
+    organization_id: Optional[str] = None
+    projection_type: Optional[str] = None
+    execution_id: Optional[int] = None
+    limit: int = 100
+
+
 class ProjectionStore(Protocol):
     async def save_projection(self, record: ProjectionRecord) -> bool:
         """Save a projection. Return True when state changed."""
 
     async def load_projection(self, projection_id: str) -> Optional[ProjectionRecord]:
         """Load the current projection state."""
+
+    async def query_projections(self, query: ProjectionQuery) -> list[ProjectionRecord]:
+        """Query projections by tenant, type, execution, or backend-supported indexes."""
 
     async def save_snapshot(self, snapshot: ProjectionSnapshot) -> bool:
         """Save an aggregate snapshot. Return True when state changed."""

--- a/noetl/core/projection_store/postgres.py
+++ b/noetl/core/projection_store/postgres.py
@@ -7,7 +7,7 @@ from psycopg.types.json import Json
 
 from noetl.core.db.pool import get_pool_connection
 
-from .ports import ProjectionRecord, ProjectionSnapshot
+from .ports import ProjectionQuery, ProjectionRecord, ProjectionSnapshot
 
 
 _PROJECTION_DDL = """
@@ -118,6 +118,41 @@ class PostgresProjectionStore:
         if not row:
             return None
         return ProjectionRecord(**dict(row))
+
+    async def query_projections(self, query: ProjectionQuery) -> list[ProjectionRecord]:
+        predicates: list[str] = []
+        params: list[Any] = []
+        if query.tenant_id is not None:
+            predicates.append("tenant_id = %s")
+            params.append(query.tenant_id)
+        if query.organization_id is not None:
+            predicates.append("organization_id = %s")
+            params.append(query.organization_id)
+        if query.projection_type is not None:
+            predicates.append("projection_type = %s")
+            params.append(query.projection_type)
+        if query.execution_id is not None:
+            predicates.append("execution_id = %s")
+            params.append(int(query.execution_id))
+
+        where_clause = f"WHERE {' AND '.join(predicates)}" if predicates else ""
+        params.append(max(1, int(query.limit or 100)))
+
+        async with get_pool_connection() as conn:
+            async with conn.cursor(row_factory=dict_row) as cur:
+                await cur.execute(
+                    f"""
+                    SELECT projection_id, projection_type, tenant_id, organization_id,
+                           execution_id, version, source_event_id, state, checksum, meta
+                    FROM noetl.projection
+                    {where_clause}
+                    ORDER BY updated_at DESC, projection_id ASC
+                    LIMIT %s
+                    """,
+                    params,
+                )
+                rows = await cur.fetchall()
+        return [ProjectionRecord(**dict(row)) for row in rows]
 
     async def save_snapshot(self, snapshot: ProjectionSnapshot) -> bool:
         checksum = snapshot.resolved_checksum()

--- a/tests/core/test_projection_store_ports.py
+++ b/tests/core/test_projection_store_ports.py
@@ -64,3 +64,78 @@ async def test_postgres_projection_store_save_projection_reports_stale_noop(monk
     )
 
     assert changed is False
+
+
+@pytest.mark.asyncio
+async def test_postgres_projection_store_query_projections_filters_and_limits(monkeypatch):
+    from noetl.core.projection_store import PostgresProjectionStore, ProjectionQuery
+    import noetl.core.projection_store.postgres as postgres_module
+
+    class Cursor:
+        def __init__(self):
+            self.query = ""
+            self.params = []
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, query, params=None):
+            self.query = query
+            self.params = list(params or [])
+
+        async def fetchall(self):
+            return [
+                {
+                    "projection_id": "execution/7/all",
+                    "projection_type": "replay_state:all",
+                    "tenant_id": "tenant-a",
+                    "organization_id": "org-a",
+                    "execution_id": 7,
+                    "version": 12,
+                    "source_event_id": 99,
+                    "state": {"status": "COMPLETED"},
+                    "checksum": "abc",
+                    "meta": {"projector": "replay_state"},
+                }
+            ]
+
+    class Conn:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def cursor(self, row_factory=None):  # noqa: ARG002
+            return self._cursor
+
+    class Ctx:
+        def __init__(self, conn):
+            self._conn = conn
+
+        async def __aenter__(self):
+            return self._conn
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    cursor = Cursor()
+    monkeypatch.setattr(postgres_module, "get_pool_connection", lambda: Ctx(Conn(cursor)))
+
+    records = await PostgresProjectionStore().query_projections(
+        ProjectionQuery(
+            tenant_id="tenant-a",
+            organization_id="org-a",
+            projection_type="replay_state:all",
+            execution_id=7,
+            limit=25,
+        )
+    )
+
+    assert [record.projection_id for record in records] == ["execution/7/all"]
+    assert "FROM noetl.projection" in cursor.query
+    assert "tenant_id = %s" in cursor.query
+    assert "organization_id = %s" in cursor.query
+    assert "projection_type = %s" in cursor.query
+    assert "execution_id = %s" in cursor.query
+    assert cursor.params == ["tenant-a", "org-a", "replay_state:all", 7, 25]


### PR DESCRIPTION
## Summary
- add ProjectionQuery and ProjectionStore.query_projections to the backend-neutral projection-store port
- implement indexed Postgres projection queries by tenant, organization, projection type, execution id, and limit
- add focused port tests for query SQL and record mapping

## Tests
- .venv/bin/python -m pytest tests/core/test_projection_store_ports.py tests/database/test_distributed_runtime_schema.py -q

Tracks noetl/noetl#439.