### PR TITLE
Require replay state report envelope fields

### DIFF
--- a/scripts/check_replay_state_report.py
+++ b/scripts/check_replay_state_report.py
@@ -13,6 +13,20 @@ from typing import Any, Mapping
 
 from noetl.server.api.replay import replay_projection_checksum_bundle
 
+REQUIRED_TOP_LEVEL_FIELDS = (
+    "tenant_id",
+    "organization_id",
+    "execution_id",
+    "projection",
+    "upcaster_registry_digest",
+    "event_count",
+    "last_event_id",
+    "last_event_type",
+    "checksum_algorithm",
+    "checksum",
+    "projection_checksums",
+)
+
 
 def _load_report(path: Path) -> dict[str, Any]:
     data: Any = json.loads(path.read_text())
@@ -51,6 +65,10 @@ def replay_state_checksum(report: Mapping[str, Any]) -> str:
 def validate_replay_state_report(report: dict[str, Any]) -> dict[str, Any]:
     failures: list[dict[str, Any]] = []
 
+    for field in REQUIRED_TOP_LEVEL_FIELDS:
+        if field not in report:
+            failures.append({"field": field, "reason": "missing required replay state field"})
+
     supplied_bundle = report.get("projection_checksums")
     if not isinstance(supplied_bundle, dict):
         failures.append({"field": "projection_checksums", "reason": "missing or not an object"})
@@ -68,11 +86,11 @@ def validate_replay_state_report(report: dict[str, Any]) -> dict[str, Any]:
                     }
                 )
 
-    if report.get("checksum_algorithm") not in {None, "sha256"}:
+    if report.get("checksum_algorithm") != "sha256":
         failures.append(
             {
                 "field": "checksum_algorithm",
-                "reason": "unsupported checksum algorithm",
+                "reason": "checksum_algorithm must be sha256",
                 "supplied": report.get("checksum_algorithm"),
             }
         )

--- a/tests/scripts/test_check_replay_state_report.py
+++ b/tests/scripts/test_check_replay_state_report.py
@@ -63,6 +63,33 @@ def test_check_replay_state_report_rejects_state_checksum_drift(tmp_path: Path, 
     assert "checksum" in fields
 
 
+def test_check_replay_state_report_rejects_missing_required_fields(tmp_path: Path, capsys):
+    state = _replay_state()
+    state.pop("tenant_id")
+    state.pop("checksum")
+    path = tmp_path / "replay.json"
+    path.write_text(json.dumps(state))
+
+    assert main(["--report", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    fields = {failure["field"] for failure in output["failures"]}
+    assert {"tenant_id", "checksum"} <= fields
+
+
+def test_check_replay_state_report_requires_sha256_algorithm(tmp_path: Path, capsys):
+    state = _replay_state()
+    state["checksum_algorithm"] = "md5"
+    path = tmp_path / "replay.json"
+    path.write_text(json.dumps(state))
+
+    assert main(["--report", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    fields = {failure["field"] for failure in output["failures"]}
+    assert "checksum_algorithm" in fields
+
+
 def test_check_replay_state_report_rejects_inconsistent_snapshot(tmp_path: Path, capsys):
     base = _replay_state()
     seed = ReplaySnapshotSeed(


### PR DESCRIPTION
## Summary
- make `scripts/check_replay_state_report.py` require canonical replay-state envelope fields
- require `checksum_algorithm` to be exactly `sha256`
- add regression coverage for missing envelope fields and unsupported checksum algorithms

Tracks noetl/noetl#434.

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_check_replay_state_report.py tests/scripts/test_run_replay_validation.py -q`
- `scripts/check_replay_release_gate.sh`
