### PR TITLE
feat(projector): label metrics with shard identity

### DIFF
--- a/noetl/core/projector/nats_worker.py
+++ b/noetl/core/projector/nats_worker.py
@@ -225,7 +225,11 @@ async def run_projector_worker(settings: Optional[ProjectorWorkerSettings] = Non
             port=effective_settings.metrics_port,
             labels={
                 "shard_id": effective_settings.shard_id,
+                "shard_index": str(effective_settings.shard_index),
+                "shard_count": str(effective_settings.shard_count),
                 "consumer": effective_settings.consumer_name,
+                "stream": effective_settings.stream_name,
+                "subject": effective_settings.subject,
             },
         )
         logger.info(

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -19,11 +19,22 @@ def test_projector_metrics_render_prometheus_labels():
 
     body = render_projector_metrics(
         metrics,
-        labels={"shard_id": "noetl-projector-0", "consumer": "consumer-a"},
+        labels={
+            "shard_id": "noetl-projector-0",
+            "shard_index": "0",
+            "shard_count": "2",
+            "consumer": "consumer-a",
+            "stream": "NOETL_EVENTS",
+            "subject": "noetl.events.>",
+        },
     )
 
     assert 'consumer="consumer-a"' in body
+    assert 'shard_count="2"' in body
     assert 'shard_id="noetl-projector-0"' in body
+    assert 'shard_index="0"' in body
+    assert 'stream="NOETL_EVENTS"' in body
+    assert 'subject="noetl.events.>"' in body
     assert "noetl_projector_notifications_total" in body
     assert "noetl_projector_events_extracted_total" in body
     assert "noetl_projector_events_owned_total" in body

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -557,14 +557,51 @@ async def test_run_projector_worker_initializes_and_closes_db_pool(monkeypatch):
     monkeypatch.setattr(module, "close_pool", fake_close_pool)
     monkeypatch.setattr(module, "NATSProjectorWorker", FakeWorker)
 
+    def fake_metrics_server(_metrics, *, host, port, labels):
+        calls.append(("metrics", host, port, labels))
+
+        class FakeMetricsServer:
+            def shutdown(self):
+                calls.append(("metrics_shutdown", None))
+
+            def server_close(self):
+                calls.append(("metrics_close", None))
+
+        return FakeMetricsServer()
+
+    monkeypatch.setattr(module, "start_projector_metrics_server", fake_metrics_server)
+
     with pytest.raises(RuntimeError, match="stop projector test"):
         await module.run_projector_worker(
-            module.ProjectorWorkerSettings(shard_id="noetl-projector-0")
+            module.ProjectorWorkerSettings(
+                shard_id="noetl-projector-1",
+                consumer_name="consumer-a",
+                shard_count=2,
+                stream_name="NOETL_EVENTS",
+                subject="noetl.events.>",
+                metrics_host="127.0.0.1",
+                metrics_port=9090,
+            )
         )
 
     assert calls == [
         ("init", "dbname=noetl"),
-        ("start", "noetl-projector-0"),
+        (
+            "metrics",
+            "127.0.0.1",
+            9090,
+            {
+                "shard_id": "noetl-projector-1",
+                "shard_index": "1",
+                "shard_count": "2",
+                "consumer": "consumer-a",
+                "stream": "NOETL_EVENTS",
+                "subject": "noetl.events.>",
+            },
+        ),
+        ("start", "noetl-projector-1"),
+        ("metrics_shutdown", None),
+        ("metrics_close", None),
         ("worker_close", None),
         ("close", None),
     ]


### PR DESCRIPTION
## Summary
- add stable projector metrics labels for shard_index, shard_count, stream, and subject
- keep existing shard_id and consumer labels
- cover metrics rendering and worker startup label wiring in tests

## Validation
- .venv/bin/python -m pytest -q tests/core/test_replay_state_projector.py tests/core/test_projector_metrics.py
- scripts/check_replay_release_gate.sh

Tracking noetl/noetl#434
Related noetl/noetl#437