### PR TITLE
feat(projector): split shard skip metrics

### DIFF
--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -18,6 +18,8 @@ class ProjectorMetrics:
             "notifications_total": 0.0,
             "events_extracted_total": 0.0,
             "events_owned_total": 0.0,
+            "events_unowned_total": 0.0,
+            "events_unshardable_total": 0.0,
             "projection_records_total": 0.0,
             "empty_or_unowned_notifications_total": 0.0,
             "errors_total": 0.0,
@@ -38,12 +40,16 @@ class ProjectorMetrics:
         extracted_events: int,
         owned_events: int,
         projection_records: int,
+        unowned_events: int = 0,
+        unshardable_events: int = 0,
     ) -> None:
         now = time.time()
         with self._lock:
             self._values["notifications_total"] += 1.0
             self._values["events_extracted_total"] += float(max(0, extracted_events))
             self._values["events_owned_total"] += float(max(0, owned_events))
+            self._values["events_unowned_total"] += float(max(0, unowned_events))
+            self._values["events_unshardable_total"] += float(max(0, unshardable_events))
             self._values["projection_records_total"] += float(max(0, projection_records))
             self._values["last_success_unixtime"] = now
             self._values["last_batch_events"] = float(max(0, owned_events))
@@ -101,6 +107,12 @@ def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapp
         "# HELP noetl_projector_events_owned_total Events owned by this projector shard.",
         "# TYPE noetl_projector_events_owned_total counter",
         f"noetl_projector_events_owned_total{label_text} {snapshot['events_owned_total']}",
+        "# HELP noetl_projector_events_unowned_total Events assigned to another projector shard.",
+        "# TYPE noetl_projector_events_unowned_total counter",
+        f"noetl_projector_events_unowned_total{label_text} {snapshot['events_unowned_total']}",
+        "# HELP noetl_projector_events_unshardable_total Events without a valid shard key.",
+        "# TYPE noetl_projector_events_unshardable_total counter",
+        f"noetl_projector_events_unshardable_total{label_text} {snapshot['events_unshardable_total']}",
         "# HELP noetl_projector_projection_records_total Projection records written by this projector.",
         "# TYPE noetl_projector_projection_records_total counter",
         f"noetl_projector_projection_records_total{label_text} {snapshot['projection_records_total']}",

--- a/noetl/core/projector/nats_worker.py
+++ b/noetl/core/projector/nats_worker.py
@@ -131,12 +131,24 @@ class NATSProjectorWorker:
         """Project one NATS notification and return an ack action."""
 
         extracted_events = _extract_events(notification)
-        events = [event for event in extracted_events if self._owns_event(event)]
+        events: list[dict[str, Any]] = []
+        unowned_events = 0
+        unshardable_events = 0
+        for event in extracted_events:
+            decision = self._shard_decision(event)
+            if decision == "owned":
+                events.append(event)
+            elif decision == "unowned":
+                unowned_events += 1
+            else:
+                unshardable_events += 1
         if not events:
             self.metrics.record_notification(
                 extracted_events=len(extracted_events),
                 owned_events=0,
                 projection_records=0,
+                unowned_events=unowned_events,
+                unshardable_events=unshardable_events,
             )
             return "ack"
 
@@ -149,6 +161,8 @@ class NATSProjectorWorker:
             extracted_events=len(extracted_events),
             owned_events=len(events),
             projection_records=len(written),
