### PR TITLE
test(replay): make artifact index paths portable

### DIFF
--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -10,7 +10,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from scripts.package_replay_validation_artifacts import validate_artifact_index
+from scripts.package_replay_validation_artifacts import (
+    resolve_indexed_path,
+    validate_artifact_index,
+)
 
 REQUIRED_CONFIG_FIELDS = (
     "base_url",
@@ -144,7 +147,7 @@ def _validate_manifest(
                                         "path": artifact_index,
                                     }
                                 )
-                            elif _artifact_path(indexed_manifest, index_path) != manifest_path.resolve():
+                            elif resolve_indexed_path(indexed_manifest, index_path=index_path) != manifest_path.resolve():
                                 failures.append(
                                     {
                                         "field": "artifacts.artifact_index",

--- a/scripts/package_replay_validation_artifacts.py
+++ b/scripts/package_replay_validation_artifacts.py
@@ -35,11 +35,26 @@ def _load_json(path: Path) -> dict[str, Any]:
     return data
 
 
-def _artifact_entry(role: str, path: Path, *, required: bool = True) -> dict[str, Any]:
+def _portable_path(path: Path, *, base_dir: Path | None = None) -> str:
+    if base_dir is None:
+        return str(path)
+    try:
+        return str(path.resolve().relative_to(base_dir.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def _artifact_entry(
+    role: str,
+    path: Path,
+    *,
+    required: bool = True,
+    base_dir: Path | None = None,
+) -> dict[str, Any]:
     exists = path.exists()
     entry: dict[str, Any] = {
         "role": role,
-        "path": str(path),
+        "path": _portable_path(path, base_dir=base_dir),
         "required": required,
         "exists": exists,
     }
@@ -52,13 +67,17 @@ def _artifact_entry(role: str, path: Path, *, required: bool = True) -> dict[str
 def build_artifact_index(
     *,
     manifest_path: Path,
+    output_path: Path | None = None,
     extra_artifacts: list[tuple[str, Path]] | None = None,
 ) -> dict[str, Any]:
     manifest = _load_json(manifest_path)
     artifacts = manifest.get("artifacts")
     artifacts = artifacts if isinstance(artifacts, dict) else {}
+    base_dir = output_path.parent if output_path is not None else manifest_path.parent
 
-    entries: list[dict[str, Any]] = [_artifact_entry("manifest", manifest_path)]
+    entries: list[dict[str, Any]] = [
+        _artifact_entry("manifest", manifest_path, base_dir=base_dir)
+    ]
     for role in ("replay", "live_rows", "live_checksums", "report"):
         value = artifacts.get(role)
         if value is None:
@@ -77,18 +96,26 @@ def build_artifact_index(
         path = Path(value)
         if not path.is_absolute():
             path = (manifest_path.parent / path).resolve()
-        entries.append(_artifact_entry(role, path))
+        entries.append(_artifact_entry(role, path, base_dir=base_dir))
 
     for role, path in extra_artifacts or []:
-        entries.append(_artifact_entry(role, path))
+        entries.append(_artifact_entry(role, path, base_dir=base_dir))
 
     return {
         "schema_version": INDEX_SCHEMA_VERSION,
         "generated_at": _utc_now(),
-        "manifest": str(manifest_path),
+        "path_base": "artifact_index_dir",
+        "manifest": _portable_path(manifest_path, base_dir=base_dir),
         "matched": all(entry.get("exists") for entry in entries if entry.get("required", True)),
         "artifacts": entries,
     }
+
+
+def resolve_indexed_path(path_value: str, *, index_path: Path) -> Path:
+    path = Path(path_value)
+    if not path.is_absolute():
+        return (index_path.parent / path).resolve()
+    return path
 
 
 def validate_artifact_index(index_path: Path) -> dict[str, Any]:
@@ -119,7 +146,7 @@ def validate_artifact_index(index_path: Path) -> dict[str, Any]:
         if not isinstance(path_value, str) or not path_value:
             failures.append({"field": f"artifacts[{idx}].path", "reason": "must be a non-empty string"})
             continue
-        path = Path(path_value)
+        path = resolve_indexed_path(path_value, index_path=index_path)
         required = bool(entry.get("required", True))
         if required and not path.exists():
             failures.append(
@@ -216,8 +243,12 @@ def main(argv: list[str] | None = None) -> int:
             parser.error("--artifact must be ROLE=PATH")
         extra_artifacts.append((role, Path(value)))
 
-    index = build_artifact_index(manifest_path=args.manifest, extra_artifacts=extra_artifacts)
     args.output.parent.mkdir(parents=True, exist_ok=True)
+    index = build_artifact_index(
+        manifest_path=args.manifest,
+        output_path=args.output,
+        extra_artifacts=extra_artifacts,
+    )
     args.output.write_text(json.dumps(index, indent=2, sort_keys=True) + "\n")
     print(json.dumps({"output": str(args.output), "matched": index["matched"]}, sort_keys=True))
     return 0 if index["matched"] else 1

--- a/scripts/package_replay_validation_artifacts.py
+++ b/scripts/package_replay_validation_artifacts.py
@@ -126,6 +126,20 @@ def validate_artifact_index(index_path: Path) -> dict[str, Any]:
         failures.append({"field": "schema_version", "reason": f"must be {INDEX_SCHEMA_VERSION}"})
     if not isinstance(index.get("generated_at"), str) or not index.get("generated_at"):
         failures.append({"field": "generated_at", "reason": "must be a non-empty string"})
+    if index.get("path_base") not in (None, "artifact_index_dir"):
+        failures.append({"field": "path_base", "reason": "must be artifact_index_dir when present"})
+
+    indexed_manifest = index.get("manifest")
+    if not isinstance(indexed_manifest, str) or not indexed_manifest:
+        failures.append({"field": "manifest", "reason": "must be a non-empty string"})
+    elif not resolve_indexed_path(indexed_manifest, index_path=index_path).exists():
+        failures.append(
+            {
+                "field": "manifest",
+                "reason": "manifest path does not exist",
+                "path": indexed_manifest,
+            }
+        )
 
     artifacts = index.get("artifacts")
     if not isinstance(artifacts, list):

--- a/tests/scripts/test_package_replay_validation_artifacts.py
+++ b/tests/scripts/test_package_replay_validation_artifacts.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 from scripts.package_replay_validation_artifacts import main
@@ -38,10 +39,65 @@ def test_package_replay_validation_artifacts_builds_and_checks_index(tmp_path: P
     assert created["output"] == str(output)
 
     index = json.loads(output.read_text())
+    assert index["path_base"] == "artifact_index_dir"
+    assert index["manifest"] == "validation.json"
     roles = {entry["role"] for entry in index["artifacts"]}
     assert {"manifest", "replay", "live_rows", "live_checksums", "report"} <= roles
     assert all(entry["exists"] for entry in index["artifacts"])
+    assert all(not Path(entry["path"]).is_absolute() for entry in index["artifacts"])
 
+    assert main(["--check", str(output)]) == 0
+    assert json.loads(capsys.readouterr().out)["matched"] is True
+
+
+def test_package_replay_validation_artifacts_checks_relative_paths_from_index_dir(
+    tmp_path: Path,
+    capsys,
+):
+    manifest = _manifest(tmp_path)
+    output = tmp_path / "artifact-index.json"
+    assert main(["--manifest", str(manifest), "--output", str(output)]) == 0
+    capsys.readouterr()
+
+    previous_cwd = Path.cwd()
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    try:
+        os.chdir(other_dir)
+        assert main(["--check", str(output)]) == 0
+    finally:
+        os.chdir(previous_cwd)
+    assert json.loads(capsys.readouterr().out)["matched"] is True
+
+
+def test_package_replay_validation_artifacts_keeps_external_paths_absolute(
+    tmp_path: Path,
+    capsys,
+):
+    manifest = _manifest(tmp_path)
+    external_dir = tmp_path.parent / f"{tmp_path.name}-external"
+    external_dir.mkdir()
+    external = external_dir / "extra.json"
+    external.write_text("{}")
+    output = tmp_path / "artifact-index.json"
+
+    assert (
+        main(
+            [
+                "--manifest",
+                str(manifest),
+                "--output",
+                str(output),
+                "--artifact",
+                f"extra={external}",
+            ]
+        )
+        == 0
+    )
+    index = json.loads(output.read_text())
+    extra = next(entry for entry in index["artifacts"] if entry["role"] == "extra")
+    assert extra["path"] == str(external)
+    capsys.readouterr()
     assert main(["--check", str(output)]) == 0
     assert json.loads(capsys.readouterr().out)["matched"] is True
 

--- a/tests/scripts/test_package_replay_validation_artifacts.py
+++ b/tests/scripts/test_package_replay_validation_artifacts.py
@@ -118,12 +118,16 @@ def test_package_replay_validation_artifacts_rejects_missing_required_role(
     tmp_path: Path,
     capsys,
 ):
+    manifest = tmp_path / "validation.json"
+    manifest.write_text("{}")
     output = tmp_path / "artifact-index.json"
     output.write_text(
         json.dumps(
             {
                 "schema_version": 1,
                 "generated_at": "2026-05-20T00:00:00Z",
+                "path_base": "artifact_index_dir",
+                "manifest": "validation.json",
                 "artifacts": [],
             }
         )
@@ -132,6 +136,52 @@ def test_package_replay_validation_artifacts_rejects_missing_required_role(
     assert main(["--check", str(output)]) == 1
     result = json.loads(capsys.readouterr().out)
     assert any(failure.get("role") == "manifest" for failure in result["failures"])
+
+
+def test_package_replay_validation_artifacts_rejects_missing_manifest_pointer(
+    tmp_path: Path,
+    capsys,
+):
+    output = tmp_path / "artifact-index.json"
+    output.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "generated_at": "2026-05-20T00:00:00Z",
+                "path_base": "artifact_index_dir",
+                "manifest": "missing-validation.json",
+                "artifacts": [],
+            }
+        )
+    )
+
+    assert main(["--check", str(output)]) == 1
+    result = json.loads(capsys.readouterr().out)
+    assert any(failure["field"] == "manifest" for failure in result["failures"])
+
+
+def test_package_replay_validation_artifacts_rejects_unknown_path_base(
+    tmp_path: Path,
+    capsys,
+):
+    manifest = tmp_path / "validation.json"
+    manifest.write_text("{}")
+    output = tmp_path / "artifact-index.json"
+    output.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "generated_at": "2026-05-20T00:00:00Z",
+                "path_base": "cwd",
+                "manifest": "validation.json",
+                "artifacts": [],
+            }
+        )
+    )
+
+    assert main(["--check", str(output)]) == 1
+    result = json.loads(capsys.readouterr().out)
+    assert any(failure["field"] == "path_base" for failure in result["failures"])
 
 
 def test_package_replay_validation_artifacts_rejects_duplicate_roles(tmp_path: Path, capsys):


### PR DESCRIPTION
## Summary
- store artifact-index manifest/artifact paths relative to the index directory when possible
- resolve relative index paths from the index location during validation, independent of caller cwd
- reuse the same indexed-path resolver from the manifest gate when checking that an index points at the same manifest
- validate top-level artifact-index portability metadata: known `path_base` and resolvable `manifest` pointer

## Validation
- `.venv/bin/python -m pytest -q tests/scripts/test_package_replay_validation_artifacts.py tests/scripts/test_check_replay_validation_manifest.py tests/scripts/test_run_replay_validation.py` (`34 passed`)
- `scripts/check_replay_release_gate.sh` (`156 passed`)

Tracking: noetl/noetl#434
Companion docs: noetl/docs#149