### PR TITLE
Require replay state projection checksum surfaces

### DIFF
--- a/scripts/check_replay_state_report.py
+++ b/scripts/check_replay_state_report.py
@@ -15,6 +15,14 @@ from typing import Any, Mapping
 from noetl.server.api.replay import replay_projection_checksum_bundle
 
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+REQUIRED_PROJECTION_SURFACES = (
+    "execution",
+    "stages",
+    "frames",
+    "commands",
+    "business_objects",
+    "loops",
+)
 
 REQUIRED_TOP_LEVEL_FIELDS = (
     "tenant_id",
@@ -79,6 +87,28 @@ def _validate_digest_shape(
                 "field": field,
                 "reason": "digest must be a lowercase sha256 hex value",
                 "supplied": value,
+            }
+        )
+
+
+def _validate_projection_surface_shape(
+    failures: list[dict[str, Any]],
+    *,
+    bundle: dict[str, Any],
+) -> None:
+    for surface in REQUIRED_PROJECTION_SURFACES:
+        if surface not in bundle:
+            failures.append(
+                {
+                    "field": f"projection_checksums.{surface}",
+                    "reason": "missing required projection checksum surface",
+                }
+            )
+    for surface in sorted(set(bundle) - set(REQUIRED_PROJECTION_SURFACES)):
+        failures.append(
+            {
+                "field": f"projection_checksums.{surface}",
+                "reason": "unknown projection checksum surface",
             }
         )
 
@@ -160,6 +190,7 @@ def validate_replay_state_report(report: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(supplied_bundle, dict):
         failures.append({"field": "projection_checksums", "reason": "missing or not an object"})
     else:
+        _validate_projection_surface_shape(failures, bundle=supplied_bundle)
         try:
             computed_bundle = replay_projection_checksum_bundle(report)
         except (TypeError, ValueError) as exc:

--- a/tests/scripts/test_check_replay_state_report.py
+++ b/tests/scripts/test_check_replay_state_report.py
@@ -52,6 +52,38 @@ def test_check_replay_state_report_rejects_projection_checksum_drift(tmp_path: P
     assert output["failures"][0]["field"] == "projection_checksums.execution"
 
 
+def test_check_replay_state_report_rejects_missing_projection_checksum_surface(
+    tmp_path: Path,
+    capsys,
+):
+    state = _replay_state()
+    state["projection_checksums"].pop("loops")
+    path = tmp_path / "replay.json"
+    path.write_text(json.dumps(state))
+
+    assert main(["--report", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    fields = {failure["field"] for failure in output["failures"]}
+    assert "projection_checksums.loops" in fields
+
+
+def test_check_replay_state_report_rejects_unknown_projection_checksum_surface(
+    tmp_path: Path,
+    capsys,
+):
+    state = _replay_state()
+    state["projection_checksums"]["extra"] = "0" * 64
+    path = tmp_path / "replay.json"
+    path.write_text(json.dumps(state))
+
+    assert main(["--report", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    fields = {failure["field"] for failure in output["failures"]}
+    assert "projection_checksums.extra" in fields
+
+
 def test_check_replay_state_report_rejects_state_checksum_drift(tmp_path: Path, capsys):
     state = _replay_state()
     state["execution"]["status"] = "FAILED"


### PR DESCRIPTION
## Summary
- make the replay state-report gate require the complete canonical projection checksum surface set
- reject unknown extra projection checksum surfaces before parity validation
- add regression coverage for missing and unexpected state-report checksum surfaces

Tracks noetl/noetl#434.

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_check_replay_state_report.py tests/scripts/test_run_replay_validation.py -q`
- `scripts/check_replay_release_gate.sh`
