### PR TITLE
Add replay payload resolver port

### DIFF
--- a/noetl/server/api/replay/__init__.py
+++ b/noetl/server/api/replay/__init__.py
@@ -2,6 +2,12 @@
 
 from .endpoint import router
 from .event_reader import PostgresReplayEventReader, ReplayEventReader
+from .payload_resolver import (
+    ReplayPayloadResolution,
+    ReplayPayloadResolver,
+    TempStoreReplayPayloadResolver,
+    replay_payload_ref_locator,
+)
 from .service import (
     ReplayCutoff,
     ReplayService,
@@ -27,12 +33,19 @@ from .service import (
     normalize_replayed_stage_projection,
     replay_projection_checksum_bundle,
     projection_checksum_parity_report,
+    replay_payload_references,
+    replay_payload_resolution_summary,
+    resolve_replay_payload_references,
 )
 
 __all__ = [
     "router",
     "PostgresReplayEventReader",
     "ReplayEventReader",
+    "ReplayPayloadResolution",
+    "ReplayPayloadResolver",
+    "TempStoreReplayPayloadResolver",
+    "replay_payload_ref_locator",
     "ReplayCutoff",
     "ReplayService",
     "business_object_projection_checksum",
@@ -57,4 +70,7 @@ __all__ = [
     "normalize_replayed_stage_projection",
     "replay_projection_checksum_bundle",
     "projection_checksum_parity_report",
+    "replay_payload_references",
+    "replay_payload_resolution_summary",
+    "resolve_replay_payload_references",
 ]

--- a/noetl/server/api/replay/endpoint.py
+++ b/noetl/server/api/replay/endpoint.py
@@ -25,6 +25,7 @@ async def replay_state(
     as_of_time: Optional[datetime] = Query(None, description="Replay through this event_time"),
     projection: str = Query("all", description="Projection to fold: execution | frame | loop | business_object | all"),
     limit: int = Query(10000, ge=1, le=100000, description="Maximum events to fold in this Phase 0 endpoint"),
+    resolve_payloads: bool = Query(False, description="Resolve payload refs and return bounded verification summaries"),
 ) -> dict:
     """Reconstruct lightweight state from canonical events.
 
@@ -50,6 +51,7 @@ async def replay_state(
             ),
             projection=projection,
             limit=limit,
+            resolve_payloads=resolve_payloads,
         )
     except HTTPException:
         raise

--- a/noetl/server/api/replay/payload_resolver.py
+++ b/noetl/server/api/replay/payload_resolver.py
@@ -1,0 +1,129 @@
+"""Replay payload-resolution ports and reference adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Protocol
+
+from noetl.core.storage import default_store
+
+
+@dataclass(frozen=True)
+class ReplayPayloadResolution:
+    """Bounded verification result for a replay payload reference."""
+
+    ref: str
+    resolved: bool
+    checksum: str | None = None
+    size_bytes: int | None = None
+    row_count: int | None = None
+    value_type: str | None = None
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class ReplayPayloadResolver(Protocol):
+    """Storage-neutral read port for immutable replay payload references."""
+
+    async def resolve_payload_ref(self, reference: Any) -> ReplayPayloadResolution:
+        """Resolve and summarize a payload reference without returning the payload body."""
+
+
+class TempStoreReplayPayloadResolver:
+    """Replay payload resolver backed by TempStore/ResultStore."""
+
+    def __init__(self, store: Any = None) -> None:
+        self.store = store or default_store
+
+    async def resolve_payload_ref(self, reference: Any) -> ReplayPayloadResolution:
+        ref = _reference_locator(reference)
+        if ref is None:
+            return ReplayPayloadResolution(
+                ref="",
+                resolved=False,
+                error="payload reference has no resolvable locator",
+            )
+        try:
+            resolved = await self.store.resolve(_resolve_input(reference, ref))
+        except Exception as exc:
+            return ReplayPayloadResolution(
+                ref=ref,
+                resolved=False,
+                error=str(exc),
+            )
+        payload_bytes = _canonical_payload_bytes(resolved)
+        return ReplayPayloadResolution(
+            ref=ref,
+            resolved=True,
+            checksum=hashlib.sha256(payload_bytes).hexdigest(),
+            size_bytes=len(payload_bytes),
+            row_count=_row_count(resolved),
+            value_type=type(resolved).__name__,
+        )
+
+
+def _resolve_input(reference: Any, ref: str) -> Any:
+    if isinstance(reference, Mapping):
+        if reference.get("kind") in {"temp_ref", "result_ref", "manifest"}:
+            return dict(reference)
+        rows_ref = reference.get("rows_ref")
+        if isinstance(rows_ref, Mapping):
+            return dict(rows_ref)
+    return ref
+
+
+def replay_payload_ref_locator(reference: Any) -> str | None:
+    """Return the stable locator for a replay payload reference, when present."""
+    if isinstance(reference, str):
+        return reference
+    if not isinstance(reference, Mapping):
+        return None
+    for key in ("ref", "uri", "locator"):
+        value = reference.get(key)
+        if value:
+            return str(value)
+    rows_ref = reference.get("rows_ref")
+    if isinstance(rows_ref, Mapping):
+        for key in ("ref", "uri", "locator"):
+            value = rows_ref.get(key)
+            if value:
+                return str(value)
+    return None
+
+
+def _reference_locator(reference: Any) -> str | None:
+    return replay_payload_ref_locator(reference)
+
+
+def _canonical_payload_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_json_default,
+    ).encode("utf-8")
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.hex()
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def _row_count(value: Any) -> int | None:
+    if isinstance(value, list):
+        return len(value)
+    if isinstance(value, Mapping):
+        rows = value.get("rows")
+        if isinstance(rows, list):
+            return len(rows)
+    return None

--- a/noetl/server/api/replay/service.py
+++ b/noetl/server/api/replay/service.py
@@ -16,6 +16,11 @@ from typing import Any, Iterable, Mapping, Optional
 from noetl.core.replay import default_upcaster_registry
 
 from .event_reader import PostgresReplayEventReader, ReplayEventReader
+from .payload_resolver import (
+    ReplayPayloadResolver,
+    TempStoreReplayPayloadResolver,
+    replay_payload_ref_locator,
+)
 from .types import ReplayCutoff, ReplaySnapshotSeed
 
 PROJECTION_CHECKSUM_SURFACES = (
@@ -26,6 +31,8 @@ PROJECTION_CHECKSUM_SURFACES = (
     "business_objects",
     "loops",
 )
+
+DEFAULT_REPLAY_PAYLOAD_RESOLVER = TempStoreReplayPayloadResolver()
 
 
 def _json_default(value: Any) -> str:
@@ -949,14 +956,127 @@ def projection_checksum_parity_report(
     }
 
 
+def replay_payload_references(state: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return payload references carried by the replay state with lineage labels."""
+    references: list[dict[str, Any]] = []
+    execution = state.get("execution")
+    if isinstance(execution, Mapping):
+        for payload_ref in execution.get("payload_refs") or []:
+            if isinstance(payload_ref, Mapping) and payload_ref.get("reference") is not None:
+                references.append(
+                    {
+                        "scope": "execution",
+                        "event_id": payload_ref.get("event_id"),
+                        "reference": payload_ref["reference"],
+                    }
+                )
+    frames = state.get("frames")
+    if isinstance(frames, Mapping):
+        for frame_id, frame in frames.items():
+            if isinstance(frame, Mapping) and frame.get("output_ref") is not None:
+                references.append(
+                    {
+                        "scope": "frame",
+                        "frame_id": str(frame.get("frame_id") or frame_id),
+                        "event_id": frame.get("terminal_event_id"),
+                        "reference": frame["output_ref"],
+                    }
+                )
+    business_objects = state.get("business_objects")
+    if isinstance(business_objects, Mapping):
+        for object_key, business_object in business_objects.items():
+            if not isinstance(business_object, Mapping):
+                continue
+            for payload_ref in business_object.get("payload_refs") or []:
+                if isinstance(payload_ref, Mapping) and payload_ref.get("reference") is not None:
+                    references.append(
+                        {
+                            "scope": "business_object",
+                            "object_key": str(business_object.get("object_key") or object_key),
+                            "event_id": payload_ref.get("event_id"),
+                            "reference": payload_ref["reference"],
+                        }
+                    )
+    return references
+
+
+async def resolve_replay_payload_references(
+    state: Mapping[str, Any],
+    *,
+    payload_resolver: ReplayPayloadResolver,
+) -> list[dict[str, Any]]:
+    """Resolve replay payload refs through a storage adapter and return bounded summaries."""
+    resolved: list[dict[str, Any]] = []
+    resolution_cache: dict[str, dict[str, Any]] = {}
+    for payload_ref in replay_payload_references(state):
+        locator = replay_payload_ref_locator(payload_ref["reference"]) or json.dumps(
+            payload_ref["reference"],
+            sort_keys=True,
+            default=_json_default,
+        )
+        if locator not in resolution_cache:
+            resolution = await payload_resolver.resolve_payload_ref(payload_ref["reference"])
+            resolution_cache[locator] = resolution.as_dict()
+        resolved.append(
+            {
+                **{key: value for key, value in payload_ref.items() if key != "reference"},
+                "reference_summary": _payload_summary(payload_ref["reference"]),
+                "resolution": resolution_cache[locator],
+            }
+        )
+    return resolved
+
+
+def replay_payload_resolution_summary(resolutions: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    """Return deterministic aggregate status for resolved replay payload references."""
+    resolution_rows = list(resolutions)
+    resolved_count = sum(
+        1
+        for row in resolution_rows
+        if isinstance(row.get("resolution"), Mapping)
+        and row["resolution"].get("resolved") is True
+    )
+    unresolved_count = len(resolution_rows) - resolved_count
+    unique_refs = sorted(
+        {
+            str(row["resolution"]["ref"])
+            for row in resolution_rows
+            if isinstance(row.get("resolution"), Mapping)
+            and row["resolution"].get("ref")
+        }
+    )
+    summary = {
+        "total": len(resolution_rows),
+        "resolved": resolved_count,
+        "unresolved": unresolved_count,
+        "unique_refs": len(unique_refs),
+        "all_resolved": unresolved_count == 0,
+    }
+    return {
+        **summary,
+        "checksum": _canonical_checksum(
+            {
+                **summary,
+                "unique_refs": unique_refs,
+                "rows": resolution_rows,
+            }
+        ),
+    }
+
+
 class ReplayService:
     """Read canonical events and fold replay state."""
 
     event_reader: ReplayEventReader = PostgresReplayEventReader()
+    payload_resolver: ReplayPayloadResolver = DEFAULT_REPLAY_PAYLOAD_RESOLVER
 
     @classmethod
     def configure_event_reader(cls, event_reader: ReplayEventReader) -> None:
         cls.event_reader = event_reader
+
+    @classmethod
+    def configure_payload_resolver(cls, payload_resolver: ReplayPayloadResolver) -> None:
+        cls.payload_resolver = payload_resolver
 
     @classmethod
     async def load_events(
@@ -1007,6 +1127,8 @@ class ReplayService:
         projection: str,
         limit: int,
         event_reader: ReplayEventReader | None = None,
+        resolve_payloads: bool = False,
+        payload_resolver: ReplayPayloadResolver | None = None,
     ) -> dict[str, Any]:
         reader = event_reader or cls.event_reader
         snapshot_seed = await reader.load_snapshot_seed(
@@ -1026,7 +1148,7 @@ class ReplayService:
                 after_event_id=snapshot_seed.version if snapshot_seed else None,
             )
         )
-        return fold_replay_state(
+        state = fold_replay_state(
             events,
             tenant_id=tenant_id,
             organization_id=organization_id,
@@ -1036,3 +1158,12 @@ class ReplayService:
             base_state=snapshot_seed.state if snapshot_seed else None,
             snapshot_seed=snapshot_seed,
         )
+        if resolve_payloads:
+            state["payload_resolution"] = await resolve_replay_payload_references(
+                state,
+                payload_resolver=payload_resolver or cls.payload_resolver,
+            )
+            state["payload_resolution_summary"] = replay_payload_resolution_summary(
+                state["payload_resolution"]
+            )
+        return state

--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -11,6 +11,7 @@ fi
 
 "$PYTHON_BIN" -m pytest -q \
   tests/core/test_replay_golden_corpus.py \
+  tests/core/test_replay_payload_resolver.py \
   tests/scripts/test_check_replay_parity_report.py \
   tests/api/test_replay_routes.py \
   tests/core/test_replay_upcasters.py \

--- a/tests/api/test_replay_routes.py
+++ b/tests/api/test_replay_routes.py
@@ -154,6 +154,7 @@ def test_fold_replay_state_tracks_execution_frames_loops_and_checksum():
         "business_objects",
         "loops",
     }
+    assert all(len(checksum) == 64 for checksum in state["projection_checksums"].values())
 
 
 @pytest.mark.asyncio
@@ -186,7 +187,150 @@ async def test_replay_service_accepts_per_call_event_reader():
 
     assert state["execution_id"] == 456
     assert state["execution"]["status"] == "FAILED"
-    assert all(len(checksum) == 64 for checksum in state["projection_checksums"].values())
+
+
+@pytest.mark.asyncio
+async def test_replay_service_resolves_payload_refs_with_adapter():
+    from noetl.server.api.replay import (
+        ReplayCutoff,
+        ReplayPayloadResolution,
+        ReplayService,
+        replay_payload_references,
+    )
+
+    payload_ref = {
+        "rows_ref": {
+            "ref": "noetl://execution/123/result/frame/9",
+            "meta": {
+                "sha256": "payload-sha",
+                "row_count": 2,
+                "media_type": "application/vnd.apache.arrow.stream",
+            },
+        }
+    }
+
+    class _Reader:
+        async def load_snapshot_seed(self, **kwargs):
+            return None
+
+        async def load_events(self, **kwargs):
+            return [
+                {
+                    "event_id": 1,
+                    "event_type": "frame.committed",
+                    "aggregate_type": "frame",
+                    "aggregate_id": "frame/9",
+                    "stage_id": 7,
+                    "payload_ref": payload_ref,
+                    "meta": {"row_count": 2},
+                    "execution_id": kwargs["execution_id"],
+                }
+            ]
+
+    class _Resolver:
+        def __init__(self):
+            self.references = []
+
+        async def resolve_payload_ref(self, reference):
+            self.references.append(reference)
+            return ReplayPayloadResolution(
+                ref=reference["rows_ref"]["ref"],
+                resolved=True,
+                checksum="a" * 64,
+                size_bytes=128,
+                row_count=2,
+                value_type="list",
+            )
+
+    resolver = _Resolver()
+    state = await ReplayService.replay_state(
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        execution_id=123,
+        cutoff=ReplayCutoff(),
+        projection="all",
+        limit=100,
+        event_reader=_Reader(),
+        resolve_payloads=True,
+        payload_resolver=resolver,
+    )
+
+    references = replay_payload_references(state)
+    assert len(references) == 2
+    assert references[0]["scope"] == "execution"
+    assert references[1]["scope"] == "frame"
+    assert resolver.references == [payload_ref]
+    assert state["payload_resolution"] == [
+        {
+            "scope": "execution",
+            "event_id": 1,
+            "reference_summary": {
+                "sha256": "payload-sha",
+                "schema_digest": None,
+                "row_count": 2,
+                "media_type": "application/vnd.apache.arrow.stream",
+                "ref": "noetl://execution/123/result/frame/9",
+            },
+            "resolution": {
+                "ref": "noetl://execution/123/result/frame/9",
+                "resolved": True,
+                "checksum": "a" * 64,
+                "size_bytes": 128,
+                "row_count": 2,
+                "value_type": "list",
+                "error": None,
+            },
+        },
+        {
+            "scope": "frame",
+            "frame_id": "9",
+            "event_id": 1,
+            "reference_summary": {
+                "sha256": "payload-sha",
+                "schema_digest": None,
+                "row_count": 2,
+                "media_type": "application/vnd.apache.arrow.stream",
+                "ref": "noetl://execution/123/result/frame/9",
+            },
+            "resolution": {
+                "ref": "noetl://execution/123/result/frame/9",
+                "resolved": True,
+                "checksum": "a" * 64,
+                "size_bytes": 128,
+                "row_count": 2,
+                "value_type": "list",
+                "error": None,
+            },
+        },
+    ]
+    assert state["payload_resolution_summary"] == {
+        "total": 2,
+        "resolved": 2,
+        "unresolved": 0,
+        "unique_refs": 1,
+        "all_resolved": True,
+        "checksum": state["payload_resolution_summary"]["checksum"],
+    }
+    assert len(state["payload_resolution_summary"]["checksum"]) == 64
+
+
+def test_replay_payload_resolution_summary_reports_unresolved_refs():
+    from noetl.server.api.replay import replay_payload_resolution_summary
+
+    summary = replay_payload_resolution_summary(
+        [
+            {"resolution": {"ref": "noetl://payload/1", "resolved": True}},
+            {"resolution": {"ref": "noetl://payload/2", "resolved": False}},
+            {"resolution": {"ref": "noetl://payload/1", "resolved": True}},
+        ]
+    )
+
+    assert summary["total"] == 3
+    assert summary["resolved"] == 2
+    assert summary["unresolved"] == 1
+    assert summary["unique_refs"] == 2
+    assert summary["all_resolved"] is False
+    assert len(summary["checksum"]) == 64
 
 
 def test_fold_replay_state_tracks_commands_and_topology():

--- a/tests/core/test_replay_payload_resolver.py
+++ b/tests/core/test_replay_payload_resolver.py
@@ -1,0 +1,51 @@
+import hashlib
+import json
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_temp_store_replay_payload_resolver_returns_bounded_summary():
+    from noetl.core.storage import Scope, StoreTier, TempStore
+    from noetl.server.api.replay import TempStoreReplayPayloadResolver
+
+    store = TempStore(max_ref_cache_entries=10, max_memory_cache_entries=10)
+    rows = [{"id": 1}, {"id": 2}]
+    ref = await store.put(
+        execution_id="123",
+        name="frame_rows",
+        data=rows,
+        scope=Scope.EXECUTION,
+        store=StoreTier.MEMORY,
+    )
+
+    resolution = await TempStoreReplayPayloadResolver(store).resolve_payload_ref(
+        ref.model_dump(mode="json")
+    )
+
+    payload_bytes = json.dumps(
+        rows,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    assert resolution.resolved is True
+    assert resolution.ref == ref.ref
+    assert resolution.checksum == hashlib.sha256(payload_bytes).hexdigest()
+    assert resolution.size_bytes == len(payload_bytes)
+    assert resolution.row_count == 2
+    assert resolution.value_type == "list"
+    assert resolution.error is None
+
+
+@pytest.mark.asyncio
+async def test_temp_store_replay_payload_resolver_reports_missing_locator():
+    from noetl.core.storage import TempStore
+    from noetl.server.api.replay import TempStoreReplayPayloadResolver
+
+    resolution = await TempStoreReplayPayloadResolver(TempStore()).resolve_payload_ref(
+        {"sha256": "abc"}
+    )
+
+    assert resolution.resolved is False
+    assert resolution.checksum is None
+    assert resolution.error == "payload reference has no resolvable locator"


### PR DESCRIPTION
## Summary
- add `ReplayPayloadResolver` and `TempStoreReplayPayloadResolver` for storage-neutral replay payload verification
- add opt-in `resolve_payloads=true` support on replay state responses, returning bounded checksums/shape instead of payload bodies
- expose payload-reference collection, locator, resolution, and aggregate summary helpers for validation tools
- cache duplicate payload-reference resolutions within one replay response while preserving all lineage entries
- return `payload_resolution_summary` with total/resolved/unresolved/unique-ref counts and a deterministic checksum
- cover fake resolver and TempStore-backed resolver behavior in tests
- include payload resolver coverage in the replay release gate

## Validation
- `.venv/bin/python -m pytest tests/api/test_replay_routes.py tests/core/test_replay_payload_resolver.py -q`
- `scripts/check_replay_release_gate.sh`

Tracks noetl/noetl#434.