### PR TITLE
Add replay validation runner

### DIFF
--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -13,6 +13,7 @@ fi
   tests/core/test_replay_golden_corpus.py \
   tests/core/test_replay_payload_resolver.py \
   tests/scripts/test_fetch_replay_state_report.py \
+  tests/scripts/test_run_replay_validation.py \
   tests/scripts/test_check_replay_parity_report.py \
   tests/scripts/test_check_replay_payload_resolution_report.py \
   tests/api/test_replay_routes.py \

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+"""Fetch replay state and run offline replay validation gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(command: list[str]) -> tuple[int, str, str]:
+    completed = subprocess.run(
+        command,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    return completed.returncode, completed.stdout, completed.stderr
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fetch NoETL replay state and run offline validation gates",
+    )
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--execution-id", required=True, type=int)
+    parser.add_argument("--tenant-id", default="default")
+    parser.add_argument("--organization-id", default="default")
+    parser.add_argument("--projection", default="all")
+    parser.add_argument("--limit", default=100000, type=int)
+    parser.add_argument("--as-of-event-id", type=int)
+    parser.add_argument("--as-of-position", type=int)
+    parser.add_argument("--as-of-time")
+    parser.add_argument("--resolve-payloads", action="store_true")
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--timeout", default=60.0, type=float)
+    parser.add_argument("--live-checksums", type=Path)
+    args = parser.parse_args(argv)
+
+    output_dir = args.output_dir
+    replay_path = output_dir / f"replay-{args.execution_id}.json"
+    fetch_command = [
+        sys.executable,
+        "scripts/fetch_replay_state_report.py",
+        "--base-url",
+        args.base_url,
+        "--execution-id",
+        str(args.execution_id),
+        "--tenant-id",
+        args.tenant_id,
+        "--organization-id",
+        args.organization_id,
+        "--projection",
+        args.projection,
+        "--limit",
+        str(args.limit),
+        "--output",
+        str(replay_path),
+        "--timeout",
+        str(args.timeout),
+    ]
+    for flag in ("as_of_event_id", "as_of_position", "as_of_time"):
+        value = getattr(args, flag)
+        if value is not None:
+            fetch_command.extend([f"--{flag.replace('_', '-')}", str(value)])
+    if args.resolve_payloads:
+        fetch_command.append("--resolve-payloads")
+
+    steps: list[dict[str, object]] = []
+    for name, command in [
+        ("fetch", fetch_command),
+        (
+            "projection_parity",
+            [
+                sys.executable,
+                "scripts/check_replay_parity_report.py",
+                "--replayed",
+                str(replay_path),
+                "--live",
+                str(args.live_checksums),
+            ]
+            if args.live_checksums
+            else [],
+        ),
+        (
+            "payload_resolution",
+            [
+                sys.executable,
+                "scripts/check_replay_payload_resolution_report.py",
+                "--report",
+                str(replay_path),
+            ]
+            if args.resolve_payloads
+            else [],
+        ),
+    ]:
+        if not command:
+            steps.append({"name": name, "skipped": True})
+            continue
+        code, stdout, stderr = _run(command)
+        steps.append(
+            {
+                "name": name,
+                "command": command,
+                "returncode": code,
+                "stdout": stdout,
+                "stderr": stderr,
+            }
+        )
+        if code != 0:
+            print(json.dumps({"matched": False, "replay": str(replay_path), "steps": steps}, indent=2))
+            return code
+
+    print(json.dumps({"matched": True, "replay": str(replay_path), "steps": steps}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+from scripts import run_replay_validation
+
+
+def test_run_replay_validation_fetches_and_runs_selected_gates(monkeypatch, tmp_path: Path, capsys):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if "fetch_replay_state_report.py" in command:
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
+        return 0, json.dumps({"ok": True}), ""
+
+    monkeypatch.setattr(run_replay_validation, "_run", _run)
+    live_path = tmp_path / "live.json"
+    live_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
+
+    assert (
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--tenant-id",
+                "tenant-a",
+                "--organization-id",
+                "org-a",
+                "--resolve-payloads",
+                "--live-checksums",
+                str(live_path),
+                "--output-dir",
+                str(tmp_path / "reports"),
+            ]
+        )
+        == 0
+    )
+
+    assert len(calls) == 3
+    assert "scripts/fetch_replay_state_report.py" in calls[0]
+    assert "--resolve-payloads" in calls[0]
+    assert "scripts/check_replay_parity_report.py" in calls[1]
+    assert "scripts/check_replay_payload_resolution_report.py" in calls[2]
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True
+    assert output["replay"].endswith("replay-123.json")
+
+
+def test_run_replay_validation_stops_on_gate_failure(monkeypatch, tmp_path: Path, capsys):
+    def _run(command):
+        if "fetch_replay_state_report.py" in command:
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text("{}")
+            return 0, "", ""
+        return 1, "", "failed"
+
+    monkeypatch.setattr(run_replay_validation, "_run", _run)
+    live_path = tmp_path / "live.json"
+    live_path.write_text("{}")
+
+    assert (
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--live-checksums",
+                str(live_path),
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+        == 1
+    )
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    assert output["steps"][-1]["stderr"] == "failed"


### PR DESCRIPTION
## Summary
- add `scripts/run_replay_validation.py` to fetch replay state and run offline replay gates in one command
- supports projection parity via `--live-checksums` and payload verification via `--resolve-payloads`
- emits a JSON run report with per-step commands, stdout/stderr, and pass/fail status
- includes runner coverage in the replay release gate

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_run_replay_validation.py tests/scripts/test_fetch_replay_state_report.py tests/scripts/test_check_replay_parity_report.py -q`
- `scripts/check_replay_release_gate.sh`

Tracks noetl/noetl#434.