### PR TITLE
Add core NoETL resource locator helper

### DIFF
--- a/noetl/core/resource_locator.py
+++ b/noetl/core/resource_locator.py
@@ -1,0 +1,119 @@
+"""Utilities for canonical NoETL resource locators.
+
+NoETL locators are durable identities, not transport URLs. They use the
+``noetl://`` scheme followed by slash-separated resource segments, for example:
+
+``noetl://tenant/t1/org/o1/cluster/prod/node/node-a/worker/cpu-01``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Optional
+from urllib.parse import quote, unquote, urlparse
+
+
+SCHEME = "noetl"
+
+
+class ResourceLocatorError(ValueError):
+    """Raised when a NoETL resource locator is malformed."""
+
+
+@dataclass(frozen=True)
+class NoetlResourceLocator:
+    """Parsed NoETL resource locator."""
+
+    segments: tuple[str, ...]
+
+    @classmethod
+    def parse(cls, value: str) -> "NoetlResourceLocator":
+        if not isinstance(value, str) or not value.strip():
+            raise ResourceLocatorError("locator must be a non-empty string")
+        parsed = urlparse(value.strip())
+        if parsed.scheme != SCHEME:
+            raise ResourceLocatorError("locator must use noetl:// scheme")
+        if parsed.params or parsed.query or parsed.fragment:
+            raise ResourceLocatorError("locator must not include params, query, or fragment")
+
+        raw_segments: list[str] = []
+        if parsed.netloc:
+            raw_segments.append(parsed.netloc)
+        raw_segments.extend(part for part in parsed.path.split("/") if part)
+        segments = tuple(unquote(part) for part in raw_segments)
+        return cls.from_segments(segments)
+
+    @classmethod
+    def from_segments(cls, segments: Iterable[str]) -> "NoetlResourceLocator":
+        normalized = tuple(_normalize_segment(segment) for segment in segments)
+        if not normalized:
+            raise ResourceLocatorError("locator must include at least one segment")
+        return cls(normalized)
+
+    @classmethod
+    def from_pairs(cls, pairs: Mapping[str, object] | Iterable[tuple[str, object]]) -> "NoetlResourceLocator":
+        items = pairs.items() if isinstance(pairs, Mapping) else pairs
+        segments: list[str] = []
+        for key, value in items:
+            if value is None or value == "":
+                continue
+            segments.extend((str(key), str(value)))
+        return cls.from_segments(segments)
+
+    @property
+    def kind(self) -> str:
+        return self.segments[0]
+
+    @property
+    def identity(self) -> Optional[str]:
+        return self.segments[1] if len(self.segments) > 1 else None
+
+    def value_after(self, key: str) -> Optional[str]:
+        """Return the first segment immediately following ``key``."""
+        for index, segment in enumerate(self.segments[:-1]):
+            if segment == key:
+                return self.segments[index + 1]
+        return None
+
+    def pairs(self) -> dict[str, str]:
+        """Return alternating key/value segments as a dictionary.
+
+        Raises if the locator is not a pure alternating key/value shape.
+        """
+        if len(self.segments) % 2 != 0:
+            raise ResourceLocatorError("locator does not contain alternating key/value segments")
+        result: dict[str, str] = {}
+        for index in range(0, len(self.segments), 2):
+            result[self.segments[index]] = self.segments[index + 1]
+        return result
+
+    def child(self, *segments: object) -> "NoetlResourceLocator":
+        return NoetlResourceLocator.from_segments((*self.segments, *(str(segment) for segment in segments)))
+
+    def __str__(self) -> str:
+        return f"{SCHEME}://" + "/".join(quote(segment, safe="") for segment in self.segments)
+
+
+def parse_noetl_locator(value: str) -> NoetlResourceLocator:
+    return NoetlResourceLocator.parse(value)
+
+
+def build_noetl_locator(*segments: object) -> str:
+    return str(NoetlResourceLocator.from_segments(str(segment) for segment in segments))
+
+
+def _normalize_segment(segment: object) -> str:
+    value = str(segment).strip()
+    if not value:
+        raise ResourceLocatorError("locator segments must be non-empty")
+    if "/" in value:
+        raise ResourceLocatorError("locator segments must not contain '/'")
+    return value
+
+
+__all__ = [
+    "NoetlResourceLocator",
+    "ResourceLocatorError",
+    "build_noetl_locator",
+    "parse_noetl_locator",
+]

--- a/tests/core/test_resource_locator.py
+++ b/tests/core/test_resource_locator.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_resource_locator_parses_execution_result_ref():
+    from noetl.core.resource_locator import parse_noetl_locator
+
+    locator = parse_noetl_locator("noetl://execution/123/result/load/abcd")
+
+    assert locator.kind == "execution"
+    assert locator.identity == "123"
+    assert locator.value_after("result") == "load"
+    assert str(locator) == "noetl://execution/123/result/load/abcd"
+
+
+def test_resource_locator_builds_cloud_os_identity():
+    from noetl.core.resource_locator import NoetlResourceLocator
+
+    locator = NoetlResourceLocator.from_pairs(
+        [
+            ("tenant", "tenant-123"),
+            ("org", "org-456"),
+            ("cluster", "prod-1"),
+            ("node", "node-a"),
+            ("worker", "cpu-01"),
+        ]
+    )
+
+    assert str(locator) == "noetl://tenant/tenant-123/org/org-456/cluster/prod-1/node/node-a/worker/cpu-01"
+    assert locator.pairs()["worker"] == "cpu-01"
+
+
+def test_resource_locator_quotes_and_decodes_segments():
+    from noetl.core.resource_locator import build_noetl_locator, parse_noetl_locator
+
+    encoded = build_noetl_locator("tenant", "tenant 123", "org", "r&d")
+    locator = parse_noetl_locator(encoded)
+
+    assert encoded == "noetl://tenant/tenant%20123/org/r%26d"
+    assert locator.value_after("tenant") == "tenant 123"
+    assert locator.value_after("org") == "r&d"
+
+
+def test_resource_locator_rejects_non_noetl_urls():
+    from noetl.core.resource_locator import ResourceLocatorError, parse_noetl_locator
+
+    with pytest.raises(ResourceLocatorError, match="noetl://"):
+        parse_noetl_locator("https://example.com")
+
+
+def test_resource_locator_rejects_query_and_slash_segments():
+    from noetl.core.resource_locator import NoetlResourceLocator, ResourceLocatorError, parse_noetl_locator
+
+    with pytest.raises(ResourceLocatorError, match="query"):
+        parse_noetl_locator("noetl://execution/123?debug=true")
+
+    with pytest.raises(ResourceLocatorError, match="must not contain"):
+        NoetlResourceLocator.from_segments(["execution", "bad/id"])


### PR DESCRIPTION
## Summary
- add a side-effect-free parser/builder for canonical noetl:// resource locators
- support existing execution result refs and future tenant/org/cluster/node/worker identities
- validate scheme/query/fragment and percent-encode path segments

## Validation
- .venv/bin/python -m pytest tests/core/test_resource_locator.py -q
- .venv/bin/python -m compileall noetl/core/resource_locator.py
- git diff --check

Refs noetl/noetl#434