### PR TITLE
feat(projector): enforce strict settings loaders

### DIFF
--- a/noetl/core/projector/nats_worker.py
+++ b/noetl/core/projector/nats_worker.py
@@ -81,11 +81,11 @@ def load_projector_worker_settings() -> ProjectorWorkerSettings:
         subject=os.getenv("NOETL_PROJECTOR_NATS_SUBJECT") or "noetl.events.>",
         consumer_name=consumer_name,
         shard_id=shard_id,
-        shard_count=max(1, _int_env("NOETL_PROJECTOR_SHARD_COUNT", 1)),
-        max_inflight=max(1, _int_env("NOETL_PROJECTOR_MAX_INFLIGHT", 8)),
-        max_ack_pending=max(1, _int_env("NOETL_PROJECTOR_NATS_MAX_ACK_PENDING", 64)),
-        fetch_timeout_seconds=max(0.1, _float_env("NOETL_PROJECTOR_NATS_FETCH_TIMEOUT_SECONDS", 30.0)),
-        fetch_heartbeat_seconds=max(0.1, _float_env("NOETL_PROJECTOR_NATS_FETCH_HEARTBEAT_SECONDS", 5.0)),
+        shard_count=_int_env("NOETL_PROJECTOR_SHARD_COUNT", 1),
+        max_inflight=_int_env("NOETL_PROJECTOR_MAX_INFLIGHT", 8),
+        max_ack_pending=_int_env("NOETL_PROJECTOR_NATS_MAX_ACK_PENDING", 64),
+        fetch_timeout_seconds=_float_env("NOETL_PROJECTOR_NATS_FETCH_TIMEOUT_SECONDS", 30.0),
+        fetch_heartbeat_seconds=_float_env("NOETL_PROJECTOR_NATS_FETCH_HEARTBEAT_SECONDS", 5.0),
         metrics_host=os.getenv("NOETL_PROJECTOR_METRICS_HOST") or "0.0.0.0",
         metrics_port=_optional_int_env("NOETL_PROJECTOR_METRICS_PORT"),
     )
@@ -316,8 +316,7 @@ def _optional_int_env(name: str) -> Optional[int]:
     value = os.getenv(name)
     if value is None or value.strip() == "":
         return None
-    parsed = int(value)
-    return parsed if parsed > 0 else None
+    return int(value)
 
 
 def _float_env(name: str, default: float) -> float:

--- a/noetl/projector/__main__.py
+++ b/noetl/projector/__main__.py
@@ -33,7 +33,7 @@ def main() -> None:
             subject=args.subject or base.subject,
             consumer_name=args.consumer or base.consumer_name,
             shard_id=args.shard_id or base.shard_id,
-            shard_count=max(1, args.shard_count or base.shard_count),
+            shard_count=args.shard_count if args.shard_count is not None else base.shard_count,
             max_inflight=base.max_inflight,
             max_ack_pending=base.max_ack_pending,
             fetch_timeout_seconds=base.fetch_timeout_seconds,

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -400,6 +400,36 @@ def test_projector_worker_settings_rejects_invalid_runtime_limits():
         ProjectorWorkerSettings(metrics_port=0)
 
 
+@pytest.mark.parametrize(
+    ("env_name", "env_value", "error_match"),
+    [
+        ("NOETL_PROJECTOR_SHARD_COUNT", "0", "shard_count"),
+        ("NOETL_PROJECTOR_MAX_INFLIGHT", "0", "max_inflight"),
+        ("NOETL_PROJECTOR_NATS_MAX_ACK_PENDING", "0", "max_ack_pending"),
+        ("NOETL_PROJECTOR_NATS_FETCH_TIMEOUT_SECONDS", "0", "fetch_timeout_seconds"),
+        ("NOETL_PROJECTOR_NATS_FETCH_HEARTBEAT_SECONDS", "0", "fetch_heartbeat_seconds"),
+        ("NOETL_PROJECTOR_METRICS_PORT", "0", "metrics_port"),
+    ],
+)
+def test_load_projector_worker_settings_rejects_invalid_env_values(monkeypatch, env_name, env_value, error_match):
+    from noetl.core.projector.nats_worker import load_projector_worker_settings
+
+    monkeypatch.setenv(env_name, env_value)
+
+    with pytest.raises(ValueError, match=error_match):
+        load_projector_worker_settings()
+
+
+def test_load_projector_worker_settings_rejects_env_shard_id_outside_count(monkeypatch):
+    from noetl.core.projector.nats_worker import load_projector_worker_settings
+
+    monkeypatch.setenv("NOETL_PROJECTOR_SHARD_ID", "noetl-projector-2")
+    monkeypatch.setenv("NOETL_PROJECTOR_SHARD_COUNT", "2")
+
+    with pytest.raises(ValueError, match="shard index must be less than shard_count"):
+        load_projector_worker_settings()
+
+
 @pytest.mark.asyncio
 async def test_nats_projector_worker_acks_empty_or_unowned_notifications():
     from noetl.core.projector.metrics import ProjectorMetrics


### PR DESCRIPTION
## Summary
- remove silent clamping from projector environment settings so invalid values reach ProjectorWorkerSettings validation
- stop CLI --shard-count from coercing 0 to the base/default shard count
- cover invalid env values and out-of-range env shard identity in projector tests

## Validation
- .venv/bin/python -m pytest -q tests/core/test_replay_state_projector.py tests/core/test_projector_metrics.py
- scripts/check_replay_release_gate.sh

Tracking noetl/noetl#434
Related noetl/noetl#437