### PR TITLE
Add command replay projection checksum helpers

### DIFF
--- a/noetl/server/api/replay/__init__.py
+++ b/noetl/server/api/replay/__init__.py
@@ -4,9 +4,12 @@ from .endpoint import router
 from .service import (
     ReplayCutoff,
     ReplayService,
+    command_projection_checksum,
     fold_replay_state,
     frame_projection_checksum,
+    normalize_live_command_projection,
     normalize_live_frame_projection,
+    normalize_replayed_command_projection,
     normalize_replayed_frame_projection,
 )
 
@@ -14,8 +17,11 @@ __all__ = [
     "router",
     "ReplayCutoff",
     "ReplayService",
+    "command_projection_checksum",
     "fold_replay_state",
     "frame_projection_checksum",
+    "normalize_live_command_projection",
     "normalize_live_frame_projection",
+    "normalize_replayed_command_projection",
     "normalize_replayed_frame_projection",
 ]

--- a/noetl/server/api/replay/service.py
+++ b/noetl/server/api/replay/service.py
@@ -502,6 +502,67 @@ def frame_projection_checksum(rows: Iterable[Mapping[str, Any]]) -> str:
     return _canonical_checksum({"frames": list(rows)})
 
 
+def _normalized_command_projection_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "command_id": str(row.get("command_id")),
+        "stage_id": str(row.get("stage_id")) if row.get("stage_id") is not None else None,
+        "frame_id": str(row.get("frame_id")) if row.get("frame_id") is not None else None,
+        "parent_command_id": (
+            str(row.get("parent_command_id")) if row.get("parent_command_id") is not None else None
+        ),
+        "worker_id": str(row.get("worker_id")) if row.get("worker_id") is not None else None,
+        "worker_locator": (
+            str(row.get("worker_locator")) if row.get("worker_locator") is not None else None
+        ),
+        "locality": row.get("locality") or {},
+        "source_locality": row.get("source_locality") or {},
+        "placement": row.get("placement") or {},
+        "status": row.get("status"),
+        "issued_event_id": (
+            int(row.get("issued_event_id")) if row.get("issued_event_id") is not None else None
+        ),
+        "claimed_event_id": (
+            int(row.get("claimed_event_id")) if row.get("claimed_event_id") is not None else None
+        ),
+        "started_event_id": (
+            int(row.get("started_event_id")) if row.get("started_event_id") is not None else None
+        ),
+        "terminal_event_id": (
+            int(row.get("terminal_event_id")) if row.get("terminal_event_id") is not None else None
+        ),
+    }
+
+
+def normalize_live_command_projection(rows: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        (_normalized_command_projection_row(row) for row in rows),
+        key=lambda row: int(row["command_id"]),
+    )
+
+
+def normalize_replayed_command_projection(state: Mapping[str, Any]) -> list[dict[str, Any]]:
+    commands = state.get("commands")
+    if not isinstance(commands, Mapping):
+        return []
+    return sorted(
+        (
+            _normalized_command_projection_row(
+                {
+                    "command_id": command.get("command_id") or command_id,
+                    **command,
+                }
+            )
+            for command_id, command in commands.items()
+            if isinstance(command, Mapping)
+        ),
+        key=lambda row: int(row["command_id"]),
+    )
+
+
+def command_projection_checksum(rows: Iterable[Mapping[str, Any]]) -> str:
+    return _canonical_checksum({"commands": list(rows)})
+
+
 class ReplayService:
     """Read canonical events and fold replay state."""
 

--- a/tests/api/test_replay_routes.py
+++ b/tests/api/test_replay_routes.py
@@ -356,3 +356,86 @@ def test_frame_projection_checksum_matches_live_rows_and_replayed_state():
         "media_type": "application/vnd.apache.arrow.stream",
         "ref": "noetl://execution/123/result/frame/abc",
     }
+
+
+def test_command_projection_checksum_matches_live_rows_and_replayed_state():
+    from noetl.server.api.replay import (
+        command_projection_checksum,
+        fold_replay_state,
+        normalize_live_command_projection,
+        normalize_replayed_command_projection,
+    )
+
+    events = [
+        {
+            "event_id": 20,
+            "event_type": "command.issued",
+            "status": "PENDING",
+            "command_id": 900,
+            "stage_id": 7,
+            "frame_id": 42,
+            "meta": {"parent_command_id": "899"},
+        },
+        {
+            "event_id": 21,
+            "event_type": "command.claimed",
+            "status": "CLAIMED",
+            "command_id": 900,
+            "stage_id": 7,
+            "frame_id": 42,
+            "worker_id": "worker-a",
+            "meta": {
+                "worker_id": "worker-a",
+                "worker_locator": "noetl://tenant/tenant-a/org/org-a/node/node-a/worker/worker-cpu-01",
+                "locality": {"node_id": "node-a"},
+                "source_locality": {"node_id": "node-a"},
+                "placement": {
+                    "distance": "node",
+                    "max_distance": "node",
+                    "within_max_distance": True,
+                },
+            },
+        },
+        {
+            "event_id": 22,
+            "event_type": "command.completed",
+            "status": "COMPLETED",
+            "command_id": 900,
+            "stage_id": 7,
+            "frame_id": 42,
+        },
+    ]
+    state = fold_replay_state(
+        events,
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        execution_id=123,
+    )
+    live_rows = normalize_live_command_projection(
+        [
+            {
+                "command_id": 900,
+                "stage_id": 7,
+                "frame_id": 42,
+                "parent_command_id": "899",
+                "worker_id": "worker-a",
+                "worker_locator": "noetl://tenant/tenant-a/org/org-a/node/node-a/worker/worker-cpu-01",
+                "locality": {"node_id": "node-a"},
+                "source_locality": {"node_id": "node-a"},
+                "placement": {
+                    "distance": "node",
+                    "max_distance": "node",
+                    "within_max_distance": True,
+                },
+                "status": "COMPLETED",
+                "issued_event_id": 20,
+                "claimed_event_id": 21,
+                "started_event_id": None,
+                "terminal_event_id": 22,
+            }
+        ]
+    )
+    replayed_rows = normalize_replayed_command_projection(state)
+
+    assert replayed_rows == live_rows
+    assert command_projection_checksum(replayed_rows) == command_projection_checksum(live_rows)


### PR DESCRIPTION
## Summary
- add normalized command projection rows for live-vs-replayed parity checks
- expose command_projection_checksum plus live/replayed command normalizers from the replay package
- cover command projection checksum parity across claim topology metadata

## Validation
- .venv/bin/python -m pytest tests/api/test_replay_routes.py tests/core/test_replay_golden_corpus.py -q
- scripts/check_replay_release_gate.sh

Tracks noetl/noetl#434.