### PR TITLE
feat(replay): export live projection rows

### DIFF
--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -14,6 +14,7 @@ fi
   tests/core/test_replay_payload_resolver.py \
   tests/scripts/test_fetch_replay_state_report.py \
   tests/scripts/test_run_replay_validation.py \
+  tests/scripts/test_export_live_projection_rows_postgres.py \
   tests/scripts/test_check_replay_validation_manifest.py \
   tests/scripts/test_check_replay_state_report.py \
   tests/scripts/test_check_replay_parity_report.py \

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -20,7 +20,12 @@ REQUIRED_CONFIG_FIELDS = (
     "resolve_payloads",
 )
 REQUIRED_STEP_ORDER = ("fetch", "state_integrity")
-OPTIONAL_STEP_NAMES = ("live_checksums", "projection_parity", "payload_resolution")
+OPTIONAL_STEP_NAMES = (
+    "live_rows_export",
+    "live_checksums",
+    "projection_parity",
+    "payload_resolution",
+)
 
 
 def _load_manifest(path: Path) -> dict[str, Any]:

--- a/scripts/export_live_projection_rows_postgres.py
+++ b/scripts/export_live_projection_rows_postgres.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python
+"""Export live projection rows from the reference Postgres adapter.
+
+The JSON this script writes is the stable validation contract. Postgres is only
+the current adapter used to read live rows; replay validation consumes the
+adapter-neutral row JSON through scripts/build_live_projection_checksums.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Mapping
+from datetime import date, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import psycopg
+from psycopg.rows import dict_row
+
+from noetl.core.common import get_pgdb_connection
+
+SURFACES = ("execution", "stages", "frames", "commands", "business_objects", "loops")
+
+EXECUTION_SQL = """
+WITH event_rollup AS (
+    SELECT
+        execution_id,
+        count(*)::bigint AS event_count,
+        max(event_id) AS max_event_id,
+        jsonb_agg(payload_ref ORDER BY event_id) FILTER (WHERE payload_ref IS NOT NULL) AS payload_refs
+    FROM noetl.event
+    WHERE execution_id = %s
+      AND tenant_id = %s
+      AND organization_id = %s
+    GROUP BY execution_id
+)
+SELECT
+    e.execution_id,
+    %s::text AS tenant_id,
+    %s::text AS organization_id,
+    %s::text AS projection,
+    e.status,
+    e.last_node_name,
+    COALESCE(e.last_event_id, er.max_event_id) AS last_event_id,
+    e.last_event_type,
+    COALESCE(er.event_count, 0) AS event_count,
+    COALESCE(er.payload_refs, '[]'::jsonb) AS payload_refs,
+    NULL::text AS upcaster_registry_digest
+FROM noetl.execution e
+LEFT JOIN event_rollup er ON er.execution_id = e.execution_id
+WHERE e.execution_id = %s
+"""
+
+STAGE_SQL = """
+WITH frame_rollup AS (
+    SELECT
+        stage_id,
+        count(*)::bigint AS frame_count,
+        COALESCE(sum(row_count), 0)::bigint AS row_count,
+        COALESCE(sum(events_emitted), 0)::bigint AS events_emitted,
+        count(*) FILTER (WHERE status IN ('FAILED', 'ABANDONED'))::bigint AS failed_count
+    FROM noetl.frame
+    WHERE execution_id = %s
+      AND tenant_id = %s
+      AND organization_id = %s
+    GROUP BY stage_id
+),
+event_rollup AS (
+    SELECT
+        stage_id,
+        max(event_id) AS last_event_id
+    FROM noetl.event
+    WHERE execution_id = %s
+      AND tenant_id = %s
+      AND organization_id = %s
+      AND stage_id IS NOT NULL
+    GROUP BY stage_id
+)
+SELECT
+    s.stage_id,
+    s.status,
+    s.kind,
+    s.step_name,
+    s.parent_stage_id,
+    s.loop_event_id,
+    s.opened_event_id,
+    s.closed_event_id,
+    COALESCE(fr.frame_count, 0) AS frame_count,
+    COALESCE(fr.row_count, 0) AS row_count,
+    COALESCE(fr.events_emitted, 0) AS events_emitted,
+    COALESCE(fr.failed_count, 0) AS failed_count,
+    COALESCE(er.last_event_id, s.closed_event_id, s.opened_event_id) AS last_event_id
+FROM noetl.stage s
+LEFT JOIN frame_rollup fr ON fr.stage_id = s.stage_id
+LEFT JOIN event_rollup er ON er.stage_id = s.stage_id
+WHERE s.execution_id = %s
+  AND s.tenant_id = %s
+  AND s.organization_id = %s
+ORDER BY s.stage_id
+"""
+
+FRAME_SQL = """
+SELECT
+    frame_id,
+    stage_id,
+    parent_frame_id,
+    command_id,
+    claimed_event_id,
+    terminal_event_id,
+    status,
+    row_count,
+    cursor,
+    events_emitted,
+    output_ref
+FROM noetl.frame
+WHERE execution_id = %s
+  AND tenant_id = %s
+  AND organization_id = %s
+ORDER BY frame_id
+"""
+
+COMMAND_SQL = """
+WITH command_events AS (
+    SELECT
+        command_id,
+        max(event_id) FILTER (WHERE event_type = 'command.claimed') AS claimed_event_id,
+        max(event_id) FILTER (WHERE event_type = 'command.started') AS started_event_id,
+        max(event_id) FILTER (
+            WHERE event_type IN (
+                'command.completed',
+                'command.failed',
+                'command.cancelled',
+                'command.timed_out',
+                'command.timeout'
+            )
+        ) AS terminal_event_id
+    FROM noetl.event
+    WHERE execution_id = %s
+      AND tenant_id = %s
+      AND organization_id = %s
+      AND command_id IS NOT NULL
+    GROUP BY command_id
+)
+SELECT
+    c.command_id,
+    c.stage_id,
+    c.frame_id,
+    c.parent_command_id,
+    c.worker_id,
+    c.meta->>'worker_locator' AS worker_locator,
+    COALESCE(c.meta->'locality', '{}'::jsonb) AS locality,
+    COALESCE(c.meta->'source_locality', '{}'::jsonb) AS source_locality,
+    COALESCE(c.meta->'placement', '{}'::jsonb) AS placement,
+    c.status,
+    c.event_id AS issued_event_id,
+    ce.claimed_event_id,
+    ce.started_event_id,
+    COALESCE(ce.terminal_event_id, c.latest_event_id) AS terminal_event_id
+FROM noetl.command c
+LEFT JOIN command_events ce ON ce.command_id = c.command_id
+WHERE c.execution_id = %s
+ORDER BY c.command_id
+"""
+
+PROJECTION_SQL = """
+SELECT state
+FROM noetl.projection
+WHERE tenant_id = %s
+  AND organization_id = %s
+  AND projection_id = %s
+ORDER BY updated_at DESC
+LIMIT 1
+"""
+
+
+def _json_default(value: Any) -> str | int | float:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        if value == value.to_integral_value():
+            return int(value)
+        return float(value)
+    raise TypeError(f"{type(value).__name__} is not JSON serializable")
+
+
+def _connect(dsn: str | None):
+    conninfo = dsn or os.getenv("NOETL_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not conninfo:
+        conninfo = get_pgdb_connection()
+    return psycopg.connect(conninfo, row_factory=dict_row)
+
+
+def _select_all(conn, sql: str, params: tuple[Any, ...]) -> list[dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        return [dict(row) for row in cur.fetchall()]
+
+
+def _rows_from_projection_state(
+    state: Mapping[str, Any] | None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if not isinstance(state, Mapping):
+        return [], []
+
+    business_objects = state.get("business_objects")
+    business_rows: list[dict[str, Any]] = []
+    if isinstance(business_objects, Mapping):
+        for object_key, row in business_objects.items():
+            if isinstance(row, Mapping):
+                business_rows.append(
+                    {"object_key": row.get("object_key") or object_key, **dict(row)}
+                )
+
+    loops = state.get("loops")
+    loop_rows: list[dict[str, Any]] = []
+    if isinstance(loops, Mapping):
+        for loop_id, row in loops.items():
+            if isinstance(row, Mapping):
+                loop_rows.append({"loop_id": row.get("loop_id") or loop_id, **dict(row)})
+
+    return business_rows, loop_rows
+
+
+def export_live_projection_rows(
+    conn,
+    *,
+    execution_id: int,
+    tenant_id: str,
+    organization_id: str,
+    projection: str,
+) -> dict[str, list[dict[str, Any]]]:
+    execution_rows = _select_all(
+        conn,
+        EXECUTION_SQL,
+        (
+            execution_id,
+            tenant_id,
+            organization_id,
+            tenant_id,
+            organization_id,
+            projection,
+            execution_id,
+        ),
+    )
+    stage_rows = _select_all(
+        conn,
+        STAGE_SQL,
+        (
+            execution_id,
+            tenant_id,
+            organization_id,
+            execution_id,
+            tenant_id,
+            organization_id,
+            execution_id,
+            tenant_id,
+            organization_id,
+        ),
+    )
+    frame_rows = _select_all(
+        conn,
+        FRAME_SQL,
+        (execution_id, tenant_id, organization_id),
+    )
+    command_rows = _select_all(
+        conn,
+        COMMAND_SQL,
+        (execution_id, tenant_id, organization_id, execution_id),
+    )
+    projection_rows = _select_all(
+        conn,
+        PROJECTION_SQL,
+        (tenant_id, organization_id, f"execution/{execution_id}/{projection}"),
+    )
+    projection_state = projection_rows[0].get("state") if projection_rows else None
+    business_rows, loop_rows = _rows_from_projection_state(projection_state)
+
+    return {
+        "execution": execution_rows,
+        "stages": stage_rows,
+        "frames": frame_rows,
+        "commands": command_rows,
+        "business_objects": business_rows,
+        "loops": loop_rows,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Export NoETL live projection rows from the reference Postgres adapter",
+    )
+    parser.add_argument("--execution-id", required=True, type=int)
+    parser.add_argument("--tenant-id", default="default")
+    parser.add_argument("--organization-id", default="default")
+    parser.add_argument("--projection", default="all")
+    parser.add_argument("--dsn", help="Optional Postgres connection string; defaults to NoETL env")
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    with _connect(args.dsn) as conn:
+        rows = export_live_projection_rows(
+            conn,
+            execution_id=args.execution_id,
+            tenant_id=args.tenant_id,
+            organization_id=args.organization_id,
+            projection=args.projection,
+        )
+
+    payload = {
+        "adapter": "postgres",
+        "execution_id": args.execution_id,
+        "tenant_id": args.tenant_id,
+        "organization_id": args.organization_id,
+        "projection": args.projection,
+        "rows": rows,
+        "row_counts": {surface: len(rows[surface]) for surface in SURFACES},
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(payload, default=_json_default, indent=2, sort_keys=True) + "\n"
+    )
+    print(json.dumps({"output": str(args.output), "row_counts": payload["row_counts"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -43,6 +43,7 @@ def _build_report(
     args: argparse.Namespace,
     replay_path: Path,
     live_checksums_path: Path | None,
+    live_rows_path: Path | None,
     steps: list[dict[str, object]],
     started_at: str,
 ) -> dict[str, object]:
@@ -54,6 +55,7 @@ def _build_report(
         "replay": str(replay_path),
         "artifacts": {
             "replay": str(replay_path),
+            "live_rows": str(live_rows_path) if live_rows_path else None,
             "live_checksums": str(live_checksums_path) if live_checksums_path else None,
             "report": str(args.report_output) if args.report_output else None,
         },
@@ -70,6 +72,7 @@ def _build_report(
             "resolve_payloads": args.resolve_payloads,
             "live_checksums": str(args.live_checksums) if args.live_checksums else None,
             "live_rows": str(args.live_rows) if args.live_rows else None,
+            "export_live_rows_postgres": args.export_live_rows_postgres,
         },
         "steps": steps,
     }
@@ -106,6 +109,15 @@ def main(argv: list[str] | None = None) -> int:
         help="Optional adapter-exported live projection rows JSON; converted to live checksums before parity",
     )
     parser.add_argument(
+        "--export-live-rows-postgres",
+        action="store_true",
+        help="Export live rows from the reference Postgres adapter before parity",
+    )
+    parser.add_argument(
+        "--postgres-dsn",
+        help="Optional Postgres DSN for --export-live-rows-postgres; defaults to NoETL env",
+    )
+    parser.add_argument(
         "--report-output",
         type=Path,
         help="Optional path to write the validation run manifest JSON",
@@ -118,15 +130,31 @@ def main(argv: list[str] | None = None) -> int:
     )
     if cutoff_count > 1:
         parser.error("use only one replay cutoff")
-    if args.live_checksums and args.live_rows:
-        parser.error("use only one live parity input: --live-checksums or --live-rows")
+    live_input_count = sum(
+        1
+        for enabled in (
+            bool(args.live_checksums),
+            bool(args.live_rows),
+            bool(args.export_live_rows_postgres),
+        )
+        if enabled
+    )
+    if live_input_count > 1:
+        parser.error(
+            "use only one live parity input: --live-checksums, --live-rows, or --export-live-rows-postgres"
+        )
+    if args.postgres_dsn and not args.export_live_rows_postgres:
+        parser.error("--postgres-dsn requires --export-live-rows-postgres")
 
     started_at = _utc_now()
     output_dir = args.output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
     replay_path = output_dir / f"replay-{args.execution_id}.json"
     live_checksums_path = args.live_checksums
-    if args.live_rows:
+    live_rows_path = args.live_rows
+    if args.export_live_rows_postgres:
+        live_rows_path = output_dir / f"live-rows-{args.execution_id}.json"
+    if live_rows_path:
         live_checksums_path = output_dir / f"live-checksums-{args.execution_id}.json"
     fetch_command = [
         sys.executable,
@@ -168,16 +196,36 @@ def main(argv: list[str] | None = None) -> int:
             ],
         ),
         (
+            "live_rows_export",
+            [
+                sys.executable,
+                "scripts/export_live_projection_rows_postgres.py",
+                "--execution-id",
+                str(args.execution_id),
+                "--tenant-id",
+                args.tenant_id,
+                "--organization-id",
+                args.organization_id,
+                "--projection",
+                args.projection,
+                "--output",
+                str(live_rows_path),
+            ]
+            + (["--dsn", args.postgres_dsn] if args.postgres_dsn else [])
+            if args.export_live_rows_postgres
+            else [],
+        ),
+        (
             "live_checksums",
             [
                 sys.executable,
                 "scripts/build_live_projection_checksums.py",
                 "--rows",
-                str(args.live_rows),
+                str(live_rows_path),
                 "--output",
                 str(live_checksums_path),
             ]
-            if args.live_rows
+            if live_rows_path
             else [],
         ),
         (
@@ -228,6 +276,7 @@ def main(argv: list[str] | None = None) -> int:
                     args=args,
                     replay_path=replay_path,
                     live_checksums_path=live_checksums_path,
+                    live_rows_path=live_rows_path,
                     steps=steps,
                     started_at=started_at,
                 ),
@@ -250,6 +299,7 @@ def main(argv: list[str] | None = None) -> int:
                     args=args,
                     replay_path=replay_path,
                     live_checksums_path=live_checksums_path,
+                    live_rows_path=live_rows_path,
                     steps=steps,
                     started_at=started_at,
                 ),
@@ -263,6 +313,7 @@ def main(argv: list[str] | None = None) -> int:
             args=args,
             replay_path=replay_path,
             live_checksums_path=live_checksums_path,
+            live_rows_path=live_rows_path,
             steps=steps,
             started_at=started_at,
         ),

--- a/tests/scripts/test_check_replay_validation_manifest.py
+++ b/tests/scripts/test_check_replay_validation_manifest.py
@@ -12,7 +12,12 @@ def _manifest(tmp_path: Path) -> dict:
         "started_at": "2026-05-20T00:00:00Z",
         "finished_at": "2026-05-20T00:00:01Z",
         "replay": str(replay),
-        "artifacts": {"replay": str(replay), "live_checksums": None, "report": None},
+        "artifacts": {
+            "replay": str(replay),
+            "live_rows": None,
+            "live_checksums": None,
+            "report": None,
+        },
         "config": {
             "base_url": "http://noetl.example",
             "execution_id": 123,
@@ -26,6 +31,7 @@ def _manifest(tmp_path: Path) -> dict:
             "resolve_payloads": False,
             "live_checksums": None,
             "live_rows": None,
+            "export_live_rows_postgres": False,
         },
         "steps": [
             {
@@ -44,6 +50,10 @@ def _manifest(tmp_path: Path) -> dict:
                 "duration_seconds": 0.1,
                 "stdout": "{}",
                 "stderr": "",
+            },
+            {
+                "name": "live_rows_export",
+                "skipped": True,
             },
             {"name": "projection_parity", "skipped": True},
             {"name": "payload_resolution", "skipped": True},
@@ -104,6 +114,18 @@ def test_check_replay_validation_manifest_rejects_missing_artifact(tmp_path: Pat
     assert main(["--manifest", str(path), "--check-artifacts"]) == 1
     output = json.loads(capsys.readouterr().out)
     assert output["failures"][0]["field"] == "artifacts.replay"
+
+
+def test_check_replay_validation_manifest_checks_live_rows_artifact(tmp_path: Path, capsys):
+    manifest = _manifest(tmp_path)
+    live_rows = tmp_path / "live-rows.json"
+    live_rows.write_text("{}")
+    manifest["artifacts"]["live_rows"] = str(live_rows)
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 0
+    assert json.loads(capsys.readouterr().out)["matched"] is True
 
 
 def test_check_replay_validation_manifest_rejects_multiple_live_inputs(tmp_path: Path, capsys):

--- a/tests/scripts/test_export_live_projection_rows_postgres.py
+++ b/tests/scripts/test_export_live_projection_rows_postgres.py
@@ -1,0 +1,148 @@
+import json
+from pathlib import Path
+
+from scripts import export_live_projection_rows_postgres as exporter
+
+
+def test_rows_from_projection_state_exports_business_objects_and_loops():
+    business_rows, loop_rows = exporter._rows_from_projection_state(
+        {
+            "business_objects": {
+                "patient/1": {
+                    "object_type": "patient",
+                    "object_id": "1",
+                    "status": "active",
+                }
+            },
+            "loops": {
+                "loop-a": {
+                    "step_name": "fetch",
+                    "done": 10,
+                    "failed": 0,
+                    "completed": True,
+                }
+            },
+        }
+    )
+
+    assert business_rows == [
+        {
+            "object_key": "patient/1",
+            "object_type": "patient",
+            "object_id": "1",
+            "status": "active",
+        }
+    ]
+    assert loop_rows == [
+        {
+            "loop_id": "loop-a",
+            "step_name": "fetch",
+            "done": 10,
+            "failed": 0,
+            "completed": True,
+        }
+    ]
+
+
+def test_export_live_projection_rows_uses_plain_adapter_queries(monkeypatch):
+    calls = []
+
+    def _select_all(conn, sql, params):
+        calls.append((sql, params))
+        if sql is exporter.EXECUTION_SQL:
+            return [{"execution_id": 123, "status": "COMPLETED", "event_count": 4}]
+        if sql is exporter.STAGE_SQL:
+            return [{"stage_id": 10, "status": "CLOSED", "frame_count": 1}]
+        if sql is exporter.FRAME_SQL:
+            return [{"frame_id": 20, "stage_id": 10, "status": "COMMITTED"}]
+        if sql is exporter.COMMAND_SQL:
+            return [
+                {
+                    "command_id": 30,
+                    "stage_id": 10,
+                    "frame_id": 20,
+                    "status": "COMPLETED",
+                }
+            ]
+        if sql is exporter.PROJECTION_SQL:
+            return [
+                {
+                    "state": {
+                        "business_objects": {
+                            "patient/1": {"object_type": "patient", "object_id": "1"}
+                        },
+                        "loops": {
+                            "loop-a": {
+                                "step_name": "fetch",
+                                "done": 1,
+                                "completed": True,
+                            }
+                        },
+                    }
+                }
+            ]
+        raise AssertionError("unexpected query")
+
+    monkeypatch.setattr(exporter, "_select_all", _select_all)
+
+    rows = exporter.export_live_projection_rows(
+        object(),
+        execution_id=123,
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        projection="all",
+    )
+
+    assert set(rows) == set(exporter.SURFACES)
+    assert rows["execution"][0]["execution_id"] == 123
+    assert rows["business_objects"][0]["object_key"] == "patient/1"
+    assert rows["loops"][0]["loop_id"] == "loop-a"
+    assert calls[-1][1] == ("tenant-a", "org-a", "execution/123/all")
+
+
+def test_main_writes_adapter_neutral_rows(monkeypatch, tmp_path: Path, capsys):
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    def _connect(dsn):
+        assert dsn == "postgresql://example"
+        return FakeConnection()
+
+    def _export(conn, *, execution_id, tenant_id, organization_id, projection):
+        assert execution_id == 123
+        assert tenant_id == "tenant-a"
+        assert organization_id == "org-a"
+        assert projection == "all"
+        return {surface: [] for surface in exporter.SURFACES}
+
+    monkeypatch.setattr(exporter, "_connect", _connect)
+    monkeypatch.setattr(exporter, "export_live_projection_rows", _export)
+
+    output = tmp_path / "live-rows.json"
+    assert (
+        exporter.main(
+            [
+                "--execution-id",
+                "123",
+                "--tenant-id",
+                "tenant-a",
+                "--organization-id",
+                "org-a",
+                "--dsn",
+                "postgresql://example",
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(output.read_text())
+    assert payload["adapter"] == "postgres"
+    assert payload["rows"] == {surface: [] for surface in exporter.SURFACES}
+    assert payload["row_counts"] == {surface: 0 for surface in exporter.SURFACES}
+    assert json.loads(capsys.readouterr().out)["output"] == str(output)

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -53,6 +53,7 @@ def test_run_replay_validation_fetches_and_runs_selected_gates(monkeypatch, tmp_
     assert output["replay"].endswith("replay-123.json")
     assert output["config"]["execution_id"] == 123
     assert output["artifacts"]["replay"].endswith("replay-123.json")
+    assert output["artifacts"]["live_rows"] is None
     assert output["artifacts"]["report"].endswith("manifest.json")
     assert output["steps"][0]["stdout_json"] == {"ok": True}
     assert output["steps"][0]["duration_seconds"] == 0.01
@@ -132,7 +133,66 @@ def test_run_replay_validation_builds_live_checksums_from_rows(monkeypatch, tmp_
     assert any("live-checksums-123.json" in str(part) for call in calls for part in call)
     output = json.loads(capsys.readouterr().out)
     assert output["config"]["live_rows"] == str(live_rows_path)
+    assert output["artifacts"]["live_rows"] == str(live_rows_path)
     assert output["artifacts"]["live_checksums"].endswith("live-checksums-123.json")
+
+
+def test_run_replay_validation_can_export_live_rows_from_postgres(monkeypatch, tmp_path: Path, capsys):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if any(str(part).endswith("fetch_replay_state_report.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
+        if any(str(part).endswith("export_live_projection_rows_postgres.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.write_text(json.dumps({"rows": {"execution": []}}))
+        if any(str(part).endswith("build_live_projection_checksums.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
+        return 0, json.dumps({"ok": True}), "", 0.01
+
+    monkeypatch.setattr(run_replay_validation, "_run", _run)
+
+    assert (
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--tenant-id",
+                "tenant-a",
+                "--organization-id",
+                "org-a",
+                "--export-live-rows-postgres",
+                "--postgres-dsn",
+                "postgresql://example",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+        == 0
+    )
+
+    assert any("scripts/export_live_projection_rows_postgres.py" in call for call in calls)
+    export_call = next(
+        call for call in calls if "scripts/export_live_projection_rows_postgres.py" in call
+    )
+    assert "--dsn" in export_call
+    assert "postgresql://example" in export_call
+    output = json.loads(capsys.readouterr().out)
+    assert output["config"]["export_live_rows_postgres"] is True
+    assert output["artifacts"]["live_rows"].endswith("live-rows-123.json")
+    assert output["artifacts"]["live_checksums"].endswith("live-checksums-123.json")
+    assert [step["name"] for step in output["steps"][:4]] == [
+        "fetch",
+        "state_integrity",
+        "live_rows_export",
+        "live_checksums",
+    ]
 
 
 def test_run_replay_validation_rejects_multiple_cutoffs(tmp_path: Path):
@@ -169,6 +229,27 @@ def test_run_replay_validation_rejects_multiple_live_inputs(tmp_path: Path):
                 str(tmp_path / "live-checksums.json"),
                 "--live-rows",
                 str(tmp_path / "live-rows.json"),
+                "--export-live-rows-postgres",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected parser error")
+
+
+def test_run_replay_validation_rejects_postgres_dsn_without_export(tmp_path: Path):
+    try:
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--postgres-dsn",
+                "postgresql://example",
                 "--output-dir",
                 str(tmp_path),
             ]


### PR DESCRIPTION
## Summary
- add a reference Postgres adapter script that exports live projection rows as the existing storage-neutral JSON contract
- include execution, stage, frame, command, business-object, and loop surfaces for replay parity
- let `scripts/run_replay_validation.py --export-live-rows-postgres` produce the live-row artifact, derive live checksums, and gate parity in one local-kind/GKE command
- record the source `live_rows` artifact in validation manifests so `--check-artifacts` proves both the adapter export and derived checksum artifact exist
- wire exporter and manifest tests into the replay release gate

## Design notes
- Postgres is used only as the current row-export adapter; replay validation still consumes adapter-neutral JSON through `scripts/build_live_projection_checksums.py`
- the exporter uses plain SELECTs and no database routines, keeping replacement storage backends free to produce the same row artifact

## Validation
- `python -m pytest -q tests/scripts/test_export_live_projection_rows_postgres.py tests/scripts/test_build_live_projection_checksums.py tests/scripts/test_run_replay_validation.py`
- `python -m pytest -q tests/scripts/test_run_replay_validation.py tests/scripts/test_check_replay_validation_manifest.py`
- `python -m pytest -q tests/scripts/test_run_replay_validation.py tests/scripts/test_check_replay_validation_manifest.py tests/scripts/test_export_live_projection_rows_postgres.py`
- `scripts/check_replay_release_gate.sh`