### PR TITLE
Carry locality hints on frame claims

### DIFF
--- a/noetl/server/api/frames/endpoint.py
+++ b/noetl/server/api/frames/endpoint.py
@@ -673,6 +673,7 @@ async def claim_frames(stage_id: int, req: FrameClaimRequest) -> dict[str, Any]:
                             "recovery": _frame_recovery_policy(
                                 req.frame_policy or stage.get("frame_policy") or {}
                             ),
+                            "locality": req.locality or {},
                         },
                         event_id=updated.get("claimed_event_id"),
                     )

--- a/noetl/server/api/frames/endpoint.py
+++ b/noetl/server/api/frames/endpoint.py
@@ -15,6 +15,7 @@ from noetl.core.event_store.ports import canonical_event_checksum
 from noetl.core.logger import setup_logger
 from noetl.core.messaging import NATSEventPublisher
 from noetl.core.outbox import enqueue_outbox, publish_outbox_batch
+from noetl.core.resource_locator import ResourceLocatorError, build_noetl_locator
 
 from noetl.server.api.core.db import _next_snowflake_id
 
@@ -40,6 +41,28 @@ def _event_meta(*, frame: dict[str, Any], worker_id: str, extra: dict[str, Any] 
     if extra:
         meta.update(extra)
     return meta
+
+
+def _worker_locator(*, stage: dict[str, Any], worker_id: str, locality: dict[str, Any] | None) -> str | None:
+    locality = locality or {}
+    try:
+        segments: list[str] = [
+            "tenant",
+            stage.get("tenant_id") or "default",
+            "org",
+            stage.get("organization_id") or "default",
+        ]
+        cluster_id = locality.get("cluster_id")
+        node_id = locality.get("node_id")
+        worker_pool = locality.get("worker_pool") or worker_id
+        if cluster_id:
+            segments.extend(["cluster", cluster_id])
+        if node_id:
+            segments.extend(["node", node_id])
+        segments.extend(["worker", worker_pool])
+        return build_noetl_locator(*segments)
+    except (ResourceLocatorError, TypeError, ValueError):
+        return None
 
 
 async def _load_stage(cur: Any, stage_id: int) -> dict[str, Any]:
@@ -661,6 +684,7 @@ async def claim_frames(stage_id: int, req: FrameClaimRequest) -> dict[str, Any]:
                     updated = dict(await cur.fetchone())
                     updated["step_name"] = stage["step_name"]
                     updated["catalog_id"] = stage["catalog_id"]
+                    locality = req.locality or {}
                     event = await _insert_frame_event(
                         cur,
                         frame=updated,
@@ -673,7 +697,12 @@ async def claim_frames(stage_id: int, req: FrameClaimRequest) -> dict[str, Any]:
                             "recovery": _frame_recovery_policy(
                                 req.frame_policy or stage.get("frame_policy") or {}
                             ),
-                            "locality": req.locality or {},
+                            "locality": locality,
+                            "worker_locator": _worker_locator(
+                                stage=stage,
+                                worker_id=req.worker_id,
+                                locality=locality,
+                            ),
                         },
                         event_id=updated.get("claimed_event_id"),
                     )

--- a/noetl/server/api/frames/schema.py
+++ b/noetl/server/api/frames/schema.py
@@ -53,6 +53,7 @@ class FrameClaimRequest(BaseModel):
     lease_seconds: int = Field(60, ge=5, le=3600)
     cursor: dict[str, Any] = Field(default_factory=dict)
     frame_policy: dict[str, Any] = Field(default_factory=dict)
+    locality: dict[str, Any] = Field(default_factory=dict)
 
 
 class FrameHeartbeatRequest(BaseModel):

--- a/noetl/worker/cursor_worker.py
+++ b/noetl/worker/cursor_worker.py
@@ -187,6 +187,19 @@ def _runtime_api_base(context: dict[str, Any]) -> str:
     ).rstrip("/")
 
 
