### PR TITLE
Resolve Arrow result refs through IPC fallback path

### DIFF
--- a/noetl/core/storage/result_store.py
+++ b/noetl/core/storage/result_store.py
@@ -39,6 +39,7 @@ from noetl.core.storage.models import (
     TempRefMeta,
     IpcHint,
 )
+from noetl.core.storage.arrow_ipc import ARROW_STREAM_MEDIA_TYPE, arrow_ipc_to_rows
 from noetl.core.storage.router import StorageRouter, default_router
 from noetl.core.storage.extractor import create_preview
 from noetl.core.logger import setup_logger
@@ -992,6 +993,8 @@ class TempStore:
         ref_uri = ref.get("ref")
         if ref_uri:
             try:
+                if self._is_arrow_ipc_ref(ref):
+                    return await self._resolve_arrow_ipc_ref(ref)
                 return await self.get(ref_uri)
             except KeyError:
                 logger.warning(
@@ -1008,6 +1011,34 @@ class TempStore:
                 return ref.get("preview", {})
 
         return ref.get("preview", ref)
+
+    def _is_arrow_ipc_ref(self, ref: Dict[str, Any]) -> bool:
+        meta = ref.get("meta")
+        meta = meta if isinstance(meta, dict) else {}
+        media_type = ref.get("media_type") or meta.get("media_type") or meta.get("content_type")
+        return str(media_type or "").lower() == ARROW_STREAM_MEDIA_TYPE
+
+    async def _resolve_arrow_ipc_ref(self, ref: Dict[str, Any]) -> list[Dict[str, Any]]:
+        temp_ref = TempRef.model_validate(ref)
+        data = await self.get_ipc_bytes(
+            temp_ref,
+            ipc_cache=self._default_ipc_cache_for_ref(temp_ref),
+        )
+        return arrow_ipc_to_rows(data)
+
+    def _default_ipc_cache_for_ref(self, temp_ref: TempRef) -> Any:
+        if temp_ref.ipc is None:
+            return None
+        try:
+            from noetl.core.storage import ArrowIpcSharedMemoryCache
+
+            return ArrowIpcSharedMemoryCache(
+                namespace=os.getenv("NOETL_CURSOR_FRAME_IPC_NAMESPACE", "noetl_frame"),
+                producer=os.getenv("HOSTNAME") or "resolver",
+            )
+        except Exception as exc:
+            logger.debug("TEMP: IPC cache unavailable for %s: %s", temp_ref.ref, exc)
+            return None
 
     async def _resolve_manifest(self, manifest: Dict[str, Any]) -> List[Any]:
         """Resolve a Manifest to its combined data."""

--- a/tests/core/test_storage_ipc_cache.py
+++ b/tests/core/test_storage_ipc_cache.py
@@ -110,3 +110,80 @@ async def test_tempstore_ipc_stats_track_admission_failure():
         assert store.ipc_stats()["fallback_reads"] == 1
     finally:
         await store.delete(ref)
+
+
+@pytest.mark.asyncio
+async def test_tempstore_resolve_arrow_result_ref_uses_ipc_then_decodes_rows():
+    from noetl.core.storage import (
+        ArrowIpcSharedMemoryCache,
+        Scope,
+        StoreTier,
+        TempStore,
+        rows_to_arrow_ipc,
+    )
+
+    rows = [{"id": 1, "name": "Ada"}, {"id": 2, "name": "Grace"}]
+    payload, schema_digest, row_count = rows_to_arrow_ipc(rows)
+    store = TempStore()
+    cache = ArrowIpcSharedMemoryCache(namespace="noetl-test", budget_bytes=4096)
+    ref = await store.put_ipc_bytes(
+        execution_id="exec-1",
+        name="frame-1",
+        data_bytes=payload,
+        schema_digest=schema_digest,
+        row_count=row_count,
+        scope=Scope.EXECUTION,
+        store=StoreTier.MEMORY,
+        ipc_cache=cache,
+    )
+
+    try:
+        store._default_ipc_cache_for_ref = lambda _ref: cache
+
+        assert await store.resolve(ref.model_dump(mode="json")) == rows
+
+        stats = store.ipc_stats()
+        assert stats["read_attempts"] == 1
+        assert stats["read_hits"] == 1
+        assert stats["fallback_reads"] == 0
+    finally:
+        await store.delete(ref)
+
+
+@pytest.mark.asyncio
+async def test_tempstore_resolve_arrow_result_ref_falls_back_to_durable_bytes():
+    from noetl.core.storage import (
+        ArrowIpcSharedMemoryCache,
+        Scope,
+        StoreTier,
+        TempStore,
+        rows_to_arrow_ipc,
+    )
+
+    rows = [{"id": 1, "name": "Ada"}]
+    payload, schema_digest, row_count = rows_to_arrow_ipc(rows)
+    store = TempStore()
+    cache = ArrowIpcSharedMemoryCache(namespace="noetl-test", budget_bytes=4096)
+    ref = await store.put_ipc_bytes(
+        execution_id="exec-1",
+        name="frame-1",
+        data_bytes=payload,
+        schema_digest=schema_digest,
+        row_count=row_count,
+        scope=Scope.EXECUTION,
+        store=StoreTier.MEMORY,
+        ipc_cache=cache,
+    )
+
+    try:
+        store._default_ipc_cache_for_ref = lambda _ref: cache
+        cache.delete(ref.ipc)
+
+        assert await store.resolve(ref.model_dump(mode="json")) == rows
+
+        stats = store.ipc_stats()
+        assert stats["read_attempts"] == 1
+        assert stats["read_misses"] == 1
+        assert stats["fallback_reads"] == 1
+    finally:
+        await store.delete(ref)


### PR DESCRIPTION
## Summary
- make TempStore.resolve(result_ref) recognize application/vnd.apache.arrow.stream refs
- resolve Arrow refs through the existing get_ipc_bytes Tier 1.5 -> durable fallback path
- decode Arrow rows only at the consumer boundary so generic JSON refs keep existing behavior

## Validation
- .venv/bin/python -m pytest tests/core/test_storage_ipc_cache.py tests/core/test_arrow_ipc_serialization.py -q
- .venv/bin/python -m pytest tests/core/test_storage_ipc_cache.py tests/core/test_storage_ipc_hint.py tests/core/test_arrow_ipc_serialization.py tests/api/test_replay_routes.py tests/core/test_replay_state_projector.py -q

Refs noetl/noetl#438