### PR TITLE
Validate replay registry digest shape

### DIFF
--- a/scripts/check_replay_state_report.py
+++ b/scripts/check_replay_state_report.py
@@ -6,12 +6,15 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
 
 from noetl.server.api.replay import replay_projection_checksum_bundle
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 REQUIRED_TOP_LEVEL_FIELDS = (
     "tenant_id",
@@ -62,12 +65,36 @@ def replay_state_checksum(report: Mapping[str, Any]) -> str:
     return _canonical_checksum(checksum_input)
 
 
+def _validate_digest_shape(
+    failures: list[dict[str, Any]],
+    *,
+    field: str,
+    value: Any,
+) -> None:
+    if value is None:
+        return
+    if not _SHA256_RE.fullmatch(str(value)):
+        failures.append(
+            {
+                "field": field,
+                "reason": "digest must be a lowercase sha256 hex value",
+                "supplied": value,
+            }
+        )
+
+
 def validate_replay_state_report(report: dict[str, Any]) -> dict[str, Any]:
     failures: list[dict[str, Any]] = []
 
     for field in REQUIRED_TOP_LEVEL_FIELDS:
         if field not in report:
             failures.append({"field": field, "reason": "missing required replay state field"})
+
+    _validate_digest_shape(
+        failures,
+        field="upcaster_registry_digest",
+        value=report.get("upcaster_registry_digest"),
+    )
 
     supplied_bundle = report.get("projection_checksums")
     if not isinstance(supplied_bundle, dict):
@@ -128,6 +155,11 @@ def validate_replay_state_report(report: dict[str, Any]) -> dict[str, Any]:
             state_digest = report.get("upcaster_registry_digest")
             snapshot_meta = snapshot.get("meta") if isinstance(snapshot.get("meta"), dict) else {}
             snapshot_digest = snapshot_meta.get("upcaster_registry_digest")
+            _validate_digest_shape(
+                failures,
+                field="replay_snapshot.meta.upcaster_registry_digest",
+                value=snapshot_digest,
+            )
             if snapshot_digest is not None and state_digest is not None and snapshot_digest != state_digest:
                 failures.append(
                     {

--- a/tests/scripts/test_check_replay_state_report.py
+++ b/tests/scripts/test_check_replay_state_report.py
@@ -5,6 +5,8 @@ from noetl.server.api.replay import fold_replay_state
 from noetl.server.api.replay.types import ReplaySnapshotSeed
 from scripts.check_replay_state_report import main
 
+REGISTRY_DIGEST = "a" * 64
+
 
 def _replay_state():
     return fold_replay_state(
@@ -25,7 +27,7 @@ def _replay_state():
         tenant_id="tenant-a",
         organization_id="org-a",
         execution_id=123,
-        upcaster_registry_digest="digest-a",
+        upcaster_registry_digest=REGISTRY_DIGEST,
     )
 
 
@@ -90,6 +92,22 @@ def test_check_replay_state_report_requires_sha256_algorithm(tmp_path: Path, cap
     assert "checksum_algorithm" in fields
 
 
+def test_check_replay_state_report_rejects_invalid_registry_digest_shape(
+    tmp_path: Path,
+    capsys,
+):
+    state = _replay_state()
+    state["upcaster_registry_digest"] = "digest-a"
+    path = tmp_path / "replay.json"
+    path.write_text(json.dumps(state))
+
+    assert main(["--report", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    fields = {failure["field"] for failure in output["failures"]}
+    assert "upcaster_registry_digest" in fields
+
+
 def test_check_replay_state_report_rejects_inconsistent_snapshot(tmp_path: Path, capsys):
     base = _replay_state()
     seed = ReplaySnapshotSeed(
@@ -98,7 +116,7 @@ def test_check_replay_state_report_rejects_inconsistent_snapshot(tmp_path: Path,
         version=2,
         checksum=base["checksum"],
         state=base,
-        meta={"upcaster_registry_digest": "digest-a"},
+        meta={"upcaster_registry_digest": REGISTRY_DIGEST},
     )
     state = fold_replay_state(
         [
@@ -112,11 +130,11 @@ def test_check_replay_state_report_rejects_inconsistent_snapshot(tmp_path: Path,
         tenant_id="tenant-a",
         organization_id="org-a",
         execution_id=123,
-        upcaster_registry_digest="digest-a",
+        upcaster_registry_digest=REGISTRY_DIGEST,
         base_state=base,
         snapshot_seed=seed,
     )
-    state["replay_snapshot"]["meta"]["upcaster_registry_digest"] = "digest-b"
+    state["replay_snapshot"]["meta"]["upcaster_registry_digest"] = "b" * 64
     path = tmp_path / "replay.json"
     path.write_text(json.dumps(state))
 


### PR DESCRIPTION
## Summary
- make `scripts/check_replay_state_report.py` validate `upcaster_registry_digest` is a lowercase SHA-256 hex digest
- validate snapshot registry digest shape before comparing it to replay state
- update replay state report tests to use realistic digest-shaped values

Tracks noetl/noetl#434.

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_check_replay_state_report.py tests/scripts/test_run_replay_validation.py -q`
- `scripts/check_replay_release_gate.sh`
