### PR TITLE
Allow templated loop max_in_flight

### DIFF
--- a/noetl/core/dsl/engine/executor/commands.py
+++ b/noetl/core/dsl/engine/executor/commands.py
@@ -419,7 +419,12 @@ class CommandCreationMixin:
             if nats_loop_state:
                 completed_count = int(nats_loop_state.get("completed_count", completed_count_local) or completed_count_local)
 
-            max_in_flight = self._get_loop_max_in_flight(step)
+            max_context = locals().get("context")
+            if max_context is None:
+                max_context = state.get_render_context(Event(
+                    execution_id=state.execution_id, step=step.step, name="loop_init", payload={}
+                ))
+            max_in_flight = self._get_loop_max_in_flight(step, max_context)
 
             # Repair invalid distributed metadata from older writes/restarts where
             # collection_size regressed to 0 while local loop collection is valid.

--- a/noetl/core/dsl/engine/executor/events.py
+++ b/noetl/core/dsl/engine/executor/events.py
@@ -810,9 +810,10 @@ class EventHandlingMixin:
                             # slot per worker).  Recover size from the step
                             # spec instead of trying to re-render loop.in_.
                             if parent_step_def.loop and parent_step_def.loop.is_cursor:
-                                worker_count_fallback = 1
-                                if parent_step_def.loop.spec and parent_step_def.loop.spec.max_in_flight:
-                                    worker_count_fallback = max(1, int(parent_step_def.loop.spec.max_in_flight))
+                                worker_count_fallback = self._get_loop_max_in_flight(
+                                    parent_step_def,
+                                    state.get_render_context(event),
+                                )
                                 collection_size = worker_count_fallback
                                 loop_state["collection_size"] = collection_size
                                 logger.info(
@@ -1460,9 +1461,10 @@ class EventHandlingMixin:
                     if collection_size == 0:
                         if step_def.loop and step_def.loop.is_cursor:
                             # Cursor loops: collection_size == worker concurrency.
-                            worker_count_fallback = 1
-                            if step_def.loop.spec and step_def.loop.spec.max_in_flight:
-                                worker_count_fallback = max(1, int(step_def.loop.spec.max_in_flight))
+                            worker_count_fallback = self._get_loop_max_in_flight(
+                                step_def,
+                                state.get_render_context(event),
+                            )
                             collection_size = worker_count_fallback
                             loop_state["collection_size"] = collection_size
                             logger.info(
@@ -1865,9 +1867,10 @@ class EventHandlingMixin:
                             # Cursor loops: collection is synthetic (one
                             # slot per worker); there is no loop.in_ to
                             # render.  Rebuild the synthetic collection.
-                            worker_count_fallback = 1
-                            if step_def.loop.spec and step_def.loop.spec.max_in_flight:
-                                worker_count_fallback = max(1, int(step_def.loop.spec.max_in_flight))
+                            worker_count_fallback = self._get_loop_max_in_flight(
+                                step_def,
+                                state.get_render_context(event),
+                            )
                             collection = list(range(worker_count_fallback))
                             loop_state["collection"] = collection
                             logger.info(

--- a/noetl/core/dsl/engine/executor/rendering.py
+++ b/noetl/core/dsl/engine/executor/rendering.py
@@ -276,9 +276,10 @@ class RenderingMixin:
 
         if not collection:
             if step.loop and step.loop.is_cursor:
-                worker_count_fallback = 1
-                if step.loop.spec and step.loop.spec.max_in_flight:
-                    worker_count_fallback = max(1, int(step.loop.spec.max_in_flight))
+                worker_count_fallback = self._get_loop_max_in_flight(
+                    step,
+                    state.get_render_context(event),
+                )
                 collection = list(range(worker_count_fallback))
                 logger.info(
                     "[CURSOR-LOOP] Hydrated synthetic collection (size=%d) for %s epoch=%s",

--- a/noetl/core/dsl/engine/executor/transitions.py
+++ b/noetl/core/dsl/engine/executor/transitions.py
@@ -5,9 +5,10 @@ from .outbox import drain_executor_outbox, enqueue_executor_outbox
 from .state import ExecutionState
 from .store import PlaybookRepo, StateStore
 from noetl.core.event_store.ports import canonical_event_checksum
+from noetl.core.dsl.render import render_template
 
 class TransitionMixin:
-    def _get_loop_max_in_flight(self, step: Step) -> int:
+    def _get_loop_max_in_flight(self, step: Step, context: dict[str, Any] | None = None) -> int:
         """Resolve max in-flight limit for loop scheduling.
 
         For cursor loops max_in_flight is the worker concurrency — the
@@ -20,8 +21,30 @@ class TransitionMixin:
         if loop_mode not in ("parallel", "cursor"):
             return 1
         if step.loop.spec and step.loop.spec.max_in_flight:
-            return max(1, int(step.loop.spec.max_in_flight))
+            return self._coerce_loop_max_in_flight(step.loop.spec.max_in_flight, context=context)
         return 1
+
+    def _coerce_loop_max_in_flight(self, raw_value: Any, context: dict[str, Any] | None = None) -> int:
+        rendered_value = raw_value
+        if isinstance(raw_value, str):
+            candidate = raw_value.strip()
+            if "{{" in candidate or "{%" in candidate:
+                if context is None:
+                    raise ValueError("loop.spec.max_in_flight template requires render context")
+                rendered_value = render_template(self.jinja_env, candidate, context)
+            else:
+                rendered_value = candidate
+        try:
+            value = int(rendered_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"loop.spec.max_in_flight must render to a positive integer, got {rendered_value!r}"
+            ) from exc
+        if value < 1:
+            raise ValueError(
+                f"loop.spec.max_in_flight must render to a positive integer, got {rendered_value!r}"
+            )
+        return value
 
     async def _issue_cursor_loop_commands(
         self,
@@ -58,7 +81,13 @@ class TransitionMixin:
             # Workers self-continue; nothing to re-dispatch.
             return []
 
-        worker_count = self._get_loop_max_in_flight(step_def)
+        base_context = state.get_render_context(Event(
+            execution_id=state.execution_id,
+            step=step_def.step,
+            name="cursor_loop_init",
+            payload={},
+        ))
+        worker_count = self._get_loop_max_in_flight(step_def, base_context)
         loop_event_id = f"loop_{state.execution_id}_{int(time.time() * 1_000_000)}"
         if existing_loop_state:
             del state.loop_state[step_def.step]
@@ -134,12 +163,6 @@ class TransitionMixin:
             )
         except Exception as _e:
             logger.info("[DIAG-DISPATCH] failed: %s", _e)
-        base_context = state.get_render_context(Event(
-            execution_id=state.execution_id,
-            step=step_def.step,
-            name="cursor_loop_init",
-            payload={},
-        ))
         max_frame_rows = max(1, int((frame_policy or {}).get("max_rows") or 1))
         base_context["__frame_max_rows"] = max_frame_rows
         base_context["__frame_policy"] = frame_policy or {}
@@ -540,7 +563,7 @@ class TransitionMixin:
                     str(state.execution_id), step_def.step, loop_event_id, collection
                 )
 
-        issue_budget = self._get_loop_max_in_flight(step_def)
+        issue_budget = self._get_loop_max_in_flight(step_def, context)
         commands: list[Command] = []
         shared_control_args = dict(step_input)
         shared_control_args["__base_context"] = context

--- a/noetl/core/dsl/engine/models/workflow.py
+++ b/noetl/core/dsl/engine/models/workflow.py
@@ -93,9 +93,12 @@ class LoopSpec(BaseModel):
         default="sequential",
         description="Execution mode: sequential, parallel, or cursor"
     )
-    max_in_flight: Optional[int] = Field(
+    max_in_flight: Optional[Union[int, str]] = Field(
         None,
-        description="Maximum concurrent iterations (parallel) / workers (cursor)"
+        description=(
+            "Maximum concurrent iterations (parallel) / workers (cursor). "
+            "May be an integer or a renderable expression resolved before dispatch."
+        )
     )
     policy: Optional[LoopPolicy] = Field(
         None,

--- a/noetl/core/dsl/engine/parser/validation.py
+++ b/noetl/core/dsl/engine/parser/validation.py
@@ -479,9 +479,15 @@ class ParserValidationMixin:
                 f"Step '{step_name}': 'loop' must be an object"
             )
 
-        if "in" not in loop_data:
+        has_in = "in" in loop_data and loop_data.get("in") not in (None, "")
+        has_cursor = "cursor" in loop_data and loop_data.get("cursor") not in (None, "")
+        if has_in and has_cursor:
             raise ValueError(
-                f"Step '{step_name}': loop must have 'in' field"
+                f"Step '{step_name}': loop must specify either 'in' or 'cursor', not both"
+            )
+        if not has_in and not has_cursor:
+            raise ValueError(
+                f"Step '{step_name}': loop must have 'in' or 'cursor' field"
             )
 
         if "iterator" not in loop_data:
@@ -496,16 +502,22 @@ class ParserValidationMixin:
                     f"Step '{step_name}': loop.spec must be an object"
                 )
 
-            if "mode" in spec and spec["mode"] not in ("sequential", "parallel"):
+            if "mode" in spec and spec["mode"] not in ("sequential", "parallel", "cursor"):
                 raise ValueError(
-                    f"Step '{step_name}': loop.spec.mode must be 'sequential' or 'parallel'"
+                    f"Step '{step_name}': loop.spec.mode must be 'sequential', 'parallel', or 'cursor'"
                 )
 
             if "max_in_flight" in spec:
                 max_flight = spec["max_in_flight"]
-                if not isinstance(max_flight, int) or max_flight < 1:
+                if isinstance(max_flight, int):
+                    valid_max_flight = max_flight >= 1
+                elif isinstance(max_flight, str):
+                    valid_max_flight = bool(max_flight.strip())
+                else:
+                    valid_max_flight = False
+                if not valid_max_flight:
                     raise ValueError(
-                        f"Step '{step_name}': loop.spec.max_in_flight must be a positive integer"
+                        f"Step '{step_name}': loop.spec.max_in_flight must be a positive integer or renderable expression"
                     )
 
             if "policy" in spec:

--- a/tests/core/test_frame_policy_model.py
+++ b/tests/core/test_frame_policy_model.py
@@ -46,6 +46,132 @@ def test_cursor_loop_accepts_frame_policy_alias():
     assert loop.frame_policy.process == "frame"
 
 
+def test_cursor_loop_accepts_templated_max_in_flight():
+    from noetl.core.dsl.engine.models.workflow import CursorSpec, Loop, LoopSpec
+
+    loop = Loop(
+        cursor=CursorSpec(kind="postgres", auth="pg", claim="select 1"),
+        iterator="row",
+        spec=LoopSpec(mode="cursor", max_in_flight="{{ workload.pft_http_concurrency }}"),
+    )
+
+    assert loop.spec.max_in_flight == "{{ workload.pft_http_concurrency }}"
+
+
+def test_templated_max_in_flight_resolves_against_workload_context():
+    from jinja2 import Environment
+
+    from noetl.core.dsl.engine.executor.transitions import TransitionMixin
+    from noetl.core.dsl.engine.models.workflow import CursorSpec, Loop, Step
+
+    class DummyTransitions(TransitionMixin):
+        jinja_env = Environment()
+
+    step = Step(
+        step="fetch_patients",
+        loop=Loop(
+            cursor=CursorSpec(kind="postgres", auth="pg", claim="select 1"),
+            iterator="row",
+            spec={"mode": "cursor", "max_in_flight": "{{ workload.pft_http_concurrency }}"},
+        ),
+    )
+
+    assert DummyTransitions()._get_loop_max_in_flight(
+        step,
+        {"workload": {"pft_http_concurrency": 8}},
+    ) == 8
+
+
+def test_templated_max_in_flight_rejects_non_positive_rendered_value():
+    from jinja2 import Environment
+
+    from noetl.core.dsl.engine.executor.transitions import TransitionMixin
+    from noetl.core.dsl.engine.models.workflow import CursorSpec, Loop, Step
+
+    class DummyTransitions(TransitionMixin):
+        jinja_env = Environment()
+
+    step = Step(
+        step="fetch_patients",
+        loop=Loop(
+            cursor=CursorSpec(kind="postgres", auth="pg", claim="select 1"),
+            iterator="row",
+            spec={"mode": "cursor", "max_in_flight": "{{ workload.pft_http_concurrency }}"},
+        ),
+    )
+
+    with pytest.raises(ValueError, match="positive integer"):
+        DummyTransitions()._get_loop_max_in_flight(
+            step,
+            {"workload": {"pft_http_concurrency": 0}},
+        )
+
+
+def test_parser_validation_allows_renderable_max_in_flight():
+    from noetl.core.dsl.engine.parser.validation import ParserValidationMixin
+
+    class Validator(ParserValidationMixin):
+        pass
+
+    Validator()._validate_loop_v10(
+        {
+            "cursor": {"kind": "postgres", "auth": "pg", "claim": "select 1"},
+            "iterator": "row",
+            "spec": {"mode": "cursor", "max_in_flight": "{{ workload.pft_http_concurrency }}"},
+        },
+        "fetch_patients",
+    )
+
+
+def test_parser_accepts_cursor_loop_with_renderable_max_in_flight():
+    from noetl.core.dsl.engine.parser import DSLParser
+
+    playbook = DSLParser().parse(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: templated-cursor-concurrency
+workload:
+  pft_http_concurrency: 8
+workflow:
+  - step: fetch_patients
+    loop:
+      cursor:
+        kind: postgres
+        auth: pg
+        claim: select 1
+      iterator: row
+      spec:
+        mode: cursor
+        max_in_flight: "{{ workload.pft_http_concurrency }}"
+    tool:
+      kind: noop
+"""
+    )
+
+    step = playbook.workflow[0]
+    assert step.loop.spec.max_in_flight == "{{ workload.pft_http_concurrency }}"
+
+
+def test_parser_validation_rejects_loop_with_both_collection_and_cursor():
+    from noetl.core.dsl.engine.parser.validation import ParserValidationMixin
+
+    class Validator(ParserValidationMixin):
+        pass
+
+    with pytest.raises(ValueError, match="either 'in' or 'cursor'"):
+        Validator()._validate_loop_v10(
+            {
+                "in": "{{ workload.items }}",
+                "cursor": {"kind": "postgres", "auth": "pg", "claim": "select 1"},
+                "iterator": "row",
+                "spec": {"mode": "cursor", "max_in_flight": 2},
+            },
+            "fetch_patients",
+        )
+
+
 def test_frame_policy_rejects_non_positive_bounds():
     from noetl.core.dsl.engine.models.workflow import FramePolicy
 


### PR DESCRIPTION
## Summary
- allow loop.spec.max_in_flight to be an integer or renderable expression at model/catalog validation time
- render and re-validate max_in_flight before loop dispatch and cursor worker-count recovery paths
- let parser validation accept cursor loops and templated concurrency expressions
- add regressions for parser/model/runtime coercion and invalid rendered values

## Validation
- .venv/bin/python -m pytest tests/core/test_frame_policy_model.py tests/unit/dsl/engine -q
- .venv/bin/python -m compileall noetl/core/dsl/engine/models/workflow.py noetl/core/dsl/engine/parser/validation.py noetl/core/dsl/engine/executor/transitions.py noetl/core/dsl/engine/executor/commands.py noetl/core/dsl/engine/executor/events.py noetl/core/dsl/engine/executor/rendering.py
- git diff --check

Closes noetl/noetl#442