### PR TITLE
test(replay): validate artifact index roles

### DIFF
--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -214,6 +214,29 @@ def _validate_manifest(
                     "reason": "live_rows_integrity must run before live_checksums",
                 }
             )
+    artifacts_index = artifacts.get("artifact_index") if isinstance(artifacts, dict) else None
+    if artifacts_index:
+        if "artifact_index" not in step_names:
+            failures.append(
+                {
+                    "field": "steps",
+                    "reason": "artifact index manifests require artifact_index step",
+                }
+            )
+        elif step_names.index("artifact_index") != len(step_names) - 1:
+            failures.append(
+                {
+                    "field": "steps",
+                    "reason": "artifact_index step must be last",
+                }
+            )
+    elif "artifact_index" in step_names:
+        failures.append(
+            {
+                "field": "artifacts.artifact_index",
+                "reason": "artifact_index step requires artifacts.artifact_index",
+            }
+        )
     for name in step_names:
         if name not in (*REQUIRED_STEP_ORDER, *OPTIONAL_STEP_NAMES, "fetch_artifact"):
             failures.append({"field": "steps", "reason": "unknown validation step", "step": name})

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -10,6 +10,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from scripts.package_replay_validation_artifacts import validate_artifact_index
+
 REQUIRED_CONFIG_FIELDS = (
     "base_url",
     "execution_id",
@@ -47,7 +49,20 @@ def _valid_timestamp(value: Any) -> bool:
     return True
 
 
-def _validate_manifest(manifest: dict[str, Any], *, require_matched: bool, check_artifacts: bool) -> dict[str, Any]:
+def _artifact_path(value: str, manifest_path: Path | None) -> Path:
+    path = Path(value)
+    if not path.is_absolute() and manifest_path is not None:
+        return (manifest_path.parent / path).resolve()
+    return path
+
+
+def _validate_manifest(
+    manifest: dict[str, Any],
+    *,
+    require_matched: bool,
+    check_artifacts: bool,
+    manifest_path: Path | None = None,
+) -> dict[str, Any]:
     failures: list[dict[str, Any]] = []
 
     if require_matched and manifest.get("matched") is not True:
@@ -89,8 +104,64 @@ def _validate_manifest(manifest: dict[str, Any], *, require_matched: bool, check
                 continue
             if not isinstance(value, str) or not value:
                 failures.append({"field": f"artifacts.{field}", "reason": "artifact path must be a string"})
-            elif not Path(value).exists():
+            elif not _artifact_path(value, manifest_path).exists():
                 failures.append({"field": f"artifacts.{field}", "reason": "artifact path does not exist", "path": value})
+
+        artifact_index = artifacts.get("artifact_index")
+        if isinstance(artifact_index, str) and artifact_index:
+            index_path = _artifact_path(artifact_index, manifest_path)
+            if index_path.exists():
+                try:
+                    index_output = validate_artifact_index(index_path)
+                except (OSError, json.JSONDecodeError, ValueError) as exc:
+                    failures.append(
+                        {
+                            "field": "artifacts.artifact_index",
+                            "reason": "artifact index could not be validated",
+                            "path": artifact_index,
+                            "error": str(exc),
+                        }
+                    )
+                else:
+                    if index_output.get("matched") is not True:
+                        failures.append(
+                            {
+                                "field": "artifacts.artifact_index",
+                                "reason": "artifact index validation failed",
+                                "path": artifact_index,
+                                "failures": index_output.get("failures", []),
+                            }
+                        )
+                    if manifest_path is not None:
+                        try:
+                            index_data = _load_manifest(index_path)
+                            indexed_manifest = index_data.get("manifest")
+                            if not isinstance(indexed_manifest, str) or not indexed_manifest:
+                                failures.append(
+                                    {
+                                        "field": "artifacts.artifact_index",
+                                        "reason": "artifact index manifest path is missing",
+                                        "path": artifact_index,
+                                    }
+                                )
+                            elif _artifact_path(indexed_manifest, index_path) != manifest_path.resolve():
+                                failures.append(
+                                    {
+                                        "field": "artifacts.artifact_index",
+                                        "reason": "artifact index points at a different manifest",
+                                        "path": artifact_index,
+                                        "indexed_manifest": indexed_manifest,
+                                    }
+                                )
+                        except (OSError, json.JSONDecodeError, ValueError) as exc:
+                            failures.append(
+                                {
+                                    "field": "artifacts.artifact_index",
+                                    "reason": "artifact index manifest path could not be checked",
+                                    "path": artifact_index,
+                                    "error": str(exc),
+                                }
+                            )
 
     steps = manifest.get("steps")
     if not isinstance(steps, list):
@@ -161,6 +232,7 @@ def main(argv: list[str] | None = None) -> int:
         _load_manifest(args.manifest),
         require_matched=not args.allow_failed,
         check_artifacts=args.check_artifacts,
+        manifest_path=args.manifest,
     )
     print(json.dumps(output, indent=2, sort_keys=True))
     return 0 if output["matched"] else 1

--- a/scripts/package_replay_validation_artifacts.py
+++ b/scripts/package_replay_validation_artifacts.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Any
 
 INDEX_SCHEMA_VERSION = 1
+REQUIRED_ROLES = ("manifest", "replay", "report")
+PAIRED_ROLES = (("live_rows", "live_checksums"),)
 
 
 def _utc_now() -> str:
@@ -103,12 +105,16 @@ def validate_artifact_index(index_path: Path) -> dict[str, Any]:
         failures.append({"field": "artifacts", "reason": "must be a list"})
         artifacts = []
 
+    roles: dict[str, int] = {}
     for idx, entry in enumerate(artifacts):
         if not isinstance(entry, dict):
             failures.append({"field": f"artifacts[{idx}]", "reason": "must be an object"})
             continue
-        if not isinstance(entry.get("role"), str) or not entry.get("role"):
+        role = entry.get("role")
+        if not isinstance(role, str) or not role:
             failures.append({"field": f"artifacts[{idx}].role", "reason": "must be a non-empty string"})
+        else:
+            roles[role] = roles.get(role, 0) + 1
         path_value = entry.get("path")
         if not isinstance(path_value, str) or not path_value:
             failures.append({"field": f"artifacts[{idx}].path", "reason": "must be a non-empty string"})
@@ -146,6 +152,29 @@ def validate_artifact_index(index_path: Path) -> dict[str, Any]:
                     "reason": "sha256 drift",
                     "expected": entry.get("sha256"),
                     "actual": actual_sha,
+                }
+            )
+
+    for role in REQUIRED_ROLES:
+        if roles.get(role, 0) == 0:
+            failures.append({"field": "artifacts", "reason": "missing required artifact role", "role": role})
+    for role, count in sorted(roles.items()):
+        if count > 1:
+            failures.append(
+                {
+                    "field": "artifacts",
+                    "reason": "duplicate artifact role",
+                    "role": role,
+                    "count": count,
+                }
+            )
+    for left, right in PAIRED_ROLES:
+        if bool(roles.get(left)) != bool(roles.get(right)):
+            failures.append(
+                {
+                    "field": "artifacts",
+                    "reason": "paired artifact roles must appear together",
+                    "roles": [left, right],
                 }
             )
 

