### PR TITLE
test(replay): finalize artifact index manifests

### DIFF
--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -327,6 +327,34 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 1
 
+    artifact_index_command: list[str] | None = None
+    if args.artifact_index_output:
+        artifact_index_command = [
+            sys.executable,
+            "scripts/package_replay_validation_artifacts.py",
+            "--manifest",
+            str(args.report_output),
+            "--output",
+            str(args.artifact_index_output),
+        ]
+        steps.append(
+            {
+                "name": "artifact_index",
+                "command": artifact_index_command,
+                "returncode": 0,
+                "duration_seconds": 0.0,
+                "stdout": json.dumps(
+                    {"output": str(args.artifact_index_output), "matched": True},
+                    sort_keys=True,
+                ),
+                "stderr": "",
+                "stdout_json": {
+                    "output": str(args.artifact_index_output),
+                    "matched": True,
+                },
+            }
+        )
+
     _emit_report(
         _build_report(
             matched=True,
@@ -339,29 +367,20 @@ def main(argv: list[str] | None = None) -> int:
         ),
         args.report_output,
     )
-    if args.artifact_index_output:
-        command = [
-            sys.executable,
-            "scripts/package_replay_validation_artifacts.py",
-            "--manifest",
-            str(args.report_output),
-            "--output",
-            str(args.artifact_index_output),
-        ]
-        code, stdout, stderr, duration = _run(command)
-        step = {
-            "name": "artifact_index",
-            "command": command,
-            "returncode": code,
-            "duration_seconds": round(duration, 6),
-            "stdout": stdout,
-            "stderr": stderr,
-        }
-        stdout_json = _parse_json(stdout)
-        if stdout_json is not None:
-            step["stdout_json"] = stdout_json
-        steps.append(step)
+    if artifact_index_command:
+        code, stdout, stderr, duration = _run(artifact_index_command)
         if code != 0:
+            steps[-1] = {
+                "name": "artifact_index",
+                "command": artifact_index_command,
+                "returncode": code,
+                "duration_seconds": round(duration, 6),
+                "stdout": stdout,
+                "stderr": stderr,
+            }
+            stdout_json = _parse_json(stdout)
+            if stdout_json is not None:
+                steps[-1]["stdout_json"] = stdout_json
             _emit_report(
                 _build_report(
                     matched=False,

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -236,6 +236,11 @@ def test_run_replay_validation_can_write_artifact_index(monkeypatch, tmp_path: P
     assert any("scripts/package_replay_validation_artifacts.py" in call for call in calls)
     manifest_payload = json.loads(manifest.read_text())
     assert manifest_payload["artifacts"]["artifact_index"] == str(artifact_index)
+    assert manifest_payload["steps"][-1]["name"] == "artifact_index"
+    assert manifest_payload["steps"][-1]["stdout_json"] == {
+        "matched": True,
+        "output": str(artifact_index),
+    }
     assert json.loads(capsys.readouterr().out)["artifacts"]["artifact_index"] == str(artifact_index)
 
 


### PR DESCRIPTION
## Summary
- make `run_replay_validation.py --artifact-index-output` record the `artifact_index` step in the manifest before packaging the index
- keep the artifact index hashing the final manifest content, including the artifact-index step and artifact path
- update runner tests to assert the final manifest contains the artifact-index evidence step

## Why
The previous phase generated the index after writing the manifest, so the manifest on disk did not include the `artifact_index` step. This makes the final evidence bundle internally consistent.

## Validation
- `python -m pytest -q tests/scripts/test_run_replay_validation.py tests/scripts/test_package_replay_validation_artifacts.py tests/scripts/test_check_replay_validation_manifest.py`
- `scripts/check_replay_release_gate.sh`