### PR TITLE
Build live replay checksum artifacts

### DIFF
--- a/scripts/build_live_projection_checksums.py
+++ b/scripts/build_live_projection_checksums.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+"""Build live projection checksum bundles from adapter-exported JSON rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from noetl.server.api.replay import live_projection_checksum_bundle
+
+SURFACE_ROW_KEYS = {
+    "execution": "execution_rows",
+    "stages": "stage_rows",
+    "frames": "frame_rows",
+    "commands": "command_rows",
+    "business_objects": "business_object_rows",
+    "loops": "loop_rows",
+}
+
+
+def _load_rows(path: Path) -> dict[str, list[dict[str, Any]]]:
+    data: Any = json.loads(path.read_text())
+    if isinstance(data, dict) and isinstance(data.get("rows"), dict):
+        data = data["rows"]
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object of live projection rows")
+
+    rows: dict[str, list[dict[str, Any]]] = {}
+    for surface in SURFACE_ROW_KEYS:
+        value = data.get(surface, [])
+        if not isinstance(value, list):
+            raise ValueError(f"{path}: {surface} must be a list")
+        if not all(isinstance(row, dict) for row in value):
+            raise ValueError(f"{path}: {surface} rows must be objects")
+        rows[surface] = value
+
+    unknown = sorted(set(data) - set(SURFACE_ROW_KEYS))
+    if unknown:
+        raise ValueError(f"{path}: unknown live projection row surfaces: {', '.join(unknown)}")
+    return rows
+
+
+def build_live_projection_checksums(rows: dict[str, list[dict[str, Any]]]) -> dict[str, Any]:
+    bundle = live_projection_checksum_bundle(
+        execution_rows=rows["execution"],
+        stage_rows=rows["stages"],
+        frame_rows=rows["frames"],
+        command_rows=rows["commands"],
+        business_object_rows=rows["business_objects"],
+        loop_rows=rows["loops"],
+    )
+    return {
+        "projection_checksums": bundle,
+        "row_counts": {surface: len(values) for surface, values in rows.items()},
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build NoETL live projection checksum bundle from exported row JSON",
+    )
+    parser.add_argument("--rows", required=True, type=Path, help="Live projection row export JSON")
+    parser.add_argument("--output", required=True, type=Path, help="Output checksum bundle JSON")
+    args = parser.parse_args(argv)
+
+    output = build_live_projection_checksums(_load_rows(args.rows))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n")
+    print(json.dumps({"output": str(args.output), "row_counts": output["row_counts"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -63,6 +63,7 @@ def _build_report(
             "as_of_time": args.as_of_time,
             "resolve_payloads": args.resolve_payloads,
             "live_checksums": str(args.live_checksums) if args.live_checksums else None,
+            "live_rows": str(args.live_rows) if args.live_rows else None,
         },
         "steps": steps,
     }
@@ -94,6 +95,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--timeout", default=60.0, type=float)
     parser.add_argument("--live-checksums", type=Path)
     parser.add_argument(
+        "--live-rows",
+        type=Path,
+        help="Optional adapter-exported live projection rows JSON; converted to live checksums before parity",
+    )
+    parser.add_argument(
         "--report-output",
         type=Path,
         help="Optional path to write the validation run manifest JSON",
@@ -106,11 +112,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     if cutoff_count > 1:
         parser.error("use only one replay cutoff")
+    if args.live_checksums and args.live_rows:
+        parser.error("use only one live parity input: --live-checksums or --live-rows")
 
     started_at = _utc_now()
     output_dir = args.output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
     replay_path = output_dir / f"replay-{args.execution_id}.json"
+    live_checksums_path = args.live_checksums
+    if args.live_rows:
+        live_checksums_path = output_dir / f"live-checksums-{args.execution_id}.json"
     fetch_command = [
         sys.executable,
         "scripts/fetch_replay_state_report.py",
@@ -151,6 +162,19 @@ def main(argv: list[str] | None = None) -> int:
             ],
         ),
         (
+            "live_checksums",
+            [
+                sys.executable,
+                "scripts/build_live_projection_checksums.py",
+                "--rows",
+                str(args.live_rows),
+                "--output",
+                str(live_checksums_path),
+            ]
+            if args.live_rows
+            else [],
+        ),
+        (
             "projection_parity",
             [
                 sys.executable,
@@ -158,9 +182,9 @@ def main(argv: list[str] | None = None) -> int:
                 "--replayed",
                 str(replay_path),
                 "--live",
-                str(args.live_checksums),
+                str(live_checksums_path),
             ]
-            if args.live_checksums
+            if live_checksums_path
             else [],
         ),
         (

--- a/tests/scripts/test_build_live_projection_checksums.py
+++ b/tests/scripts/test_build_live_projection_checksums.py
@@ -1,0 +1,86 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import build_live_projection_checksums
+
+
+def _rows():
+    return {
+        "execution": [
+            {
+                "execution_id": 123,
+                "tenant_id": "tenant-a",
+                "organization_id": "org-a",
+                "status": "COMPLETED",
+                "last_event_id": 2,
+            }
+        ],
+        "stages": [],
+        "frames": [],
+        "commands": [],
+        "business_objects": [],
+        "loops": [],
+    }
+
+
+def test_build_live_projection_checksums_writes_bundle(tmp_path: Path, capsys):
+    rows_path = tmp_path / "live-rows.json"
+    output_path = tmp_path / "live-checksums.json"
+    rows_path.write_text(json.dumps(_rows()))
+
+    assert (
+        build_live_projection_checksums.main(
+            ["--rows", str(rows_path), "--output", str(output_path)]
+        )
+        == 0
+    )
+
+    output = json.loads(output_path.read_text())
+    assert set(output["projection_checksums"]) == {
+        "execution",
+        "stages",
+        "frames",
+        "commands",
+        "business_objects",
+        "loops",
+    }
+    assert output["row_counts"]["execution"] == 1
+    assert json.loads(capsys.readouterr().out)["output"] == str(output_path)
+
+
+def test_build_live_projection_checksums_accepts_nested_rows(tmp_path: Path):
+    rows_path = tmp_path / "live-rows.json"
+    output_path = tmp_path / "live-checksums.json"
+    rows_path.write_text(json.dumps({"rows": _rows()}))
+
+    assert (
+        build_live_projection_checksums.main(
+            ["--rows", str(rows_path), "--output", str(output_path)]
+        )
+        == 0
+    )
+
+
+def test_build_live_projection_checksums_rejects_unknown_surface(tmp_path: Path):
+    rows = {**_rows(), "extra": []}
+    rows_path = tmp_path / "live-rows.json"
+    rows_path.write_text(json.dumps(rows))
+
+    with pytest.raises(ValueError, match="unknown live projection row surfaces"):
+        build_live_projection_checksums.main(
+            ["--rows", str(rows_path), "--output", str(tmp_path / "out.json")]
+        )
+
+
+def test_build_live_projection_checksums_rejects_non_object_rows(tmp_path: Path):
+    rows = _rows()
+    rows["frames"] = ["not-a-row"]
+    rows_path = tmp_path / "live-rows.json"
+    rows_path.write_text(json.dumps(rows))
+
+    with pytest.raises(ValueError, match="frames rows must be objects"):
+        build_live_projection_checksums.main(
+            ["--rows", str(rows_path), "--output", str(tmp_path / "out.json")]
+        )

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -92,6 +92,46 @@ def test_run_replay_validation_stops_on_gate_failure(monkeypatch, tmp_path: Path
     assert output["steps"][-1]["duration_seconds"] == 0.02
 
 
+def test_run_replay_validation_builds_live_checksums_from_rows(monkeypatch, tmp_path: Path, capsys):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if any(str(part).endswith("fetch_replay_state_report.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
+        if any(str(part).endswith("build_live_projection_checksums.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
+        return 0, json.dumps({"ok": True}), "", 0.01
+
+    monkeypatch.setattr(run_replay_validation, "_run", _run)
+    live_rows_path = tmp_path / "live-rows.json"
+    live_rows_path.write_text(json.dumps({"execution": []}))
+
+    assert (
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--live-rows",
+                str(live_rows_path),
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+        == 0
+    )
+
+    assert any("scripts/build_live_projection_checksums.py" in call for call in calls)
+    assert any("live-checksums-123.json" in str(part) for call in calls for part in call)
+    output = json.loads(capsys.readouterr().out)
+    assert output["config"]["live_rows"] == str(live_rows_path)
+
+
 def test_run_replay_validation_rejects_multiple_cutoffs(tmp_path: Path):
     try:
         run_replay_validation.main(
@@ -104,6 +144,28 @@ def test_run_replay_validation_rejects_multiple_cutoffs(tmp_path: Path):
                 "1",
                 "--as-of-position",
                 "1",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected parser error")
+
+
+def test_run_replay_validation_rejects_multiple_live_inputs(tmp_path: Path):
+    try:
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--live-checksums",
+                str(tmp_path / "live-checksums.json"),
+                "--live-rows",
+                str(tmp_path / "live-rows.json"),
                 "--output-dir",
                 str(tmp_path),
             ]


### PR DESCRIPTION
## Summary
- add `scripts/build_live_projection_checksums.py` to turn adapter-exported live projection rows into canonical checksum bundles
- teach `scripts/run_replay_validation.py` to accept `--live-rows`, build `live-checksums-<execution_id>.json`, and run parity from that artifact
- validate mutually exclusive live parity inputs and add regression coverage for live row artifact shape

Tracks noetl/noetl#434.

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_build_live_projection_checksums.py tests/scripts/test_run_replay_validation.py tests/scripts/test_check_replay_parity_report.py -q`
- `scripts/check_replay_release_gate.sh`
