### PR TITLE
Add replay payload resolution report gate

### DIFF
--- a/scripts/check_replay_payload_resolution_report.py
+++ b/scripts/check_replay_payload_resolution_report.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""Validate replay payload-resolution summary JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from noetl.server.api.replay import replay_payload_resolution_summary
+
+
+def _load_report(path: Path) -> dict[str, Any]:
+    data: Any = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _payload_resolution_rows(report: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = report.get("payload_resolution")
+    if rows is None and isinstance(report.get("replay"), dict):
+        rows = report["replay"].get("payload_resolution")
+    if rows is None:
+        raise ValueError("report does not contain payload_resolution")
+    if not isinstance(rows, list):
+        raise ValueError("payload_resolution must be a list")
+    return [dict(row) for row in rows if isinstance(row, dict)]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate NoETL replay payload-resolution report JSON",
+    )
+    parser.add_argument(
+        "--report",
+        required=True,
+        type=Path,
+        help="Replay state JSON containing payload_resolution and optional payload_resolution_summary",
+    )
+    args = parser.parse_args(argv)
+
+    report = _load_report(args.report)
+    rows = _payload_resolution_rows(report)
+    computed_summary = replay_payload_resolution_summary(rows)
+    supplied_summary = report.get("payload_resolution_summary") or {}
+    if supplied_summary and supplied_summary.get("checksum") != computed_summary["checksum"]:
+        output = {
+            "matched": False,
+            "reason": "payload_resolution_summary checksum mismatch",
+            "supplied": supplied_summary,
+            "computed": computed_summary,
+        }
+        print(json.dumps(output, indent=2, sort_keys=True))
+        return 1
+
+    output = {
+        "matched": bool(computed_summary["all_resolved"]),
+        "summary": computed_summary,
+    }
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0 if output["matched"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -13,6 +13,7 @@ fi
   tests/core/test_replay_golden_corpus.py \
   tests/core/test_replay_payload_resolver.py \
   tests/scripts/test_check_replay_parity_report.py \
+  tests/scripts/test_check_replay_payload_resolution_report.py \
   tests/api/test_replay_routes.py \
   tests/core/test_replay_upcasters.py \
   tests/core/test_replay_state_projector.py \

--- a/tests/scripts/test_check_replay_payload_resolution_report.py
+++ b/tests/scripts/test_check_replay_payload_resolution_report.py
@@ -1,0 +1,82 @@
+import json
+from pathlib import Path
+
+from noetl.server.api.replay import replay_payload_resolution_summary
+from scripts.check_replay_payload_resolution_report import main
+
+
+def test_check_replay_payload_resolution_report_accepts_all_resolved(tmp_path: Path, capsys):
+    rows = [
+        {
+            "scope": "frame",
+            "resolution": {
+                "ref": "noetl://payload/1",
+                "resolved": True,
+                "checksum": "a" * 64,
+            },
+        }
+    ]
+    report_path = tmp_path / "replay.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "payload_resolution": rows,
+                "payload_resolution_summary": replay_payload_resolution_summary(rows),
+            }
+        )
+    )
+
+    assert main(["--report", str(report_path)]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["matched"] is True
+    assert report["summary"]["all_resolved"] is True
+
+
+def test_check_replay_payload_resolution_report_rejects_unresolved(tmp_path: Path, capsys):
+    rows = [
+        {
+            "scope": "frame",
+            "resolution": {
+                "ref": "noetl://payload/1",
+                "resolved": False,
+                "error": "missing",
+            },
+        }
+    ]
+    report_path = tmp_path / "replay.json"
+    report_path.write_text(json.dumps({"payload_resolution": rows}))
+
+    assert main(["--report", str(report_path)]) == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["matched"] is False
+    assert report["summary"]["unresolved"] == 1
+
+
+def test_check_replay_payload_resolution_report_rejects_summary_mismatch(tmp_path: Path, capsys):
+    rows = [
+        {
+            "scope": "frame",
+            "resolution": {
+                "ref": "noetl://payload/1",
+                "resolved": True,
+                "checksum": "a" * 64,
+            },
+        }
+    ]
+    report_path = tmp_path / "replay.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "payload_resolution": rows,
+                "payload_resolution_summary": {
+                    **replay_payload_resolution_summary(rows),
+                    "checksum": "0" * 64,
+                },
+            }
+        )
+    )
+
+    assert main(["--report", str(report_path)]) == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["matched"] is False
+    assert report["reason"] == "payload_resolution_summary checksum mismatch"


### PR DESCRIPTION
## Summary
- add `scripts/check_replay_payload_resolution_report.py` for offline replay payload-resolution validation
- accept replay-state JSON containing `payload_resolution` and optional `payload_resolution_summary`
- recompute the bounded summary checksum and fail on unresolved refs or summary mismatch
- include the script tests in the replay release gate

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_check_replay_payload_resolution_report.py tests/core/test_replay_payload_resolver.py tests/api/test_replay_routes.py -q`
- `scripts/check_replay_release_gate.sh`

Tracks noetl/noetl#434.