### PR TITLE
Attach topology metadata to command claims

### DIFF
--- a/noetl/server/api/core/commands.py
+++ b/noetl/server/api/core/commands.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, HTTPException
 from psycopg.rows import dict_row
 from psycopg_pool import PoolTimeout
 from noetl.core.db.pool import get_pool_connection
+from noetl.core.runtime.topology import placement_evaluation, worker_locator
 from noetl.core.storage import Scope, default_store, estimate_size
 from noetl.claim_policy import decide_reclaim_for_existing_claim
 from .core import (
@@ -44,6 +45,49 @@ router = APIRouter()
 _COMMAND_CONTEXT_FIELD_INLINE_MAX_BYTES = int(
     os.getenv("NOETL_COMMAND_CONTEXT_FIELD_INLINE_MAX_BYTES", "8192")
 )
+
+
+def _source_locality_from_command_meta(meta: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(meta, dict):
+        return {}
+    for key in ("source_locality", "producer_locality"):
+        value = meta.get(key)
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def _claim_topology_metadata(
+    *,
+    command_meta: dict[str, Any] | None,
+    request_locality: dict[str, Any] | None,
+    tenant_id: Any = None,
+    organization_id: Any = None,
+    worker_id: str,
+) -> dict[str, Any]:
+    locality = request_locality or {}
+    meta: dict[str, Any] = {}
+    if locality:
+        meta["locality"] = locality
+        locator = worker_locator(
+            tenant_id=tenant_id or (command_meta or {}).get("tenant_id"),
+            organization_id=organization_id or (command_meta or {}).get("organization_id"),
+            worker_id=worker_id,
+            locality=locality,
+        )
+        if locator:
+            meta["worker_locator"] = locator
+
+    source_locality = _source_locality_from_command_meta(command_meta)
+    if source_locality:
+        max_distance = str(locality.get("max_distance") or "any")
+        meta["source_locality"] = source_locality
+        meta["placement"] = placement_evaluation(
+            source=source_locality,
+            target=locality,
+            max_distance=max_distance,
+        )
+    return meta
 
 def _command_input_from_model(cmd: Any) -> dict[str, Any]:
     cmd_input = getattr(cmd, "input", None)
@@ -432,7 +476,17 @@ async def claim_command(event_id: int, req: ClaimRequest):
                         return ClaimResponse(status="ok", event_id=event_id, execution_id=execution_id, node_id=step, node_name=step, action=tool_kind, context=context, meta=meta)
 
                 claim_evt_id = await _next_snowflake_id(cur)
-                claim_meta = {"command_id": command_id, "worker_id": req.worker_id, "actionable": False, "informative": True}
+                claim_meta = {
+                    "command_id": command_id,
+                    "worker_id": req.worker_id,
+                    "actionable": False,
+                    "informative": True,
+                    **_claim_topology_metadata(
+                        command_meta=meta,
+                        request_locality=req.locality,
+                        worker_id=req.worker_id,
+                    ),
+                }
                 if stale_reclaim:
                     claim_meta.update({"reclaimed": True, "reclaimed_from_worker": reclaimed_from, "reclaimed_reason": reclaimed_reason})
                 

--- a/noetl/server/api/core/models.py
+++ b/noetl/server/api/core/models.py
@@ -95,6 +95,7 @@ class BatchEventResponse(BaseModel):
 class ClaimRequest(BaseModel):
     """Request to claim a command."""
     worker_id: str
+    locality: Optional[dict[str, Any]] = None
 
 class ClaimResponse(BaseModel):
     """Response for successful claim with command details."""

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -1264,9 +1264,19 @@ class Worker:
             await self._concurrency.acquire()
             _released = False
             try:
+                claim_payload: dict[str, Any] = {"worker_id": self.worker_id}
+                try:
+                    from noetl.core.runtime.topology import worker_locality_from_env
+
+                    locality = worker_locality_from_env()
+                    if locality:
+                        claim_payload["locality"] = locality
+                except Exception:
+                    logger.debug("[CLAIM] Failed to attach worker locality to claim", exc_info=True)
+
                 response = await self._http_client.post(
                     _api_url(server_url, f"commands/{event_id}/claim"),
-                    json={"worker_id": self.worker_id},
+                    json=claim_payload,
                 )
 
                 if response.status_code == 200:

--- a/tests/api/test_command_claim_outbox.py
+++ b/tests/api/test_command_claim_outbox.py
@@ -102,3 +102,35 @@ async def test_claim_command_enqueues_claimed_event_before_drain(monkeypatch):
     assert enqueued[0]["meta"]["worker_id"] == "worker-1"
     assert isinstance(enqueued[0]["created_at"], datetime)
     assert enqueued[0]["created_at"].tzinfo == timezone.utc
+
+
+def test_claim_topology_metadata_records_locator_and_placement():
+    from noetl.server.api.core.commands import _claim_topology_metadata
+
+    meta = _claim_topology_metadata(
+        command_meta={
+            "tenant_id": "tenant-a",
+            "organization_id": "org-a",
+            "source_locality": {"zone": "us-central1-a"},
+        },
+        request_locality={
+            "cluster_id": "cluster-a",
+            "node_id": "node-a",
+            "zone": "us-central1-a",
+            "worker_pool": "worker-cpu-01",
+            "max_distance": "zone",
+        },
+        worker_id="worker-a",
+    )
+
+    assert meta["locality"]["node_id"] == "node-a"
+    assert meta["source_locality"] == {"zone": "us-central1-a"}
+    assert meta["placement"] == {
+        "distance": "zone",
+        "max_distance": "zone",
+        "within_max_distance": True,
+    }
+    assert (
+        meta["worker_locator"]
+        == "noetl://tenant/tenant-a/org/org-a/cluster/cluster-a/node/node-a/worker/worker-cpu-01"
+    )

--- a/tests/worker/test_worker_claim.py
+++ b/tests/worker/test_worker_claim.py
@@ -120,6 +120,38 @@ async def test_claim_url_normalizes_server_url_with_api_suffix():
 
 
 @pytest.mark.asyncio
+async def test_claim_request_includes_worker_locality(monkeypatch):
+    worker = Worker(worker_id="test-worker")
+    worker._http_client = _FakeHttpClient(
+        _FakeResponse(
+            409,
+            payload={"detail": {"code": "active_claim", "message": "claimed elsewhere"}},
+        )
+    )
+    monkeypatch.setenv("NOETL_WORKER_POOL_NAME", "worker-cpu-01")
+    monkeypatch.setenv("NOETL_WORKER_POOL_RUNTIME", "cpu")
+    monkeypatch.setenv("NOETL_NODE_ID", "node-a")
+    monkeypatch.setenv("NOETL_CLUSTER_ID", "cluster-a")
+    monkeypatch.setenv("NOETL_REGION", "us-central1")
+    monkeypatch.setenv("NOETL_ZONE", "us-central1-a")
+
+    await worker._claim_and_fetch_command("http://server", 42)
+
+    _, _args, kwargs = worker._http_client.calls[0]
+    assert kwargs["json"] == {
+        "worker_id": "test-worker",
+        "locality": {
+            "node_id": "node-a",
+            "cluster_id": "cluster-a",
+            "region": "us-central1",
+            "zone": "us-central1-a",
+            "worker_pool": "worker-cpu-01",
+            "runtime": "cpu",
+        },
+    }
+
+
+@pytest.mark.asyncio
 async def test_emit_command_failed_normalizes_server_url_with_api_suffix():
     worker = Worker(worker_id="test-worker")
     fake_client = _FakeHttpClient(_FakeResponse(200, payload={"status": "ok"}))


### PR DESCRIPTION
## Summary
- let command claim requests carry optional worker locality without changing existing clients
- attach locality, worker_locator, source_locality, and replayable placement evaluation to command.claimed metadata
- send worker environment locality from the NATS worker claim path

## Validation
- .venv/bin/python -m pytest tests/api/test_command_claim_outbox.py tests/worker/test_worker_claim.py tests/core/test_runtime_topology.py -q
- .venv/bin/python -m pytest tests/api/test_frame_routes.py tests/worker/test_cursor_worker_frames.py tests/worker/test_worker_metrics.py -q

Tracks noetl/noetl#434.