### PR TITLE
Inject replay upcaster registry

### DIFF
--- a/noetl/server/api/replay/__init__.py
+++ b/noetl/server/api/replay/__init__.py
@@ -1,5 +1,7 @@
 """Replay API for deterministic event-sourced state reconstruction."""
 
+from noetl.core.replay import EventUpcasterRegistry
+
 from .endpoint import router
 from .event_reader import PostgresReplayEventReader, ReplayEventReader
 from .payload_resolver import (
@@ -40,6 +42,7 @@ from .service import (
 
 __all__ = [
     "router",
+    "EventUpcasterRegistry",
     "PostgresReplayEventReader",
     "ReplayEventReader",
     "ReplayPayloadResolution",

--- a/noetl/server/api/replay/service.py
+++ b/noetl/server/api/replay/service.py
@@ -13,7 +13,7 @@ import copy
 from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping, Optional
 
-from noetl.core.replay import default_upcaster_registry
+from noetl.core.replay import EventUpcasterRegistry, default_upcaster_registry
 
 from .event_reader import PostgresReplayEventReader, ReplayEventReader
 from .payload_resolver import (
@@ -1069,6 +1069,7 @@ class ReplayService:
 
     event_reader: ReplayEventReader = PostgresReplayEventReader()
     payload_resolver: ReplayPayloadResolver = DEFAULT_REPLAY_PAYLOAD_RESOLVER
+    upcaster_registry: EventUpcasterRegistry = default_upcaster_registry
 
     @classmethod
     def configure_event_reader(cls, event_reader: ReplayEventReader) -> None:
@@ -1077,6 +1078,10 @@ class ReplayService:
     @classmethod
     def configure_payload_resolver(cls, payload_resolver: ReplayPayloadResolver) -> None:
         cls.payload_resolver = payload_resolver
+
+    @classmethod
+    def configure_upcaster_registry(cls, upcaster_registry: EventUpcasterRegistry) -> None:
+        cls.upcaster_registry = upcaster_registry
 
     @classmethod
     async def load_events(
@@ -1129,8 +1134,10 @@ class ReplayService:
         event_reader: ReplayEventReader | None = None,
         resolve_payloads: bool = False,
         payload_resolver: ReplayPayloadResolver | None = None,
+        upcaster_registry: EventUpcasterRegistry | None = None,
     ) -> dict[str, Any]:
         reader = event_reader or cls.event_reader
+        registry = upcaster_registry or cls.upcaster_registry
         snapshot_seed = await reader.load_snapshot_seed(
             tenant_id=tenant_id,
             organization_id=organization_id,
@@ -1138,7 +1145,7 @@ class ReplayService:
             projection=projection,
             cutoff=cutoff,
         )
-        events = default_upcaster_registry.upcast_events(
+        events = registry.upcast_events(
             await reader.load_events(
                 tenant_id=tenant_id,
                 organization_id=organization_id,
@@ -1154,7 +1161,7 @@ class ReplayService:
             organization_id=organization_id,
             execution_id=execution_id,
             projection=projection,
-            upcaster_registry_digest=default_upcaster_registry.digest(),
+            upcaster_registry_digest=registry.digest(),
             base_state=snapshot_seed.state if snapshot_seed else None,
             snapshot_seed=snapshot_seed,
         )

--- a/tests/api/test_replay_routes.py
+++ b/tests/api/test_replay_routes.py
@@ -190,6 +190,53 @@ async def test_replay_service_accepts_per_call_event_reader():
 
 
 @pytest.mark.asyncio
+async def test_replay_service_accepts_per_call_upcaster_registry():
+    from noetl.server.api.replay import EventUpcasterRegistry, ReplayCutoff, ReplayService
+
+    class _Reader:
+        async def load_snapshot_seed(self, **kwargs):
+            return None
+
+        async def load_events(self, **kwargs):
+            return [
+                {
+                    "event_id": 1,
+                    "event_type": "legacy.execution.finished",
+                    "schema_name": "noetl.event",
+                    "schema_version": 1,
+                    "execution_id": kwargs["execution_id"],
+                }
+            ]
+
+    registry = EventUpcasterRegistry()
+    registry.register(
+        "noetl.event",
+        1,
+        lambda event: {
+            **event,
+            "schema_version": 2,
+            "event_type": "execution.completed",
+            "status": "COMPLETED",
+        },
+    )
+
+    state = await ReplayService.replay_state(
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        execution_id=789,
+        cutoff=ReplayCutoff(),
+        projection="all",
+        limit=100,
+        event_reader=_Reader(),
+        upcaster_registry=registry,
+    )
+
+    assert state["execution"]["status"] == "COMPLETED"
+    assert state["last_event_type"] == "execution.completed"
+    assert state["upcaster_registry_digest"] == registry.digest()
+
+
+@pytest.mark.asyncio
 async def test_replay_service_resolves_payload_refs_with_adapter():
     from noetl.server.api.replay import (
         ReplayCutoff,


### PR DESCRIPTION
## Summary
- make ReplayService use a configurable upcaster registry instead of hard-coding the process default
- allow per-call registry injection for replay validation and schema-migration checks
- export EventUpcasterRegistry from the replay API module for tests/tools

Tracks noetl/noetl#434.

## Validation
- .venv/bin/python -m pytest tests/api/test_replay_routes.py tests/core/test_replay_upcasters.py -q
- scripts/check_replay_release_gate.sh