### PR TITLE
Require replay parity checksum surfaces

### DIFF
--- a/scripts/check_replay_parity_report.py
+++ b/scripts/check_replay_parity_report.py
@@ -13,6 +13,14 @@ from typing import Any
 from noetl.server.api.replay import projection_checksum_parity_report
 
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+REQUIRED_PROJECTION_SURFACES = (
+    "execution",
+    "stages",
+    "frames",
+    "commands",
+    "business_objects",
+    "loops",
+)
 
 
 def _load_bundle(path: Path) -> dict[str, str]:
@@ -36,6 +44,28 @@ def _checksum_shape_report(bundle: dict[str, str], *, label: str) -> list[dict[s
                     "reason": "checksum must be a lowercase sha256 hex digest",
                 }
             )
+    return failures
+
+
+def _surface_shape_report(bundle: dict[str, str], *, label: str) -> list[dict[str, str]]:
+    failures: list[dict[str, str]] = []
+    for surface in REQUIRED_PROJECTION_SURFACES:
+        if surface not in bundle:
+            failures.append(
+                {
+                    "bundle": label,
+                    "surface": surface,
+                    "reason": "missing required projection checksum surface",
+                }
+            )
+    for surface in sorted(set(bundle) - set(REQUIRED_PROJECTION_SURFACES)):
+        failures.append(
+            {
+                "bundle": label,
+                "surface": surface,
+                "reason": "unknown projection checksum surface",
+            }
+        )
     return failures
 
 
@@ -68,6 +98,13 @@ def main(argv: list[str] | None = None) -> int:
         replayed=replayed,
         live=live,
     )
+    surface_failures: list[dict[str, str]] = []
+    surface_failures.extend(_surface_shape_report(replayed, label="replayed"))
+    surface_failures.extend(_surface_shape_report(live, label="live"))
+    if surface_failures:
+        report["matched"] = False
+        report["surface_shape_failures"] = surface_failures
+
     shape_failures: list[dict[str, str]] = []
     if not args.allow_invalid_checksum_shape:
         shape_failures.extend(_checksum_shape_report(replayed, label="replayed"))

--- a/tests/scripts/test_check_replay_parity_report.py
+++ b/tests/scripts/test_check_replay_parity_report.py
@@ -97,3 +97,43 @@ def test_check_replay_parity_report_can_allow_legacy_checksum_shape(tmp_path: Pa
         == 0
     )
     assert json.loads(capsys.readouterr().out)["matched"] is True
+
+
+def test_check_replay_parity_report_rejects_missing_required_surface(tmp_path: Path, capsys):
+    bundle = {
+        "execution": "a" * 64,
+        "stages": "b" * 64,
+        "frames": "c" * 64,
+        "commands": "d" * 64,
+        "business_objects": "e" * 64,
+    }
+    replayed_path = tmp_path / "replayed.json"
+    live_path = tmp_path / "live.json"
+    replayed_path.write_text(json.dumps(bundle))
+    live_path.write_text(json.dumps(bundle))
+
+    assert main(["--replayed", str(replayed_path), "--live", str(live_path)]) == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["matched"] is False
+    assert report["surface_shape_failures"][0]["surface"] == "loops"
+
+
+def test_check_replay_parity_report_rejects_unknown_surface(tmp_path: Path, capsys):
+    bundle = {
+        "execution": "a" * 64,
+        "stages": "b" * 64,
+        "frames": "c" * 64,
+        "commands": "d" * 64,
+        "business_objects": "e" * 64,
+        "loops": "f" * 64,
+        "extra": "0" * 64,
+    }
+    replayed_path = tmp_path / "replayed.json"
+    live_path = tmp_path / "live.json"
+    replayed_path.write_text(json.dumps(bundle))
+    live_path.write_text(json.dumps(bundle))
+
+    assert main(["--replayed", str(replayed_path), "--live", str(live_path)]) == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["matched"] is False
+    assert report["surface_shape_failures"][0]["surface"] == "extra"


### PR DESCRIPTION
## Summary
- make the offline replay parity gate require the complete canonical projection checksum bundle
- reject missing required surfaces and unknown extra surfaces on replayed/live bundles
- add regression coverage for partial and unexpected checksum maps

Tracks noetl/noetl#434.

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_check_replay_parity_report.py tests/scripts/test_run_replay_validation.py -q`
- `scripts/check_replay_release_gate.sh`
