### PR TITLE
Validate replay state report checksum

### DIFF
--- a/scripts/check_replay_state_report.py
+++ b/scripts/check_replay_state_report.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from noetl.server.api.replay import replay_projection_checksum_bundle
 
@@ -17,6 +19,33 @@ def _load_report(path: Path) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise ValueError(f"{path} must contain a JSON object")
     return data
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def _canonical_checksum(value: Mapping[str, Any]) -> str:
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_json_default,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def replay_state_checksum(report: Mapping[str, Any]) -> str:
+    checksum_input = {
+        key: value
+        for key, value in report.items()
+        if key not in {"checksum", "checksum_algorithm", "projection_checksums"}
+    }
+    return _canonical_checksum(checksum_input)
 
 
 def validate_replay_state_report(report: dict[str, Any]) -> dict[str, Any]:
@@ -47,6 +76,17 @@ def validate_replay_state_report(report: dict[str, Any]) -> dict[str, Any]:
                 "supplied": report.get("checksum_algorithm"),
             }
         )
+    elif report.get("checksum") is not None:
+        computed_checksum = replay_state_checksum(report)
+        if report.get("checksum") != computed_checksum:
+            failures.append(
+                {
+                    "field": "checksum",
+                    "reason": "checksum mismatch",
+                    "supplied": report.get("checksum"),
+                    "computed": computed_checksum,
+                }
+            )
 
     snapshot = report.get("replay_snapshot")
     if snapshot is not None:

--- a/tests/scripts/test_check_replay_state_report.py
+++ b/tests/scripts/test_check_replay_state_report.py
@@ -50,6 +50,19 @@ def test_check_replay_state_report_rejects_projection_checksum_drift(tmp_path: P
     assert output["failures"][0]["field"] == "projection_checksums.execution"
 
 
+def test_check_replay_state_report_rejects_state_checksum_drift(tmp_path: Path, capsys):
+    state = _replay_state()
+    state["execution"]["status"] = "FAILED"
+    path = tmp_path / "replay.json"
+    path.write_text(json.dumps(state))
+
+    assert main(["--report", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    fields = {failure["field"] for failure in output["failures"]}
+    assert "checksum" in fields
+
+
 def test_check_replay_state_report_rejects_inconsistent_snapshot(tmp_path: Path, capsys):
     base = _replay_state()
     seed = ReplaySnapshotSeed(
@@ -83,4 +96,5 @@ def test_check_replay_state_report_rejects_inconsistent_snapshot(tmp_path: Path,
     assert main(["--report", str(path)]) == 1
     output = json.loads(capsys.readouterr().out)
     assert output["matched"] is False
-    assert output["failures"][0]["field"] == "replay_snapshot.meta.upcaster_registry_digest"
+    fields = {failure["field"] for failure in output["failures"]}
+    assert "replay_snapshot.meta.upcaster_registry_digest" in fields


### PR DESCRIPTION
## Summary
- extend `scripts/check_replay_state_report.py` to recompute and validate the top-level replay state checksum
- keep projection checksum validation separate for surface-level diagnostics
- add regression coverage for mutated replay state reports

Tracks noetl/noetl#434.

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_check_replay_state_report.py tests/scripts/test_run_replay_validation.py -q`
- `scripts/check_replay_release_gate.sh`
