### PR TITLE
Validate replay run manifests

### DIFF
--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -14,6 +14,7 @@ fi
   tests/core/test_replay_payload_resolver.py \
   tests/scripts/test_fetch_replay_state_report.py \
   tests/scripts/test_run_replay_validation.py \
+  tests/scripts/test_check_replay_validation_manifest.py \
   tests/scripts/test_check_replay_state_report.py \
   tests/scripts/test_check_replay_parity_report.py \
   tests/scripts/test_check_replay_payload_resolution_report.py \

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+"""Validate replay validation run manifest JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+REQUIRED_CONFIG_FIELDS = (
+    "base_url",
+    "execution_id",
+    "tenant_id",
+    "organization_id",
+    "projection",
+    "limit",
+    "resolve_payloads",
+)
+REQUIRED_STEP_ORDER = ("fetch", "state_integrity")
+OPTIONAL_STEP_NAMES = ("live_checksums", "projection_parity", "payload_resolution")
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    data: Any = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _valid_timestamp(value: Any) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
+
+
+def _validate_manifest(manifest: dict[str, Any], *, require_matched: bool, check_artifacts: bool) -> dict[str, Any]:
+    failures: list[dict[str, Any]] = []
+
+    if require_matched and manifest.get("matched") is not True:
+        failures.append({"field": "matched", "reason": "manifest must be matched=true"})
+    elif not isinstance(manifest.get("matched"), bool):
+        failures.append({"field": "matched", "reason": "must be a boolean"})
+
+    for field in ("started_at", "finished_at"):
+        if not _valid_timestamp(manifest.get(field)):
+            failures.append({"field": field, "reason": "must be an ISO-8601 timestamp"})
+
+    config = manifest.get("config")
+    if not isinstance(config, dict):
+        failures.append({"field": "config", "reason": "must be an object"})
+    else:
+        for field in REQUIRED_CONFIG_FIELDS:
+            if field not in config:
+                failures.append({"field": f"config.{field}", "reason": "missing required config field"})
+        if isinstance(config.get("execution_id"), bool) or not isinstance(config.get("execution_id"), int):
+            failures.append({"field": "config.execution_id", "reason": "must be an integer"})
+        if isinstance(config.get("limit"), bool) or not isinstance(config.get("limit"), int):
+            failures.append({"field": "config.limit", "reason": "must be an integer"})
+        if not isinstance(config.get("resolve_payloads"), bool):
+            failures.append({"field": "config.resolve_payloads", "reason": "must be a boolean"})
+        if config.get("live_checksums") and config.get("live_rows"):
+            failures.append(
+                {
+                    "field": "config.live_checksums",
+                    "reason": "live_checksums and live_rows are mutually exclusive",
+                }
+            )
+
+    artifacts = manifest.get("artifacts")
+    if artifacts is not None and not isinstance(artifacts, dict):
+        failures.append({"field": "artifacts", "reason": "must be an object"})
+    elif isinstance(artifacts, dict) and check_artifacts:
+        for field, value in artifacts.items():
+            if value is None:
+                continue
+            if not isinstance(value, str) or not value:
+                failures.append({"field": f"artifacts.{field}", "reason": "artifact path must be a string"})
+            elif not Path(value).exists():
+                failures.append({"field": f"artifacts.{field}", "reason": "artifact path does not exist", "path": value})
+
+    steps = manifest.get("steps")
+    if not isinstance(steps, list):
+        failures.append({"field": "steps", "reason": "must be a list"})
+        steps = []
+
+    step_names: list[str] = []
+    for index, step in enumerate(steps):
+        if not isinstance(step, dict):
+            failures.append({"field": f"steps[{index}]", "reason": "step must be an object"})
+            continue
+        name = step.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append({"field": f"steps[{index}].name", "reason": "must be a non-empty string"})
+        else:
+            step_names.append(name)
+        if step.get("skipped") is True:
+            continue
+        if isinstance(step.get("returncode"), bool) or not isinstance(step.get("returncode"), int):
+            failures.append({"field": f"steps[{index}].returncode", "reason": "must be an integer"})
+        elif require_matched and step.get("returncode") != 0:
+            failures.append({"field": f"steps[{index}].returncode", "reason": "successful manifests require returncode=0"})
+        duration = step.get("duration_seconds")
+        if isinstance(duration, bool) or not isinstance(duration, (int, float)) or duration < 0:
+            failures.append({"field": f"steps[{index}].duration_seconds", "reason": "must be a non-negative number"})
+        command = step.get("command")
+        if command is not None and not (isinstance(command, list) and all(isinstance(part, str) for part in command)):
+            failures.append({"field": f"steps[{index}].command", "reason": "must be a list of strings"})
+
+    for expected_index, name in enumerate(REQUIRED_STEP_ORDER):
+        if len(step_names) <= expected_index or step_names[expected_index] != name:
+            failures.append({"field": "steps", "reason": f"required step {name} missing or out of order"})
+    for name in step_names:
+        if name not in (*REQUIRED_STEP_ORDER, *OPTIONAL_STEP_NAMES, "fetch_artifact"):
+            failures.append({"field": "steps", "reason": "unknown validation step", "step": name})
+
+    return {"matched": not failures, "failures": failures}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate replay validation manifest JSON")
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--allow-failed", action="store_true", help="Allow matched=false manifests")
+    parser.add_argument("--check-artifacts", action="store_true", help="Require artifact paths to exist")
+    args = parser.parse_args(argv)
+
+    output = _validate_manifest(
+        _load_manifest(args.manifest),
+        require_matched=not args.allow_failed,
+        check_artifacts=args.check_artifacts,
+    )
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0 if output["matched"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -42,6 +42,7 @@ def _build_report(
     matched: bool,
     args: argparse.Namespace,
     replay_path: Path,
+    live_checksums_path: Path | None,
     steps: list[dict[str, object]],
     started_at: str,
 ) -> dict[str, object]:
@@ -51,6 +52,11 @@ def _build_report(
         "started_at": started_at,
         "finished_at": finished_at,
         "replay": str(replay_path),
+        "artifacts": {
+            "replay": str(replay_path),
+            "live_checksums": str(live_checksums_path) if live_checksums_path else None,
+            "report": str(args.report_output) if args.report_output else None,
+        },
         "config": {
             "base_url": args.base_url,
             "execution_id": args.execution_id,
@@ -221,6 +227,7 @@ def main(argv: list[str] | None = None) -> int:
                     matched=False,
                     args=args,
                     replay_path=replay_path,
+                    live_checksums_path=live_checksums_path,
                     steps=steps,
                     started_at=started_at,
                 ),
@@ -242,6 +249,7 @@ def main(argv: list[str] | None = None) -> int:
                     matched=False,
                     args=args,
                     replay_path=replay_path,
+                    live_checksums_path=live_checksums_path,
                     steps=steps,
                     started_at=started_at,
                 ),
@@ -254,6 +262,7 @@ def main(argv: list[str] | None = None) -> int:
             matched=True,
             args=args,
             replay_path=replay_path,
+            live_checksums_path=live_checksums_path,
             steps=steps,
             started_at=started_at,
         ),

--- a/tests/scripts/test_check_replay_validation_manifest.py
+++ b/tests/scripts/test_check_replay_validation_manifest.py
@@ -1,0 +1,118 @@
+import json
+from pathlib import Path
+
+from scripts.check_replay_validation_manifest import main
+
+
+def _manifest(tmp_path: Path) -> dict:
+    replay = tmp_path / "replay.json"
+    replay.write_text("{}")
+    return {
+        "matched": True,
+        "started_at": "2026-05-20T00:00:00Z",
+        "finished_at": "2026-05-20T00:00:01Z",
+        "replay": str(replay),
+        "artifacts": {"replay": str(replay), "live_checksums": None, "report": None},
+        "config": {
+            "base_url": "http://noetl.example",
+            "execution_id": 123,
+            "tenant_id": "tenant-a",
+            "organization_id": "org-a",
+            "projection": "all",
+            "limit": 100000,
+            "as_of_event_id": None,
+            "as_of_position": None,
+            "as_of_time": None,
+            "resolve_payloads": False,
+            "live_checksums": None,
+            "live_rows": None,
+        },
+        "steps": [
+            {
+                "name": "fetch",
+                "command": ["python", "scripts/fetch_replay_state_report.py"],
+                "returncode": 0,
+                "duration_seconds": 0.1,
+                "stdout": "{}",
+                "stderr": "",
+                "stdout_json": {},
+            },
+            {
+                "name": "state_integrity",
+                "command": ["python", "scripts/check_replay_state_report.py"],
+                "returncode": 0,
+                "duration_seconds": 0.1,
+                "stdout": "{}",
+                "stderr": "",
+            },
+            {"name": "projection_parity", "skipped": True},
+            {"name": "payload_resolution", "skipped": True},
+        ],
+    }
+
+
+def test_check_replay_validation_manifest_accepts_success(tmp_path: Path, capsys):
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(_manifest(tmp_path)))
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 0
+    assert json.loads(capsys.readouterr().out)["matched"] is True
+
+
+def test_check_replay_validation_manifest_rejects_failed_by_default(tmp_path: Path, capsys):
+    manifest = _manifest(tmp_path)
+    manifest["matched"] = False
+    manifest["steps"][1]["returncode"] = 1
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    fields = {failure["field"] for failure in output["failures"]}
+    assert {"matched", "steps[1].returncode"} <= fields
+
+
+def test_check_replay_validation_manifest_can_allow_failed(tmp_path: Path, capsys):
+    manifest = _manifest(tmp_path)
+    manifest["matched"] = False
+    manifest["steps"][1]["returncode"] = 1
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path), "--allow-failed"]) == 0
+    assert json.loads(capsys.readouterr().out)["matched"] is True
+
+
+def test_check_replay_validation_manifest_rejects_bad_step_order(tmp_path: Path, capsys):
+    manifest = _manifest(tmp_path)
+    manifest["steps"] = list(reversed(manifest["steps"]))
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any("required step fetch" in failure["reason"] for failure in output["failures"])
+
+
+def test_check_replay_validation_manifest_rejects_missing_artifact(tmp_path: Path, capsys):
+    manifest = _manifest(tmp_path)
+    manifest["artifacts"]["replay"] = str(tmp_path / "missing.json")
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["failures"][0]["field"] == "artifacts.replay"
+
+
+def test_check_replay_validation_manifest_rejects_multiple_live_inputs(tmp_path: Path, capsys):
+    manifest = _manifest(tmp_path)
+    manifest["config"]["live_checksums"] = "live.json"
+    manifest["config"]["live_rows"] = "rows.json"
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert "config.live_checksums" in {failure["field"] for failure in output["failures"]}

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -52,6 +52,8 @@ def test_run_replay_validation_fetches_and_runs_selected_gates(monkeypatch, tmp_
     assert output["matched"] is True
     assert output["replay"].endswith("replay-123.json")
     assert output["config"]["execution_id"] == 123
+    assert output["artifacts"]["replay"].endswith("replay-123.json")
+    assert output["artifacts"]["report"].endswith("manifest.json")
     assert output["steps"][0]["stdout_json"] == {"ok": True}
     assert output["steps"][0]["duration_seconds"] == 0.01
     manifest_path = tmp_path / "reports" / "manifest.json"
@@ -130,6 +132,7 @@ def test_run_replay_validation_builds_live_checksums_from_rows(monkeypatch, tmp_
     assert any("live-checksums-123.json" in str(part) for call in calls for part in call)
     output = json.loads(capsys.readouterr().out)
     assert output["config"]["live_rows"] == str(live_rows_path)
+    assert output["artifacts"]["live_checksums"].endswith("live-checksums-123.json")
 
 
 def test_run_replay_validation_rejects_multiple_cutoffs(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add `scripts/check_replay_validation_manifest.py` for validating replay validation run manifests
- include generated artifact paths in `run_replay_validation.py` manifests
- wire manifest checker coverage into the replay release gate

Tracks noetl/noetl#434.

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_check_replay_validation_manifest.py tests/scripts/test_run_replay_validation.py -q`
- `scripts/check_replay_release_gate.sh`
