### PR TITLE
feat(projector): report stale projection writes

### DIFF
--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -21,6 +21,7 @@ class ProjectorMetrics:
             "events_unowned_total": 0.0,
             "events_unshardable_total": 0.0,
             "projection_records_total": 0.0,
+            "projection_stale_records_total": 0.0,
             "empty_or_unowned_notifications_total": 0.0,
             "errors_total": 0.0,
             "last_success_unixtime": 0.0,
@@ -42,6 +43,7 @@ class ProjectorMetrics:
         projection_records: int,
         unowned_events: int = 0,
         unshardable_events: int = 0,
+        stale_projection_records: int = 0,
     ) -> None:
         now = time.time()
         with self._lock:
@@ -51,6 +53,7 @@ class ProjectorMetrics:
             self._values["events_unowned_total"] += float(max(0, unowned_events))
             self._values["events_unshardable_total"] += float(max(0, unshardable_events))
             self._values["projection_records_total"] += float(max(0, projection_records))
+            self._values["projection_stale_records_total"] += float(max(0, stale_projection_records))
             self._values["last_success_unixtime"] = now
             self._values["last_batch_events"] = float(max(0, owned_events))
             self._values["last_batch_projection_records"] = float(max(0, projection_records))
@@ -116,6 +119,12 @@ def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapp
         "# HELP noetl_projector_projection_records_total Projection records written by this projector.",
         "# TYPE noetl_projector_projection_records_total counter",
         f"noetl_projector_projection_records_total{label_text} {snapshot['projection_records_total']}",
+        "# HELP noetl_projector_projection_stale_records_total Projection records skipped because a newer version already exists.",
+        "# TYPE noetl_projector_projection_stale_records_total counter",
+        (
+            "noetl_projector_projection_stale_records_total"
+            f"{label_text} {snapshot['projection_stale_records_total']}"
+        ),
         "# HELP noetl_projector_empty_or_unowned_notifications_total Notifications with no owned events.",
         "# TYPE noetl_projector_empty_or_unowned_notifications_total counter",
         (

--- a/noetl/core/projector/nats_worker.py
+++ b/noetl/core/projector/nats_worker.py
@@ -153,6 +153,7 @@ class NATSProjectorWorker:
             return "ack"
 
         try:
+            projection_group_count = _projection_group_count(events)
             written = await self.projector.project(events)
         except Exception:
             self.metrics.record_error()
@@ -163,6 +164,7 @@ class NATSProjectorWorker:
             projection_records=len(written),
             unowned_events=unowned_events,
             unshardable_events=unshardable_events,
+            stale_projection_records=max(0, projection_group_count - len(written)),
         )
         self.metrics.record_projection_checkpoints(written)
         logger.debug(
@@ -240,6 +242,26 @@ def _extract_events(notification: dict[str, Any]) -> list[dict[str, Any]]:
         return [dict(notification)]
 
     return []
+
+
+def _projection_group_count(events: Iterable[dict[str, Any]]) -> int:
+    groups: set[tuple[str, str, int]] = set()
+    for event in events:
+        execution_id = event.get("execution_id")
+        if execution_id is None:
+            continue
+        try:
+            parsed_execution_id = int(execution_id)
+        except (TypeError, ValueError):
+            continue
+        groups.add(
+            (
+                str(event.get("tenant_id") or "default"),
+                str(event.get("organization_id") or "default"),
+                parsed_execution_id,
+            )
+        )
+    return len(groups)
 
 
 def decode_projector_notification(payload: bytes) -> dict[str, Any]:

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -13,6 +13,7 @@ def test_projector_metrics_render_prometheus_labels():
         owned_events=2,
         unowned_events=1,
         unshardable_events=0,
+        stale_projection_records=1,
         projection_records=1,
     )
 
@@ -29,6 +30,7 @@ def test_projector_metrics_render_prometheus_labels():
     assert "noetl_projector_events_unowned_total" in body
     assert "noetl_projector_events_unshardable_total" in body
     assert "noetl_projector_projection_records_total" in body
