### PR TITLE
Introduce replay event reader port

### DIFF
--- a/noetl/server/api/replay/__init__.py
+++ b/noetl/server/api/replay/__init__.py
@@ -1,6 +1,7 @@
 """Replay API for deterministic event-sourced state reconstruction."""
 
 from .endpoint import router
+from .event_reader import PostgresReplayEventReader, ReplayEventReader
 from .service import (
     ReplayCutoff,
     ReplayService,
@@ -30,6 +31,8 @@ from .service import (
 
 __all__ = [
     "router",
+    "PostgresReplayEventReader",
+    "ReplayEventReader",
     "ReplayCutoff",
     "ReplayService",
     "business_object_projection_checksum",

--- a/noetl/server/api/replay/event_reader.py
+++ b/noetl/server/api/replay/event_reader.py
@@ -1,0 +1,204 @@
+"""Replay event-reader ports and reference storage adapter."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional, Protocol
+
+from psycopg.rows import dict_row
+
+from noetl.core.db.pool import get_pool_connection
+
+from .types import ReplayCutoff, ReplaySnapshotSeed
+
+ENVELOPE_COLUMNS = (
+    "tenant_id",
+    "organization_id",
+    "stream_id",
+    "stream_version",
+    "aggregate_id",
+    "aggregate_type",
+    "schema_name",
+    "schema_version",
+    "event_time",
+    "ingest_time",
+    "producer",
+    "causation_id",
+    "correlation_id",
+    "idempotency_key",
+    "payload_ref",
+    "stage_id",
+    "frame_id",
+    "command_id",
+    "envelope_checksum",
+)
+
+
+class ReplayEventReader(Protocol):
+    """Storage-neutral read port for canonical replay inputs."""
+
+    async def load_events(
+        self,
+        *,
+        tenant_id: str,
+        organization_id: str,
+        execution_id: int,
+        cutoff: ReplayCutoff,
+        limit: int,
+        after_event_id: Optional[int] = None,
+    ) -> list[dict[str, Any]]:
+        """Load canonical events in replay order."""
+
+    async def load_snapshot_seed(
+        self,
+        *,
+        tenant_id: str,
+        organization_id: str,
+        execution_id: int,
+        projection: str,
+        cutoff: ReplayCutoff,
+    ) -> Optional[ReplaySnapshotSeed]:
+        """Load the latest safe replay snapshot seed, when available."""
+
+
+class PostgresReplayEventReader:
+    """Postgres-backed reference adapter for replay input reads."""
+
+    @staticmethod
+    async def _event_columns(conn: Any) -> set[str]:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_schema = 'noetl'
+                  AND table_name = 'event'
+                """
+            )
+            rows = await cur.fetchall()
+        return {
+            str(row["column_name"] if isinstance(row, Mapping) else row[0])
+            for row in rows
+        }
+
+    async def load_events(
+        self,
+        *,
+        tenant_id: str,
+        organization_id: str,
+        execution_id: int,
+        cutoff: ReplayCutoff,
+        limit: int,
+        after_event_id: Optional[int] = None,
+    ) -> list[dict[str, Any]]:
+        async with get_pool_connection() as conn:
+            columns = await self._event_columns(conn)
+            predicates = ["execution_id = %s"]
+            params: list[Any] = [execution_id]
+            if "tenant_id" in columns:
+                predicates.append("tenant_id = %s")
+                params.append(tenant_id)
+            elif tenant_id != "default":
+                return []
+            if "organization_id" in columns:
+                predicates.append("organization_id = %s")
+                params.append(organization_id)
+            elif organization_id != "default":
+                return []
+
+            cutoff_event_id = cutoff.as_of_event_id or cutoff.as_of_position
+            if after_event_id is not None:
+                predicates.append("event_id > %s")
+                params.append(int(after_event_id))
+            if cutoff_event_id is not None:
+                predicates.append("event_id <= %s")
+                params.append(int(cutoff_event_id))
+            if cutoff.as_of_time is not None:
+                time_column = "event_time" if "event_time" in columns else "created_at"
+                predicates.append(f"{time_column} <= %s")
+                params.append(cutoff.as_of_time)
+            params.append(limit)
+
+            select_columns = [
+                "event_id",
+                "event_type",
+                "status",
+                "node_name",
+                "result",
+                "meta",
+            ]
+            select_columns.extend(column for column in ENVELOPE_COLUMNS if column in columns)
+
+            query = f"""
+                SELECT {', '.join(select_columns)}
+                FROM noetl.event
+                WHERE {' AND '.join(predicates)}
+                ORDER BY event_id ASC
+                LIMIT %s
+            """
+
+            async with conn.cursor(row_factory=dict_row) as cur:
+                await cur.execute(query, params)
+                rows = await cur.fetchall()
+
+        events = [dict(row) for row in rows]
+        for event in events:
+            event.setdefault("tenant_id", tenant_id)
+            event.setdefault("organization_id", organization_id)
+            for column in ENVELOPE_COLUMNS:
+                event.setdefault(column, None)
+        return events
+
+    async def load_snapshot_seed(
+        self,
+        *,
+        tenant_id: str,
+        organization_id: str,
+        execution_id: int,
+        projection: str,
+        cutoff: ReplayCutoff,
+    ) -> Optional[ReplaySnapshotSeed]:
+        cutoff_event_id = cutoff.as_of_event_id or cutoff.as_of_position
+        if cutoff.as_of_time is not None:
+            return None
+
+        aggregate_id = f"execution/{execution_id}/{projection}"
+        aggregate_type = "replay_state"
+        predicates = [
+            "tenant_id = %s",
+            "organization_id = %s",
+            "aggregate_type = %s",
+            "aggregate_id = %s",
+        ]
+        params: list[Any] = [tenant_id, organization_id, aggregate_type, aggregate_id]
+        if cutoff_event_id is not None:
+            predicates.append("version <= %s")
+            params.append(int(cutoff_event_id))
+
+        try:
+            async with get_pool_connection() as conn:
+                async with conn.cursor(row_factory=dict_row) as cur:
+                    await cur.execute(
+                        f"""
+                        SELECT aggregate_id, aggregate_type, version, snapshot, checksum, meta
+                        FROM noetl.projection_snapshot
+                        WHERE {' AND '.join(predicates)}
+                        ORDER BY version DESC
+                        LIMIT 1
+                        """,
+                        params,
+                    )
+                    row = await cur.fetchone()
+        except Exception:
+            return None
+        if not row:
+            return None
+        snapshot = row["snapshot"] if isinstance(row["snapshot"], dict) else {}
+        meta = row["meta"] if isinstance(row["meta"], dict) else {}
+        return ReplaySnapshotSeed(
+            aggregate_id=str(row["aggregate_id"]),
+            aggregate_type=str(row["aggregate_type"]),
+            version=int(row["version"]),
+            checksum=str(row["checksum"]),
+            state=snapshot,
+            meta=meta,
+        )

--- a/noetl/server/api/replay/service.py
+++ b/noetl/server/api/replay/service.py
@@ -10,14 +10,13 @@ from __future__ import annotations
 import hashlib
 import json
 import copy
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping, Optional
 
-from psycopg.rows import dict_row
-
-from noetl.core.db.pool import get_pool_connection
 from noetl.core.replay import default_upcaster_registry
+
+from .event_reader import PostgresReplayEventReader, ReplayEventReader
+from .types import ReplayCutoff, ReplaySnapshotSeed
 
 PROJECTION_CHECKSUM_SURFACES = (
     "execution",
@@ -27,27 +26,6 @@ PROJECTION_CHECKSUM_SURFACES = (
     "business_objects",
     "loops",
 )
-
-
-@dataclass(frozen=True)
-class ReplayCutoff:
-    """Replay cutoff. Exactly one field is normally set."""
-
-    as_of_event_id: Optional[int] = None
-    as_of_position: Optional[int] = None
-    as_of_time: Optional[datetime] = None
-
-
-@dataclass(frozen=True)
-class ReplaySnapshotSeed:
-    """Snapshot state used as replay seed."""
-
-    aggregate_id: str
-    aggregate_type: str
-    version: int
-    checksum: str
-    state: dict[str, Any]
-    meta: dict[str, Any]
 
 
 def _json_default(value: Any) -> str:
@@ -974,25 +952,15 @@ def projection_checksum_parity_report(
 class ReplayService:
     """Read canonical events and fold replay state."""
 
-    @staticmethod
-    async def _event_columns(conn: Any) -> set[str]:
-        async with conn.cursor() as cur:
-            await cur.execute(
-                """
-                SELECT column_name
-                FROM information_schema.columns
-                WHERE table_schema = 'noetl'
-                  AND table_name = 'event'
-                """
-            )
-            rows = await cur.fetchall()
-        return {
-            str(row["column_name"] if isinstance(row, Mapping) else row[0])
-            for row in rows
-        }
+    event_reader: ReplayEventReader = PostgresReplayEventReader()
 
-    @staticmethod
+    @classmethod
+    def configure_event_reader(cls, event_reader: ReplayEventReader) -> None:
+        cls.event_reader = event_reader
+
+    @classmethod
     async def load_events(
+        cls,
         *,
         tenant_id: str,
         organization_id: str,
@@ -1001,88 +969,18 @@ class ReplayService:
         limit: int,
         after_event_id: Optional[int] = None,
     ) -> list[dict[str, Any]]:
-        async with get_pool_connection() as conn:
-            columns = await ReplayService._event_columns(conn)
-            envelope_columns = (
-                "tenant_id",
-                "organization_id",
-                "stream_id",
-                "stream_version",
-                "aggregate_id",
-                "aggregate_type",
-                "schema_name",
-                "schema_version",
-                "event_time",
-                "ingest_time",
-                "producer",
-                "causation_id",
-                "correlation_id",
-                "idempotency_key",
-                "payload_ref",
-                "stage_id",
-                "frame_id",
-                "command_id",
-                "envelope_checksum",
-            )
+        return await cls.event_reader.load_events(
+            tenant_id=tenant_id,
+            organization_id=organization_id,
+            execution_id=execution_id,
+            cutoff=cutoff,
+            limit=limit,
+            after_event_id=after_event_id,
+        )
 
-            predicates = ["execution_id = %s"]
-            params: list[Any] = [execution_id]
-            if "tenant_id" in columns:
-                predicates.append("tenant_id = %s")
-                params.append(tenant_id)
-            elif tenant_id != "default":
-                return []
-            if "organization_id" in columns:
-                predicates.append("organization_id = %s")
-                params.append(organization_id)
-            elif organization_id != "default":
-                return []
-
-            cutoff_event_id = cutoff.as_of_event_id or cutoff.as_of_position
-            if after_event_id is not None:
-                predicates.append("event_id > %s")
-                params.append(int(after_event_id))
-            if cutoff_event_id is not None:
-                predicates.append("event_id <= %s")
-                params.append(int(cutoff_event_id))
-            if cutoff.as_of_time is not None:
-                time_column = "event_time" if "event_time" in columns else "created_at"
-                predicates.append(f"{time_column} <= %s")
-                params.append(cutoff.as_of_time)
-            params.append(limit)
-
-            select_columns = [
-                "event_id",
-                "event_type",
-                "status",
-                "node_name",
-                "result",
-                "meta",
-            ]
-            select_columns.extend(column for column in envelope_columns if column in columns)
-
-            query = f"""
-                SELECT {', '.join(select_columns)}
-                FROM noetl.event
-                WHERE {' AND '.join(predicates)}
-                ORDER BY event_id ASC
-                LIMIT %s
-            """
-
-            async with conn.cursor(row_factory=dict_row) as cur:
-                await cur.execute(query, params)
-                rows = await cur.fetchall()
-
-        events = [dict(row) for row in rows]
-        for event in events:
-            event.setdefault("tenant_id", tenant_id)
-            event.setdefault("organization_id", organization_id)
-            for column in envelope_columns:
-                event.setdefault(column, None)
-        return events
-
-    @staticmethod
+    @classmethod
     async def load_snapshot_seed(
+        cls,
         *,
         tenant_id: str,
         organization_id: str,
@@ -1090,57 +988,17 @@ class ReplayService:
         projection: str,
         cutoff: ReplayCutoff,
     ) -> Optional[ReplaySnapshotSeed]:
-        # Event-id/position snapshots are safe because projection_snapshot.version
-        # records an event position. Time-based snapshot selection needs a separate
-        # event-time index and remains a later release gate.
-        cutoff_event_id = cutoff.as_of_event_id or cutoff.as_of_position
-        if cutoff.as_of_time is not None:
-            return None
-
-        aggregate_id = f"execution/{execution_id}/{projection}"
-        aggregate_type = "replay_state"
-        predicates = [
-            "tenant_id = %s",
-            "organization_id = %s",
-            "aggregate_type = %s",
-            "aggregate_id = %s",
-        ]
-        params: list[Any] = [tenant_id, organization_id, aggregate_type, aggregate_id]
-        if cutoff_event_id is not None:
-            predicates.append("version <= %s")
-            params.append(int(cutoff_event_id))
-
-        try:
-            async with get_pool_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    await cur.execute(
-                        f"""
-                        SELECT aggregate_id, aggregate_type, version, snapshot, checksum, meta
-                        FROM noetl.projection_snapshot
-                        WHERE {' AND '.join(predicates)}
-                        ORDER BY version DESC
-                        LIMIT 1
-                        """,
-                        params,
-                    )
-                    row = await cur.fetchone()
-        except Exception:
-            return None
-        if not row:
-            return None
-        snapshot = row["snapshot"] if isinstance(row["snapshot"], dict) else {}
-        meta = row["meta"] if isinstance(row["meta"], dict) else {}
-        return ReplaySnapshotSeed(
-            aggregate_id=str(row["aggregate_id"]),
-            aggregate_type=str(row["aggregate_type"]),
-            version=int(row["version"]),
-            checksum=str(row["checksum"]),
-            state=snapshot,
-            meta=meta,
+        return await cls.event_reader.load_snapshot_seed(
+            tenant_id=tenant_id,
+            organization_id=organization_id,
+            execution_id=execution_id,
+            projection=projection,
+            cutoff=cutoff,
         )
 
-    @staticmethod
+    @classmethod
     async def replay_state(
+        cls,
         *,
         tenant_id: str,
         organization_id: str,
@@ -1148,8 +1006,10 @@ class ReplayService:
         cutoff: ReplayCutoff,
         projection: str,
         limit: int,
+        event_reader: ReplayEventReader | None = None,
     ) -> dict[str, Any]:
-        snapshot_seed = await ReplayService.load_snapshot_seed(
+        reader = event_reader or cls.event_reader
+        snapshot_seed = await reader.load_snapshot_seed(
             tenant_id=tenant_id,
             organization_id=organization_id,
             execution_id=execution_id,
@@ -1157,7 +1017,7 @@ class ReplayService:
             cutoff=cutoff,
         )
         events = default_upcaster_registry.upcast_events(
-            await ReplayService.load_events(
+            await reader.load_events(
                 tenant_id=tenant_id,
                 organization_id=organization_id,
                 execution_id=execution_id,

--- a/noetl/server/api/replay/types.py
+++ b/noetl/server/api/replay/types.py
@@ -1,0 +1,28 @@
+"""Replay API data types shared by services and storage adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class ReplayCutoff:
+    """Replay cutoff. Exactly one field is normally set."""
+
+    as_of_event_id: Optional[int] = None
+    as_of_position: Optional[int] = None
+    as_of_time: Optional[datetime] = None
+
+
+@dataclass(frozen=True)
+class ReplaySnapshotSeed:
+    """Snapshot state used as replay seed."""
+
+    aggregate_id: str
+    aggregate_type: str
+    version: int
+    checksum: str
+    state: dict[str, Any]
+    meta: dict[str, Any]

--- a/tests/api/test_replay_routes.py
+++ b/tests/api/test_replay_routes.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -153,6 +154,38 @@ def test_fold_replay_state_tracks_execution_frames_loops_and_checksum():
         "business_objects",
         "loops",
     }
+
+
+@pytest.mark.asyncio
+async def test_replay_service_accepts_per_call_event_reader():
+    from noetl.server.api.replay import ReplayCutoff, ReplayService
+
+    class _Reader:
+        async def load_snapshot_seed(self, **kwargs):
+            return None
+
+        async def load_events(self, **kwargs):
+            return [
+                {
+                    "event_id": 2,
+                    "event_type": "execution.failed",
+                    "status": "FAILED",
+                    "execution_id": kwargs["execution_id"],
+                }
+            ]
+
+    state = await ReplayService.replay_state(
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        execution_id=456,
+        cutoff=ReplayCutoff(),
+        projection="all",
+        limit=100,
+        event_reader=_Reader(),
+    )
+
+    assert state["execution_id"] == 456
+    assert state["execution"]["status"] == "FAILED"
     assert all(len(checksum) == 64 for checksum in state["projection_checksums"].values())
 
 
@@ -338,6 +371,55 @@ def test_fold_replay_state_can_resume_from_snapshot_seed():
     assert resumed["frames"]["10"]["row_count"] == 3
     assert resumed["replay_snapshot"]["version"] == 2
     assert resumed["replay_snapshot"]["meta"] == {"projection_code_version": "test"}
+
+
+@pytest.mark.asyncio
+async def test_replay_service_uses_configured_event_reader():
+    from noetl.server.api.replay import ReplayCutoff, ReplayService
+
+    class _Reader:
+        def __init__(self):
+            self.after_event_id = None
+
+        async def load_snapshot_seed(self, **kwargs):
+            return None
+
+        async def load_events(self, **kwargs):
+            self.after_event_id = kwargs["after_event_id"]
+            return [
+                {
+                    "event_id": 1,
+                    "event_type": "execution.completed",
+                    "status": "COMPLETED",
+                    "execution_id": kwargs["execution_id"],
+                }
+            ]
+
+    reader = _Reader()
+    previous_reader = ReplayService.event_reader
+    ReplayService.configure_event_reader(reader)
+    try:
+        state = await ReplayService.replay_state(
+            tenant_id="tenant-a",
+            organization_id="org-a",
+            execution_id=123,
+            cutoff=ReplayCutoff(),
+            projection="all",
+            limit=100,
+        )
+    finally:
+        ReplayService.configure_event_reader(previous_reader)
+
+    assert reader.after_event_id is None
+    assert state["execution"]["status"] == "COMPLETED"
+    assert set(state["projection_checksums"]) == {
+        "execution",
+        "stages",
+        "frames",
+        "commands",
+        "business_objects",
+        "loops",
+    }
 
 
 def test_frame_projection_checksum_matches_live_rows_and_replayed_state():


### PR DESCRIPTION
## Summary
- introduce `ReplayEventReader` as the storage-neutral read port for canonical replay inputs
- move the current SQL reads into `PostgresReplayEventReader`, keeping Postgres as a replaceable reference adapter
- move replay cutoff/snapshot seed types into shared replay types
- wire `ReplayService` through a configurable event reader and also allow per-call reader injection for validation/adapters
- cover class-level and per-call fake reader usage in replay tests

## Validation
- `.venv/bin/python -m pytest tests/api/test_replay_routes.py tests/core/test_replay_state_projector.py tests/scripts/test_check_replay_parity_report.py tests/core/test_replay_golden_corpus.py -q`
- `scripts/check_replay_release_gate.sh`

Stacked on noetl/noetl#505. Tracks noetl/noetl#434.