### PR TITLE
Seed replay snapshots for time cutoffs

### DIFF
--- a/noetl/server/api/replay/event_reader.py
+++ b/noetl/server/api/replay/event_reader.py
@@ -80,6 +80,51 @@ class PostgresReplayEventReader:
             for row in rows
         }
 
+    async def _time_cutoff_event_id(
+        self,
+        conn: Any,
+        *,
+        columns: set[str],
+        tenant_id: str,
+        organization_id: str,
+        execution_id: int,
+        cutoff: ReplayCutoff,
+    ) -> Optional[int]:
+        if cutoff.as_of_time is None:
+            return None
+
+        predicates = ["execution_id = %s"]
+        params: list[Any] = [execution_id]
+        if "tenant_id" in columns:
+            predicates.append("tenant_id = %s")
+            params.append(tenant_id)
+        elif tenant_id != "default":
+            return None
+        if "organization_id" in columns:
+            predicates.append("organization_id = %s")
+            params.append(organization_id)
+        elif organization_id != "default":
+            return None
+
+        time_column = "event_time" if "event_time" in columns else "created_at"
+        predicates.append(f"{time_column} <= %s")
+        params.append(cutoff.as_of_time)
+
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                f"""
+                SELECT MAX(event_id) AS cutoff_event_id
+                FROM noetl.event
+                WHERE {' AND '.join(predicates)}
+                """,
+                params,
+            )
+            row = await cur.fetchone()
+        if not row:
+            return None
+        value = row.get("cutoff_event_id") if isinstance(row, Mapping) else row[0]
+        return int(value) if value is not None else None
+
     async def load_events(
         self,
         *,
@@ -158,8 +203,6 @@ class PostgresReplayEventReader:
         cutoff: ReplayCutoff,
     ) -> Optional[ReplaySnapshotSeed]:
         cutoff_event_id = cutoff.as_of_event_id or cutoff.as_of_position
-        if cutoff.as_of_time is not None:
-            return None
 
         aggregate_id = f"execution/{execution_id}/{projection}"
         aggregate_type = "replay_state"
@@ -176,6 +219,21 @@ class PostgresReplayEventReader:
 
         try:
             async with get_pool_connection() as conn:
+                if cutoff.as_of_time is not None:
+                    columns = await self._event_columns(conn)
+                    cutoff_event_id = await self._time_cutoff_event_id(
+                        conn,
+                        columns=columns,
+                        tenant_id=tenant_id,
+                        organization_id=organization_id,
+                        execution_id=execution_id,
+                        cutoff=cutoff,
+                    )
+                    if cutoff_event_id is None:
+                        return None
+                    predicates.append("version <= %s")
+                    params.append(cutoff_event_id)
+
                 async with conn.cursor(row_factory=dict_row) as cur:
                     await cur.execute(
                         f"""

--- a/tests/api/test_replay_routes.py
+++ b/tests/api/test_replay_routes.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -564,6 +566,103 @@ async def test_replay_service_uses_configured_event_reader():
         "business_objects",
         "loops",
     }
+
+
+@pytest.mark.asyncio
+async def test_postgres_replay_reader_uses_snapshot_seed_for_time_cutoff(monkeypatch):
+    import noetl.server.api.replay.event_reader as event_reader_module
+
+    from noetl.server.api.replay import ReplayCutoff
+    from noetl.server.api.replay.event_reader import PostgresReplayEventReader
+
+    cutoff_time = datetime(2026, 5, 20, 4, 30, tzinfo=timezone.utc)
+
+    class _Cursor:
+        def __init__(self, conn):
+            self.conn = conn
+            self.kind = None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, query, params=None):
+            self.conn.calls.append((query, list(params or [])))
+            if "information_schema.columns" in query:
+                self.kind = "columns"
+            elif "MAX(event_id)" in query:
+                self.kind = "time_cutoff"
+            elif "FROM noetl.projection_snapshot" in query:
+                self.kind = "snapshot"
+            else:  # pragma: no cover - catches unexpected SQL shape
+                raise AssertionError(query)
+
+        async def fetchall(self):
+            assert self.kind == "columns"
+            return [
+                {"column_name": "tenant_id"},
+                {"column_name": "organization_id"},
+                {"column_name": "event_time"},
+            ]
+
+        async def fetchone(self):
+            if self.kind == "time_cutoff":
+                return {"cutoff_event_id": 10}
+            if self.kind == "snapshot":
+                return {
+                    "aggregate_id": "execution/123/all",
+                    "aggregate_type": "replay_state",
+                    "version": 7,
+                    "snapshot": {"event_count": 7},
+                    "checksum": "abc",
+                    "meta": {"projection_code_version": "test"},
+                }
+            raise AssertionError(self.kind)
+
+    class _Conn:
+        def __init__(self):
+            self.calls = []
+
+        def cursor(self, **_kwargs):
+            return _Cursor(self)
+
+    class _ConnCtx:
+        def __init__(self, conn):
+            self.conn = conn
+
+        async def __aenter__(self):
+            return self.conn
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    conn = _Conn()
+    monkeypatch.setattr(event_reader_module, "get_pool_connection", lambda: _ConnCtx(conn))
+
+    seed = await PostgresReplayEventReader().load_snapshot_seed(
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        execution_id=123,
+        projection="all",
+        cutoff=ReplayCutoff(as_of_time=cutoff_time),
+    )
+
+    assert seed is not None
+    assert seed.version == 7
+    time_query, time_params = conn.calls[1]
+    snapshot_query, snapshot_params = conn.calls[2]
+    assert "event_time <= %s" in time_query
+    assert time_params == [123, "tenant-a", "org-a", cutoff_time]
+    assert "version <= %s" in snapshot_query
+    assert snapshot_params == [
+        "tenant-a",
+        "org-a",
+        "replay_state",
+        "execution/123/all",
+        10,
+    ]
 
 
 def test_frame_projection_checksum_matches_live_rows_and_replayed_state():


### PR DESCRIPTION
## Summary
- let the Postgres replay reader use replay snapshots for `as_of_time` cutoffs when the snapshot version is at or before the resolved cutoff event id
- preserve the storage-neutral `ReplayEventReader` contract; this is only the reference adapter implementation
- add a focused test for the time-cutoff snapshot lookup and version guard

Tracks noetl/noetl#434.

## Validation
- `.venv/bin/python -m pytest tests/api/test_replay_routes.py -q`
- `scripts/check_replay_release_gate.sh`
