### PR TITLE
feat(projector): validate shard settings

### DIFF
--- a/noetl/core/projector/nats_worker.py
+++ b/noetl/core/projector/nats_worker.py
@@ -41,6 +41,25 @@ class ProjectorWorkerSettings:
     metrics_host: str = "0.0.0.0"
     metrics_port: Optional[int] = None
 
+    def __post_init__(self) -> None:
+        if self.shard_count < 1:
+            raise ValueError("projector shard_count must be at least 1")
+        if self.shard_index >= self.shard_count:
+            raise ValueError(
+                "projector shard index must be less than shard_count "
+                f"(shard_id={self.shard_id!r}, shard_index={self.shard_index}, shard_count={self.shard_count})"
+            )
+        if self.max_inflight < 1:
+            raise ValueError("projector max_inflight must be at least 1")
+        if self.max_ack_pending < 1:
+            raise ValueError("projector max_ack_pending must be at least 1")
+        if self.fetch_timeout_seconds <= 0:
+            raise ValueError("projector fetch_timeout_seconds must be positive")
+        if self.fetch_heartbeat_seconds <= 0:
+            raise ValueError("projector fetch_heartbeat_seconds must be positive")
+        if self.metrics_port is not None and self.metrics_port <= 0:
+            raise ValueError("projector metrics_port must be positive when set")
+
     @property
     def shard_index(self) -> int:
         return _parse_shard_index(self.shard_id)

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -376,6 +376,30 @@ def test_projector_notification_decoder_wraps_arrow_batches():
     assert [event["event_id"] for event in decoded["events"]] == [21, 22]
 
 
+def test_projector_worker_settings_rejects_out_of_range_shard_id():
+    from noetl.core.projector.nats_worker import ProjectorWorkerSettings
+
+    with pytest.raises(ValueError, match="shard index must be less than shard_count"):
+        ProjectorWorkerSettings(shard_id="noetl-projector-2", shard_count=2)
+
+
+def test_projector_worker_settings_rejects_invalid_runtime_limits():
+    from noetl.core.projector.nats_worker import ProjectorWorkerSettings
+
+    with pytest.raises(ValueError, match="shard_count"):
+        ProjectorWorkerSettings(shard_count=0)
+    with pytest.raises(ValueError, match="max_inflight"):
+        ProjectorWorkerSettings(max_inflight=0)
+    with pytest.raises(ValueError, match="max_ack_pending"):
+        ProjectorWorkerSettings(max_ack_pending=0)
+    with pytest.raises(ValueError, match="fetch_timeout_seconds"):
+        ProjectorWorkerSettings(fetch_timeout_seconds=0)
+    with pytest.raises(ValueError, match="fetch_heartbeat_seconds"):
+        ProjectorWorkerSettings(fetch_heartbeat_seconds=0)
+    with pytest.raises(ValueError, match="metrics_port"):
+        ProjectorWorkerSettings(metrics_port=0)
+
+
 @pytest.mark.asyncio
 async def test_nats_projector_worker_acks_empty_or_unowned_notifications():
     from noetl.core.projector.metrics import ProjectorMetrics


### PR DESCRIPTION
## Summary
- fail fast when a projector shard id resolves to a shard index outside shard_count
- validate projector runtime limits so invalid fetch/ack/metrics settings do not start silently
- cover invalid shard identity and runtime limits in replay projector tests

## Validation
- .venv/bin/python -m pytest -q tests/core/test_replay_state_projector.py tests/core/test_projector_metrics.py
- scripts/check_replay_release_gate.sh

Tracking noetl/noetl#434
Related noetl/noetl#437