### PR TITLE
Expose worker IPC cache metrics

### DIFF
--- a/noetl/server/metrics.py
+++ b/noetl/server/metrics.py
@@ -16,20 +16,38 @@ _IPC_COUNTERS = {
 }
 
 
-def append_storage_ipc_metrics(lines: list[str], stats: Mapping[str, int | float]) -> None:
+def append_storage_ipc_metrics(
+    lines: list[str],
+    stats: Mapping[str, int | float],
+    *,
+    labels: Mapping[str, str] | None = None,
+) -> None:
     """Append TempStore IPC counters and derived hit ratio to metrics output."""
+    label_text = _format_labels(labels or {})
     for key, (metric_name, help_text) in _IPC_COUNTERS.items():
         value = stats.get(key, 0)
         lines.append(f"# HELP {metric_name} {help_text}")
         lines.append(f"# TYPE {metric_name} counter")
-        lines.append(f"{metric_name} {value}")
+        lines.append(f"{metric_name}{label_text} {value}")
 
     read_attempts = float(stats.get("read_attempts", 0) or 0)
     read_hits = float(stats.get("read_hits", 0) or 0)
     hit_ratio = read_hits / read_attempts if read_attempts > 0 else 0.0
     lines.append("# HELP noetl_storage_ipc_read_hit_ratio IPC cache read hit ratio for this process")
     lines.append("# TYPE noetl_storage_ipc_read_hit_ratio gauge")
-    lines.append(f"noetl_storage_ipc_read_hit_ratio {hit_ratio}")
+    lines.append(f"noetl_storage_ipc_read_hit_ratio{label_text} {hit_ratio}")
+
+
+def _format_labels(labels: Mapping[str, str]) -> str:
+    filtered = {key: value for key, value in labels.items() if value}
+    if not filtered:
+        return ""
+    body = ",".join(f'{key}="{_escape_label(value)}"' for key, value in sorted(filtered.items()))
+    return "{" + body + "}"
+
+
+def _escape_label(value: str) -> str:
+    return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
 
 
 __all__ = ["append_storage_ipc_metrics"]

--- a/noetl/worker/metrics.py
+++ b/noetl/worker/metrics.py
@@ -1,0 +1,68 @@
+"""Lightweight metrics endpoint for standalone NoETL workers."""
+
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from typing import Mapping
+
+from noetl.core.storage import default_store
+from noetl.server.metrics import append_storage_ipc_metrics
+
+
+def render_worker_metrics(*, worker_id: str, labels: Mapping[str, str] | None = None) -> str:
+    """Render worker-local counters using Prometheus text exposition."""
+    metric_labels = {"worker_id": worker_id}
+    metric_labels.update(labels or {})
+
+    lines = [
+        "# HELP noetl_worker_up NoETL worker up status",
+        "# TYPE noetl_worker_up gauge",
+        f"noetl_worker_up{{worker_id=\"{_escape_label(worker_id)}\"}} 1",
+    ]
+    append_storage_ipc_metrics(lines, default_store.ipc_stats(), labels=metric_labels)
+    return "\n".join(lines) + "\n"
+
+
+def start_worker_metrics_server(
+    *,
+    worker_id: str,
+    host: str,
+    port: int,
+    labels: Mapping[str, str] | None = None,
+) -> ThreadingHTTPServer:
+    """Start a daemon `/metrics` HTTP server for this worker process."""
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+            if self.path == "/health":
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(b"ok\n")
+                return
+            if self.path != "/metrics":
+                self.send_response(404)
+                self.end_headers()
+                return
+            body = render_worker_metrics(worker_id=worker_id, labels=labels).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer((host, port), _Handler)
+    thread = Thread(target=server.serve_forever, name="noetl-worker-metrics", daemon=True)
+    thread.start()
+    return server
+
+
+def _escape_label(value: str) -> str:
+    return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+__all__ = ["render_worker_metrics", "start_worker_metrics_server"]

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -43,6 +43,13 @@ _HOT_PATH_INITIAL_EVENT_MAX_RETRIES = max(
 )
 
 
+def _optional_int_env(name: str) -> Optional[int]:
+    raw = os.getenv(name)
+    if raw is None or str(raw).strip() == "":
+        return None
+    return int(raw)
+
+
 def _safe_keys(value: Any, max_items: int = 10) -> list[str]:
     if isinstance(value, dict):
         return list(value.keys())[:max_items]
