### PR TITLE
Label worker metrics with topology

### DIFF
--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -3685,6 +3685,9 @@ async def run_worker(
                 "worker_pool": os.getenv("NOETL_WORKER_POOL_NAME") or "worker-cpu-01",
                 "runtime": os.getenv("NOETL_WORKER_POOL_RUNTIME") or "cpu",
                 "node_id": os.getenv("NOETL_NODE_ID") or os.getenv("NODE_NAME") or "",
+                "cluster_id": os.getenv("NOETL_CLUSTER_ID") or os.getenv("NOETL_CLUSTER_NAME") or "",
+                "region": os.getenv("NOETL_REGION") or "",
+                "zone": os.getenv("NOETL_ZONE") or "",
             },
         )
     

--- a/tests/worker/test_worker_metrics.py
+++ b/tests/worker/test_worker_metrics.py
@@ -22,13 +22,23 @@ def test_worker_metrics_render_storage_ipc_labels(monkeypatch):
 
     body = worker_metrics.render_worker_metrics(
         worker_id='worker-"a"',
-        labels={"worker_pool": "worker-cpu-01", "runtime": "cpu", "node_id": "node-a"},
+        labels={
+            "worker_pool": "worker-cpu-01",
+            "runtime": "cpu",
+            "node_id": "node-a",
+            "cluster_id": "cluster-a",
+            "region": "us-central1",
+            "zone": "us-central1-a",
+        },
     )
 
+    assert 'cluster_id="cluster-a"' in body
     assert 'worker_id="worker-\\"a\\""' in body
     assert 'worker_pool="worker-cpu-01"' in body
     assert 'runtime="cpu"' in body
     assert 'node_id="node-a"' in body
+    assert 'region="us-central1"' in body
+    assert 'zone="us-central1-a"' in body
     assert "noetl_storage_ipc_admit_attempts_total" in body
     assert "noetl_storage_ipc_read_hit_ratio" in body
     assert " 0.75" in body


### PR DESCRIPTION
## Summary
- add optional cluster_id, region, and zone labels to worker-local metrics
- source labels from NOETL_CLUSTER_ID / NOETL_CLUSTER_NAME, NOETL_REGION, and NOETL_ZONE
- preserve existing worker_pool, runtime, and node_id labels for IPC/cache analysis

## Validation
- `.venv/bin/python -m pytest tests/worker/test_worker_metrics.py -q`
