### PR TITLE
Expose frame backlog metric for worker autoscaling

### DIFF
--- a/noetl/server/app.py
+++ b/noetl/server/app.py
@@ -33,7 +33,8 @@ from noetl.server.command_reaper import (
     run_command_reaper,
     is_reaper_enabled as is_command_reaper_enabled,
 )
-from noetl.server.metrics import append_storage_ipc_metrics
+from noetl.server.frame_backlog import collect_frame_backlog_snapshot
+from noetl.server.metrics import append_frame_backlog_metrics, append_storage_ipc_metrics
 from noetl.server.runtime_leases import RuntimeLease, load_control_lease_seconds
 
 logger = setup_logger(__name__, include_location=True)
@@ -558,6 +559,11 @@ def _create_app(settings: Settings) -> FastAPI:
             append_storage_ipc_metrics(lines, default_store.ipc_stats())
         except Exception as exc:
             logger.debug("Failed to append storage IPC metrics: %s", exc)
+
+        try:
+            append_frame_backlog_metrics(lines, await collect_frame_backlog_snapshot())
+        except Exception as exc:
+            logger.debug("Failed to append frame backlog metrics: %s", exc)
 
         body = "\n".join(lines) + "\n"
         return Response(content=body, media_type="text/plain; version=0.0.4; charset=utf-8")

--- a/noetl/server/frame_backlog.py
+++ b/noetl/server/frame_backlog.py
@@ -1,0 +1,41 @@
+"""Frame backlog provider for runtime metrics and autoscaling signals."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from noetl.core.common import get_async_db_connection
+
+
+async def collect_frame_backlog_snapshot() -> list[dict[str, Any]]:
+    """Return worker-claimable frame backlog grouped by stage kind and status.
+
+    This is the NoETL runtime boundary used by metrics and autoscaling. The
+    current adapter reads the projection store; callers should not depend on
+    the storage engine or query shape.
+    """
+    async with get_async_db_connection(optional=True) as conn:
+        if conn is None:
+            return []
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                SELECT s.kind AS stage_kind, f.status, COUNT(*)::int AS count
+                FROM noetl.frame f
+                JOIN noetl.stage s ON s.stage_id = f.stage_id
+                WHERE f.status IN ('PENDING','CLAIMED','RUNNING')
+                GROUP BY s.kind, f.status
+                ORDER BY s.kind, f.status
+                """
+            )
+            return [
+                {
+                    "stage_kind": row[0],
+                    "status": row[1],
+                    "count": row[2],
+                }
+                for row in await cur.fetchall()
+            ]
+
+
+__all__ = ["collect_frame_backlog_snapshot"]

--- a/noetl/server/metrics.py
+++ b/noetl/server/metrics.py
@@ -38,6 +38,30 @@ def append_storage_ipc_metrics(
     lines.append(f"noetl_storage_ipc_read_hit_ratio{label_text} {hit_ratio}")
 
 
+def append_frame_backlog_metrics(
+    lines: list[str],
+    rows: list[Mapping[str, object]],
+) -> None:
+    """Append frame backlog gauges grouped by status and stage kind."""
+    metric_name = "noetl_frame_backlog_total"
+    lines.append("# HELP noetl_frame_backlog_total Worker-claimable frame backlog by stage kind and status")
+    lines.append("# TYPE noetl_frame_backlog_total gauge")
+    totals_by_status: dict[str, int] = {}
+    total = 0
+    for row in rows:
+        stage_kind = str(row.get("stage_kind") or "unknown")
+        status = str(row.get("status") or "unknown")
+        count = int(row.get("count") or 0)
+        total += count
+        totals_by_status[status] = totals_by_status.get(status, 0) + count
+        labels = _format_labels({"stage_kind": stage_kind, "status": status})
+        lines.append(f"{metric_name}{labels} {count}")
+
+    for status, count in sorted(totals_by_status.items()):
+        lines.append(f'{metric_name}{{stage_kind="all",status="{_escape_label(status)}"}} {count}')
+    lines.append(f'{metric_name}{{stage_kind="all",status="all"}} {total}')
+
+
 def _format_labels(labels: Mapping[str, str]) -> str:
     filtered = {key: value for key, value in labels.items() if value}
     if not filtered:
@@ -50,4 +74,4 @@ def _escape_label(value: str) -> str:
     return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
 
 
-__all__ = ["append_storage_ipc_metrics"]
+__all__ = ["append_frame_backlog_metrics", "append_storage_ipc_metrics"]

--- a/tests/server/test_metrics.py
+++ b/tests/server/test_metrics.py
@@ -34,3 +34,23 @@ def test_core_batch_metrics_export_is_callable_without_route_state():
     assert "accepted_total" in snapshot
     assert "queue_depth" in snapshot
     assert "worker_count" in snapshot
+
+
+def test_append_frame_backlog_metrics_exports_stage_and_total_gauges():
+    from noetl.server.metrics import append_frame_backlog_metrics
+
+    lines: list[str] = []
+    append_frame_backlog_metrics(
+        lines,
+        [
+            {"stage_kind": "loop", "status": "PENDING", "count": 3},
+            {"stage_kind": "loop", "status": "RUNNING", "count": 2},
+            {"stage_kind": "reduce", "status": "PENDING", "count": 1},
+        ],
+    )
+    body = "\n".join(lines)
+
+    assert "noetl_frame_backlog_total{stage_kind=\"loop\",status=\"PENDING\"} 3" in body
+    assert "noetl_frame_backlog_total{stage_kind=\"reduce\",status=\"PENDING\"} 1" in body
+    assert "noetl_frame_backlog_total{stage_kind=\"all\",status=\"PENDING\"} 4" in body
+    assert "noetl_frame_backlog_total{stage_kind=\"all\",status=\"all\"} 6" in body


### PR DESCRIPTION
## Summary
- expose `noetl_frame_backlog_total` on the NoETL server metrics endpoint for worker autoscaling
- keep database access behind a NoETL backlog provider boundary so KEDA and ops consume the runtime metric contract, not storage SQL
- include per-stage-kind/status gauges plus `stage_kind="all",status="all"` for simple scale triggers

## Validation
- `.venv/bin/python -m pytest tests/server/test_metrics.py -q`
- `.venv/bin/python -m pytest tests/server/test_metrics.py tests/worker/test_worker_metrics.py tests/api/test_frame_routes.py -q`