+            unowned_events=unowned_events,
+            unshardable_events=unshardable_events,
         )
         self.metrics.record_projection_checkpoints(written)
         logger.debug(
@@ -160,15 +174,22 @@ class NATSProjectorWorker:
         return "ack"
 
     def _owns_event(self, event: dict[str, Any]) -> bool:
+        return self._shard_decision(event) == "owned"
+
+    def _shard_decision(self, event: dict[str, Any]) -> str:
         if self.settings.shard_count <= 1:
-            return True
+            return "owned"
         execution_id = event.get("execution_id")
         if execution_id is None:
-            return False
+            return "unshardable"
         try:
-            return int(execution_id) % self.settings.shard_count == self.settings.shard_index
+            return (
+                "owned"
+                if int(execution_id) % self.settings.shard_count == self.settings.shard_index
+                else "unowned"
+            )
         except (TypeError, ValueError):
-            return False
+            return "unshardable"
 
 
 async def run_projector_worker(settings: Optional[ProjectorWorkerSettings] = None) -> None:

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -8,7 +8,13 @@ def test_projector_metrics_render_prometheus_labels():
     from noetl.core.projector.metrics import ProjectorMetrics, render_projector_metrics
 
     metrics = ProjectorMetrics()
-    metrics.record_notification(extracted_events=3, owned_events=2, projection_records=1)
+    metrics.record_notification(
+        extracted_events=3,
+        owned_events=2,
+        unowned_events=1,
+        unshardable_events=0,
+        projection_records=1,
+    )
 
     body = render_projector_metrics(
         metrics,
@@ -20,6 +26,8 @@ def test_projector_metrics_render_prometheus_labels():
     assert "noetl_projector_notifications_total" in body
     assert "noetl_projector_events_extracted_total" in body
     assert "noetl_projector_events_owned_total" in body
+    assert "noetl_projector_events_unowned_total" in body
+    assert "noetl_projector_events_unshardable_total" in body
     assert "noetl_projector_projection_records_total" in body
     assert " 1.0" in body
 

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -224,6 +224,8 @@ async def test_nats_projector_worker_projects_owned_event_batch():
     assert snapshot["notifications_total"] == 1
     assert snapshot["events_extracted_total"] == 2
     assert snapshot["events_owned_total"] == 1
+    assert snapshot["events_unowned_total"] == 1
+    assert snapshot["events_unshardable_total"] == 0
     assert snapshot["projection_records_total"] == 1
     assert snapshot["last_projection_source_event_id"] == 20
 
@@ -291,6 +293,45 @@ async def test_nats_projector_worker_acks_empty_or_unowned_notifications():
     snapshot = metrics.snapshot()
     assert snapshot["notifications_total"] == 2
     assert snapshot["empty_or_unowned_notifications_total"] == 2
+    assert snapshot["events_unowned_total"] == 1
+    assert snapshot["events_unshardable_total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_nats_projector_worker_counts_unshardable_events():
+    from noetl.core.projector.metrics import ProjectorMetrics
+    from noetl.core.projector.nats_worker import NATSProjectorWorker, ProjectorWorkerSettings
+
+    metrics = ProjectorMetrics()
+    store = _MemoryProjectionStore()
+    worker = NATSProjectorWorker(
+        projection_store=store,
+        settings=ProjectorWorkerSettings(
+            shard_id="noetl-projector-0",
+            consumer_name="noetl-projector-0",
+            shard_count=2,
+        ),
+        metrics=metrics,
+    )
+
+    assert await worker.handle_notification({"event": {"event_type": "workflow.completed"}}) == "ack"
+    assert store.records == {}
+    snapshot = metrics.snapshot()
+    assert snapshot["notifications_total"] == 1
+    assert snapshot["events_extracted_total"] == 1
+    assert snapshot["events_unowned_total"] == 0
+    assert snapshot["events_unshardable_total"] == 1
+
+    assert (
+        await worker.handle_notification(
+            {"event": {"execution_id": "not-an-int", "event_type": "workflow.completed"}}
+        )
+        == "ack"
+    )
+    snapshot = metrics.snapshot()
+    assert snapshot["notifications_total"] == 2
+    assert snapshot["events_extracted_total"] == 2
+    assert snapshot["events_unshardable_total"] == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- classify projector notification events as owned, unowned, or unshardable before projection
- export `noetl_projector_events_unowned_total` for healthy other-shard traffic
- export `noetl_projector_events_unshardable_total` for events missing/invalid shard keys
- keep existing empty/unowned notification counter for compatibility

## Validation
- `.venv/bin/python -m pytest -q tests/core/test_replay_state_projector.py tests/core/test_projector_metrics.py` (`13 passed`)
- `scripts/check_replay_release_gate.sh` (`162 passed`)

Tracking: noetl/noetl#434
Related: noetl/noetl#437