### PR TITLE
Reject malformed replay payload-resolution rows

### DIFF
--- a/scripts/check_replay_payload_resolution_report.py
+++ b/scripts/check_replay_payload_resolution_report.py
@@ -30,7 +30,32 @@ def _payload_resolution_rows(report: dict[str, Any]) -> list[dict[str, Any]]:
         raise ValueError("report does not contain payload_resolution")
     if not isinstance(rows, list):
         raise ValueError("payload_resolution must be a list")
-    return [dict(row) for row in rows if isinstance(row, dict)]
+    return rows
+
+
+def _row_shape_failures(rows: list[Any]) -> list[dict[str, Any]]:
+    failures: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            failures.append(
+                {
+                    "index": index,
+                    "reason": "payload_resolution row must be an object",
+                    "supplied_type": type(row).__name__,
+                }
+            )
+            continue
+        resolution = row.get("resolution")
+        if not isinstance(resolution, dict):
+            failures.append(
+                {
+                    "index": index,
+                    "scope": row.get("scope"),
+                    "reason": "payload_resolution row resolution must be an object",
+                    "supplied_type": type(resolution).__name__,
+                }
+            )
+    return failures
 
 
 def _checksum_shape_failures(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -69,6 +94,16 @@ def main(argv: list[str] | None = None) -> int:
 
     report = _load_report(args.report)
     rows = _payload_resolution_rows(report)
+    row_shape_failures = _row_shape_failures(rows)
+    if row_shape_failures:
+        output = {
+            "matched": False,
+            "reason": "payload_resolution row shape mismatch",
+            "row_shape_failures": row_shape_failures,
+        }
+        print(json.dumps(output, indent=2, sort_keys=True))
+        return 1
+
     checksum_shape_failures = _checksum_shape_failures(rows)
     if checksum_shape_failures:
         output = {

--- a/tests/scripts/test_check_replay_payload_resolution_report.py
+++ b/tests/scripts/test_check_replay_payload_resolution_report.py
@@ -104,3 +104,33 @@ def test_check_replay_payload_resolution_report_rejects_invalid_checksum_shape(
     assert report["matched"] is False
     assert report["reason"] == "payload checksum shape mismatch"
     assert report["checksum_shape_failures"][0]["ref"] == "noetl://payload/1"
+
+
+def test_check_replay_payload_resolution_report_rejects_non_object_rows(
+    tmp_path: Path,
+    capsys,
+):
+    report_path = tmp_path / "replay.json"
+    report_path.write_text(json.dumps({"payload_resolution": ["not-a-row"]}))
+
+    assert main(["--report", str(report_path)]) == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["matched"] is False
+    assert report["reason"] == "payload_resolution row shape mismatch"
+    assert report["row_shape_failures"][0]["index"] == 0
+
+
+def test_check_replay_payload_resolution_report_rejects_non_object_resolution(
+    tmp_path: Path,
+    capsys,
+):
+    report_path = tmp_path / "replay.json"
+    report_path.write_text(
+        json.dumps({"payload_resolution": [{"scope": "frame", "resolution": "not-an-object"}]})
+    )
+
+    assert main(["--report", str(report_path)]) == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["matched"] is False
+    assert report["reason"] == "payload_resolution row shape mismatch"
+    assert report["row_shape_failures"][0]["scope"] == "frame"


### PR DESCRIPTION
## Summary
- make the replay payload-resolution gate reject non-object payload_resolution rows
- reject rows whose resolution field is missing or not an object before checksum/summary validation
- add regression coverage so malformed replay evidence cannot be silently filtered out

Tracks noetl/noetl#434.

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_check_replay_payload_resolution_report.py tests/scripts/test_run_replay_validation.py -q`
- `scripts/check_replay_release_gate.sh`
