### PR TITLE
Add stage replay projection checksums

### DIFF
--- a/noetl/server/api/replay/__init__.py
+++ b/noetl/server/api/replay/__init__.py
@@ -9,14 +9,17 @@ from .service import (
     fold_replay_state,
     frame_projection_checksum,
     loop_projection_checksum,
+    stage_projection_checksum,
     normalize_live_business_object_projection,
     normalize_live_command_projection,
     normalize_live_frame_projection,
     normalize_live_loop_projection,
+    normalize_live_stage_projection,
     normalize_replayed_business_object_projection,
     normalize_replayed_command_projection,
     normalize_replayed_frame_projection,
     normalize_replayed_loop_projection,
+    normalize_replayed_stage_projection,
 )
 
 __all__ = [
@@ -28,12 +31,15 @@ __all__ = [
     "fold_replay_state",
     "frame_projection_checksum",
     "loop_projection_checksum",
+    "stage_projection_checksum",
     "normalize_live_business_object_projection",
     "normalize_live_command_projection",
     "normalize_live_frame_projection",
     "normalize_live_loop_projection",
+    "normalize_live_stage_projection",
     "normalize_replayed_business_object_projection",
     "normalize_replayed_command_projection",
     "normalize_replayed_frame_projection",
     "normalize_replayed_loop_projection",
+    "normalize_replayed_stage_projection",
 ]

--- a/noetl/server/api/replay/service.py
+++ b/noetl/server/api/replay/service.py
@@ -608,6 +608,64 @@ def frame_projection_checksum(rows: Iterable[Mapping[str, Any]]) -> str:
     return _canonical_checksum({"frames": list(rows)})
 
 
+def _normalized_stage_projection_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "stage_id": str(row.get("stage_id")),
+        "status": row.get("status"),
+        "kind": row.get("kind"),
+        "step_name": row.get("step_name"),
+        "parent_stage_id": (
+            str(row.get("parent_stage_id")) if row.get("parent_stage_id") is not None else None
+        ),
+        "loop_event_id": (
+            str(row.get("loop_event_id")) if row.get("loop_event_id") is not None else None
+        ),
+        "opened_event_id": (
+            int(row.get("opened_event_id")) if row.get("opened_event_id") is not None else None
+        ),
+        "closed_event_id": (
+            int(row.get("closed_event_id")) if row.get("closed_event_id") is not None else None
+        ),
+        "frame_count": int(row.get("frame_count") or 0),
+        "row_count": int(row.get("row_count") or 0),
+        "events_emitted": int(row.get("events_emitted") or 0),
+        "failed_count": int(row.get("failed_count") or 0),
+        "last_event_id": (
+            int(row.get("last_event_id")) if row.get("last_event_id") is not None else None
+        ),
+    }
+
+
+def normalize_live_stage_projection(rows: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        (_normalized_stage_projection_row(row) for row in rows),
+        key=lambda row: int(row["stage_id"]),
+    )
+
+
+def normalize_replayed_stage_projection(state: Mapping[str, Any]) -> list[dict[str, Any]]:
+    stages = state.get("stages")
+    if not isinstance(stages, Mapping):
+        return []
+    return sorted(
+        (
+            _normalized_stage_projection_row(
+                {
+                    "stage_id": stage.get("stage_id") or stage_id,
+                    **stage,
+                }
+            )
+            for stage_id, stage in stages.items()
+            if isinstance(stage, Mapping)
+        ),
+        key=lambda row: int(row["stage_id"]),
+    )
+
+
+def stage_projection_checksum(rows: Iterable[Mapping[str, Any]]) -> str:
+    return _canonical_checksum({"stages": list(rows)})
+
+
 def _normalized_command_projection_row(row: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "command_id": str(row.get("command_id")),

--- a/tests/api/test_replay_routes.py
+++ b/tests/api/test_replay_routes.py
@@ -415,6 +415,74 @@ def test_frame_projection_checksum_matches_live_rows_and_replayed_state():
     }
 
 
+def test_stage_projection_checksum_matches_live_rows_and_replayed_state():
+    from noetl.server.api.replay import (
+        fold_replay_state,
+        normalize_live_stage_projection,
+        normalize_replayed_stage_projection,
+        stage_projection_checksum,
+    )
+
+    events = [
+        {
+            "event_id": 60,
+            "event_type": "stage.opened",
+            "aggregate_type": "stage",
+            "aggregate_id": "stage/7",
+            "status": "OPEN",
+            "node_name": "fetch_patients",
+            "meta": {
+                "kind": "loop",
+                "parent_stage_id": "6",
+                "loop_event_id": "loop-1",
+            },
+        },
+        {
+            "event_id": 61,
+            "event_type": "stage.closed",
+            "aggregate_type": "stage",
+            "aggregate_id": "stage/7",
+            "status": "COMPLETED",
+            "node_name": "fetch_patients",
+            "meta": {
+                "frame_count": 3,
+                "row_count": 150,
+                "events_emitted": 6,
+                "failed_count": 1,
+            },
+        },
+    ]
+    state = fold_replay_state(
+        events,
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        execution_id=123,
+    )
+    live_rows = normalize_live_stage_projection(
+        [
+            {
+                "stage_id": 7,
+                "status": "COMPLETED",
+                "kind": "loop",
+                "step_name": "fetch_patients",
+                "parent_stage_id": "6",
+                "loop_event_id": "loop-1",
+                "opened_event_id": 60,
+                "closed_event_id": 61,
+                "frame_count": 3,
+                "row_count": 150,
+                "events_emitted": 6,
+                "failed_count": 1,
+                "last_event_id": 61,
+            }
+        ]
+    )
+    replayed_rows = normalize_replayed_stage_projection(state)
+
+    assert replayed_rows == live_rows
+    assert stage_projection_checksum(replayed_rows) == stage_projection_checksum(live_rows)
+
+
 def test_command_projection_checksum_matches_live_rows_and_replayed_state():
     from noetl.server.api.replay import (
         command_projection_checksum,


### PR DESCRIPTION
## Summary
- add normalized stage projection rows for live-vs-replayed parity checks
- expose stage_projection_checksum plus live/replayed stage normalizers
- cover stage status, kind, parent/loop linkage, open/close event ids, frame/row/emitted/failed counters, and last event linkage

## Validation
- .venv/bin/python -m pytest tests/api/test_replay_routes.py tests/core/test_replay_golden_corpus.py -q
- scripts/check_replay_release_gate.sh

Tracks noetl/noetl#434.