### PR TITLE
Fold command ownership into replay state

### DIFF
--- a/noetl/server/api/replay/service.py
+++ b/noetl/server/api/replay/service.py
@@ -197,6 +197,7 @@ def fold_replay_state(
         state.setdefault("execution", {"status": "UNKNOWN", "last_node_name": None, "payload_refs": []})
         state.setdefault("stages", {})
         state.setdefault("frames", {})
+        state.setdefault("commands", {})
         state.setdefault("loops", {})
     else:
         state = {
@@ -215,6 +216,7 @@ def fold_replay_state(
             },
             "stages": {},
             "frames": {},
+            "commands": {},
             "loops": {},
         }
     if snapshot_seed is not None:
@@ -343,6 +345,64 @@ def fold_replay_state(
                 frame["terminal_event_id"] = event_id
             elif status:
                 frame["status"] = str(status)
+
+        command_id = _command_id(event)
+        if command_id:
+            command = state["commands"].setdefault(
+                command_id,
+                {
+                    "command_id": command_id,
+                    "stage_id": str(_stage_id(event)) if _stage_id(event) is not None else None,
+                    "frame_id": _frame_id(event),
+                    "parent_command_id": None,
+                    "worker_id": None,
+                    "worker_locator": None,
+                    "locality": {},
+                    "source_locality": {},
+                    "placement": {},
+                    "status": "UNKNOWN",
+                    "issued_event_id": None,
+                    "claimed_event_id": None,
+                    "started_event_id": None,
+                    "terminal_event_id": None,
+                    "last_event_id": None,
+                },
+            )
+            command["last_event_id"] = event_id
+            command_stage_id = _stage_id(event)
+            if command_stage_id is not None:
+                command["stage_id"] = str(command_stage_id)
+            command_frame_id = _frame_id(event)
+            if command_frame_id:
+                command["frame_id"] = command_frame_id
+            if meta.get("parent_command_id") is not None:
+                command["parent_command_id"] = str(meta.get("parent_command_id"))
+            worker_id = event.get("worker_id") or meta.get("worker_id")
+            if worker_id is not None:
+                command["worker_id"] = str(worker_id)
+            if meta.get("worker_locator") is not None:
+                command["worker_locator"] = str(meta.get("worker_locator"))
+            if isinstance(meta.get("locality"), Mapping):
+                command["locality"] = dict(meta["locality"])
+            if isinstance(meta.get("source_locality"), Mapping):
+                command["source_locality"] = dict(meta["source_locality"])
+            if isinstance(meta.get("placement"), Mapping):
+                command["placement"] = dict(meta["placement"])
+
+            if event_type == "command.issued":
+                command["status"] = status or "PENDING"
+                command["issued_event_id"] = event_id
+            elif event_type == "command.claimed":
+                command["status"] = status or "CLAIMED"
+                command["claimed_event_id"] = event_id
+            elif event_type == "command.started":
+                command["status"] = status or "RUNNING"
+                command["started_event_id"] = event_id
+            elif event_type in {"command.completed", "command.failed", "command.cancelled"}:
+                command["status"] = status or event_type.removeprefix("command.").upper()
+                command["terminal_event_id"] = event_id
+            elif event_type.startswith("command.") and status:
+                command["status"] = str(status)
 
         loop_id = _loop_id(event)
         if loop_id:

--- a/tests/api/test_replay_routes.py
+++ b/tests/api/test_replay_routes.py
@@ -147,6 +147,74 @@ def test_fold_replay_state_tracks_execution_frames_loops_and_checksum():
     assert len(state["checksum"]) == 64
 
 
+def test_fold_replay_state_tracks_commands_and_topology():
+    from noetl.server.api.replay import fold_replay_state
+
+    state = fold_replay_state(
+        [
+            {
+                "event_id": 11,
+                "event_type": "command.issued",
+                "status": "PENDING",
+                "command_id": 900,
+                "stage_id": 7,
+                "node_name": "fetch",
+                "meta": {"parent_command_id": "899"},
+            },
+            {
+                "event_id": 12,
+                "event_type": "command.claimed",
+                "status": "CLAIMED",
+                "command_id": 900,
+                "stage_id": 7,
+                "worker_id": "worker-a",
+                "meta": {
+                    "worker_id": "worker-a",
+                    "worker_locator": "noetl://tenant/tenant-a/org/org-a/node/node-a/worker/worker-cpu-01",
+                    "locality": {"node_id": "node-a", "worker_pool": "worker-cpu-01"},
+                    "source_locality": {"node_id": "node-a"},
+                    "placement": {
+                        "distance": "node",
+                        "max_distance": "node",
+                        "within_max_distance": True,
+                    },
+                },
+            },
+            {
+                "event_id": 13,
+                "event_type": "command.started",
+                "status": "RUNNING",
+                "command_id": 900,
+                "stage_id": 7,
+            },
+            {
+                "event_id": 14,
+                "event_type": "command.completed",
+                "status": "COMPLETED",
+                "command_id": 900,
+                "stage_id": 7,
+            },
+        ],
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        execution_id=123,
+    )
+
+    command = state["commands"]["900"]
+    assert command["status"] == "COMPLETED"
+    assert command["stage_id"] == "7"
+    assert command["parent_command_id"] == "899"
+    assert command["worker_id"] == "worker-a"
+    assert command["issued_event_id"] == 11
+    assert command["claimed_event_id"] == 12
+    assert command["started_event_id"] == 13
+    assert command["terminal_event_id"] == 14
+    assert command["worker_locator"].endswith("/node/node-a/worker/worker-cpu-01")
+    assert command["locality"] == {"node_id": "node-a", "worker_pool": "worker-cpu-01"}
+    assert command["source_locality"] == {"node_id": "node-a"}
+    assert command["placement"]["within_max_distance"] is True
+
+
 def test_fold_replay_state_can_resume_from_snapshot_seed():
     from noetl.server.api.replay.service import ReplaySnapshotSeed, fold_replay_state
 

--- a/tests/core/test_replay_golden_corpus.py
+++ b/tests/core/test_replay_golden_corpus.py
@@ -26,4 +26,5 @@ def test_golden_replay_corpus_checksum_is_stable():
     assert state["frames"]["100"]["claimed_event_id"] == 3
     assert state["frames"]["100"]["terminal_event_id"] == 5
     assert state["frames"]["100"]["output_ref"]["sha256"] == "golden"
-    assert state["checksum"] == "c2b423fdebfb189911bc7c9d875a98e9d9a9f9227033d80650551682117f32ee"
+    assert state["commands"] == {}
+    assert state["checksum"] == "43f0a7fe649fb361b9ecac5968004afccde11121b211a1750e30f37cad710732"


### PR DESCRIPTION
## Summary
- add a first-class commands projection to deterministic replay state
- fold command issued/claimed/started/terminal events with stage, frame, parent command, worker, locality, worker_locator, source_locality, and placement metadata
- update replay route and golden corpus coverage for the checksum change

## Validation
- .venv/bin/python -m pytest tests/api/test_replay_routes.py tests/core/test_replay_golden_corpus.py -q
- .venv/bin/python -m pytest tests/api/test_command_claim_outbox.py tests/worker/test_worker_claim.py tests/core/test_runtime_topology.py -q

Tracks noetl/noetl#434.