### PR TITLE
test(replay): gate live row artifacts

### DIFF
--- a/scripts/build_live_projection_checksums.py
+++ b/scripts/build_live_projection_checksums.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -23,6 +24,7 @@ SURFACE_ROW_KEYS = {
 
 def _load_rows(path: Path) -> dict[str, list[dict[str, Any]]]:
     data: Any = json.loads(path.read_text())
+    artifact = data if isinstance(data, dict) and isinstance(data.get("rows"), dict) else None
     if isinstance(data, dict) and isinstance(data.get("rows"), dict):
         data = data["rows"]
     if not isinstance(data, dict):
@@ -40,6 +42,19 @@ def _load_rows(path: Path) -> dict[str, list[dict[str, Any]]]:
     unknown = sorted(set(data) - set(SURFACE_ROW_KEYS))
     if unknown:
         raise ValueError(f"{path}: unknown live projection row surfaces: {', '.join(unknown)}")
+
+    if artifact is not None:
+        row_counts = artifact.get("row_counts")
+        if isinstance(row_counts, dict):
+            for surface, surface_rows in rows.items():
+                if row_counts.get(surface) != len(surface_rows):
+                    raise ValueError(f"{path}: row_counts.{surface} does not match exported rows")
+        rows_checksum = artifact.get("rows_checksum")
+        if rows_checksum is not None:
+            rendered = json.dumps(rows, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+            expected = hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+            if rows_checksum != expected:
+                raise ValueError(f"{path}: rows_checksum does not match exported rows")
     return rows
 
 

--- a/scripts/check_live_projection_rows.py
+++ b/scripts/check_live_projection_rows.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+"""Validate adapter-exported live projection row artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.build_live_projection_checksums import SURFACE_ROW_KEYS, _load_rows
+
+
+def _canonical_checksum(value: Any) -> str:
+    rendered = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+
+
+def _valid_timestamp(value: Any) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
+
+
+def _load_artifact(path: Path) -> dict[str, Any]:
+    data: Any = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def validate_live_projection_rows(path: Path) -> dict[str, Any]:
+    failures: list[dict[str, Any]] = []
+    artifact = _load_artifact(path)
+
+    if artifact.get("schema_version") != 1:
+        failures.append({"field": "schema_version", "reason": "must be 1"})
+    if not isinstance(artifact.get("adapter"), str) or not artifact.get("adapter"):
+        failures.append({"field": "adapter", "reason": "must be a non-empty string"})
+    if isinstance(artifact.get("execution_id"), bool) or not isinstance(artifact.get("execution_id"), int):
+        failures.append({"field": "execution_id", "reason": "must be an integer"})
+    for field in ("tenant_id", "organization_id", "projection"):
+        if not isinstance(artifact.get(field), str) or not artifact.get(field):
+            failures.append({"field": field, "reason": "must be a non-empty string"})
+    if not _valid_timestamp(artifact.get("exported_at")):
+        failures.append({"field": "exported_at", "reason": "must be an ISO-8601 timestamp"})
+
+    try:
+        rows = _load_rows(path)
+    except ValueError as exc:
+        failures.append({"field": "rows", "reason": str(exc)})
+        rows = {surface: [] for surface in SURFACE_ROW_KEYS}
+
+    row_counts = artifact.get("row_counts")
+    if not isinstance(row_counts, dict):
+        failures.append({"field": "row_counts", "reason": "must be an object"})
+    else:
+        unknown_counts = sorted(set(row_counts) - set(SURFACE_ROW_KEYS))
+        if unknown_counts:
+            failures.append(
+                {
+                    "field": "row_counts",
+                    "reason": "unknown row count surfaces",
+                    "surfaces": unknown_counts,
+                }
+            )
+        for surface, surface_rows in rows.items():
+            value = row_counts.get(surface)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                failures.append(
+                    {
+                        "field": f"row_counts.{surface}",
+                        "reason": "must be a non-negative integer",
+                    }
+                )
+            elif value != len(surface_rows):
+                failures.append(
+                    {
+                        "field": f"row_counts.{surface}",
+                        "reason": "does not match exported row count",
+                        "expected": len(surface_rows),
+                        "actual": value,
+                    }
+                )
+
+    expected_checksum = _canonical_checksum(rows)
+    if artifact.get("rows_checksum") != expected_checksum:
+        failures.append(
+            {
+                "field": "rows_checksum",
+                "reason": "does not match canonical rows checksum",
+                "expected": expected_checksum,
+                "actual": artifact.get("rows_checksum"),
+            }
+        )
+
+    return {
+        "matched": not failures,
+        "adapter": artifact.get("adapter"),
+        "execution_id": artifact.get("execution_id"),
+        "row_counts": {surface: len(rows.get(surface, [])) for surface in SURFACE_ROW_KEYS},
+        "rows_checksum": expected_checksum,
+        "failures": failures,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate live projection row artifact JSON")
+    parser.add_argument("--rows", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    output = validate_live_projection_rows(args.rows)
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0 if output["matched"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -15,6 +15,7 @@ fi
   tests/scripts/test_fetch_replay_state_report.py \
   tests/scripts/test_run_replay_validation.py \
   tests/scripts/test_export_live_projection_rows_postgres.py \
+  tests/scripts/test_check_live_projection_rows.py \
   tests/scripts/test_check_replay_validation_manifest.py \
   tests/scripts/test_check_replay_state_report.py \
   tests/scripts/test_check_replay_parity_report.py \

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -22,6 +22,7 @@ REQUIRED_CONFIG_FIELDS = (
 REQUIRED_STEP_ORDER = ("fetch", "state_integrity")
 OPTIONAL_STEP_NAMES = (
     "live_rows_export",
+    "live_rows_integrity",
     "live_checksums",
     "projection_parity",
     "payload_resolution",
@@ -121,6 +122,26 @@ def _validate_manifest(manifest: dict[str, Any], *, require_matched: bool, check
     for expected_index, name in enumerate(REQUIRED_STEP_ORDER):
         if len(step_names) <= expected_index or step_names[expected_index] != name:
             failures.append({"field": "steps", "reason": f"required step {name} missing or out of order"})
+    artifacts_live_rows = artifacts.get("live_rows") if isinstance(artifacts, dict) else None
+    config_live_rows = config.get("live_rows") if isinstance(config, dict) else None
+    export_live_rows = (
+        config.get("export_live_rows_postgres") if isinstance(config, dict) else False
+    )
+    if artifacts_live_rows or config_live_rows or export_live_rows:
+        if "live_rows_integrity" not in step_names:
+            failures.append(
+                {
+                    "field": "steps",
+                    "reason": "live row manifests require live_rows_integrity step",
+                }
+            )
+        elif "live_checksums" in step_names and step_names.index("live_rows_integrity") > step_names.index("live_checksums"):
+            failures.append(
+                {
+                    "field": "steps",
+                    "reason": "live_rows_integrity must run before live_checksums",
+                }
+            )
     for name in step_names:
         if name not in (*REQUIRED_STEP_ORDER, *OPTIONAL_STEP_NAMES, "fetch_artifact"):
             failures.append({"field": "steps", "reason": "unknown validation step", "step": name})

--- a/scripts/export_live_projection_rows_postgres.py
+++ b/scripts/export_live_projection_rows_postgres.py
@@ -9,11 +9,12 @@ adapter-neutral row JSON through scripts/build_live_projection_checksums.py.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sys
 from collections.abc import Mapping
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
@@ -189,6 +190,16 @@ def _json_default(value: Any) -> str | int | float:
     raise TypeError(f"{type(value).__name__} is not JSON serializable")
 
 
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _canonical_checksum(value: Any) -> str:
+    normalized = json.loads(json.dumps(value, default=_json_default, sort_keys=True))
+    rendered = json.dumps(normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+
+
 def _connect(dsn: str | None):
     conninfo = dsn or os.getenv("NOETL_DATABASE_URL") or os.getenv("DATABASE_URL")
     if not conninfo:
@@ -313,13 +324,16 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     payload = {
+        "schema_version": 1,
         "adapter": "postgres",
         "execution_id": args.execution_id,
         "tenant_id": args.tenant_id,
         "organization_id": args.organization_id,
         "projection": args.projection,
+        "exported_at": _utc_now(),
         "rows": rows,
         "row_counts": {surface: len(rows[surface]) for surface in SURFACES},
+        "rows_checksum": _canonical_checksum(rows),
     }
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -216,6 +216,17 @@ def main(argv: list[str] | None = None) -> int:
             else [],
         ),
         (
+            "live_rows_integrity",
+            [
+                sys.executable,
+                "scripts/check_live_projection_rows.py",
+                "--rows",
+                str(live_rows_path),
+            ]
+            if live_rows_path
+            else [],
+        ),
+        (
             "live_checksums",
             [
                 sys.executable,

--- a/tests/scripts/test_build_live_projection_checksums.py
+++ b/tests/scripts/test_build_live_projection_checksums.py
@@ -63,6 +63,17 @@ def test_build_live_projection_checksums_accepts_nested_rows(tmp_path: Path):
     )
 
 
+def test_build_live_projection_checksums_rejects_nested_row_count_drift(tmp_path: Path):
+    rows_path = tmp_path / "live-rows.json"
+    output_path = tmp_path / "live-checksums.json"
+    rows_path.write_text(json.dumps({"rows": _rows(), "row_counts": {"execution": 2}}))
+
+    with pytest.raises(ValueError, match="row_counts.execution"):
+        build_live_projection_checksums.main(
+            ["--rows", str(rows_path), "--output", str(output_path)]
+        )
+
+
 def test_build_live_projection_checksums_rejects_unknown_surface(tmp_path: Path):
     rows = {**_rows(), "extra": []}
     rows_path = tmp_path / "live-rows.json"

--- a/tests/scripts/test_check_live_projection_rows.py
+++ b/tests/scripts/test_check_live_projection_rows.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+from scripts.check_live_projection_rows import _canonical_checksum, main
+
+
+def _artifact() -> dict:
+    rows = {
+        "execution": [{"execution_id": 123}],
+        "stages": [],
+        "frames": [],
+        "commands": [],
+        "business_objects": [],
+        "loops": [],
+    }
+    return {
+        "schema_version": 1,
+        "adapter": "postgres",
+        "execution_id": 123,
+        "tenant_id": "tenant-a",
+        "organization_id": "org-a",
+        "projection": "all",
+        "exported_at": "2026-05-20T00:00:00Z",
+        "rows": rows,
+        "row_counts": {surface: len(values) for surface, values in rows.items()},
+        "rows_checksum": _canonical_checksum(rows),
+    }
+
+
+def test_check_live_projection_rows_accepts_valid_artifact(tmp_path: Path, capsys):
+    path = tmp_path / "live-rows.json"
+    path.write_text(json.dumps(_artifact()))
+
+    assert main(["--rows", str(path)]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True
+    assert output["row_counts"]["execution"] == 1
+
+
+def test_check_live_projection_rows_rejects_bad_row_count(tmp_path: Path, capsys):
+    artifact = _artifact()
+    artifact["row_counts"]["execution"] = 99
+    path = tmp_path / "live-rows.json"
+    path.write_text(json.dumps(artifact))
+
+    assert main(["--rows", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert "row_counts.execution" in {failure["field"] for failure in output["failures"]}
+
+
+def test_check_live_projection_rows_rejects_checksum_drift(tmp_path: Path, capsys):
+    artifact = _artifact()
+    artifact["rows"]["execution"].append({"execution_id": 124})
+    path = tmp_path / "live-rows.json"
+    path.write_text(json.dumps(artifact))
+
+    assert main(["--rows", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert "rows_checksum" in {failure["field"] for failure in output["failures"]}

--- a/tests/scripts/test_check_replay_validation_manifest.py
+++ b/tests/scripts/test_check_replay_validation_manifest.py
@@ -55,6 +55,14 @@ def _manifest(tmp_path: Path) -> dict:
                 "name": "live_rows_export",
                 "skipped": True,
             },
+            {
+                "name": "live_rows_integrity",
+                "skipped": True,
+            },
+            {
+                "name": "live_checksums",
+                "skipped": True,
+            },
             {"name": "projection_parity", "skipped": True},
             {"name": "payload_resolution", "skipped": True},
         ],
@@ -126,6 +134,41 @@ def test_check_replay_validation_manifest_checks_live_rows_artifact(tmp_path: Pa
 
     assert main(["--manifest", str(path), "--check-artifacts"]) == 0
     assert json.loads(capsys.readouterr().out)["matched"] is True
+
+
+def test_check_replay_validation_manifest_requires_live_rows_integrity(tmp_path: Path, capsys):
+    manifest = _manifest(tmp_path)
+    live_rows = tmp_path / "live-rows.json"
+    live_rows.write_text("{}")
+    manifest["artifacts"]["live_rows"] = str(live_rows)
+    manifest["steps"] = [
+        step for step in manifest["steps"] if step["name"] != "live_rows_integrity"
+    ]
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any("live_rows_integrity" in failure["reason"] for failure in output["failures"])
+
+
+def test_check_replay_validation_manifest_requires_live_rows_integrity_before_checksums(
+    tmp_path: Path,
+    capsys,
+):
+    manifest = _manifest(tmp_path)
+    manifest["config"]["live_rows"] = "live-rows.json"
+    live_integrity = next(step for step in manifest["steps"] if step["name"] == "live_rows_integrity")
+    manifest["steps"] = [
+        step for step in manifest["steps"] if step["name"] != "live_rows_integrity"
+    ]
+    manifest["steps"].append(live_integrity)
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any("before live_checksums" in failure["reason"] for failure in output["failures"])
 
 
 def test_check_replay_validation_manifest_rejects_multiple_live_inputs(tmp_path: Path, capsys):

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -187,10 +187,11 @@ def test_run_replay_validation_can_export_live_rows_from_postgres(monkeypatch, t
     assert output["config"]["export_live_rows_postgres"] is True
     assert output["artifacts"]["live_rows"].endswith("live-rows-123.json")
     assert output["artifacts"]["live_checksums"].endswith("live-checksums-123.json")
-    assert [step["name"] for step in output["steps"][:4]] == [
+    assert [step["name"] for step in output["steps"][:5]] == [
         "fetch",
         "state_integrity",
         "live_rows_export",
+        "live_rows_integrity",
         "live_checksums",
     ]
 


### PR DESCRIPTION
## Summary
- add `scripts/check_live_projection_rows.py` to validate adapter-exported live-row evidence before live checksum generation
- make the Postgres live-row exporter write `schema_version`, `exported_at`, canonical `rows_checksum`, and surface row counts
- make `build_live_projection_checksums.py` reject row-count or rows-checksum drift in nested live-row artifacts
- add `live_rows_integrity` to `run_replay_validation.py` and require it in validation manifests whenever live-row evidence is present

## Design notes
- the gate validates the storage-neutral row artifact, not the Postgres adapter itself
- checksum generation remains backend-neutral: any future storage adapter can emit the same JSON schema and pass the same integrity gate

## Validation
- `python -m pytest -q tests/scripts/test_export_live_projection_rows_postgres.py tests/scripts/test_check_live_projection_rows.py tests/scripts/test_build_live_projection_checksums.py tests/scripts/test_run_replay_validation.py tests/scripts/test_check_replay_validation_manifest.py`
- `python -m pytest -q tests/scripts/test_check_replay_validation_manifest.py tests/scripts/test_run_replay_validation.py tests/scripts/test_check_live_projection_rows.py`
- `scripts/check_replay_release_gate.sh`