### PR TITLE
Require integer JSON fields in replay state gate

### DIFF
--- a/scripts/check_replay_state_report.py
+++ b/scripts/check_replay_state_report.py
@@ -95,14 +95,10 @@ def _validate_int_field(
         if required:
             failures.append({"field": field, "reason": "must be an integer"})
         return None
-    if isinstance(value, bool):
+    if isinstance(value, bool) or not isinstance(value, int):
         failures.append({"field": field, "reason": "must be an integer", "supplied": value})
         return None
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        failures.append({"field": field, "reason": "must be an integer", "supplied": value})
-        return None
+    parsed = value
     if minimum is not None and parsed < minimum:
         failures.append(
             {

--- a/tests/scripts/test_check_replay_state_report.py
+++ b/tests/scripts/test_check_replay_state_report.py
@@ -123,6 +123,21 @@ def test_check_replay_state_report_rejects_invalid_field_types(tmp_path: Path, c
     assert {"execution_id", "event_count", "tenant_id"} <= fields
 
 
+def test_check_replay_state_report_rejects_string_integer_fields(tmp_path: Path, capsys):
+    state = _replay_state()
+    state["execution_id"] = "123"
+    state["event_count"] = "4"
+    state["last_event_id"] = "9"
+    path = tmp_path / "replay.json"
+    path.write_text(json.dumps(state))
+
+    assert main(["--report", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    fields = {failure["field"] for failure in output["failures"]}
+    assert {"execution_id", "event_count", "last_event_id"} <= fields
+
+
 def test_check_replay_state_report_rejects_invalid_snapshot_version_without_crashing(
     tmp_path: Path,
     capsys,
@@ -132,6 +147,28 @@ def test_check_replay_state_report_rejects_invalid_snapshot_version_without_cras
         "aggregate_id": "execution/123/all",
         "aggregate_type": "replay_state",
         "version": "not-an-int",
+        "checksum": "a" * 64,
+        "meta": {"upcaster_registry_digest": REGISTRY_DIGEST},
+    }
+    path = tmp_path / "replay.json"
+    path.write_text(json.dumps(state))
+
+    assert main(["--report", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    fields = {failure["field"] for failure in output["failures"]}
+    assert "replay_snapshot.version" in fields
+
+
+def test_check_replay_state_report_rejects_string_snapshot_version(
+    tmp_path: Path,
+    capsys,
+):
+    state = _replay_state()
+    state["replay_snapshot"] = {
+        "aggregate_id": "execution/123/all",
+        "aggregate_type": "replay_state",
+        "version": "5",
         "checksum": "a" * 64,
         "meta": {"upcaster_registry_digest": REGISTRY_DIGEST},
     }


### PR DESCRIPTION
## Summary
- require replay state-report integer fields to be actual JSON integers instead of coercible strings
- apply the same strict integer shape to replay snapshot versions
- add regression coverage for stringified execution/event counters and snapshot versions

Tracks noetl/noetl#434.

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_check_replay_state_report.py tests/scripts/test_run_replay_validation.py -q`
- `scripts/check_replay_release_gate.sh`
