### PR TITLE
Add loop replay projection checksums

### DIFF
--- a/noetl/server/api/replay/__init__.py
+++ b/noetl/server/api/replay/__init__.py
@@ -8,12 +8,15 @@ from .service import (
     command_projection_checksum,
     fold_replay_state,
     frame_projection_checksum,
+    loop_projection_checksum,
     normalize_live_business_object_projection,
     normalize_live_command_projection,
     normalize_live_frame_projection,
+    normalize_live_loop_projection,
     normalize_replayed_business_object_projection,
     normalize_replayed_command_projection,
     normalize_replayed_frame_projection,
+    normalize_replayed_loop_projection,
 )
 
 __all__ = [
@@ -24,10 +27,13 @@ __all__ = [
     "command_projection_checksum",
     "fold_replay_state",
     "frame_projection_checksum",
+    "loop_projection_checksum",
     "normalize_live_business_object_projection",
     "normalize_live_command_projection",
     "normalize_live_frame_projection",
+    "normalize_live_loop_projection",
     "normalize_replayed_business_object_projection",
     "normalize_replayed_command_projection",
     "normalize_replayed_frame_projection",
+    "normalize_replayed_loop_projection",
 ]

--- a/noetl/server/api/replay/service.py
+++ b/noetl/server/api/replay/service.py
@@ -727,6 +727,50 @@ def business_object_projection_checksum(rows: Iterable[Mapping[str, Any]]) -> st
     return _canonical_checksum({"business_objects": list(rows)})
 
 
+def _normalized_loop_projection_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "loop_id": str(row.get("loop_id")),
+        "step_name": row.get("step_name"),
+        "total": int(row.get("total")) if row.get("total") is not None else None,
+        "done": int(row.get("done") or 0),
+        "failed": int(row.get("failed") or 0),
+        "completed": bool(row.get("completed")),
+        "last_event_id": (
+            int(row.get("last_event_id")) if row.get("last_event_id") is not None else None
+        ),
+    }
+
+
+def normalize_live_loop_projection(rows: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        (_normalized_loop_projection_row(row) for row in rows),
+        key=lambda row: row["loop_id"],
+    )
+
+
+def normalize_replayed_loop_projection(state: Mapping[str, Any]) -> list[dict[str, Any]]:
+    loops = state.get("loops")
+    if not isinstance(loops, Mapping):
+        return []
+    return sorted(
+        (
+            _normalized_loop_projection_row(
+                {
+                    "loop_id": loop.get("loop_id") or loop_id,
+                    **loop,
+                }
+            )
+            for loop_id, loop in loops.items()
+            if isinstance(loop, Mapping)
+        ),
+        key=lambda row: row["loop_id"],
+    )
+
+
+def loop_projection_checksum(rows: Iterable[Mapping[str, Any]]) -> str:
+    return _canonical_checksum({"loops": list(rows)})
+
+
 class ReplayService:
     """Read canonical events and fold replay state."""
 

--- a/tests/api/test_replay_routes.py
+++ b/tests/api/test_replay_routes.py
@@ -565,3 +565,62 @@ def test_business_object_projection_checksum_matches_live_rows_and_replayed_stat
 
     assert replayed_rows == live_rows
     assert business_object_projection_checksum(replayed_rows) == business_object_projection_checksum(live_rows)
+
+
+def test_loop_projection_checksum_matches_live_rows_and_replayed_state():
+    from noetl.server.api.replay import (
+        fold_replay_state,
+        loop_projection_checksum,
+        normalize_live_loop_projection,
+        normalize_replayed_loop_projection,
+    )
+
+    events = [
+        {
+            "event_id": 40,
+            "event_type": "stage.opened",
+            "node_name": "fetch_patients",
+            "meta": {"loop_id": "loop-1", "total": 3},
+        },
+        {
+            "event_id": 41,
+            "event_type": "command.completed",
+            "node_name": "fetch_patients",
+            "meta": {"loop_id": "loop-1"},
+        },
+        {
+            "event_id": 42,
+            "event_type": "command.failed",
+            "node_name": "fetch_patients",
+            "meta": {"loop_id": "loop-1"},
+        },
+        {
+            "event_id": 43,
+            "event_type": "loop.done",
+            "node_name": "fetch_patients",
+            "meta": {"loop_id": "loop-1"},
+        },
+    ]
+    state = fold_replay_state(
+        events,
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        execution_id=123,
+    )
+    live_rows = normalize_live_loop_projection(
+        [
+            {
+                "loop_id": "loop-1",
+                "step_name": "fetch_patients",
+                "total": 3,
+                "done": 1,
+                "failed": 1,
+                "completed": True,
+                "last_event_id": 43,
+            }
+        ]
+    )
+    replayed_rows = normalize_replayed_loop_projection(state)
+
+    assert replayed_rows == live_rows
+    assert loop_projection_checksum(replayed_rows) == loop_projection_checksum(live_rows)


### PR DESCRIPTION
## Summary
- add normalized loop projection rows for live-vs-replayed parity checks
- expose loop_projection_checksum plus live/replayed loop normalizers
- cover loop total/done/failed/completed counters and last event linkage

## Validation
- .venv/bin/python -m pytest tests/api/test_replay_routes.py tests/core/test_replay_golden_corpus.py -q
- scripts/check_replay_release_gate.sh

Tracks noetl/noetl#434.