### PR TITLE
test(replay): index validation artifacts

### DIFF
--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -16,6 +16,7 @@ fi
   tests/scripts/test_run_replay_validation.py \
   tests/scripts/test_export_live_projection_rows_postgres.py \
   tests/scripts/test_check_live_projection_rows.py \
+  tests/scripts/test_package_replay_validation_artifacts.py \
   tests/scripts/test_check_replay_validation_manifest.py \
   tests/scripts/test_check_replay_state_report.py \
   tests/scripts/test_check_replay_parity_report.py \

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -26,6 +26,7 @@ OPTIONAL_STEP_NAMES = (
     "live_checksums",
     "projection_parity",
     "payload_resolution",
+    "artifact_index",
 )
 
 

--- a/scripts/package_replay_validation_artifacts.py
+++ b/scripts/package_replay_validation_artifacts.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+"""Build and validate a SHA-256 index for replay validation artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+INDEX_SCHEMA_VERSION = 1
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    data: Any = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _artifact_entry(role: str, path: Path, *, required: bool = True) -> dict[str, Any]:
+    exists = path.exists()
+    entry: dict[str, Any] = {
+        "role": role,
+        "path": str(path),
+        "required": required,
+        "exists": exists,
+    }
+    if exists:
+        entry["size_bytes"] = path.stat().st_size
+        entry["sha256"] = _sha256(path)
+    return entry
+
+
+def build_artifact_index(
+    *,
+    manifest_path: Path,
+    extra_artifacts: list[tuple[str, Path]] | None = None,
+) -> dict[str, Any]:
+    manifest = _load_json(manifest_path)
+    artifacts = manifest.get("artifacts")
+    artifacts = artifacts if isinstance(artifacts, dict) else {}
+
+    entries: list[dict[str, Any]] = [_artifact_entry("manifest", manifest_path)]
+    for role in ("replay", "live_rows", "live_checksums", "report"):
+        value = artifacts.get(role)
+        if value is None:
+            continue
+        if not isinstance(value, str) or not value:
+            entries.append(
+                {
+                    "role": role,
+                    "path": value,
+                    "required": True,
+                    "exists": False,
+                    "error": "artifact path is not a non-empty string",
+                }
+            )
+            continue
+        path = Path(value)
+        if not path.is_absolute():
+            path = (manifest_path.parent / path).resolve()
+        entries.append(_artifact_entry(role, path))
+
+    for role, path in extra_artifacts or []:
+        entries.append(_artifact_entry(role, path))
+
+    return {
+        "schema_version": INDEX_SCHEMA_VERSION,
+        "generated_at": _utc_now(),
+        "manifest": str(manifest_path),
+        "matched": all(entry.get("exists") for entry in entries if entry.get("required", True)),
+        "artifacts": entries,
+    }
+
+
+def validate_artifact_index(index_path: Path) -> dict[str, Any]:
+    index = _load_json(index_path)
+    failures: list[dict[str, Any]] = []
+
+    if index.get("schema_version") != INDEX_SCHEMA_VERSION:
+        failures.append({"field": "schema_version", "reason": f"must be {INDEX_SCHEMA_VERSION}"})
+    if not isinstance(index.get("generated_at"), str) or not index.get("generated_at"):
+        failures.append({"field": "generated_at", "reason": "must be a non-empty string"})
+
+    artifacts = index.get("artifacts")
+    if not isinstance(artifacts, list):
+        failures.append({"field": "artifacts", "reason": "must be a list"})
+        artifacts = []
+
+    for idx, entry in enumerate(artifacts):
+        if not isinstance(entry, dict):
+            failures.append({"field": f"artifacts[{idx}]", "reason": "must be an object"})
+            continue
+        if not isinstance(entry.get("role"), str) or not entry.get("role"):
+            failures.append({"field": f"artifacts[{idx}].role", "reason": "must be a non-empty string"})
+        path_value = entry.get("path")
+        if not isinstance(path_value, str) or not path_value:
+            failures.append({"field": f"artifacts[{idx}].path", "reason": "must be a non-empty string"})
+            continue
+        path = Path(path_value)
+        required = bool(entry.get("required", True))
+        if required and not path.exists():
+            failures.append(
+                {
+                    "field": f"artifacts[{idx}].path",
+                    "reason": "artifact path does not exist",
+                    "path": path_value,
+                }
+            )
+            continue
+        if not path.exists():
+            continue
+        size_bytes = entry.get("size_bytes")
+        if isinstance(size_bytes, bool) or not isinstance(size_bytes, int) or size_bytes < 0:
+            failures.append({"field": f"artifacts[{idx}].size_bytes", "reason": "must be a non-negative integer"})
+        elif size_bytes != path.stat().st_size:
+            failures.append(
+                {
+                    "field": f"artifacts[{idx}].size_bytes",
+                    "reason": "size drift",
+                    "expected": size_bytes,
+                    "actual": path.stat().st_size,
+                }
+            )
+        actual_sha = _sha256(path)
+        if entry.get("sha256") != actual_sha:
+            failures.append(
+                {
+                    "field": f"artifacts[{idx}].sha256",
+                    "reason": "sha256 drift",
+                    "expected": entry.get("sha256"),
+                    "actual": actual_sha,
+                }
+            )
+
+    matched = not failures and all(
+        bool(entry.get("exists"))
+        for entry in artifacts
+        if isinstance(entry, dict) and entry.get("required", True)
+    )
+    return {"matched": matched, "failures": failures}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build or validate replay validation artifact index")
+    parser.add_argument("--manifest", type=Path, help="Replay validation manifest JSON")
+    parser.add_argument("--output", type=Path, help="Output artifact index JSON")
+    parser.add_argument("--check", type=Path, help="Validate an existing artifact index JSON")
+    parser.add_argument(
+        "--artifact",
+        action="append",
+        default=[],
+        metavar="ROLE=PATH",
+        help="Extra artifact to include in the index",
+    )
+    args = parser.parse_args(argv)
+
+    if args.check:
+        output = validate_artifact_index(args.check)
+        print(json.dumps(output, indent=2, sort_keys=True))
+        return 0 if output["matched"] else 1
+    if not args.manifest or not args.output:
+        parser.error("--manifest and --output are required unless --check is used")
+
+    extra_artifacts: list[tuple[str, Path]] = []
+    for raw in args.artifact:
+        if "=" not in raw:
+            parser.error("--artifact must be ROLE=PATH")
+        role, value = raw.split("=", 1)
+        if not role or not value:
+            parser.error("--artifact must be ROLE=PATH")
+        extra_artifacts.append((role, Path(value)))
+
+    index = build_artifact_index(manifest_path=args.manifest, extra_artifacts=extra_artifacts)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(index, indent=2, sort_keys=True) + "\n")
+    print(json.dumps({"output": str(args.output), "matched": index["matched"]}, sort_keys=True))
+    return 0 if index["matched"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -58,6 +58,7 @@ def _build_report(
             "live_rows": str(live_rows_path) if live_rows_path else None,
             "live_checksums": str(live_checksums_path) if live_checksums_path else None,
             "report": str(args.report_output) if args.report_output else None,
+            "artifact_index": str(args.artifact_index_output) if args.artifact_index_output else None,
         },
         "config": {
             "base_url": args.base_url,
@@ -73,6 +74,7 @@ def _build_report(
             "live_checksums": str(args.live_checksums) if args.live_checksums else None,
             "live_rows": str(args.live_rows) if args.live_rows else None,
             "export_live_rows_postgres": args.export_live_rows_postgres,
+            "artifact_index_output": str(args.artifact_index_output) if args.artifact_index_output else None,
         },
         "steps": steps,
     }
@@ -122,6 +124,11 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         help="Optional path to write the validation run manifest JSON",
     )
+    parser.add_argument(
+        "--artifact-index-output",
+        type=Path,
+        help="Optional path to write SHA-256/size index for validation artifacts",
+    )
     args = parser.parse_args(argv)
 
     cutoff_count = sum(
@@ -145,6 +152,8 @@ def main(argv: list[str] | None = None) -> int:
         )
     if args.postgres_dsn and not args.export_live_rows_postgres:
         parser.error("--postgres-dsn requires --export-live-rows-postgres")
+    if args.artifact_index_output and args.report_output is None:
+        parser.error("--artifact-index-output requires --report-output")
 
     started_at = _utc_now()
     output_dir = args.output_dir
@@ -330,6 +339,42 @@ def main(argv: list[str] | None = None) -> int:
         ),
         args.report_output,
     )
+    if args.artifact_index_output:
+        command = [
+            sys.executable,
+            "scripts/package_replay_validation_artifacts.py",
+            "--manifest",
+            str(args.report_output),
+            "--output",
+            str(args.artifact_index_output),
+        ]
+        code, stdout, stderr, duration = _run(command)
+        step = {
+            "name": "artifact_index",
+            "command": command,
+            "returncode": code,
+            "duration_seconds": round(duration, 6),
+            "stdout": stdout,
+            "stderr": stderr,
+        }
+        stdout_json = _parse_json(stdout)
+        if stdout_json is not None:
+            step["stdout_json"] = stdout_json
+        steps.append(step)
+        if code != 0:
+            _emit_report(
+                _build_report(
+                    matched=False,
+                    args=args,
+                    replay_path=replay_path,
+                    live_checksums_path=live_checksums_path,
+                    live_rows_path=live_rows_path,
+                    steps=steps,
+                    started_at=started_at,
+                ),
+                args.report_output,
+            )
+            return code
     return 0
 
 

--- a/tests/scripts/test_check_replay_validation_manifest.py
+++ b/tests/scripts/test_check_replay_validation_manifest.py
@@ -17,6 +17,7 @@ def _manifest(tmp_path: Path) -> dict:
             "live_rows": None,
             "live_checksums": None,
             "report": None,
+            "artifact_index": None,
         },
         "config": {
             "base_url": "http://noetl.example",

--- a/tests/scripts/test_package_replay_validation_artifacts.py
+++ b/tests/scripts/test_package_replay_validation_artifacts.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+
+from scripts.package_replay_validation_artifacts import main
+
+
+def _manifest(tmp_path: Path) -> Path:
+    replay = tmp_path / "replay.json"
+    replay.write_text("{}")
+    live_rows = tmp_path / "live-rows.json"
+    live_rows.write_text("{}")
+    live_checksums = tmp_path / "live-checksums.json"
+    live_checksums.write_text("{}")
+    manifest = tmp_path / "validation.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "matched": True,
+                "artifacts": {
+                    "replay": str(replay),
+                    "live_rows": str(live_rows),
+                    "live_checksums": str(live_checksums),
+                    "report": str(manifest),
+                },
+            }
+        )
+    )
+    return manifest
+
+
+def test_package_replay_validation_artifacts_builds_and_checks_index(tmp_path: Path, capsys):
+    manifest = _manifest(tmp_path)
+    output = tmp_path / "artifact-index.json"
+
+    assert main(["--manifest", str(manifest), "--output", str(output)]) == 0
+    created = json.loads(capsys.readouterr().out)
+    assert created["matched"] is True
+    assert created["output"] == str(output)
+
+    index = json.loads(output.read_text())
+    roles = {entry["role"] for entry in index["artifacts"]}
+    assert {"manifest", "replay", "live_rows", "live_checksums", "report"} <= roles
+    assert all(entry["exists"] for entry in index["artifacts"])
+
+    assert main(["--check", str(output)]) == 0
+    assert json.loads(capsys.readouterr().out)["matched"] is True
+
+
+def test_package_replay_validation_artifacts_rejects_digest_drift(tmp_path: Path, capsys):
+    manifest = _manifest(tmp_path)
+    output = tmp_path / "artifact-index.json"
+    assert main(["--manifest", str(manifest), "--output", str(output)]) == 0
+    capsys.readouterr()
+
+    (tmp_path / "replay.json").write_text('{"changed":true}')
+    assert main(["--check", str(output)]) == 1
+    result = json.loads(capsys.readouterr().out)
+    assert any(failure["reason"] == "sha256 drift" for failure in result["failures"])

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -196,6 +196,49 @@ def test_run_replay_validation_can_export_live_rows_from_postgres(monkeypatch, t
     ]
 
 
+def test_run_replay_validation_can_write_artifact_index(monkeypatch, tmp_path: Path, capsys):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if any(str(part).endswith("fetch_replay_state_report.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
+        if any(str(part).endswith("package_replay_validation_artifacts.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.write_text(json.dumps({"schema_version": 1, "matched": True, "artifacts": []}))
+        return 0, json.dumps({"ok": True}), "", 0.01
+
+    monkeypatch.setattr(run_replay_validation, "_run", _run)
+    manifest = tmp_path / "validation.json"
+    artifact_index = tmp_path / "artifact-index.json"
+
+    assert (
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--output-dir",
+                str(tmp_path),
+                "--report-output",
+                str(manifest),
+                "--artifact-index-output",
+                str(artifact_index),
+            ]
+        )
+        == 0
+    )
+
+    assert artifact_index.exists()
+    assert any("scripts/package_replay_validation_artifacts.py" in call for call in calls)
+    manifest_payload = json.loads(manifest.read_text())
+    assert manifest_payload["artifacts"]["artifact_index"] == str(artifact_index)
+    assert json.loads(capsys.readouterr().out)["artifacts"]["artifact_index"] == str(artifact_index)
+
+
 def test_run_replay_validation_rejects_multiple_cutoffs(tmp_path: Path):
     try:
         run_replay_validation.main(
@@ -251,6 +294,26 @@ def test_run_replay_validation_rejects_postgres_dsn_without_export(tmp_path: Pat
                 "123",
                 "--postgres-dsn",
                 "postgresql://example",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected parser error")
+
+
+def test_run_replay_validation_rejects_artifact_index_without_manifest(tmp_path: Path):
+    try:
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--artifact-index-output",
+                str(tmp_path / "artifact-index.json"),
                 "--output-dir",
                 str(tmp_path),
             ]


### PR DESCRIPTION
## Summary
- add `scripts/package_replay_validation_artifacts.py` to build/check a SHA-256 and size index for replay validation evidence
- let `scripts/run_replay_validation.py --artifact-index-output ...` write that index after the validation manifest
- include `artifact_index` in manifests and allow the manifest checker to recognize the packaging step
- cover digest drift and runner integration in tests

## Design notes
- the index is storage-neutral evidence packaging: it records files produced by validation, not Postgres internals
- `--artifact-index-output` requires `--report-output` so the index can point at a stable validation manifest

## Validation
- `python -m pytest -q tests/scripts/test_package_replay_validation_artifacts.py tests/scripts/test_run_replay_validation.py tests/scripts/test_check_replay_validation_manifest.py`
- `scripts/check_replay_release_gate.sh`