@@ -3665,6 +3672,20 @@ async def run_worker(
         nats_url=nats_url,
         server_url=server_url
     )
+    metrics_server = None
+    metrics_port = _optional_int_env("NOETL_WORKER_METRICS_PORT")
+    if metrics_port is not None:
+        from noetl.worker.metrics import start_worker_metrics_server
+
+        metrics_server = start_worker_metrics_server(
+            worker_id=worker_id,
+            host=os.getenv("NOETL_WORKER_METRICS_HOST") or "0.0.0.0",
+            port=metrics_port,
+            labels={
+                "worker_pool": os.getenv("NOETL_WORKER_POOL_NAME") or "worker-cpu-01",
+                "runtime": os.getenv("NOETL_WORKER_POOL_RUNTIME") or "cpu",
+            },
+        )
     
     try:
         await worker.start()  # Should run forever
@@ -3674,6 +3695,9 @@ async def run_worker(
         logger.error(f"Worker error: {e}", exc_info=True)
         raise
     finally:
+        if metrics_server is not None:
+            metrics_server.shutdown()
+            metrics_server.server_close()
         await worker.cleanup()
         logger.info("Worker cleanup complete")
 

--- a/tests/worker/test_worker_metrics.py
+++ b/tests/worker/test_worker_metrics.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from urllib.request import urlopen
+
+
+def test_worker_metrics_render_storage_ipc_labels(monkeypatch):
+    from noetl.worker import metrics as worker_metrics
+
+    monkeypatch.setattr(
+        worker_metrics.default_store,
+        "ipc_stats",
+        lambda: {
+            "admit_attempts": 2,
+            "admit_success": 1,
+            "admit_failures": 1,
+            "read_attempts": 4,
+            "read_hits": 3,
+            "read_misses": 1,
+            "fallback_reads": 1,
+        },
+    )
+
+    body = worker_metrics.render_worker_metrics(
+        worker_id='worker-"a"',
+        labels={"worker_pool": "worker-cpu-01", "runtime": "cpu"},
+    )
+
+    assert 'worker_id="worker-\\"a\\""' in body
+    assert 'worker_pool="worker-cpu-01"' in body
+    assert 'runtime="cpu"' in body
+    assert "noetl_storage_ipc_admit_attempts_total" in body
+    assert "noetl_storage_ipc_read_hit_ratio" in body
+    assert " 0.75" in body
+
+
+def test_worker_metrics_server_exposes_metrics_and_health(monkeypatch):
+    from noetl.worker import metrics as worker_metrics
+
+    monkeypatch.setattr(
+        worker_metrics.default_store,
+        "ipc_stats",
+        lambda: {
+            "admit_attempts": 1,
+            "admit_success": 1,
+            "admit_failures": 0,
+            "read_attempts": 0,
+            "read_hits": 0,
+            "read_misses": 0,
+            "fallback_reads": 0,
+        },
+    )
+
+    server = worker_metrics.start_worker_metrics_server(
+        worker_id="worker-test",
+        host="127.0.0.1",
+        port=0,
+    )
+    host, port = server.server_address
+    try:
+        with urlopen(f"http://{host}:{port}/health", timeout=2) as response:
+            assert response.read() == b"ok\n"
+        with urlopen(f"http://{host}:{port}/metrics", timeout=2) as response:
+            body = response.read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert "noetl_worker_up" in body
+    assert "noetl_storage_ipc_admit_success_total" in body


### PR DESCRIPTION
## Summary
- add a lightweight worker /health and /metrics HTTP endpoint gated by NOETL_WORKER_METRICS_PORT
- export worker-local TempStore IPC counters and read-hit ratio with worker_id, worker_pool, and runtime labels
- keep server metrics behavior backward-compatible while allowing optional labels

## Validation
- .venv/bin/python -m pytest tests/server/test_metrics.py tests/worker/test_worker_metrics.py -q
- .venv/bin/python -m pytest tests/server/test_metrics.py tests/worker/test_worker_metrics.py tests/core/test_storage_ipc_cache.py tests/core/test_storage_ipc_hint.py -q

Refs noetl/noetl#438