### PR TITLE
Emit replay validation run manifests

### DIFF
--- a/scripts/fetch_replay_state_report.py
+++ b/scripts/fetch_replay_state_report.py
@@ -59,6 +59,8 @@ def main(argv: list[str] | None = None) -> int:
     with urlopen(request, timeout=args.timeout) as response:
         body = response.read()
     data = json.loads(body.decode("utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("replay state response must be a JSON object")
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
     print(json.dumps({"output": str(args.output), "bytes": len(body)}, sort_keys=True))

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -7,17 +7,73 @@ import argparse
 import json
 import subprocess
 import sys
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 
-def _run(command: list[str]) -> tuple[int, str, str]:
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_json(value: str) -> object | None:
+    if not value.strip():
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return None
+
+
+def _run(command: list[str]) -> tuple[int, str, str, float]:
+    started = time.monotonic()
     completed = subprocess.run(
         command,
         check=False,
         text=True,
         capture_output=True,
     )
-    return completed.returncode, completed.stdout, completed.stderr
+    duration = time.monotonic() - started
+    return completed.returncode, completed.stdout, completed.stderr, duration
+
+
+def _build_report(
+    *,
+    matched: bool,
+    args: argparse.Namespace,
+    replay_path: Path,
+    steps: list[dict[str, object]],
+    started_at: str,
+) -> dict[str, object]:
+    finished_at = _utc_now()
+    return {
+        "matched": matched,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "replay": str(replay_path),
+        "config": {
+            "base_url": args.base_url,
+            "execution_id": args.execution_id,
+            "tenant_id": args.tenant_id,
+            "organization_id": args.organization_id,
+            "projection": args.projection,
+            "limit": args.limit,
+            "as_of_event_id": args.as_of_event_id,
+            "as_of_position": args.as_of_position,
+            "as_of_time": args.as_of_time,
+            "resolve_payloads": args.resolve_payloads,
+            "live_checksums": str(args.live_checksums) if args.live_checksums else None,
+        },
+        "steps": steps,
+    }
+
+
+def _emit_report(report: dict[str, object], report_output: Path | None) -> None:
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    if report_output is not None:
+        report_output.parent.mkdir(parents=True, exist_ok=True)
+        report_output.write_text(rendered + "\n")
+    print(rendered)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -37,9 +93,23 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--output-dir", required=True, type=Path)
     parser.add_argument("--timeout", default=60.0, type=float)
     parser.add_argument("--live-checksums", type=Path)
+    parser.add_argument(
+        "--report-output",
+        type=Path,
+        help="Optional path to write the validation run manifest JSON",
+    )
     args = parser.parse_args(argv)
 
+    cutoff_count = sum(
+        value is not None
+        for value in (args.as_of_event_id, args.as_of_position, args.as_of_time)
+    )
+    if cutoff_count > 1:
+        parser.error("use only one replay cutoff")
+
+    started_at = _utc_now()
     output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
     replay_path = output_dir / f"replay-{args.execution_id}.json"
     fetch_command = [
         sys.executable,
@@ -108,21 +178,63 @@ def main(argv: list[str] | None = None) -> int:
         if not command:
             steps.append({"name": name, "skipped": True})
             continue
-        code, stdout, stderr = _run(command)
-        steps.append(
-            {
-                "name": name,
-                "command": command,
-                "returncode": code,
-                "stdout": stdout,
-                "stderr": stderr,
-            }
-        )
+        code, stdout, stderr, duration = _run(command)
+        step = {
+            "name": name,
+            "command": command,
+            "returncode": code,
+            "duration_seconds": round(duration, 6),
+            "stdout": stdout,
+            "stderr": stderr,
+        }
+        stdout_json = _parse_json(stdout)
+        if stdout_json is not None:
+            step["stdout_json"] = stdout_json
+        steps.append(step)
         if code != 0:
-            print(json.dumps({"matched": False, "replay": str(replay_path), "steps": steps}, indent=2))
+            _emit_report(
+                _build_report(
+                    matched=False,
+                    args=args,
+                    replay_path=replay_path,
+                    steps=steps,
+                    started_at=started_at,
+                ),
+                args.report_output,
+            )
             return code
+        if name == "fetch" and not replay_path.exists():
+            steps.append(
+                {
+                    "name": "fetch_artifact",
+                    "returncode": 1,
+                    "duration_seconds": 0.0,
+                    "stdout": "",
+                    "stderr": f"fetch step did not create replay report: {replay_path}",
+                }
+            )
+            _emit_report(
+                _build_report(
+                    matched=False,
+                    args=args,
+                    replay_path=replay_path,
+                    steps=steps,
+                    started_at=started_at,
+                ),
+                args.report_output,
+            )
+            return 1
 
-    print(json.dumps({"matched": True, "replay": str(replay_path), "steps": steps}, indent=2))
+    _emit_report(
+        _build_report(
+            matched=True,
+            args=args,
+            replay_path=replay_path,
+            steps=steps,
+            started_at=started_at,
+        ),
+        args.report_output,
+    )
     return 0
 
 

--- a/tests/scripts/test_fetch_replay_state_report.py
+++ b/tests/scripts/test_fetch_replay_state_report.py
@@ -76,3 +76,29 @@ def test_fetch_replay_state_report_rejects_multiple_cutoffs(tmp_path: Path):
                 str(tmp_path / "replay.json"),
             ]
         )
+
+
+def test_fetch_replay_state_report_rejects_non_object_response(monkeypatch, tmp_path: Path):
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return b"[]"
+
+    monkeypatch.setattr(fetch_replay_state_report, "urlopen", lambda *_args, **_kwargs: _Response())
+
+    with pytest.raises(ValueError, match="JSON object"):
+        fetch_replay_state_report.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--output",
+                str(tmp_path / "replay.json"),
+            ]
+        )

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -9,11 +9,11 @@ def test_run_replay_validation_fetches_and_runs_selected_gates(monkeypatch, tmp_
 
     def _run(command):
         calls.append(command)
-        if "fetch_replay_state_report.py" in command:
+        if any(str(part).endswith("fetch_replay_state_report.py") for part in command):
             output_path = Path(command[command.index("--output") + 1])
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
-        return 0, json.dumps({"ok": True}), ""
+        return 0, json.dumps({"ok": True}), "", 0.01
 
     monkeypatch.setattr(run_replay_validation, "_run", _run)
     live_path = tmp_path / "live.json"
@@ -35,6 +35,8 @@ def test_run_replay_validation_fetches_and_runs_selected_gates(monkeypatch, tmp_
                 str(live_path),
                 "--output-dir",
                 str(tmp_path / "reports"),
+                "--report-output",
+                str(tmp_path / "reports" / "manifest.json"),
             ]
         )
         == 0
