### PR TITLE
Record locality placement evaluation on frame dispatch

### DIFF
--- a/noetl/core/runtime/topology.py
+++ b/noetl/core/runtime/topology.py
@@ -86,6 +86,21 @@ def locality_within(
         return False
 
 
+def placement_evaluation(
+    *,
+    source: Mapping[str, Any] | None,
+    target: Mapping[str, Any] | None,
+    max_distance: str = "any",
+) -> dict[str, Any]:
+    """Return a replayable placement evaluation for scheduler/audit metadata."""
+    distance = locality_distance(source, target)
+    return {
+        "distance": distance,
+        "max_distance": max_distance,
+        "within_max_distance": locality_within(source, target, max_distance=max_distance),
+    }
+
+
 def _same_non_empty(source: Mapping[str, Any], target: Mapping[str, Any], key: str) -> bool:
     source_value = str(source.get(key) or "").strip()
     target_value = str(target.get(key) or "").strip()
@@ -96,6 +111,7 @@ __all__ = [
     "LOCALITY_DISTANCES",
     "locality_distance",
     "locality_within",
+    "placement_evaluation",
     "worker_locality_from_env",
     "worker_locator",
 ]

--- a/noetl/server/api/frames/endpoint.py
+++ b/noetl/server/api/frames/endpoint.py
@@ -15,7 +15,7 @@ from noetl.core.event_store.ports import canonical_event_checksum
 from noetl.core.logger import setup_logger
 from noetl.core.messaging import NATSEventPublisher
 from noetl.core.outbox import enqueue_outbox, publish_outbox_batch
-from noetl.core.runtime.topology import worker_locator
+from noetl.core.runtime.topology import placement_evaluation, worker_locator
 
 from noetl.server.api.core.db import _next_snowflake_id
 
@@ -41,6 +41,31 @@ def _event_meta(*, frame: dict[str, Any], worker_id: str, extra: dict[str, Any] 
     if extra:
         meta.update(extra)
     return meta
+
+
+def _source_locality_from_cursor(cursor: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(cursor, dict):
+        return {}
+    for key in ("source_locality", "producer_locality"):
+        value = cursor.get(key)
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def _claim_locality_metadata(*, frame: dict[str, Any], request_locality: dict[str, Any]) -> dict[str, Any]:
+    source_locality = _source_locality_from_cursor(frame.get("cursor") or {})
+    if not source_locality:
+        return {}
+    max_distance = str(request_locality.get("max_distance") or "any")
+    return {
+        "source_locality": source_locality,
+        "placement": placement_evaluation(
+            source=source_locality,
+            target=request_locality,
+            max_distance=max_distance,
+        ),
+    }
 
 
 async def _load_stage(cur: Any, stage_id: int) -> dict[str, Any]:
@@ -663,6 +688,10 @@ async def claim_frames(stage_id: int, req: FrameClaimRequest) -> dict[str, Any]:
                     updated["step_name"] = stage["step_name"]
                     updated["catalog_id"] = stage["catalog_id"]
                     locality = req.locality or {}
+                    locality_metadata = _claim_locality_metadata(
+                        frame=updated,
+                        request_locality=locality,
+                    )
                     event = await _insert_frame_event(
                         cur,
                         frame=updated,
@@ -676,6 +705,7 @@ async def claim_frames(stage_id: int, req: FrameClaimRequest) -> dict[str, Any]:
                                 req.frame_policy or stage.get("frame_policy") or {}
                             ),
                             "locality": locality,
+                            **locality_metadata,
                             "worker_locator": worker_locator(
                                 tenant_id=stage.get("tenant_id"),
                                 organization_id=stage.get("organization_id"),

--- a/tests/api/test_frame_routes.py
+++ b/tests/api/test_frame_routes.py
@@ -712,7 +712,11 @@ async def test_claim_frames_mints_without_advisory_lock(monkeypatch):
                     "command_id": 5,
                     "claimed_event_id": None,
                     "terminal_event_id": None,
-                    "cursor": {"worker_slot_id": "slot-1", "frame_index": 0},
+                    "cursor": {
+                        "worker_slot_id": "slot-1",
+                        "frame_index": 0,
+                        "source_locality": {"zone": "us-central1-a"},
+                    },
                     "row_count": 0,
                     "status": "PENDING",
                     "owner_worker": None,
@@ -732,7 +736,11 @@ async def test_claim_frames_mints_without_advisory_lock(monkeypatch):
                     "command_id": 5,
                     "claimed_event_id": 102,
                     "terminal_event_id": None,
-                    "cursor": {"worker_slot_id": "slot-1", "frame_index": 0},
+                    "cursor": {
+                        "worker_slot_id": "slot-1",
+                        "frame_index": 0,
+                        "source_locality": {"zone": "us-central1-a"},
+                    },
                     "row_count": 0,
                     "status": "CLAIMED",
                     "owner_worker": "worker-a",
@@ -794,9 +802,13 @@ async def test_claim_frames_mints_without_advisory_lock(monkeypatch):
             command_id=5,
             requested_count=1,
             lease_seconds=60,
-            cursor={"worker_slot_id": "slot-1", "frame_index": 0},
+            cursor={
+                "worker_slot_id": "slot-1",
+                "frame_index": 0,
+                "source_locality": {"zone": "us-central1-a"},
+            },
             frame_policy={"process": "frame", "max_rows": 50},
-            locality={"node_id": "node-a", "zone": "us-central1-a"},
+            locality={"node_id": "node-a", "zone": "us-central1-a", "max_distance": "zone"},
         ),
     )
 
@@ -804,7 +816,17 @@ async def test_claim_frames_mints_without_advisory_lock(monkeypatch):
     assert response["frames"][0]["frame_id"] == 9
     assert response["frames"][0]["claimed_event_id"] == 102
     assert [item["event_type"] for item in emitted] == ["frame.dispatched"]
-    assert emitted[0]["meta_extra"]["locality"] == {"node_id": "node-a", "zone": "us-central1-a"}
+    assert emitted[0]["meta_extra"]["locality"] == {
+        "node_id": "node-a",
+        "zone": "us-central1-a",
+        "max_distance": "zone",
+    }
+    assert emitted[0]["meta_extra"]["source_locality"] == {"zone": "us-central1-a"}
+    assert emitted[0]["meta_extra"]["placement"] == {
+        "distance": "zone",
+        "max_distance": "zone",
+        "within_max_distance": True,
+    }
     assert (
         emitted[0]["meta_extra"]["worker_locator"]
         == "noetl://tenant/tenant-a/org/org-a/node/node-a/worker/worker-a"

--- a/tests/core/test_runtime_topology.py
+++ b/tests/core/test_runtime_topology.py
@@ -56,7 +56,7 @@ def test_worker_locator_returns_none_for_invalid_segments():
 
 
 def test_locality_distance_prefers_closest_match():
-    from noetl.core.runtime.topology import locality_distance, locality_within
+    from noetl.core.runtime.topology import locality_distance, locality_within, placement_evaluation
 
     source = {
         "cluster_id": "cluster-a",
@@ -78,3 +78,12 @@ def test_locality_distance_prefers_closest_match():
     assert locality_distance(source, {"cluster_id": "cluster-b"}) == "any"
     assert locality_within(source, {**source, "node_id": "node-b"}, max_distance="zone")
     assert not locality_within(source, {"cluster_id": "cluster-b"}, max_distance="region")
+    assert placement_evaluation(
+        source=source,
+        target={**source, "node_id": "node-b"},
+        max_distance="zone",
+    ) == {
+        "distance": "zone",
+        "max_distance": "zone",
+        "within_max_distance": True,
+    }


### PR DESCRIPTION
## Summary
- add replayable placement evaluation metadata for frame dispatch when a frame cursor carries source/producer locality
- include source_locality plus distance/max_distance/within_max_distance in frame.dispatched metadata
- keep frame selection unchanged until producer locality is persisted consistently for scheduler enforcement

## Validation
- `.venv/bin/python -m pytest tests/core/test_runtime_topology.py tests/core/test_resource_locator.py tests/worker/test_cursor_worker_frames.py tests/worker/test_worker_metrics.py tests/api/test_frame_routes.py -q`
