### PR TITLE
Guard replay snapshots by registry digest

### DIFF
--- a/noetl/server/api/replay/__init__.py
+++ b/noetl/server/api/replay/__init__.py
@@ -37,6 +37,8 @@ from .service import (
     projection_checksum_parity_report,
     replay_payload_references,
     replay_payload_resolution_summary,
+    replay_snapshot_is_compatible,
+    replay_snapshot_upcaster_registry_digest,
     resolve_replay_payload_references,
 )
 
@@ -75,5 +77,7 @@ __all__ = [
     "projection_checksum_parity_report",
     "replay_payload_references",
     "replay_payload_resolution_summary",
+    "replay_snapshot_is_compatible",
+    "replay_snapshot_upcaster_registry_digest",
     "resolve_replay_payload_references",
 ]

--- a/noetl/server/api/replay/service.py
+++ b/noetl/server/api/replay/service.py
@@ -35,6 +35,31 @@ PROJECTION_CHECKSUM_SURFACES = (
 DEFAULT_REPLAY_PAYLOAD_RESOLVER = TempStoreReplayPayloadResolver()
 
 
+def replay_snapshot_upcaster_registry_digest(snapshot_seed: ReplaySnapshotSeed | None) -> Optional[str]:
+    """Return the upcaster registry digest recorded by a replay snapshot seed."""
+    if snapshot_seed is None:
+        return None
+    state_digest = snapshot_seed.state.get("upcaster_registry_digest")
+    if state_digest is not None:
+        return str(state_digest)
+    meta_digest = snapshot_seed.meta.get("upcaster_registry_digest")
+    if meta_digest is not None:
+        return str(meta_digest)
+    return None
+
+
+def replay_snapshot_is_compatible(
+    snapshot_seed: ReplaySnapshotSeed | None,
+    *,
+    upcaster_registry_digest: str,
+) -> bool:
+    """Snapshots are accelerators; ignore seeds produced by a different registry."""
+    if snapshot_seed is None:
+        return False
+    snapshot_digest = replay_snapshot_upcaster_registry_digest(snapshot_seed)
+    return snapshot_digest == upcaster_registry_digest
+
+
 def _json_default(value: Any) -> str:
     if isinstance(value, datetime):
         if value.tzinfo is None:
@@ -1145,6 +1170,12 @@ class ReplayService:
             projection=projection,
             cutoff=cutoff,
         )
+        registry_digest = registry.digest()
+        if not replay_snapshot_is_compatible(
+            snapshot_seed,
+            upcaster_registry_digest=registry_digest,
+        ):
+            snapshot_seed = None
         events = registry.upcast_events(
             await reader.load_events(
                 tenant_id=tenant_id,
@@ -1161,7 +1192,7 @@ class ReplayService:
             organization_id=organization_id,
             execution_id=execution_id,
             projection=projection,
-            upcaster_registry_digest=registry.digest(),
+            upcaster_registry_digest=registry_digest,
             base_state=snapshot_seed.state if snapshot_seed else None,
             snapshot_seed=snapshot_seed,
         )

--- a/tests/api/test_replay_routes.py
+++ b/tests/api/test_replay_routes.py
@@ -616,6 +616,79 @@ async def test_replay_service_uses_configured_event_reader():
 
 
 @pytest.mark.asyncio
+async def test_replay_service_ignores_snapshot_with_mismatched_upcaster_digest():
+    from noetl.core.replay import EventUpcasterRegistry
+    from noetl.server.api.replay import ReplayCutoff, ReplayService
+    from noetl.server.api.replay.service import ReplaySnapshotSeed, fold_replay_state
+
+    stale_state = fold_replay_state(
+        [
+            {
+                "event_id": 1,
+                "event_type": "execution.failed",
+                "status": "FAILED",
+                "execution_id": 123,
+            }
+        ],
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        execution_id=123,
+        upcaster_registry_digest="stale-digest",
+    )
+
+    class _Reader:
+        def __init__(self):
+            self.after_event_id = None
+
+        async def load_snapshot_seed(self, **kwargs):
+            return ReplaySnapshotSeed(
+                aggregate_id="execution/123/all",
+                aggregate_type="replay_state",
+                version=1,
+                checksum=stale_state["checksum"],
+                state=stale_state,
+                meta={},
+            )
+
+        async def load_events(self, **kwargs):
+            self.after_event_id = kwargs["after_event_id"]
+            return [
+                {
+                    "event_id": 1,
+                    "event_type": "execution.started",
+                    "status": "RUNNING",
+                    "execution_id": kwargs["execution_id"],
+                },
+                {
+                    "event_id": 2,
+                    "event_type": "execution.completed",
+                    "status": "COMPLETED",
+                    "execution_id": kwargs["execution_id"],
+                },
+            ]
+
+    reader = _Reader()
+    registry = EventUpcasterRegistry()
+
+    state = await ReplayService.replay_state(
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        execution_id=123,
+        cutoff=ReplayCutoff(),
+        projection="all",
+        limit=100,
+        event_reader=reader,
+        upcaster_registry=registry,
+    )
+
+    assert reader.after_event_id is None
+    assert "replay_snapshot" not in state
+    assert state["event_count"] == 2
+    assert state["execution"]["status"] == "COMPLETED"
+    assert state["upcaster_registry_digest"] == registry.digest()
+
+
+@pytest.mark.asyncio
 async def test_postgres_replay_reader_uses_snapshot_seed_for_time_cutoff(monkeypatch):
     import noetl.server.api.replay.event_reader as event_reader_module
 


### PR DESCRIPTION
## Summary
- ignore replay snapshot seeds whose recorded upcaster registry digest does not match the registry used for the current fold
- keep the compatibility decision in `ReplayService`, so storage adapters can stay simple candidate readers
- export small snapshot compatibility helpers for validation tooling

Tracks noetl/noetl#434.

## Validation
- `.venv/bin/python -m pytest tests/api/test_replay_routes.py tests/core/test_replay_upcasters.py -q`
- `scripts/check_replay_release_gate.sh`