--- a/tests/scripts/test_check_replay_validation_manifest.py
+++ b/tests/scripts/test_check_replay_validation_manifest.py
@@ -78,6 +78,16 @@ def _write_manifest_with_artifact_index(tmp_path: Path) -> Path:
     index_path = tmp_path / "artifact-index.json"
     manifest["artifacts"]["report"] = str(report)
     manifest["artifacts"]["artifact_index"] = str(index_path)
+    manifest["steps"].append(
+        {
+            "name": "artifact_index",
+            "command": ["python", "scripts/package_replay_validation_artifacts.py"],
+            "returncode": 0,
+            "duration_seconds": 0.1,
+            "stdout": "{}",
+            "stderr": "",
+        }
+    )
     path = tmp_path / "manifest.json"
     path.write_text(json.dumps(manifest))
     index_path.write_text(
@@ -240,3 +250,43 @@ def test_check_replay_validation_manifest_rejects_artifact_index_for_other_manif
         and failure["reason"] == "artifact index points at a different manifest"
         for failure in output["failures"]
     )
+
+
+def test_check_replay_validation_manifest_requires_artifact_index_step(tmp_path: Path, capsys):
+    path = _write_manifest_with_artifact_index(tmp_path)
+    manifest = json.loads(path.read_text())
+    manifest["steps"] = [step for step in manifest["steps"] if step["name"] != "artifact_index"]
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any("artifact_index step" in failure["reason"] for failure in output["failures"])
+
+
+def test_check_replay_validation_manifest_requires_artifact_index_step_last(
+    tmp_path: Path,
+    capsys,
+):
+    path = _write_manifest_with_artifact_index(tmp_path)
+    manifest = json.loads(path.read_text())
+    artifact_step = manifest["steps"].pop()
+    manifest["steps"].insert(1, artifact_step)
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any("artifact_index step must be last" in failure["reason"] for failure in output["failures"])
+
+
+def test_check_replay_validation_manifest_rejects_orphan_artifact_index_step(
+    tmp_path: Path,
+    capsys,
+):
+    manifest = _manifest(tmp_path)
+    manifest["steps"].append({"name": "artifact_index", "skipped": True})
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert "artifacts.artifact_index" in {failure["field"] for failure in output["failures"]}

