### PR TITLE
Add replay state report fetcher

### DIFF
--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -12,6 +12,7 @@ fi
 "$PYTHON_BIN" -m pytest -q \
   tests/core/test_replay_golden_corpus.py \
   tests/core/test_replay_payload_resolver.py \
+  tests/scripts/test_fetch_replay_state_report.py \
   tests/scripts/test_check_replay_parity_report.py \
   tests/api/test_replay_routes.py \
   tests/core/test_replay_upcasters.py \

--- a/scripts/fetch_replay_state_report.py
+++ b/scripts/fetch_replay_state_report.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""Fetch replay state JSON for offline parity and payload-resolution gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+def _build_url(args: argparse.Namespace) -> str:
+    base_url = str(args.base_url).rstrip("/")
+    params: dict[str, str | int] = {
+        "execution_id": int(args.execution_id),
+        "tenant_id": args.tenant_id,
+        "organization_id": args.organization_id,
+        "projection": args.projection,
+        "limit": int(args.limit),
+        "resolve_payloads": "true" if args.resolve_payloads else "false",
+    }
+    if args.as_of_event_id is not None:
+        params["as_of_event_id"] = int(args.as_of_event_id)
+    if args.as_of_position is not None:
+        params["as_of_position"] = int(args.as_of_position)
+    if args.as_of_time is not None:
+        params["as_of_time"] = args.as_of_time
+    return f"{base_url}/api/replay/state?{urlencode(params)}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fetch NoETL replay state JSON for validation gates",
+    )
+    parser.add_argument("--base-url", required=True, help="NoETL server base URL")
+    parser.add_argument("--execution-id", required=True, type=int)
+    parser.add_argument("--tenant-id", default="default")
+    parser.add_argument("--organization-id", default="default")
+    parser.add_argument("--projection", default="all")
+    parser.add_argument("--limit", default=100000, type=int)
+    parser.add_argument("--as-of-event-id", type=int)
+    parser.add_argument("--as-of-position", type=int)
+    parser.add_argument("--as-of-time")
+    parser.add_argument("--resolve-payloads", action="store_true")
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--timeout", default=60.0, type=float)
+    args = parser.parse_args(argv)
+
+    cutoff_count = sum(
+        value is not None
+        for value in (args.as_of_event_id, args.as_of_position, args.as_of_time)
+    )
+    if cutoff_count > 1:
+        parser.error("use only one replay cutoff")
+
+    request = Request(_build_url(args), headers={"Accept": "application/json"})
+    with urlopen(request, timeout=args.timeout) as response:
+        body = response.read()
+    data = json.loads(body.decode("utf-8"))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+    print(json.dumps({"output": str(args.output), "bytes": len(body)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_fetch_replay_state_report.py
+++ b/tests/scripts/test_fetch_replay_state_report.py
@@ -1,0 +1,78 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import fetch_replay_state_report
+
+
+def test_fetch_replay_state_report_writes_response(monkeypatch, tmp_path: Path, capsys):
+    captured = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps({"projection_checksums": {"execution": "a" * 64}}).encode()
+
+    def _urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["timeout"] = timeout
+        return _Response()
+
+    monkeypatch.setattr(fetch_replay_state_report, "urlopen", _urlopen)
+    output_path = tmp_path / "reports" / "replay.json"
+
+    assert (
+        fetch_replay_state_report.main(
+            [
+                "--base-url",
+                "http://noetl.example/",
+                "--execution-id",
+                "123",
+                "--tenant-id",
+                "tenant-a",
+                "--organization-id",
+                "org-a",
+                "--resolve-payloads",
+                "--output",
+                str(output_path),
+                "--timeout",
+                "7",
+            ]
+        )
+        == 0
+    )
+
+    assert output_path.exists()
+    assert json.loads(output_path.read_text()) == {
+        "projection_checksums": {"execution": "a" * 64}
+    }
+    assert "execution_id=123" in captured["url"]
+    assert "tenant_id=tenant-a" in captured["url"]
+    assert "organization_id=org-a" in captured["url"]
+    assert "resolve_payloads=true" in captured["url"]
+    assert captured["timeout"] == 7.0
+    assert json.loads(capsys.readouterr().out)["output"] == str(output_path)
+
+
+def test_fetch_replay_state_report_rejects_multiple_cutoffs(tmp_path: Path):
+    with pytest.raises(SystemExit):
+        fetch_replay_state_report.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--as-of-event-id",
+                "1",
+                "--as-of-position",
+                "1",
+                "--output",
+                str(tmp_path / "replay.json"),
+            ]
+        )


### PR DESCRIPTION
## Summary
- add `scripts/fetch_replay_state_report.py` to fetch `/api/replay/state` JSON for offline replay gates
- supports tenant/org scope, projection, limit, cutoffs, and `--resolve-payloads`
- writes stable pretty JSON to a requested output path
- covers URL construction, output writing, and cutoff validation with tests
- includes fetcher coverage in the replay release gate

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_fetch_replay_state_report.py tests/scripts/test_check_replay_parity_report.py -q`
- `scripts/check_replay_release_gate.sh`

Tracks noetl/noetl#434.