### PR TITLE
Validate replay payload checksum shape

### DIFF
--- a/scripts/check_replay_payload_resolution_report.py
+++ b/scripts/check_replay_payload_resolution_report.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
 
 from noetl.server.api.replay import replay_payload_resolution_summary
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 def _load_report(path: Path) -> dict[str, Any]:
@@ -30,6 +33,28 @@ def _payload_resolution_rows(report: dict[str, Any]) -> list[dict[str, Any]]:
     return [dict(row) for row in rows if isinstance(row, dict)]
 
 
+def _checksum_shape_failures(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    failures: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        resolution = row.get("resolution")
+        if not isinstance(resolution, dict):
+            continue
+        checksum = resolution.get("checksum")
+        if checksum is None:
+            continue
+        if not _SHA256_RE.fullmatch(str(checksum)):
+            failures.append(
+                {
+                    "index": index,
+                    "scope": row.get("scope"),
+                    "ref": resolution.get("ref"),
+                    "checksum": checksum,
+                    "reason": "payload checksum must be a lowercase sha256 hex digest",
+                }
+            )
+    return failures
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Validate NoETL replay payload-resolution report JSON",
@@ -44,6 +69,16 @@ def main(argv: list[str] | None = None) -> int:
 
     report = _load_report(args.report)
     rows = _payload_resolution_rows(report)
+    checksum_shape_failures = _checksum_shape_failures(rows)
+    if checksum_shape_failures:
+        output = {
+            "matched": False,
+            "reason": "payload checksum shape mismatch",
+            "checksum_shape_failures": checksum_shape_failures,
+        }
+        print(json.dumps(output, indent=2, sort_keys=True))
+        return 1
+
     computed_summary = replay_payload_resolution_summary(rows)
     supplied_summary = report.get("payload_resolution_summary") or {}
     if supplied_summary and supplied_summary.get("checksum") != computed_summary["checksum"]:

--- a/tests/scripts/test_check_replay_payload_resolution_report.py
+++ b/tests/scripts/test_check_replay_payload_resolution_report.py
@@ -80,3 +80,27 @@ def test_check_replay_payload_resolution_report_rejects_summary_mismatch(tmp_pat
     report = json.loads(capsys.readouterr().out)
     assert report["matched"] is False
     assert report["reason"] == "payload_resolution_summary checksum mismatch"
+
+
+def test_check_replay_payload_resolution_report_rejects_invalid_checksum_shape(
+    tmp_path: Path,
+    capsys,
+):
+    rows = [
+        {
+            "scope": "frame",
+            "resolution": {
+                "ref": "noetl://payload/1",
+                "resolved": True,
+                "checksum": "not-a-digest",
+            },
+        }
+    ]
+    report_path = tmp_path / "replay.json"
+    report_path.write_text(json.dumps({"payload_resolution": rows}))
+
+    assert main(["--report", str(report_path)]) == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["matched"] is False
+    assert report["reason"] == "payload checksum shape mismatch"
+    assert report["checksum_shape_failures"][0]["ref"] == "noetl://payload/1"


### PR DESCRIPTION
## Summary
- make `scripts/check_replay_payload_resolution_report.py` reject resolved payload checksums that are not lowercase SHA-256 hex digests
- report the failing payload ref/scope/index for diagnosis
- add regression coverage for invalid payload checksum shape

Tracks noetl/noetl#434.

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_check_replay_payload_resolution_report.py tests/scripts/test_run_replay_validation.py -q`
- `scripts/check_replay_release_gate.sh`
