### PR TITLE
Add replay state integrity validation gate

### DIFF
--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -14,6 +14,7 @@ fi
   tests/core/test_replay_payload_resolver.py \
   tests/scripts/test_fetch_replay_state_report.py \
   tests/scripts/test_run_replay_validation.py \
+  tests/scripts/test_check_replay_state_report.py \
   tests/scripts/test_check_replay_parity_report.py \
   tests/scripts/test_check_replay_payload_resolution_report.py \
   tests/api/test_replay_routes.py \

--- a/scripts/check_replay_state_report.py
+++ b/scripts/check_replay_state_report.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+"""Validate replay-state report structure and derived checksums."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from noetl.server.api.replay import replay_projection_checksum_bundle
+
+
+def _load_report(path: Path) -> dict[str, Any]:
+    data: Any = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def validate_replay_state_report(report: dict[str, Any]) -> dict[str, Any]:
+    failures: list[dict[str, Any]] = []
+
+    supplied_bundle = report.get("projection_checksums")
+    if not isinstance(supplied_bundle, dict):
+        failures.append({"field": "projection_checksums", "reason": "missing or not an object"})
+    else:
+        computed_bundle = replay_projection_checksum_bundle(report)
+        for surface, computed in computed_bundle.items():
+            supplied = supplied_bundle.get(surface)
+            if supplied != computed:
+                failures.append(
+                    {
+                        "field": f"projection_checksums.{surface}",
+                        "reason": "checksum mismatch",
+                        "supplied": supplied,
+                        "computed": computed,
+                    }
+                )
+
+    if report.get("checksum_algorithm") not in {None, "sha256"}:
+        failures.append(
+            {
+                "field": "checksum_algorithm",
+                "reason": "unsupported checksum algorithm",
+                "supplied": report.get("checksum_algorithm"),
+            }
+        )
+
+    snapshot = report.get("replay_snapshot")
+    if snapshot is not None:
+        if not isinstance(snapshot, dict):
+            failures.append({"field": "replay_snapshot", "reason": "must be an object"})
+        else:
+            snapshot_version = snapshot.get("version")
+            last_event_id = report.get("last_event_id")
+            if snapshot_version is None:
+                failures.append({"field": "replay_snapshot.version", "reason": "missing"})
+            elif last_event_id is not None and int(snapshot_version) > int(last_event_id):
+                failures.append(
+                    {
+                        "field": "replay_snapshot.version",
+                        "reason": "snapshot version is after replay last_event_id",
+                        "snapshot_version": snapshot_version,
+                        "last_event_id": last_event_id,
+                    }
+                )
+
+            state_digest = report.get("upcaster_registry_digest")
+            snapshot_meta = snapshot.get("meta") if isinstance(snapshot.get("meta"), dict) else {}
+            snapshot_digest = snapshot_meta.get("upcaster_registry_digest")
+            if snapshot_digest is not None and state_digest is not None and snapshot_digest != state_digest:
+                failures.append(
+                    {
+                        "field": "replay_snapshot.meta.upcaster_registry_digest",
+                        "reason": "snapshot registry digest differs from replay state",
+                        "snapshot": snapshot_digest,
+                        "state": state_digest,
+                    }
+                )
+
+    return {"matched": not failures, "failures": failures}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate NoETL replay-state report JSON",
+    )
+    parser.add_argument(
+        "--report",
+        required=True,
+        type=Path,
+        help="Replay state JSON returned by /api/replay/state",
+    )
+    args = parser.parse_args(argv)
+
+    output = validate_replay_state_report(_load_report(args.report))
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0 if output["matched"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -72,6 +72,15 @@ def main(argv: list[str] | None = None) -> int:
     for name, command in [
         ("fetch", fetch_command),
         (
+            "state_integrity",
+            [
+                sys.executable,
+                "scripts/check_replay_state_report.py",
+                "--report",
+                str(replay_path),
+            ],
+        ),
+        (
             "projection_parity",
             [
                 sys.executable,

--- a/tests/scripts/test_check_replay_state_report.py
+++ b/tests/scripts/test_check_replay_state_report.py
@@ -1,0 +1,86 @@
+import json
+from pathlib import Path
+
+from noetl.server.api.replay import fold_replay_state
+from noetl.server.api.replay.types import ReplaySnapshotSeed
+from scripts.check_replay_state_report import main
+
+
+def _replay_state():
+    return fold_replay_state(
+        [
+            {
+                "event_id": 1,
+                "event_type": "execution.started",
+                "status": "RUNNING",
+                "execution_id": 123,
+            },
+            {
+                "event_id": 2,
+                "event_type": "execution.completed",
+                "status": "COMPLETED",
+                "execution_id": 123,
+            },
+        ],
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        execution_id=123,
+        upcaster_registry_digest="digest-a",
+    )
+
+
+def test_check_replay_state_report_accepts_valid_state(tmp_path: Path, capsys):
+    path = tmp_path / "replay.json"
+    path.write_text(json.dumps(_replay_state()))
+
+    assert main(["--report", str(path)]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True
+
+
+def test_check_replay_state_report_rejects_projection_checksum_drift(tmp_path: Path, capsys):
+    state = _replay_state()
+    state["projection_checksums"]["execution"] = "0" * 64
+    path = tmp_path / "replay.json"
+    path.write_text(json.dumps(state))
+
+    assert main(["--report", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    assert output["failures"][0]["field"] == "projection_checksums.execution"
+
+
+def test_check_replay_state_report_rejects_inconsistent_snapshot(tmp_path: Path, capsys):
+    base = _replay_state()
+    seed = ReplaySnapshotSeed(
+        aggregate_id="execution/123/all",
+        aggregate_type="replay_state",
+        version=2,
+        checksum=base["checksum"],
+        state=base,
+        meta={"upcaster_registry_digest": "digest-a"},
+    )
+    state = fold_replay_state(
+        [
+            {
+                "event_id": 3,
+                "event_type": "execution.completed",
+                "status": "COMPLETED",
+                "execution_id": 123,
+            }
+        ],
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        execution_id=123,
+        upcaster_registry_digest="digest-a",
+        base_state=base,
+        snapshot_seed=seed,
+    )
+    state["replay_snapshot"]["meta"]["upcaster_registry_digest"] = "digest-b"
+    path = tmp_path / "replay.json"
+    path.write_text(json.dumps(state))
+
+    assert main(["--report", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    assert output["failures"][0]["field"] == "replay_snapshot.meta.upcaster_registry_digest"

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -40,11 +40,12 @@ def test_run_replay_validation_fetches_and_runs_selected_gates(monkeypatch, tmp_
         == 0
     )
 
-    assert len(calls) == 3
+    assert len(calls) == 4
     assert "scripts/fetch_replay_state_report.py" in calls[0]
     assert "--resolve-payloads" in calls[0]
-    assert "scripts/check_replay_parity_report.py" in calls[1]
-    assert "scripts/check_replay_payload_resolution_report.py" in calls[2]
+    assert "scripts/check_replay_state_report.py" in calls[1]
+    assert "scripts/check_replay_parity_report.py" in calls[2]
+    assert "scripts/check_replay_payload_resolution_report.py" in calls[3]
     output = json.loads(capsys.readouterr().out)
     assert output["matched"] is True
     assert output["replay"].endswith("replay-123.json")


### PR DESCRIPTION
## Summary
- add `scripts/check_replay_state_report.py` to validate replay-state report structure and recompute projection checksum bundles
- run the state-integrity gate from `scripts/run_replay_validation.py` immediately after fetching replay state
- include the new gate in `scripts/check_replay_release_gate.sh`

Tracks noetl/noetl#434.

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_check_replay_state_report.py tests/scripts/test_run_replay_validation.py tests/scripts/test_check_replay_parity_report.py -q`
- `scripts/check_replay_release_gate.sh`
