### PR TITLE
Add tenant-scoped frame backlog metric

### DIFF
--- a/noetl/server/frame_backlog.py
+++ b/noetl/server/frame_backlog.py
@@ -8,7 +8,7 @@ from noetl.core.common import get_async_db_connection
 
 
 async def collect_frame_backlog_snapshot() -> list[dict[str, Any]]:
-    """Return worker-claimable frame backlog grouped by stage kind and status.
+    """Return worker-claimable frame backlog grouped by tenant, stage kind, and status.
 
     This is the NoETL runtime boundary used by metrics and autoscaling. The
     current adapter reads the projection store; callers should not depend on
@@ -20,19 +20,26 @@ async def collect_frame_backlog_snapshot() -> list[dict[str, Any]]:
         async with conn.cursor() as cur:
             await cur.execute(
                 """
-                SELECT s.kind AS stage_kind, f.status, COUNT(*)::int AS count
+                SELECT
+                    f.tenant_id,
+                    f.organization_id,
+                    s.kind AS stage_kind,
+                    f.status,
+                    COUNT(*)::int AS count
                 FROM noetl.frame f
                 JOIN noetl.stage s ON s.stage_id = f.stage_id
                 WHERE f.status IN ('PENDING','CLAIMED','RUNNING')
-                GROUP BY s.kind, f.status
-                ORDER BY s.kind, f.status
+                GROUP BY f.tenant_id, f.organization_id, s.kind, f.status
+                ORDER BY f.tenant_id, f.organization_id, s.kind, f.status
                 """
             )
             return [
                 {
-                    "stage_kind": row[0],
-                    "status": row[1],
-                    "count": row[2],
+                    "tenant_id": row[0],
+                    "organization_id": row[1],
+                    "stage_kind": row[2],
+                    "status": row[3],
+                    "count": row[4],
                 }
                 for row in await cur.fetchall()
             ]

--- a/noetl/server/metrics.py
+++ b/noetl/server/metrics.py
@@ -42,18 +42,39 @@ def append_frame_backlog_metrics(
     lines: list[str],
     rows: list[Mapping[str, object]],
 ) -> None:
-    """Append frame backlog gauges grouped by status and stage kind."""
+    """Append global and tenant-scoped frame backlog gauges."""
     metric_name = "noetl_frame_backlog_total"
     lines.append("# HELP noetl_frame_backlog_total Worker-claimable frame backlog by stage kind and status")
     lines.append("# TYPE noetl_frame_backlog_total gauge")
+    detail_metric_name = "noetl_frame_backlog_detail_total"
+    lines.append(
+        "# HELP noetl_frame_backlog_detail_total Worker-claimable frame backlog by tenant, organization, stage kind, and status"
+    )
+    lines.append("# TYPE noetl_frame_backlog_detail_total gauge")
     totals_by_status: dict[str, int] = {}
+    totals_by_stage_status: dict[tuple[str, str], int] = {}
     total = 0
     for row in rows:
+        tenant_id = str(row.get("tenant_id") or "default")
+        organization_id = str(row.get("organization_id") or "default")
         stage_kind = str(row.get("stage_kind") or "unknown")
         status = str(row.get("status") or "unknown")
         count = int(row.get("count") or 0)
         total += count
         totals_by_status[status] = totals_by_status.get(status, 0) + count
+        stage_key = (stage_kind, status)
+        totals_by_stage_status[stage_key] = totals_by_stage_status.get(stage_key, 0) + count
+        detail_labels = _format_labels(
+            {
+                "tenant_id": tenant_id,
+                "organization_id": organization_id,
+                "stage_kind": stage_kind,
+                "status": status,
+            }
+        )
+        lines.append(f"{detail_metric_name}{detail_labels} {count}")
+
+    for (stage_kind, status), count in sorted(totals_by_stage_status.items()):
         labels = _format_labels({"stage_kind": stage_kind, "status": status})
         lines.append(f"{metric_name}{labels} {count}")
 

--- a/tests/server/test_metrics.py
+++ b/tests/server/test_metrics.py
@@ -44,13 +44,31 @@ def test_append_frame_backlog_metrics_exports_stage_and_total_gauges():
         lines,
         [
             {"stage_kind": "loop", "status": "PENDING", "count": 3},
-            {"stage_kind": "loop", "status": "RUNNING", "count": 2},
-            {"stage_kind": "reduce", "status": "PENDING", "count": 1},
+            {
+                "tenant_id": "tenant-a",
+                "organization_id": "org-a",
+                "stage_kind": "loop",
+                "status": "RUNNING",
+                "count": 2,
+            },
+            {
+                "tenant_id": "tenant-b",
+                "organization_id": "org-b",
+                "stage_kind": "reduce",
+                "status": "PENDING",
+                "count": 1,
+            },
         ],
     )
     body = "\n".join(lines)
 
+    assert (
+        "noetl_frame_backlog_detail_total"
+        "{organization_id=\"org-a\",stage_kind=\"loop\",status=\"RUNNING\",tenant_id=\"tenant-a\"} 2"
+        in body
+    )
     assert "noetl_frame_backlog_total{stage_kind=\"loop\",status=\"PENDING\"} 3" in body
+    assert "noetl_frame_backlog_total{stage_kind=\"loop\",status=\"RUNNING\"} 2" in body
     assert "noetl_frame_backlog_total{stage_kind=\"reduce\",status=\"PENDING\"} 1" in body
     assert "noetl_frame_backlog_total{stage_kind=\"all\",status=\"PENDING\"} 4" in body
     assert "noetl_frame_backlog_total{stage_kind=\"all\",status=\"all\"} 6" in body


### PR DESCRIPTION
## Summary
- add `noetl_frame_backlog_detail_total` with tenant, organization, stage kind, and status labels
- keep the existing global `noetl_frame_backlog_total` aggregated for the KEDA scaler
- group the runtime backlog provider by tenant/org without exposing storage details to callers

## Validation
- `.venv/bin/python -m pytest tests/server/test_metrics.py tests/worker/test_worker_metrics.py tests/api/test_frame_routes.py -q`
