### PR TITLE
Centralize worker topology helpers

### DIFF
--- a/noetl/core/runtime/topology.py
+++ b/noetl/core/runtime/topology.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from noetl.core.resource_locator import ResourceLocatorError, build_noetl_locator
 
+LOCALITY_DISTANCES = ("node", "zone", "region", "cluster", "any")
+
 
 def worker_locality_from_env(env: Mapping[str, str] | None = None) -> dict[str, str]:
     """Return best-effort worker topology from environment variables."""
@@ -52,4 +54,48 @@ def worker_locator(
         return None
 
 
-__all__ = ["worker_locality_from_env", "worker_locator"]
+def locality_distance(
+    source: Mapping[str, Any] | None,
+    target: Mapping[str, Any] | None,
+) -> str:
+    """Return the closest shared locality level between two topology hints."""
+    source = source or {}
+    target = target or {}
+    if _same_non_empty(source, target, "node_id"):
+        return "node"
+    if _same_non_empty(source, target, "zone"):
+        return "zone"
+    if _same_non_empty(source, target, "region"):
+        return "region"
+    if _same_non_empty(source, target, "cluster_id"):
+        return "cluster"
+    return "any"
+
+
+def locality_within(
+    source: Mapping[str, Any] | None,
+    target: Mapping[str, Any] | None,
+    *,
+    max_distance: str,
+) -> bool:
+    """Return whether target is within the requested locality distance."""
+    distance = locality_distance(source, target)
+    try:
+        return LOCALITY_DISTANCES.index(distance) <= LOCALITY_DISTANCES.index(max_distance)
+    except ValueError:
+        return False
+
+
+def _same_non_empty(source: Mapping[str, Any], target: Mapping[str, Any], key: str) -> bool:
+    source_value = str(source.get(key) or "").strip()
+    target_value = str(target.get(key) or "").strip()
+    return bool(source_value and target_value and source_value == target_value)
+
+
+__all__ = [
+    "LOCALITY_DISTANCES",
+    "locality_distance",
+    "locality_within",
+    "worker_locality_from_env",
+    "worker_locator",
+]

--- a/noetl/core/runtime/topology.py
+++ b/noetl/core/runtime/topology.py
@@ -1,0 +1,55 @@
+"""Runtime topology helpers for worker identity and placement metadata."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from noetl.core.resource_locator import ResourceLocatorError, build_noetl_locator
+
+
+def worker_locality_from_env(env: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Return best-effort worker topology from environment variables."""
+    env = env or os.environ
+    values = {
+        "node_id": env.get("NOETL_NODE_ID") or env.get("NODE_NAME") or "",
+        "cluster_id": env.get("NOETL_CLUSTER_ID") or env.get("NOETL_CLUSTER_NAME") or "",
+        "region": env.get("NOETL_REGION") or "",
+        "zone": env.get("NOETL_ZONE") or "",
+        "worker_pool": env.get("NOETL_WORKER_POOL_NAME") or "worker-cpu-01",
+        "runtime": env.get("NOETL_WORKER_POOL_RUNTIME") or "cpu",
+    }
+    return {key: value for key, value in values.items() if value}
+
+
+def worker_locator(
+    *,
+    tenant_id: Any,
+    organization_id: Any,
+    worker_id: str,
+    locality: Mapping[str, Any] | None = None,
+) -> str | None:
+    """Build a canonical worker locator from tenant/org and locality metadata."""
+    locality = locality or {}
+    try:
+        segments: list[Any] = [
+            "tenant",
+            tenant_id or "default",
+            "org",
+            organization_id or "default",
+        ]
+        cluster_id = locality.get("cluster_id")
+        node_id = locality.get("node_id")
+        worker_pool = locality.get("worker_pool") or worker_id
+        if cluster_id:
+            segments.extend(["cluster", cluster_id])
+        if node_id:
+            segments.extend(["node", node_id])
+        segments.extend(["worker", worker_pool])
+        return build_noetl_locator(*segments)
+    except (ResourceLocatorError, TypeError, ValueError):
+        return None
+
+
+__all__ = ["worker_locality_from_env", "worker_locator"]

--- a/noetl/server/api/frames/endpoint.py
+++ b/noetl/server/api/frames/endpoint.py
@@ -15,7 +15,7 @@ from noetl.core.event_store.ports import canonical_event_checksum
 from noetl.core.logger import setup_logger
 from noetl.core.messaging import NATSEventPublisher
 from noetl.core.outbox import enqueue_outbox, publish_outbox_batch
-from noetl.core.resource_locator import ResourceLocatorError, build_noetl_locator
+from noetl.core.runtime.topology import worker_locator
 
 from noetl.server.api.core.db import _next_snowflake_id
 
@@ -41,28 +41,6 @@ def _event_meta(*, frame: dict[str, Any], worker_id: str, extra: dict[str, Any] 
     if extra:
         meta.update(extra)
     return meta
-
-
-def _worker_locator(*, stage: dict[str, Any], worker_id: str, locality: dict[str, Any] | None) -> str | None:
-    locality = locality or {}
-    try:
-        segments: list[str] = [
-            "tenant",
-            stage.get("tenant_id") or "default",
-            "org",
-            stage.get("organization_id") or "default",
-        ]
-        cluster_id = locality.get("cluster_id")
-        node_id = locality.get("node_id")
-        worker_pool = locality.get("worker_pool") or worker_id
-        if cluster_id:
-            segments.extend(["cluster", cluster_id])
-        if node_id:
-            segments.extend(["node", node_id])
-        segments.extend(["worker", worker_pool])
-        return build_noetl_locator(*segments)
-    except (ResourceLocatorError, TypeError, ValueError):
-        return None
 
 
 async def _load_stage(cur: Any, stage_id: int) -> dict[str, Any]:
@@ -698,8 +676,9 @@ async def claim_frames(stage_id: int, req: FrameClaimRequest) -> dict[str, Any]:
                                 req.frame_policy or stage.get("frame_policy") or {}
                             ),
                             "locality": locality,
-                            "worker_locator": _worker_locator(
-                                stage=stage,
+                            "worker_locator": worker_locator(
+                                tenant_id=stage.get("tenant_id"),
+                                organization_id=stage.get("organization_id"),
                                 worker_id=req.worker_id,
                                 locality=locality,
                             ),

--- a/noetl/worker/cursor_worker.py
+++ b/noetl/worker/cursor_worker.py
@@ -24,6 +24,7 @@ from jinja2 import Environment
 
 from noetl.core.cursor_drivers import CursorDriverNotFoundError, get_driver
 from noetl.core.logger import setup_logger
+from noetl.core.runtime.topology import worker_locality_from_env
 from noetl.core.storage import (
     ARROW_STREAM_MEDIA_TYPE,
     ArrowIpcSharedMemoryCache,
@@ -187,19 +188,6 @@ def _runtime_api_base(context: dict[str, Any]) -> str:
     ).rstrip("/")
 
 
-def _worker_locality_hint() -> dict[str, str]:
-    """Return best-effort topology for frame claim placement metadata."""
-    values = {
-        "node_id": os.getenv("NOETL_NODE_ID") or os.getenv("NODE_NAME") or "",
-        "cluster_id": os.getenv("NOETL_CLUSTER_ID") or os.getenv("NOETL_CLUSTER_NAME") or "",
-        "region": os.getenv("NOETL_REGION") or "",
-        "zone": os.getenv("NOETL_ZONE") or "",
-        "worker_pool": os.getenv("NOETL_WORKER_POOL_NAME") or "worker-cpu-01",
-        "runtime": os.getenv("NOETL_WORKER_POOL_RUNTIME") or "cpu",
-    }
-    return {key: value for key, value in values.items() if value}
-
-
 async def _claim_runtime_frame(
     *,
     context: dict[str, Any],
@@ -224,7 +212,7 @@ async def _claim_runtime_frame(
         "requested_count": 1,
         "lease_seconds": lease_seconds,
         "frame_policy": frame_policy or {},
-        "locality": _worker_locality_hint(),
+        "locality": worker_locality_from_env(),
         "cursor": {
             **(cursor or {}),
             "frame_index": frame_index,

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -3676,19 +3676,13 @@ async def run_worker(
     metrics_port = _optional_int_env("NOETL_WORKER_METRICS_PORT")
     if metrics_port is not None:
         from noetl.worker.metrics import start_worker_metrics_server
+        from noetl.core.runtime.topology import worker_locality_from_env
 
         metrics_server = start_worker_metrics_server(
             worker_id=worker_id,
             host=os.getenv("NOETL_WORKER_METRICS_HOST") or "0.0.0.0",
             port=metrics_port,
-            labels={
-                "worker_pool": os.getenv("NOETL_WORKER_POOL_NAME") or "worker-cpu-01",
-                "runtime": os.getenv("NOETL_WORKER_POOL_RUNTIME") or "cpu",
-                "node_id": os.getenv("NOETL_NODE_ID") or os.getenv("NODE_NAME") or "",
-                "cluster_id": os.getenv("NOETL_CLUSTER_ID") or os.getenv("NOETL_CLUSTER_NAME") or "",
-                "region": os.getenv("NOETL_REGION") or "",
-                "zone": os.getenv("NOETL_ZONE") or "",
-            },
+            labels=worker_locality_from_env(),
         )
     
     try:

--- a/tests/core/test_runtime_topology.py
+++ b/tests/core/test_runtime_topology.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+
+def test_worker_locality_from_env_uses_topology_values():
+    from noetl.core.runtime.topology import worker_locality_from_env
+
+    env = {
+        "NOETL_NODE_ID": "node-a",
+        "NOETL_CLUSTER_ID": "cluster-a",
+        "NOETL_REGION": "us-central1",
+        "NOETL_ZONE": "us-central1-a",
+        "NOETL_WORKER_POOL_NAME": "worker-cpu-01",
+        "NOETL_WORKER_POOL_RUNTIME": "cpu",
+    }
+
+    assert worker_locality_from_env(env) == {
+        "node_id": "node-a",
+        "cluster_id": "cluster-a",
+        "region": "us-central1",
+        "zone": "us-central1-a",
+        "worker_pool": "worker-cpu-01",
+        "runtime": "cpu",
+    }
+
+
+def test_worker_locator_builds_canonical_identity():
+    from noetl.core.runtime.topology import worker_locator
+
+    assert (
+        worker_locator(
+            tenant_id="tenant-a",
+            organization_id="org-a",
+            worker_id="worker-a",
+            locality={
+                "cluster_id": "cluster-a",
+                "node_id": "node-a",
+                "worker_pool": "worker-cpu-01",
+            },
+        )
+        == "noetl://tenant/tenant-a/org/org-a/cluster/cluster-a/node/node-a/worker/worker-cpu-01"
+    )
+
+
+def test_worker_locator_returns_none_for_invalid_segments():
+    from noetl.core.runtime.topology import worker_locator
+
+    assert (
+        worker_locator(
+            tenant_id="tenant/a",
+            organization_id="org-a",
+            worker_id="worker-a",
+            locality={},
+        )
+        is None
+    )

--- a/tests/core/test_runtime_topology.py
+++ b/tests/core/test_runtime_topology.py
@@ -53,3 +53,28 @@ def test_worker_locator_returns_none_for_invalid_segments():
         )
         is None
     )
+
+
+def test_locality_distance_prefers_closest_match():
+    from noetl.core.runtime.topology import locality_distance, locality_within
+
+    source = {
+        "cluster_id": "cluster-a",
+        "region": "us-central1",
+        "zone": "us-central1-a",
+        "node_id": "node-a",
+    }
+
+    assert locality_distance(source, {**source, "node_id": "node-a"}) == "node"
+    assert locality_distance(source, {**source, "node_id": "node-b"}) == "zone"
+    assert locality_distance(source, {**source, "zone": "us-central1-b", "node_id": "node-c"}) == "region"
+    assert (
+        locality_distance(
+            source,
+            {"cluster_id": "cluster-a", "region": "us-east1", "zone": "us-east1-b", "node_id": "node-d"},
+        )
+        == "cluster"
+    )
+    assert locality_distance(source, {"cluster_id": "cluster-b"}) == "any"
+    assert locality_within(source, {**source, "node_id": "node-b"}, max_distance="zone")
+    assert not locality_within(source, {"cluster_id": "cluster-b"}, max_distance="region")

--- a/tests/worker/test_cursor_worker_frames.py
+++ b/tests/worker/test_cursor_worker_frames.py
@@ -105,26 +105,6 @@ class _FakeSyncClient:
         return _FakeResponse()
 
 
-def test_worker_locality_hint_uses_topology_env(monkeypatch):
-    from noetl.worker import cursor_worker
-
-    monkeypatch.setenv("NOETL_NODE_ID", "node-a")
-    monkeypatch.setenv("NOETL_CLUSTER_ID", "cluster-a")
-    monkeypatch.setenv("NOETL_REGION", "us-central1")
-    monkeypatch.setenv("NOETL_ZONE", "us-central1-a")
-    monkeypatch.setenv("NOETL_WORKER_POOL_NAME", "worker-cpu-01")
-    monkeypatch.setenv("NOETL_WORKER_POOL_RUNTIME", "cpu")
-
-    assert cursor_worker._worker_locality_hint() == {
-        "node_id": "node-a",
-        "cluster_id": "cluster-a",
-        "region": "us-central1",
-        "zone": "us-central1-a",
-        "worker_pool": "worker-cpu-01",
-        "runtime": "cpu",
-    }
-
-
 @pytest.mark.asyncio
 async def test_start_runtime_frame_emits_running_heartbeat(monkeypatch):
     from noetl.worker import cursor_worker


### PR DESCRIPTION
## Summary
- add `noetl.core.runtime.topology` for worker locality extraction and canonical worker locator construction
- reuse the helper from cursor frame claims, worker metrics, and frame dispatch metadata
- add pure locality distance helpers (`node`, `zone`, `region`, `cluster`, `any`) for scheduler enforcement follow-up
- remove duplicated env parsing / locator-building logic from worker and frame endpoint paths

## Validation
- `.venv/bin/python -m pytest tests/core/test_runtime_topology.py tests/core/test_resource_locator.py tests/worker/test_cursor_worker_frames.py tests/worker/test_worker_metrics.py tests/api/test_frame_routes.py -q`
