### PR TITLE
Label worker IPC metrics by node

### DIFF
--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -3684,6 +3684,7 @@ async def run_worker(
             labels={
                 "worker_pool": os.getenv("NOETL_WORKER_POOL_NAME") or "worker-cpu-01",
                 "runtime": os.getenv("NOETL_WORKER_POOL_RUNTIME") or "cpu",
+                "node_id": os.getenv("NOETL_NODE_ID") or os.getenv("NODE_NAME") or "",
             },
         )
     

--- a/tests/worker/test_worker_metrics.py
+++ b/tests/worker/test_worker_metrics.py
@@ -22,12 +22,13 @@ def test_worker_metrics_render_storage_ipc_labels(monkeypatch):
 
     body = worker_metrics.render_worker_metrics(
         worker_id='worker-"a"',
-        labels={"worker_pool": "worker-cpu-01", "runtime": "cpu"},
+        labels={"worker_pool": "worker-cpu-01", "runtime": "cpu", "node_id": "node-a"},
     )
 
     assert 'worker_id="worker-\\"a\\""' in body
     assert 'worker_pool="worker-cpu-01"' in body
     assert 'runtime="cpu"' in body
+    assert 'node_id="node-a"' in body
     assert "noetl_storage_ipc_admit_attempts_total" in body
     assert "noetl_storage_ipc_read_hit_ratio" in body
     assert " 0.75" in body


### PR DESCRIPTION
## Summary
- include node_id in worker metrics labels when NOETL_NODE_ID or NODE_NAME is present
- cover the label in worker metrics rendering tests

## Validation
- .venv/bin/python -m pytest tests/server/test_metrics.py tests/worker/test_worker_metrics.py -q
- git diff --check

Refs noetl/noetl#438