### PR TITLE
Add node identity to IPC hints

### DIFF
--- a/noetl/core/storage/ipc_cache.py
+++ b/noetl/core/storage/ipc_cache.py
@@ -42,6 +42,7 @@ class ArrowIpcSharedMemoryCache:
         budget_bytes: Optional[int] = None,
         default_lease_seconds: float = 60.0,
         producer: Optional[str] = None,
+        node_id: Optional[str] = None,
     ) -> None:
         self.namespace = _sanitize(namespace)[:32] or "noetl"
         self.budget_bytes = int(
@@ -51,6 +52,7 @@ class ArrowIpcSharedMemoryCache:
         )
         self.default_lease_seconds = float(default_lease_seconds)
         self.producer = producer or os.getenv("HOSTNAME") or "unknown"
+        self.node_id = node_id or _detect_node_id()
         self._entries: dict[str, IpcCacheEntry] = {}
 
     @property
@@ -101,6 +103,7 @@ class ArrowIpcSharedMemoryCache:
             byte_length=len(payload_bytes),
             row_count=row_count,
             producer=self.producer,
+            node_id=self.node_id,
             lease_expires_at=lease_expires_at,
             media_type=media_type,
         )
@@ -108,6 +111,10 @@ class ArrowIpcSharedMemoryCache:
     def get(self, hint: IpcHint) -> bytes:
         if hint.is_expired():
             raise KeyError(f"IPC hint expired: {hint.shm_name}")
+        if hint.node_id and self.node_id and hint.node_id != self.node_id:
+            raise KeyError(
+                f"IPC hint belongs to node {hint.node_id}; local node is {self.node_id}"
+            )
         shm = shared_memory.SharedMemory(name=hint.shm_name, create=False)
         try:
             return bytes(shm.buf[: hint.byte_length])
@@ -151,6 +158,16 @@ class ArrowIpcSharedMemoryCache:
 
 def _sanitize(value: str) -> str:
     return _SAFE_NAME.sub("_", value)
+
+
+def _detect_node_id() -> str:
+    return (
+        os.getenv("NOETL_NODE_ID")
+        or os.getenv("NODE_NAME")
+        or os.getenv("K8S_NODE_NAME")
+        or os.getenv("HOSTNAME")
+        or "unknown"
+    )
 
 
 __all__ = ["ArrowIpcSharedMemoryCache", "IpcCacheEntry"]

--- a/noetl/core/storage/models.py
+++ b/noetl/core/storage/models.py
@@ -99,6 +99,10 @@ class IpcHint(BaseModel):
     byte_length: int = Field(..., ge=0)
     row_count: Optional[int] = Field(default=None, ge=0)
     producer: Optional[str] = Field(default=None)
+    node_id: Optional[str] = Field(
+        default=None,
+        description="Producer node identity; consumers skip IPC attach when it differs from their node",
+    )
     lease_expires_at: Optional[datetime] = Field(default=None)
     media_type: str = Field(default="application/vnd.apache.arrow.stream")
 

--- a/noetl/core/storage/result_store.py
+++ b/noetl/core/storage/result_store.py
@@ -1035,6 +1035,7 @@ class TempStore:
             return ArrowIpcSharedMemoryCache(
                 namespace=os.getenv("NOETL_CURSOR_FRAME_IPC_NAMESPACE", "noetl_frame"),
                 producer=os.getenv("HOSTNAME") or "resolver",
+                node_id=os.getenv("NOETL_NODE_ID") or os.getenv("NODE_NAME"),
             )
         except Exception as exc:
             logger.debug("TEMP: IPC cache unavailable for %s: %s", temp_ref.ref, exc)

--- a/noetl/worker/cursor_worker.py
+++ b/noetl/worker/cursor_worker.py
@@ -114,6 +114,7 @@ def _frame_ipc_cache() -> Optional[ArrowIpcSharedMemoryCache]:
         _FRAME_IPC_CACHE = ArrowIpcSharedMemoryCache(
             namespace=os.getenv("NOETL_CURSOR_FRAME_IPC_NAMESPACE", "noetl_frame"),
             producer=os.getenv("HOSTNAME") or "cursor-worker",
+            node_id=os.getenv("NOETL_NODE_ID") or os.getenv("NODE_NAME"),
         )
     return _FRAME_IPC_CACHE
 

--- a/tests/core/test_storage_ipc_cache.py
+++ b/tests/core/test_storage_ipc_cache.py
@@ -11,6 +11,7 @@ def test_ipc_cache_round_trips_arrow_ipc_bytes():
         budget_bytes=1024,
         default_lease_seconds=30,
         producer="worker-a",
+        node_id="node-a",
     )
     hint = cache.put_arrow_ipc(
         b"arrow-stream-bytes",
@@ -20,11 +21,33 @@ def test_ipc_cache_round_trips_arrow_ipc_bytes():
     try:
         assert hint.kind == "arrow_ipc"
         assert hint.producer == "worker-a"
+        assert hint.node_id == "node-a"
         assert hint.byte_length == len(b"arrow-stream-bytes")
         assert hint.row_count == 3
         assert cache.get(hint) == b"arrow-stream-bytes"
     finally:
         cache.delete(hint)
+
+
+def test_ipc_cache_treats_foreign_node_hint_as_miss():
+    from noetl.core.storage import ArrowIpcSharedMemoryCache
+
+    producer_cache = ArrowIpcSharedMemoryCache(
+        namespace="noetl-test",
+        budget_bytes=1024,
+        node_id="node-a",
+    )
+    consumer_cache = ArrowIpcSharedMemoryCache(
+        namespace="noetl-test",
+        budget_bytes=1024,
+        node_id="node-b",
+    )
+    hint = producer_cache.put_arrow_ipc(b"payload", schema_digest="schema-1")
+    try:
+        with pytest.raises(KeyError, match="belongs to node node-a"):
+            consumer_cache.get(hint)
+    finally:
+        producer_cache.delete(hint)
 
 
 def test_ipc_cache_rejects_payload_over_budget():

--- a/tests/core/test_storage_ipc_hint.py
+++ b/tests/core/test_storage_ipc_hint.py
@@ -10,6 +10,7 @@ def test_result_ref_serializes_optional_ipc_hint():
         byte_length=4096,
         row_count=10,
         producer="worker-a",
+        node_id="node-a",
         lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=30),
     )
     ref = ResultRef.create(
@@ -31,6 +32,7 @@ def test_result_ref_serializes_optional_ipc_hint():
     encoded = ref.model_dump(mode="json")
 
     assert encoded["ipc"]["kind"] == "arrow_ipc"
+    assert encoded["ipc"]["node_id"] == "node-a"
     assert encoded["ipc"]["schema_digest"] == "sha256:abc"
     assert encoded["meta"]["row_count"] == 10
     assert encoded["store"] == "s3"


### PR DESCRIPTION
## Summary
- add optional node_id to IpcHint for same-node shared-memory routing
- populate ArrowIpcSharedMemoryCache hints from NOETL_NODE_ID/NODE_NAME/HOSTNAME
- skip IPC attach when a hint clearly belongs to another node, preserving durable fallback behavior

## Validation
- .venv/bin/python -m pytest tests/core/test_storage_ipc_cache.py tests/core/test_storage_ipc_hint.py tests/core/test_arrow_ipc_serialization.py -q
- scripts/check_replay_release_gate.sh
- git diff --check

Refs noetl/noetl#438