@@ -49,16 +51,21 @@ def test_run_replay_validation_fetches_and_runs_selected_gates(monkeypatch, tmp_
     output = json.loads(capsys.readouterr().out)
     assert output["matched"] is True
     assert output["replay"].endswith("replay-123.json")
+    assert output["config"]["execution_id"] == 123
+    assert output["steps"][0]["stdout_json"] == {"ok": True}
+    assert output["steps"][0]["duration_seconds"] == 0.01
+    manifest_path = tmp_path / "reports" / "manifest.json"
+    assert json.loads(manifest_path.read_text())["matched"] is True
 
 
 def test_run_replay_validation_stops_on_gate_failure(monkeypatch, tmp_path: Path, capsys):
     def _run(command):
-        if "fetch_replay_state_report.py" in command:
+        if any(str(part).endswith("fetch_replay_state_report.py") for part in command):
             output_path = Path(command[command.index("--output") + 1])
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_text("{}")
-            return 0, "", ""
-        return 1, "", "failed"
+            return 0, "", "", 0.01
+        return 1, "", "failed", 0.02
 
     monkeypatch.setattr(run_replay_validation, "_run", _run)
     live_path = tmp_path / "live.json"
@@ -82,3 +89,54 @@ def test_run_replay_validation_stops_on_gate_failure(monkeypatch, tmp_path: Path
     output = json.loads(capsys.readouterr().out)
     assert output["matched"] is False
     assert output["steps"][-1]["stderr"] == "failed"
+    assert output["steps"][-1]["duration_seconds"] == 0.02
+
+
+def test_run_replay_validation_rejects_multiple_cutoffs(tmp_path: Path):
+    try:
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--as-of-event-id",
+                "1",
+                "--as-of-position",
+                "1",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected parser error")
+
+
+def test_run_replay_validation_fails_when_fetch_does_not_write_report(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    def _run(_command):
+        return 0, json.dumps({"ok": True}), "", 0.01
+
+    monkeypatch.setattr(run_replay_validation, "_run", _run)
+
+    assert (
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+        == 1
+    )
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    assert output["steps"][-1]["name"] == "fetch_artifact"


### PR DESCRIPTION
## Summary
- add structured replay validation run manifests with config, UTC timestamps, step timings, parsed JSON stdout, and optional `--report-output`
- fail the runner when fetch succeeds but does not produce the replay artifact, and validate mutually exclusive replay cutoffs at the runner level
- make the replay fetcher reject non-object JSON responses before writing offline gate input

Tracks noetl/noetl#434.

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_fetch_replay_state_report.py tests/scripts/test_run_replay_validation.py tests/scripts/test_check_replay_state_report.py tests/scripts/test_check_replay_parity_report.py tests/scripts/test_check_replay_payload_resolution_report.py -q`
- `scripts/check_replay_release_gate.sh`