--- a/tests/scripts/test_check_replay_validation_manifest.py
+++ b/tests/scripts/test_check_replay_validation_manifest.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from scripts.check_replay_validation_manifest import main
+from scripts.package_replay_validation_artifacts import build_artifact_index
 
 
 def _manifest(tmp_path: Path) -> dict:
@@ -68,6 +69,22 @@ def _manifest(tmp_path: Path) -> dict:
             {"name": "payload_resolution", "skipped": True},
         ],
     }
+
+
+def _write_manifest_with_artifact_index(tmp_path: Path) -> Path:
+    manifest = _manifest(tmp_path)
+    report = tmp_path / "validation-report.json"
+    report.write_text("{}")
+    index_path = tmp_path / "artifact-index.json"
+    manifest["artifacts"]["report"] = str(report)
+    manifest["artifacts"]["artifact_index"] = str(index_path)
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+    index_path.write_text(
+        json.dumps(build_artifact_index(manifest_path=path), indent=2, sort_keys=True)
+        + "\n"
+    )
+    return path
 
 
 def test_check_replay_validation_manifest_accepts_success(tmp_path: Path, capsys):
@@ -182,3 +199,44 @@ def test_check_replay_validation_manifest_rejects_multiple_live_inputs(tmp_path:
     assert main(["--manifest", str(path)]) == 1
     output = json.loads(capsys.readouterr().out)
     assert "config.live_checksums" in {failure["field"] for failure in output["failures"]}
+
+
+def test_check_replay_validation_manifest_validates_artifact_index(tmp_path: Path, capsys):
+    path = _write_manifest_with_artifact_index(tmp_path)
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 0
+    assert json.loads(capsys.readouterr().out)["matched"] is True
+
+
+def test_check_replay_validation_manifest_rejects_artifact_index_drift(tmp_path: Path, capsys):
+    path = _write_manifest_with_artifact_index(tmp_path)
+    (tmp_path / "validation-report.json").write_text('{"mutated": true}')
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any(
+        failure["field"] == "artifacts.artifact_index"
+        and failure["reason"] == "artifact index validation failed"
+        for failure in output["failures"]
+    )
+
+
+def test_check_replay_validation_manifest_rejects_artifact_index_for_other_manifest(
+    tmp_path: Path,
+    capsys,
+):
+    path = _write_manifest_with_artifact_index(tmp_path)
+    index_path = tmp_path / "artifact-index.json"
+    index = json.loads(index_path.read_text())
+    other_manifest = tmp_path / "other-manifest.json"
+    other_manifest.write_text("{}")
+    index["manifest"] = str(other_manifest)
+    index_path.write_text(json.dumps(index))
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any(
+        failure["field"] == "artifacts.artifact_index"
+        and failure["reason"] == "artifact index points at a different manifest"
+        for failure in output["failures"]
+    )

--- a/tests/scripts/test_package_replay_validation_artifacts.py
+++ b/tests/scripts/test_package_replay_validation_artifacts.py
@@ -56,3 +56,56 @@ def test_package_replay_validation_artifacts_rejects_digest_drift(tmp_path: Path
     assert main(["--check", str(output)]) == 1
     result = json.loads(capsys.readouterr().out)
     assert any(failure["reason"] == "sha256 drift" for failure in result["failures"])
+
+
+def test_package_replay_validation_artifacts_rejects_missing_required_role(
+    tmp_path: Path,
+    capsys,
+):
+    output = tmp_path / "artifact-index.json"
+    output.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "generated_at": "2026-05-20T00:00:00Z",
+                "artifacts": [],
+            }
+        )
+    )
+
+    assert main(["--check", str(output)]) == 1
+    result = json.loads(capsys.readouterr().out)
+    assert any(failure.get("role") == "manifest" for failure in result["failures"])
+
+
+def test_package_replay_validation_artifacts_rejects_duplicate_roles(tmp_path: Path, capsys):
+    manifest = _manifest(tmp_path)
+    output = tmp_path / "artifact-index.json"
+    assert main(["--manifest", str(manifest), "--output", str(output)]) == 0
+    index = json.loads(output.read_text())
+    index["artifacts"].append(dict(index["artifacts"][0]))
+    output.write_text(json.dumps(index))
+    capsys.readouterr()
+
+    assert main(["--check", str(output)]) == 1
+    result = json.loads(capsys.readouterr().out)
+    assert any(failure["reason"] == "duplicate artifact role" for failure in result["failures"])
+
+
+def test_package_replay_validation_artifacts_rejects_unpaired_live_roles(
+    tmp_path: Path,
+    capsys,
+):
+    manifest = _manifest(tmp_path)
+    output = tmp_path / "artifact-index.json"
+    assert main(["--manifest", str(manifest), "--output", str(output)]) == 0
+    index = json.loads(output.read_text())
+    index["artifacts"] = [
+        entry for entry in index["artifacts"] if entry["role"] != "live_checksums"
+    ]
+    output.write_text(json.dumps(index))
+    capsys.readouterr()
+
+    assert main(["--check", str(output)]) == 1
+    result = json.loads(capsys.readouterr().out)
+    assert any("paired artifact roles" in failure["reason"] for failure in result["failures"])


### PR DESCRIPTION
## Summary
- validate replay artifact-index roles: exactly one `manifest`, `replay`, and `report` artifact
- reject duplicate artifact roles and unpaired `live_rows` / `live_checksums` evidence
- make `check_replay_validation_manifest.py --check-artifacts` validate the referenced artifact index and ensure it points back to the same manifest
- require manifests that advertise an artifact index to include `artifact_index` as the final validation step; reject orphan `artifact_index` steps without an artifact path

## Validation
- `.venv/bin/python -m pytest -q tests/scripts/test_check_replay_validation_manifest.py tests/scripts/test_package_replay_validation_artifacts.py tests/scripts/test_run_replay_validation.py` (`30 passed`)
- `scripts/check_replay_release_gate.sh` (`152 passed`)

Tracking: noetl/noetl#434
Companion docs: noetl/docs#148