### PR TITLE
feat(projector): expose decode error metrics

### DIFF
--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -22,6 +22,7 @@ class ProjectorMetrics:
             "events_unshardable_total": 0.0,
             "projection_records_total": 0.0,
             "projection_stale_records_total": 0.0,
+            "decode_errors_total": 0.0,
             "empty_or_unowned_notifications_total": 0.0,
             "errors_total": 0.0,
             "last_success_unixtime": 0.0,
@@ -63,6 +64,11 @@ class ProjectorMetrics:
     def record_error(self) -> None:
         with self._lock:
             self._values["errors_total"] += 1.0
+            self._values["last_error_unixtime"] = time.time()
+
+    def record_decode_error(self) -> None:
+        with self._lock:
+            self._values["decode_errors_total"] += 1.0
             self._values["last_error_unixtime"] = time.time()
 
     def record_projection_checkpoints(self, records: Iterable[Any]) -> None:
@@ -125,6 +131,9 @@ def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapp
             "noetl_projector_projection_stale_records_total"
             f"{label_text} {snapshot['projection_stale_records_total']}"
         ),
+        "# HELP noetl_projector_decode_errors_total Projector notification payload decode failures.",
+        "# TYPE noetl_projector_decode_errors_total counter",
+        f"noetl_projector_decode_errors_total{label_text} {snapshot['decode_errors_total']}",
         "# HELP noetl_projector_empty_or_unowned_notifications_total Notifications with no owned events.",
         "# TYPE noetl_projector_empty_or_unowned_notifications_total counter",
         (

--- a/noetl/core/projector/nats_worker.py
+++ b/noetl/core/projector/nats_worker.py
@@ -130,7 +130,7 @@ class NATSProjectorWorker:
             max_ack_pending=self.settings.max_ack_pending,
             fetch_timeout=self.settings.fetch_timeout_seconds,
             fetch_heartbeat=self.settings.fetch_heartbeat_seconds,
-            message_decoder=decode_projector_notification,
+            message_decoder=self._decode_notification,
         )
         await self._subscriber.connect()
         logger.info(
@@ -145,6 +145,13 @@ class NATSProjectorWorker:
     async def close(self) -> None:
         if self._subscriber is not None:
             await self._subscriber.close()
+
+    def _decode_notification(self, payload: bytes) -> dict[str, Any]:
+        try:
+            return decode_projector_notification(payload)
+        except Exception:
+            self.metrics.record_decode_error()
+            raise
 
     async def handle_notification(self, notification: dict[str, Any]) -> str:
         """Project one NATS notification and return an ack action."""

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -42,7 +42,22 @@ def test_projector_metrics_render_prometheus_labels():
     assert "noetl_projector_events_unshardable_total" in body
     assert "noetl_projector_projection_records_total" in body
     assert "noetl_projector_projection_stale_records_total" in body
+    assert "noetl_projector_decode_errors_total" in body
     assert " 1.0" in body
+
+
+def test_projector_metrics_record_decode_errors():
+    from noetl.core.projector.metrics import ProjectorMetrics, render_projector_metrics
+
+    metrics = ProjectorMetrics()
+    metrics.record_decode_error()
+
+    snapshot = metrics.snapshot()
+    assert snapshot["decode_errors_total"] == 1
+    assert snapshot["last_error_unixtime"] > 0
+
+    body = render_projector_metrics(metrics)
+    assert "noetl_projector_decode_errors_total 1.0" in body
 
 
 def test_projector_metrics_export_projection_checkpoint_gauges():

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -376,6 +376,25 @@ def test_projector_notification_decoder_wraps_arrow_batches():
     assert [event["event_id"] for event in decoded["events"]] == [21, 22]
 
 
+def test_nats_projector_worker_records_decode_errors():
+    from noetl.core.projector.metrics import ProjectorMetrics
+    from noetl.core.projector.nats_worker import NATSProjectorWorker, ProjectorWorkerSettings
+
+    metrics = ProjectorMetrics()
+    worker = NATSProjectorWorker(
+        projection_store=_MemoryProjectionStore(),
+        settings=ProjectorWorkerSettings(),
+        metrics=metrics,
+    )
+
+    with pytest.raises(Exception):
+        worker._decode_notification(b"not-json-or-arrow")
+
+    snapshot = metrics.snapshot()
+    assert snapshot["decode_errors_total"] == 1
+    assert snapshot["last_error_unixtime"] > 0
+
+
 def test_projector_worker_settings_rejects_out_of_range_shard_id():
     from noetl.core.projector.nats_worker import ProjectorWorkerSettings
 


### PR DESCRIPTION
## Summary
- add noetl_projector_decode_errors_total for projector notification payload decode failures
- route projector NATS decoding through a worker-owned wrapper so decode failures update metrics before NAK/redelivery
- cover decode metric rendering and worker decode failure accounting in tests

## Validation
- .venv/bin/python -m pytest -q tests/core/test_replay_state_projector.py tests/core/test_projector_metrics.py
- scripts/check_replay_release_gate.sh

Tracking noetl/noetl#434
Related noetl/noetl#437