### PR TITLE
Adopt resource locator validation for durable refs

### DIFF
--- a/noetl/core/dsl/engine/executor/common.py
+++ b/noetl/core/dsl/engine/executor/common.py
@@ -26,6 +26,7 @@ from psycopg.rows import dict_row
 from noetl.core.dsl.engine.models import Event, Command, Playbook, Step, ToolCall, CommandSpec, NextRouter, Arc
 from noetl.core.db import pool as db_pool
 from noetl.core.cache import nats_kv
+from noetl.core.resource_locator import ResourceLocatorError, parse_noetl_locator
 from noetl.core.storage import default_store
 
 from noetl.core.logger import setup_logger
@@ -488,7 +489,9 @@ def _reference_to_result_ref(reference: Any) -> Optional[dict[str, Any]]:
         return None
 
     locator = str(reference.get("locator") or reference.get("ref") or "").strip()
-    if not locator.startswith("noetl://"):
+    try:
+        parse_noetl_locator(locator)
+    except ResourceLocatorError:
         return None
 
     store = str(reference.get("store") or "kv").strip().lower() or "kv"

--- a/noetl/server/api/frames/schema.py
+++ b/noetl/server/api/frames/schema.py
@@ -4,6 +4,8 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
+from noetl.core.resource_locator import ResourceLocatorError, parse_noetl_locator
+
 
 _DURABLE_REF_KEYS = ("ref", "uri", "locator")
 
@@ -20,12 +22,26 @@ def _has_ipc_hint(value: Any) -> bool:
 
 def _has_durable_reference(value: Any) -> bool:
     if isinstance(value, dict):
-        if any(str(value.get(key) or "").strip() for key in _DURABLE_REF_KEYS):
-            return True
+        for key in _DURABLE_REF_KEYS:
+            if _is_valid_durable_locator(value.get(key)):
+                return True
         return any(_has_durable_reference(item) for item in value.values())
     if isinstance(value, list):
         return any(_has_durable_reference(item) for item in value)
     return False
+
+
+def _is_valid_durable_locator(value: Any) -> bool:
+    locator = str(value or "").strip()
+    if not locator:
+        return False
+    if not locator.startswith("noetl://"):
+        return True
+    try:
+        parse_noetl_locator(locator)
+        return True
+    except ResourceLocatorError:
+        return False
 
 
 class FrameClaimRequest(BaseModel):

--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -29,6 +29,7 @@ from jinja2 import Environment
 
 from noetl.core.dsl.render import render_template
 from noetl.core.logger import setup_logger
+from noetl.core.resource_locator import ResourceLocatorError, parse_noetl_locator
 
 
 # Default catalog path for the self-troubleshoot agent. Override at the
@@ -180,7 +181,9 @@ def _normalise_result_reference(reference: Any) -> Optional[Dict[str, Any]]:
     if not isinstance(reference, dict):
         return None
     locator = str(reference.get("locator") or reference.get("ref") or "").strip()
-    if not locator.startswith("noetl://"):
+    try:
+        parse_noetl_locator(locator)
+    except ResourceLocatorError:
         return None
     store = str(reference.get("store") or "kv").strip().lower() or "kv"
     return {

--- a/tests/api/test_frame_routes.py
+++ b/tests/api/test_frame_routes.py
@@ -93,6 +93,29 @@ def test_frame_commit_allows_ipc_hint_with_nested_durable_ref():
     assert commit.output_ref["rows_ref"]["ref"] == "noetl://execution/1/result/frame/abc"
 
 
+def test_frame_commit_rejects_malformed_noetl_durable_locator_with_ipc_hint():
+    from pydantic import ValidationError
+
+    from noetl.server.api.frames import FrameCommitRequest
+
+    with pytest.raises(ValidationError, match="durable ref, uri, or locator"):
+        FrameCommitRequest(
+            worker_id="worker-a",
+            row_count=10,
+            output_ref={
+                "rows_ref": {
+                    "ref": "noetl://execution/1/result/frame/abc?debug=true",
+                    "ipc": {
+                        "kind": "arrow_ipc",
+                        "shm_name": "/noetl-frame-1",
+                        "schema_digest": "sha256:abc",
+                        "byte_length": 4096,
+                    },
+                }
+            },
+        )
+
+
 def test_frame_commit_result_keeps_event_result_shape():
     from noetl.server.api.frames import endpoint
 


### PR DESCRIPTION
## Summary
- use the core noetl:// resource locator parser for frame commit durable-reference validation
- use the parser for DSL compact result-ref normalization
- use the parser for agent compact result-ref normalization
- reject malformed noetl:// durable refs with query/fragment data when paired with IPC hints

## Validation
- .venv/bin/python -m pytest tests/api/test_frame_routes.py tests/core/test_resource_locator.py tests/tools/test_agent_executor.py::test_fetch_sub_execution_terminal_result_resolves_reference_before_context tests/unit/dsl/engine/test_task_sequence_loop_completion.py -q
- git diff --check

Refs noetl/noetl#434