+    assert "noetl_projector_projection_stale_records_total" in body
     assert " 1.0" in body
 
 

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -227,7 +227,113 @@ async def test_nats_projector_worker_projects_owned_event_batch():
     assert snapshot["events_unowned_total"] == 1
     assert snapshot["events_unshardable_total"] == 0
     assert snapshot["projection_records_total"] == 1
+    assert snapshot["projection_stale_records_total"] == 0
     assert snapshot["last_projection_source_event_id"] == 20
+
+
+@pytest.mark.asyncio
+async def test_nats_projector_worker_counts_stale_projection_writes():
+    from noetl.core.projector.metrics import ProjectorMetrics
+    from noetl.core.projector.nats_worker import NATSProjectorWorker, ProjectorWorkerSettings
+
+    metrics = ProjectorMetrics()
+    store = _MemoryProjectionStore()
+    worker = NATSProjectorWorker(
+        projection_store=store,
+        settings=ProjectorWorkerSettings(
+            shard_id="noetl-projector-1",
+            consumer_name="noetl-projector-1",
+            shard_count=2,
+        ),
+        metrics=metrics,
+    )
+
+    assert (
+        await worker.handle_notification(
+            {
+                "event": {
+                    "event_id": 30,
+                    "stream_version": 3,
+                    "tenant_id": "tenant-a",
+                    "organization_id": "org-a",
+                    "execution_id": 7,
+                    "event_type": "workflow.completed",
+                }
+            }
+        )
+        == "ack"
+    )
+    assert (
+        await worker.handle_notification(
+            {
+                "event": {
+                    "event_id": 20,
+                    "stream_version": 1,
+                    "tenant_id": "tenant-a",
+                    "organization_id": "org-a",
+                    "execution_id": 7,
+                    "event_type": "execution.started",
+                }
+            }
+        )
+        == "ack"
+    )
+
+    snapshot = metrics.snapshot()
+    assert snapshot["notifications_total"] == 2
+    assert snapshot["events_owned_total"] == 2
+    assert snapshot["projection_records_total"] == 1
+    assert snapshot["projection_stale_records_total"] == 1
+    assert store.records["execution/7/all"].version == 3
+
+
+@pytest.mark.asyncio
+async def test_nats_projector_worker_does_not_count_same_execution_batch_as_stale():
+    from noetl.core.projector.metrics import ProjectorMetrics
+    from noetl.core.projector.nats_worker import NATSProjectorWorker, ProjectorWorkerSettings
+
+    metrics = ProjectorMetrics()
+    store = _MemoryProjectionStore()
+    worker = NATSProjectorWorker(
+        projection_store=store,
+        settings=ProjectorWorkerSettings(
+            shard_id="noetl-projector-1",
+            consumer_name="noetl-projector-1",
+            shard_count=2,
+        ),
+        metrics=metrics,
+    )
+
+    assert (
+        await worker.handle_notification(
+            {
+                "events": [
+                    {
+                        "event_id": 20,
+                        "stream_version": 1,
+                        "tenant_id": "tenant-a",
+                        "organization_id": "org-a",
+                        "execution_id": 7,
+                        "event_type": "execution.started",
+                    },
+                    {
+                        "event_id": 21,
+                        "stream_version": 2,
+                        "tenant_id": "tenant-a",
+                        "organization_id": "org-a",
+                        "execution_id": 7,
+                        "event_type": "workflow.completed",
+                    },
+                ]
+            }
+        )
+        == "ack"
+    )
+
+    snapshot = metrics.snapshot()
+    assert snapshot["events_owned_total"] == 2
+    assert snapshot["projection_records_total"] == 1
+    assert snapshot["projection_stale_records_total"] == 0
 
 
 def test_projector_notification_decoder_accepts_json_and_arrow_feather():


### PR DESCRIPTION
## Summary
- add `noetl_projector_projection_stale_records_total` for projection writes skipped by version monotonicity
- count stale writes by attempted tenant/org/execution projection groups, not raw event count
- keep same-execution multi-event batches from being misclassified as stale

## Validation
- `.venv/bin/python -m pytest -q tests/core/test_replay_state_projector.py tests/core/test_projector_metrics.py` (`15 passed`)
- `scripts/check_replay_release_gate.sh` (`164 passed`)

Tracking: noetl/noetl#434
Related: noetl/noetl#437