### PR TITLE
Add replay projection checksum bundle

### DIFF
--- a/noetl/core/projector/service.py
+++ b/noetl/core/projector/service.py
@@ -71,6 +71,7 @@ class ReplayStateProjector:
                     "projection_lag_ms": _projection_lag_ms(event_watermark, projected_at),
                     "projector": "replay_state",
                     "projection": self.projection,
+                    "projection_checksums": state.get("projection_checksums"),
                     "source_event_id": source_event_id,
                     "upcaster_registry_digest": state.get("upcaster_registry_digest"),
                 },

--- a/noetl/server/api/replay/__init__.py
+++ b/noetl/server/api/replay/__init__.py
@@ -11,6 +11,7 @@ from .service import (
     frame_projection_checksum,
     loop_projection_checksum,
     stage_projection_checksum,
+    live_projection_checksum_bundle,
     normalize_live_business_object_projection,
     normalize_live_command_projection,
     normalize_live_execution_projection,
@@ -23,6 +24,8 @@ from .service import (
     normalize_replayed_frame_projection,
     normalize_replayed_loop_projection,
     normalize_replayed_stage_projection,
+    replay_projection_checksum_bundle,
+    projection_checksum_parity_report,
 )
 
 __all__ = [
@@ -36,6 +39,7 @@ __all__ = [
     "frame_projection_checksum",
     "loop_projection_checksum",
     "stage_projection_checksum",
+    "live_projection_checksum_bundle",
     "normalize_live_business_object_projection",
     "normalize_live_command_projection",
     "normalize_live_execution_projection",
@@ -48,4 +52,6 @@ __all__ = [
     "normalize_replayed_frame_projection",
     "normalize_replayed_loop_projection",
     "normalize_replayed_stage_projection",
+    "replay_projection_checksum_bundle",
+    "projection_checksum_parity_report",
 ]

--- a/noetl/server/api/replay/service.py
+++ b/noetl/server/api/replay/service.py
@@ -19,6 +19,15 @@ from psycopg.rows import dict_row
 from noetl.core.db.pool import get_pool_connection
 from noetl.core.replay import default_upcaster_registry
 
+PROJECTION_CHECKSUM_SURFACES = (
+    "execution",
+    "stages",
+    "frames",
+    "commands",
+    "business_objects",
+    "loops",
+)
+
 
 @dataclass(frozen=True)
 class ReplayCutoff:
@@ -236,6 +245,7 @@ def fold_replay_state(
         state = copy.deepcopy(dict(base_state))
         state.pop("checksum", None)
         state.pop("checksum_algorithm", None)
+        state.pop("projection_checksums", None)
         state["tenant_id"] = tenant_id
         state["organization_id"] = organization_id
         state["execution_id"] = execution_id
@@ -539,6 +549,7 @@ def fold_replay_state(
     }
     state["checksum_algorithm"] = "sha256"
     state["checksum"] = _canonical_checksum(checksum_input)
+    state["projection_checksums"] = replay_projection_checksum_bundle(state)
     return state
 
 
@@ -877,6 +888,87 @@ def normalize_replayed_execution_projection(state: Mapping[str, Any]) -> list[di
 
 def execution_projection_checksum(rows: Iterable[Mapping[str, Any]]) -> str:
     return _canonical_checksum({"executions": list(rows)})
+
+
+def replay_projection_checksum_bundle(state: Mapping[str, Any]) -> dict[str, str]:
+    """Return deterministic checksums for every replay parity surface."""
+    return {
+        "execution": execution_projection_checksum(
+            normalize_replayed_execution_projection(state)
+        ),
+        "stages": stage_projection_checksum(
+            normalize_replayed_stage_projection(state)
+        ),
+        "frames": frame_projection_checksum(
+            normalize_replayed_frame_projection(state)
+        ),
+        "commands": command_projection_checksum(
+            normalize_replayed_command_projection(state)
+        ),
+        "business_objects": business_object_projection_checksum(
+            normalize_replayed_business_object_projection(state)
+        ),
+        "loops": loop_projection_checksum(
+            normalize_replayed_loop_projection(state)
+        ),
+    }
+
+
+def live_projection_checksum_bundle(
+    *,
+    execution_rows: Iterable[Mapping[str, Any]] | None = None,
+    stage_rows: Iterable[Mapping[str, Any]] | None = None,
+    frame_rows: Iterable[Mapping[str, Any]] | None = None,
+    command_rows: Iterable[Mapping[str, Any]] | None = None,
+    business_object_rows: Iterable[Mapping[str, Any]] | None = None,
+    loop_rows: Iterable[Mapping[str, Any]] | None = None,
+) -> dict[str, str]:
+    """Return deterministic checksums for live projection rows from any storage adapter."""
+    return {
+        "execution": execution_projection_checksum(
+            normalize_live_execution_projection(execution_rows or [])
+        ),
+        "stages": stage_projection_checksum(
+            normalize_live_stage_projection(stage_rows or [])
+        ),
+        "frames": frame_projection_checksum(
+            normalize_live_frame_projection(frame_rows or [])
+        ),
+        "commands": command_projection_checksum(
+            normalize_live_command_projection(command_rows or [])
+        ),
+        "business_objects": business_object_projection_checksum(
+            normalize_live_business_object_projection(business_object_rows or [])
+        ),
+        "loops": loop_projection_checksum(
+            normalize_live_loop_projection(loop_rows or [])
+        ),
+    }
+
+
+def projection_checksum_parity_report(
+    *,
+    replayed: Mapping[str, str],
+    live: Mapping[str, str],
+) -> dict[str, Any]:
+    """Compare replayed and live projection checksum bundles without storage assumptions."""
+    surfaces: dict[str, dict[str, Any]] = {}
+    for surface in PROJECTION_CHECKSUM_SURFACES:
+        replayed_checksum = replayed.get(surface)
+        live_checksum = live.get(surface)
+        surfaces[surface] = {
+            "replayed": replayed_checksum,
+            "live": live_checksum,
+            "matched": (
+                replayed_checksum is not None
+                and live_checksum is not None
+                and replayed_checksum == live_checksum
+            ),
+        }
+    return {
+        "matched": all(surface["matched"] for surface in surfaces.values()),
+        "surfaces": surfaces,
+    }
 
 
 class ReplayService:

--- a/scripts/check_replay_parity_report.py
+++ b/scripts/check_replay_parity_report.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""Compare replayed and live projection checksum bundle JSON files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from noetl.server.api.replay import projection_checksum_parity_report
+
+
+def _load_bundle(path: Path) -> dict[str, str]:
+    data: Any = json.loads(path.read_text())
+    if isinstance(data, dict) and isinstance(data.get("projection_checksums"), dict):
+        data = data["projection_checksums"]
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a checksum object")
+    return {str(key): str(value) for key, value in data.items()}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare replayed and live NoETL projection checksum bundles",
+    )
+    parser.add_argument(
+        "--replayed",
+        required=True,
+        type=Path,
+        help="JSON file containing replayed projection_checksums or a raw checksum map",
+    )
+    parser.add_argument(
+        "--live",
+        required=True,
+        type=Path,
+        help="JSON file containing live projection_checksums or a raw checksum map",
+    )
+    args = parser.parse_args(argv)
+
+    report = projection_checksum_parity_report(
+        replayed=_load_bundle(args.replayed),
+        live=_load_bundle(args.live),
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["matched"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -11,6 +11,7 @@ fi
 
 "$PYTHON_BIN" -m pytest -q \
   tests/core/test_replay_golden_corpus.py \
+  tests/scripts/test_check_replay_parity_report.py \
   tests/api/test_replay_routes.py \
   tests/core/test_replay_upcasters.py \
   tests/core/test_replay_state_projector.py \

--- a/tests/api/test_replay_routes.py
+++ b/tests/api/test_replay_routes.py
@@ -145,6 +145,15 @@ def test_fold_replay_state_tracks_execution_frames_loops_and_checksum():
     assert state["upcaster_registry_digest"] == "abc123"
     assert state["checksum_algorithm"] == "sha256"
     assert len(state["checksum"]) == 64
+    assert set(state["projection_checksums"]) == {
+        "execution",
+        "stages",
+        "frames",
+        "commands",
+        "business_objects",
+        "loops",
+    }
+    assert all(len(checksum) == 64 for checksum in state["projection_checksums"].values())
 
 
 def test_fold_replay_state_tracks_commands_and_topology():
@@ -756,3 +765,169 @@ def test_execution_projection_checksum_matches_live_rows_and_replayed_state():
 
     assert replayed_rows == live_rows
     assert execution_projection_checksum(replayed_rows) == execution_projection_checksum(live_rows)
+
+
+def test_replay_projection_checksum_bundle_includes_all_surfaces():
+    from noetl.server.api.replay import (
+        business_object_projection_checksum,
+        command_projection_checksum,
+        execution_projection_checksum,
+        fold_replay_state,
+        frame_projection_checksum,
+        loop_projection_checksum,
+        normalize_replayed_business_object_projection,
+        normalize_replayed_command_projection,
+        normalize_replayed_execution_projection,
+        normalize_replayed_frame_projection,
+        normalize_replayed_loop_projection,
+        normalize_replayed_stage_projection,
+        replay_projection_checksum_bundle,
+        stage_projection_checksum,
+    )
+
+    state = fold_replay_state(
+        [
+            {"event_id": 1, "event_type": "execution.started", "status": "RUNNING"},
+            {
+                "event_id": 2,
+                "event_type": "stage.opened",
+                "aggregate_type": "stage",
+                "aggregate_id": "stage/7",
+                "status": "OPEN",
+                "node_name": "stage",
+            },
+            {
+                "event_id": 3,
+                "event_type": "frame.dispatched",
+                "aggregate_type": "frame",
+                "aggregate_id": "frame/9",
+                "stage_id": 7,
+                "command_id": 11,
+            },
+            {
+                "event_id": 4,
+                "event_type": "command.claimed",
+                "command_id": 11,
+                "stage_id": 7,
+                "worker_id": "worker-a",
+            },
+            {
+                "event_id": 5,
+                "event_type": "patient.created",
+                "aggregate_type": "business_object",
+                "aggregate_id": "patient/p-1",
+                "meta": {"business_object": {"state": {"risk": "low"}}},
+            },
+            {
+                "event_id": 6,
+                "event_type": "loop.done",
+                "node_name": "stage",
+                "meta": {"loop_id": "loop-1"},
+            },
+        ],
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        execution_id=123,
+    )
+
+    assert replay_projection_checksum_bundle(state) == {
+        "execution": execution_projection_checksum(
+            normalize_replayed_execution_projection(state)
+        ),
+        "stages": stage_projection_checksum(normalize_replayed_stage_projection(state)),
+        "frames": frame_projection_checksum(normalize_replayed_frame_projection(state)),
+        "commands": command_projection_checksum(
+            normalize_replayed_command_projection(state)
+        ),
+        "business_objects": business_object_projection_checksum(
+            normalize_replayed_business_object_projection(state)
+        ),
+        "loops": loop_projection_checksum(normalize_replayed_loop_projection(state)),
+    }
+
+
+def test_projection_checksum_parity_report_compares_adapter_bundles():
+    from noetl.server.api.replay import (
+        fold_replay_state,
+        live_projection_checksum_bundle,
+        normalize_replayed_business_object_projection,
+        normalize_replayed_command_projection,
+        normalize_replayed_execution_projection,
+        normalize_replayed_frame_projection,
+        normalize_replayed_loop_projection,
+        normalize_replayed_stage_projection,
+        projection_checksum_parity_report,
+    )
+
+    state = fold_replay_state(
+        [
+            {"event_id": 1, "event_type": "execution.started", "status": "RUNNING"},
+            {
+                "event_id": 2,
+                "event_type": "stage.opened",
+                "aggregate_type": "stage",
+                "aggregate_id": "stage/7",
+                "status": "OPEN",
+                "node_name": "stage",
+            },
+            {
+                "event_id": 3,
+                "event_type": "frame.dispatched",
+                "aggregate_type": "frame",
+                "aggregate_id": "frame/9",
+                "stage_id": 7,
+                "command_id": 11,
+            },
+            {
+                "event_id": 4,
+                "event_type": "command.claimed",
+                "command_id": 11,
+                "stage_id": 7,
+                "worker_id": "worker-a",
+            },
+            {
+                "event_id": 5,
+                "event_type": "patient.created",
+                "aggregate_type": "business_object",
+                "aggregate_id": "patient/p-1",
+                "meta": {"business_object": {"state": {"risk": "low"}}},
+            },
+            {
+                "event_id": 6,
+                "event_type": "loop.done",
+                "node_name": "stage",
+                "meta": {"loop_id": "loop-1"},
+            },
+        ],
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        execution_id=123,
+    )
+    live_bundle = live_projection_checksum_bundle(
+        execution_rows=normalize_replayed_execution_projection(state),
+        stage_rows=normalize_replayed_stage_projection(state),
+        frame_rows=normalize_replayed_frame_projection(state),
+        command_rows=normalize_replayed_command_projection(state),
+        business_object_rows=normalize_replayed_business_object_projection(state),
+        loop_rows=normalize_replayed_loop_projection(state),
+    )
+
+    report = projection_checksum_parity_report(
+        replayed=state["projection_checksums"],
+        live=live_bundle,
+    )
+
+    assert report["matched"] is True
+    assert all(surface["matched"] for surface in report["surfaces"].values())
+
+    diverged_live_bundle = {**live_bundle, "frames": "0" * 64}
+    diverged_report = projection_checksum_parity_report(
+        replayed=state["projection_checksums"],
+        live=diverged_live_bundle,
+    )
+    assert diverged_report["matched"] is False
+    assert diverged_report["surfaces"]["frames"] == {
+        "replayed": state["projection_checksums"]["frames"],
+        "live": "0" * 64,
+        "matched": False,
+    }

--- a/tests/core/test_replay_golden_corpus.py
+++ b/tests/core/test_replay_golden_corpus.py
@@ -4,7 +4,10 @@ from pathlib import Path
 
 def test_golden_replay_corpus_checksum_is_stable():
     from noetl.core.replay import default_upcaster_registry
-    from noetl.server.api.replay import fold_replay_state
+    from noetl.server.api.replay import (
+        fold_replay_state,
+        replay_projection_checksum_bundle,
+    )
 
     events = json.loads(
         Path("tests/fixtures/replay/golden_execution_events.json").read_text()
@@ -29,3 +32,12 @@ def test_golden_replay_corpus_checksum_is_stable():
     assert state["commands"] == {}
     assert state["business_objects"] == {}
     assert state["checksum"] == "af23cf75931cf94a536184f58301592a2ee227cc52dadead2bf051cb100b85fb"
+    assert state["projection_checksums"] == {
+        "business_objects": "ebbff5b72abdea9d0b0d43ec2d3886826f04b313f48535e210120869c16d1a13",
+        "commands": "a9c3a7631d2a488d1a25c667c554f206b08ddd4ed9f3f6b3c9a4bec2e7f3bd84",
+        "execution": "8b15e0b97eb3ee60e69d01229f250aa5347ca3322c7258586f4900d01c62c6f8",
+        "frames": "2ee5a2db92349c9546b04ad39ccbe52351f37e0de5b56532e7ebfb617ef645ec",
+        "loops": "68c1d1020e5737344e10a59610494db939837977ba662211649a238d5d30561b",
+        "stages": "8a97fc5a5d69672bc627c064c8c672b49814c6e64ace3096fe4f2fe144ad0cdc",
+    }
+    assert replay_projection_checksum_bundle(state) == state["projection_checksums"]

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -81,8 +81,17 @@ async def test_replay_state_projector_writes_grouped_projection_records():
     assert first.version == 2
     assert first.source_event_id == 10
     assert first.state["frames"]["1"]["status"] == "COMPLETED"
+    assert set(first.state["projection_checksums"]) == {
+        "execution",
+        "stages",
+        "frames",
+        "commands",
+        "business_objects",
+        "loops",
+    }
     assert first.checksum == first.state["checksum"]
     assert first.meta["projector"] == "replay_state"
+    assert first.meta["projection_checksums"] == first.state["projection_checksums"]
     assert first.meta["source_event_id"] == 10
 
 

--- a/tests/scripts/test_check_replay_parity_report.py
+++ b/tests/scripts/test_check_replay_parity_report.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+from scripts.check_replay_parity_report import main
+
+
+def test_check_replay_parity_report_accepts_matching_raw_bundles(tmp_path: Path, capsys):
+    bundle = {
+        "execution": "a" * 64,
+        "stages": "b" * 64,
+        "frames": "c" * 64,
+        "commands": "d" * 64,
+        "business_objects": "e" * 64,
+        "loops": "f" * 64,
+    }
+    replayed_path = tmp_path / "replayed.json"
+    live_path = tmp_path / "live.json"
+    replayed_path.write_text(json.dumps(bundle))
+    live_path.write_text(json.dumps(bundle))
+
+    assert main(["--replayed", str(replayed_path), "--live", str(live_path)]) == 0
+    assert json.loads(capsys.readouterr().out)["matched"] is True
+
+
+def test_check_replay_parity_report_rejects_diverged_nested_bundles(tmp_path: Path, capsys):
+    replayed = {
+        "projection_checksums": {
+            "execution": "a" * 64,
+            "stages": "b" * 64,
+            "frames": "c" * 64,
+            "commands": "d" * 64,
+            "business_objects": "e" * 64,
+            "loops": "f" * 64,
+        }
+    }
+    live = {
+        "projection_checksums": {
+            **replayed["projection_checksums"],
+            "frames": "0" * 64,
+        }
+    }
+    replayed_path = tmp_path / "replayed.json"
+    live_path = tmp_path / "live.json"
+    replayed_path.write_text(json.dumps(replayed))
+    live_path.write_text(json.dumps(live))
+
+    assert main(["--replayed", str(replayed_path), "--live", str(live_path)]) == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["matched"] is False
+    assert report["surfaces"]["frames"]["matched"] is False


### PR DESCRIPTION
## Summary
- add `replay_projection_checksum_bundle(state)` as a stable aggregate checksum for execution, stages, frames, commands, business objects, and loops
- return the aggregate as `projection_checksums` from replay state responses so operators and release gates get one named parity artifact
- store the same bundle in replay-state projector metadata for cheap projection/checkpoint inspection
- add `live_projection_checksum_bundle(...)` and `projection_checksum_parity_report(...)` so future storage adapters can compare live vs replayed projections without Postgres-specific routines
- add `scripts/check_replay_parity_report.py`, an offline JSON bundle comparator for CI/GKE validation
- export the helpers from `noetl.server.api.replay`
- cover the bundle, parity report, projector metadata, and offline comparator in tests, including deliberate diverged frame checksums
- pin the aggregate bundle in the golden replay corpus so the release gate fails on replay-surface drift

## Validation
- `.venv/bin/python -m pytest tests/core/test_replay_state_projector.py tests/scripts/test_check_replay_parity_report.py tests/api/test_replay_routes.py tests/core/test_replay_golden_corpus.py -q`
- `scripts/check_replay_release_gate.sh`

Tracks noetl/noetl#434