### PR TITLE
test(replay): add validation bundle checker

### DIFF
--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -17,6 +17,7 @@ fi
   tests/scripts/test_export_live_projection_rows_postgres.py \
   tests/scripts/test_check_live_projection_rows.py \
   tests/scripts/test_package_replay_validation_artifacts.py \
+  tests/scripts/test_check_replay_validation_bundle.py \
   tests/scripts/test_check_replay_validation_manifest.py \
   tests/scripts/test_check_replay_state_report.py \
   tests/scripts/test_check_replay_parity_report.py \

--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+"""Validate a complete replay validation evidence bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from scripts.check_replay_validation_manifest import _load_manifest, _validate_manifest
+from scripts.package_replay_validation_artifacts import (
+    resolve_indexed_path,
+    validate_artifact_index,
+)
+
+
+def _artifact_index_from_manifest(manifest: dict[str, Any]) -> str | None:
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return None
+    value = artifacts.get("artifact_index")
+    if not isinstance(value, str) or not value:
+        return None
+    return value
+
+
+def validate_bundle(
+    *,
+    manifest_path: Path,
+    artifact_index_path: Path | None = None,
+    require_matched: bool = True,
+) -> dict[str, Any]:
+    failures: list[dict[str, Any]] = []
+    manifest = _load_manifest(manifest_path)
+
+    manifest_result = _validate_manifest(
+        manifest,
+        require_matched=require_matched,
+        check_artifacts=True,
+        manifest_path=manifest_path,
+    )
+    if manifest_result.get("matched") is not True:
+        failures.append(
+            {
+                "field": "manifest",
+                "reason": "manifest validation failed",
+                "failures": manifest_result.get("failures", []),
+            }
+        )
+
+    manifest_index = _artifact_index_from_manifest(manifest)
+    if artifact_index_path is None:
+        if manifest_index is None:
+            failures.append(
+                {
+                    "field": "artifacts.artifact_index",
+                    "reason": "manifest does not reference an artifact index",
+                }
+            )
+            resolved_index_path = None
+        else:
+            resolved_index_path = resolve_indexed_path(
+                manifest_index,
+                index_path=manifest_path,
+            )
+    else:
+        resolved_index_path = artifact_index_path
+        if manifest_index is not None:
+            manifest_resolved_index = resolve_indexed_path(
+                manifest_index,
+                index_path=manifest_path,
+            )
+            if manifest_resolved_index != artifact_index_path.resolve():
+                failures.append(
+                    {
+                        "field": "artifact_index",
+                        "reason": "artifact index argument differs from manifest reference",
+                        "manifest_artifact_index": manifest_index,
+                        "artifact_index": str(artifact_index_path),
+                    }
+                )
+
+    index_result: dict[str, Any] | None = None
+    if resolved_index_path is not None:
+        try:
+            index_result = validate_artifact_index(resolved_index_path)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            failures.append(
+                {
+                    "field": "artifact_index",
+                    "reason": "artifact index could not be validated",
+                    "path": str(resolved_index_path),
+                    "error": str(exc),
+                }
+            )
+        else:
+            if index_result.get("matched") is not True:
+                failures.append(
+                    {
+                        "field": "artifact_index",
+                        "reason": "artifact index validation failed",
+                        "path": str(resolved_index_path),
+                        "failures": index_result.get("failures", []),
+                    }
+                )
+
+    return {
+        "matched": not failures,
+        "manifest": str(manifest_path),
+        "artifact_index": str(resolved_index_path) if resolved_index_path else None,
+        "manifest_result": manifest_result,
+        "artifact_index_result": index_result,
+        "failures": failures,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate a replay validation evidence bundle")
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--artifact-index", type=Path)
+    parser.add_argument("--allow-failed", action="store_true", help="Allow matched=false manifests")
+    args = parser.parse_args(argv)
+
+    output = validate_bundle(
+        manifest_path=args.manifest,
+        artifact_index_path=args.artifact_index,
+        require_matched=not args.allow_failed,
+    )
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0 if output["matched"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_check_replay_validation_bundle.py
+++ b/tests/scripts/test_check_replay_validation_bundle.py
@@ -1,0 +1,153 @@
+import json
+from pathlib import Path
+
+from scripts.check_replay_validation_bundle import main
+from scripts.package_replay_validation_artifacts import build_artifact_index
+
+
+def _bundle(tmp_path: Path) -> tuple[Path, Path]:
+    replay = tmp_path / "replay.json"
+    replay.write_text("{}")
+    report = tmp_path / "validation-report.json"
+    report.write_text("{}")
+    index = tmp_path / "artifact-index.json"
+    manifest = tmp_path / "validation.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "matched": True,
+                "started_at": "2026-05-20T00:00:00Z",
+                "finished_at": "2026-05-20T00:00:01Z",
+                "replay": str(replay),
+                "artifacts": {
+                    "replay": str(replay),
+                    "live_rows": None,
+                    "live_checksums": None,
+                    "report": str(report),
+                    "artifact_index": str(index),
+                },
+                "config": {
+                    "base_url": "http://noetl.example",
+                    "execution_id": 123,
+                    "tenant_id": "tenant-a",
+                    "organization_id": "org-a",
+                    "projection": "all",
+                    "limit": 100000,
+                    "as_of_event_id": None,
+                    "as_of_position": None,
+                    "as_of_time": None,
+                    "resolve_payloads": False,
+                    "live_checksums": None,
+                    "live_rows": None,
+                    "export_live_rows_postgres": False,
+                    "artifact_index_output": str(index),
+                },
+                "steps": [
+                    {
+                        "name": "fetch",
+                        "command": ["python", "scripts/fetch_replay_state_report.py"],
+                        "returncode": 0,
+                        "duration_seconds": 0.1,
+                        "stdout": "{}",
+                        "stderr": "",
+                    },
+                    {
+                        "name": "state_integrity",
+                        "command": ["python", "scripts/check_replay_state_report.py"],
+                        "returncode": 0,
+                        "duration_seconds": 0.1,
+                        "stdout": "{}",
+                        "stderr": "",
+                    },
+                    {"name": "live_rows_export", "skipped": True},
+                    {"name": "live_rows_integrity", "skipped": True},
+                    {"name": "live_checksums", "skipped": True},
+                    {"name": "projection_parity", "skipped": True},
+                    {"name": "payload_resolution", "skipped": True},
+                    {
+                        "name": "artifact_index",
+                        "command": ["python", "scripts/package_replay_validation_artifacts.py"],
+                        "returncode": 0,
+                        "duration_seconds": 0.1,
+                        "stdout": "{}",
+                        "stderr": "",
+                    },
+                ],
+            }
+        )
+    )
+    index.write_text(
+        json.dumps(
+            build_artifact_index(manifest_path=manifest, output_path=index),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    return manifest, index
+
+
+def test_check_replay_validation_bundle_accepts_manifest_referenced_index(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, index = _bundle(tmp_path)
+
+    assert main(["--manifest", str(manifest)]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True
+    assert output["artifact_index"] == str(index)
+
+
+def test_check_replay_validation_bundle_accepts_explicit_matching_index(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, index = _bundle(tmp_path)
+
+    assert main(["--manifest", str(manifest), "--artifact-index", str(index)]) == 0
+    assert json.loads(capsys.readouterr().out)["matched"] is True
+
+
+def test_check_replay_validation_bundle_rejects_different_explicit_index(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, _index = _bundle(tmp_path)
+    other = tmp_path / "other-index.json"
+    other.write_text("{}")
+
+    assert main(["--manifest", str(manifest), "--artifact-index", str(other)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any(
+        failure["reason"] == "artifact index argument differs from manifest reference"
+        for failure in output["failures"]
+    )
+
+
+def test_check_replay_validation_bundle_rejects_index_drift(tmp_path: Path, capsys):
+    manifest, _index = _bundle(tmp_path)
+    (tmp_path / "validation-report.json").write_text('{"mutated": true}')
+
+    assert main(["--manifest", str(manifest)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any(failure["field"] == "manifest" for failure in output["failures"])
+    assert any(failure["field"] == "artifact_index" for failure in output["failures"])
+
+
+def test_check_replay_validation_bundle_rejects_missing_index_reference(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, _index = _bundle(tmp_path)
+    payload = json.loads(manifest.read_text())
+    payload["artifacts"]["artifact_index"] = None
+    payload["steps"] = [step for step in payload["steps"] if step["name"] != "artifact_index"]
+    manifest.write_text(json.dumps(payload))
+
+    assert main(["--manifest", str(manifest)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any(
+        failure["field"] == "artifacts.artifact_index"
+        for failure in output["failures"]
+    )


### PR DESCRIPTION
## Summary
- add `scripts/check_replay_validation_bundle.py` as a single entrypoint for validating replay evidence bundles
- compose the manifest gate and artifact-index gate, including manifest/index agreement checks
- add focused bundle tests and include them in `scripts/check_replay_release_gate.sh`

## Validation
- `.venv/bin/python -m pytest -q tests/scripts/test_check_replay_validation_bundle.py tests/scripts/test_package_replay_validation_artifacts.py tests/scripts/test_check_replay_validation_manifest.py tests/scripts/test_run_replay_validation.py` (`39 passed`)
- `scripts/check_replay_release_gate.sh` (`161 passed`)

Tracking: noetl/noetl#434