### PR TITLE
Enrich runtime events with worker topology

### DIFF
--- a/noetl/core/runtime/events.py
+++ b/noetl/core/runtime/events.py
@@ -15,6 +15,7 @@ from typing import Dict, Any, Optional
 
 from noetl.core.logger import setup_logger
 from noetl.core.config import WorkerSettings, get_worker_settings
+from noetl.core.runtime.topology import worker_locality_from_env, worker_locator
 
 logger = setup_logger(__name__, include_location=True)
 
@@ -170,6 +171,26 @@ def _enrich_event_metadata(event_data: Dict[str, Any]) -> None:
             meta['worker_pool'] = worker_pool
         if worker_runtime and not meta.get('worker_runtime'):
             meta['worker_runtime'] = worker_runtime
+        locality = worker_locality_from_env()
+        if worker_pool:
+            locality["worker_pool"] = worker_pool
+        if worker_runtime:
+            locality["runtime"] = worker_runtime
+        effective_locality = meta.get("locality") if isinstance(meta.get("locality"), dict) else locality
+        if locality and not meta.get("locality"):
+            meta["locality"] = locality
+
+        tenant_id = event_data.get("tenant_id") or meta.get("tenant_id") or "default"
+        organization_id = event_data.get("organization_id") or meta.get("organization_id") or "default"
+        worker_id = event_data.get("worker_id") or os.environ.get("NOETL_WORKER_ID") or socket.gethostname()
+        locator = worker_locator(
+            tenant_id=tenant_id,
+            organization_id=organization_id,
+            worker_id=str(worker_id),
+            locality=effective_locality,
+        )
+        if locator and not meta.get("worker_locator"):
+            meta["worker_locator"] = locator
             
         event_data['meta'] = meta
     except Exception:

--- a/tests/core/test_runtime_events.py
+++ b/tests/core/test_runtime_events.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+
+
+def test_prepare_event_payload_enriches_worker_topology(monkeypatch):
+    from noetl.core.runtime import events
+
+    monkeypatch.setattr(events, "_cached_worker_settings", None)
+    monkeypatch.setattr(events, "_get_worker_settings", lambda: None)
+    monkeypatch.setenv("NOETL_WORKER_ID", "worker-a")
+    monkeypatch.setenv("NOETL_WORKER_POOL_NAME", "worker-cpu-01")
+    monkeypatch.setenv("NOETL_WORKER_POOL_RUNTIME", "cpu")
+    monkeypatch.setenv("NOETL_NODE_ID", "node-a")
+    monkeypatch.setenv("NOETL_CLUSTER_ID", "cluster-a")
+    monkeypatch.setenv("NOETL_REGION", "us-central1")
+    monkeypatch.setenv("NOETL_ZONE", "us-central1-a")
+
+    _url, body = events._prepare_event_payload(
+        {
+            "execution_id": "7",
+            "event_type": "worker.test",
+            "worker_id": "worker-a",
+            "tenant_id": "tenant-a",
+            "organization_id": "org-a",
+        },
+        "http://noetl",
+    )
+    payload = json.loads(body)
+
+    assert payload["meta"]["locality"] == {
+        "node_id": "node-a",
+        "cluster_id": "cluster-a",
+        "region": "us-central1",
+        "zone": "us-central1-a",
+        "worker_pool": "worker-cpu-01",
+        "runtime": "cpu",
+    }
+    assert (
+        payload["meta"]["worker_locator"]
+        == "noetl://tenant/tenant-a/org/org-a/cluster/cluster-a/node/node-a/worker/worker-cpu-01"
+    )
+    assert payload["trace_component"]["worker"]["pool"] == "worker-cpu-01"
+
+
+def test_prepare_event_payload_preserves_explicit_worker_topology(monkeypatch):
+    from noetl.core.runtime import events
+
+    monkeypatch.setattr(events, "_cached_worker_settings", None)
+    monkeypatch.setattr(events, "_get_worker_settings", lambda: None)
+    monkeypatch.setenv("NOETL_WORKER_POOL_NAME", "worker-cpu-01")
+    monkeypatch.setenv("NOETL_WORKER_POOL_RUNTIME", "cpu")
+    monkeypatch.setenv("NOETL_NODE_ID", "env-node")
+    monkeypatch.setenv("NOETL_CLUSTER_ID", "env-cluster")
+
+    explicit_locality = {
+        "cluster_id": "cluster-b",
+        "node_id": "node-b",
+        "worker_pool": "worker-gpu-01",
+        "runtime": "gpu",
+    }
+
+    _url, body = events._prepare_event_payload(
+        {
+            "execution_id": "8",
+            "event_type": "worker.test",
+            "worker_id": "worker-b",
+            "tenant_id": "tenant-b",
+            "organization_id": "org-b",
+            "meta": {"locality": explicit_locality},
+        },
+        "http://noetl",
+    )
+    payload = json.loads(body)
+
+    assert payload["meta"]["locality"] == explicit_locality
+    assert (
+        payload["meta"]["worker_locator"]
+        == "noetl://tenant/tenant-b/org/org-b/cluster/cluster-b/node/node-b/worker/worker-gpu-01"
+    )


### PR DESCRIPTION
## Summary
- enrich worker-reported runtime event metadata with locality from the shared topology helper
- add canonical worker_locator values under meta for replay/debug without changing API shape
- preserve caller-provided meta.locality and meta.worker_locator when present

## Validation
- .venv/bin/python -m pytest tests/core/test_runtime_events.py tests/core/test_runtime_topology.py tests/core/test_resource_locator.py -q
- .venv/bin/python -m pytest tests/worker/test_cursor_worker_frames.py tests/worker/test_worker_metrics.py tests/api/test_frame_routes.py -q

Tracks noetl/noetl#434.