+def _worker_locality_hint() -> dict[str, str]:
+    """Return best-effort topology for frame claim placement metadata."""
+    values = {
+        "node_id": os.getenv("NOETL_NODE_ID") or os.getenv("NODE_NAME") or "",
+        "cluster_id": os.getenv("NOETL_CLUSTER_ID") or os.getenv("NOETL_CLUSTER_NAME") or "",
+        "region": os.getenv("NOETL_REGION") or "",
+        "zone": os.getenv("NOETL_ZONE") or "",
+        "worker_pool": os.getenv("NOETL_WORKER_POOL_NAME") or "worker-cpu-01",
+        "runtime": os.getenv("NOETL_WORKER_POOL_RUNTIME") or "cpu",
+    }
+    return {key: value for key, value in values.items() if value}
+
+
 async def _claim_runtime_frame(
     *,
     context: dict[str, Any],
@@ -211,6 +224,7 @@ async def _claim_runtime_frame(
         "requested_count": 1,
         "lease_seconds": lease_seconds,
         "frame_policy": frame_policy or {},
+        "locality": _worker_locality_hint(),
         "cursor": {
             **(cursor or {}),
             "frame_index": frame_index,

--- a/tests/api/test_frame_routes.py
+++ b/tests/api/test_frame_routes.py
@@ -805,5 +805,9 @@ async def test_claim_frames_mints_without_advisory_lock(monkeypatch):
     assert response["frames"][0]["claimed_event_id"] == 102
     assert [item["event_type"] for item in emitted] == ["frame.dispatched"]
     assert emitted[0]["meta_extra"]["locality"] == {"node_id": "node-a", "zone": "us-central1-a"}
+    assert (
+        emitted[0]["meta_extra"]["worker_locator"]
+        == "noetl://tenant/tenant-a/org/org-a/node/node-a/worker/worker-a"
+    )
     assert any("ON CONFLICT DO NOTHING" in query for query, _ in cursor.queries)
     assert conn.commits == 1

--- a/tests/api/test_frame_routes.py
+++ b/tests/api/test_frame_routes.py
@@ -796,6 +796,7 @@ async def test_claim_frames_mints_without_advisory_lock(monkeypatch):
             lease_seconds=60,
             cursor={"worker_slot_id": "slot-1", "frame_index": 0},
             frame_policy={"process": "frame", "max_rows": 50},
+            locality={"node_id": "node-a", "zone": "us-central1-a"},
         ),
     )
 
@@ -803,5 +804,6 @@ async def test_claim_frames_mints_without_advisory_lock(monkeypatch):
     assert response["frames"][0]["frame_id"] == 9
     assert response["frames"][0]["claimed_event_id"] == 102
     assert [item["event_type"] for item in emitted] == ["frame.dispatched"]
+    assert emitted[0]["meta_extra"]["locality"] == {"node_id": "node-a", "zone": "us-central1-a"}
     assert any("ON CONFLICT DO NOTHING" in query for query, _ in cursor.queries)
     assert conn.commits == 1

--- a/tests/worker/test_cursor_worker_frames.py
+++ b/tests/worker/test_cursor_worker_frames.py
@@ -105,6 +105,26 @@ class _FakeSyncClient:
         return _FakeResponse()
 
 
+def test_worker_locality_hint_uses_topology_env(monkeypatch):
+    from noetl.worker import cursor_worker
+
+    monkeypatch.setenv("NOETL_NODE_ID", "node-a")
+    monkeypatch.setenv("NOETL_CLUSTER_ID", "cluster-a")
+    monkeypatch.setenv("NOETL_REGION", "us-central1")
+    monkeypatch.setenv("NOETL_ZONE", "us-central1-a")
+    monkeypatch.setenv("NOETL_WORKER_POOL_NAME", "worker-cpu-01")
+    monkeypatch.setenv("NOETL_WORKER_POOL_RUNTIME", "cpu")
+
+    assert cursor_worker._worker_locality_hint() == {
+        "node_id": "node-a",
+        "cluster_id": "cluster-a",
+        "region": "us-central1",
+        "zone": "us-central1-a",
+        "worker_pool": "worker-cpu-01",
+        "runtime": "cpu",
+    }
+
+
 @pytest.mark.asyncio
 async def test_start_runtime_frame_emits_running_heartbeat(monkeypatch):
     from noetl.worker import cursor_worker


### PR DESCRIPTION
## Summary
- add optional `locality` to frame claim requests
- have cursor workers send best-effort node/cluster/region/zone/worker-pool/runtime locality
- persist the locality object on `frame.dispatched` event metadata so placement intent is replayable
- include a canonical `worker_locator` in dispatch metadata when enough topology is available

## Validation
- `.venv/bin/python -m pytest tests/worker/test_cursor_worker_frames.py tests/api/test_frame_routes.py -q`
- `.venv/bin/python -m pytest tests/worker/test_cursor_worker_frames.py tests/api/test_frame_routes.py tests/core/test_resource_locator.py -q`
