### PR TITLE
feat(projector): expose projection error metrics

### DIFF
--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -22,6 +22,7 @@ class ProjectorMetrics:
             "events_unshardable_total": 0.0,
             "projection_records_total": 0.0,
             "projection_stale_records_total": 0.0,
+            "projection_errors_total": 0.0,
             "decode_errors_total": 0.0,
             "empty_or_unowned_notifications_total": 0.0,
             "errors_total": 0.0,
@@ -64,6 +65,7 @@ class ProjectorMetrics:
     def record_error(self) -> None:
         with self._lock:
             self._values["errors_total"] += 1.0
+            self._values["projection_errors_total"] += 1.0
             self._values["last_error_unixtime"] = time.time()
 
     def record_decode_error(self) -> None:
@@ -131,6 +133,9 @@ def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapp
             "noetl_projector_projection_stale_records_total"
             f"{label_text} {snapshot['projection_stale_records_total']}"
         ),
+        "# HELP noetl_projector_projection_errors_total Projector notification projection callback failures.",
+        "# TYPE noetl_projector_projection_errors_total counter",
+        f"noetl_projector_projection_errors_total{label_text} {snapshot['projection_errors_total']}",
         "# HELP noetl_projector_decode_errors_total Projector notification payload decode failures.",
         "# TYPE noetl_projector_decode_errors_total counter",
         f"noetl_projector_decode_errors_total{label_text} {snapshot['decode_errors_total']}",

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -42,8 +42,25 @@ def test_projector_metrics_render_prometheus_labels():
     assert "noetl_projector_events_unshardable_total" in body
     assert "noetl_projector_projection_records_total" in body
     assert "noetl_projector_projection_stale_records_total" in body
+    assert "noetl_projector_projection_errors_total" in body
     assert "noetl_projector_decode_errors_total" in body
     assert " 1.0" in body
+
+
+def test_projector_metrics_record_projection_errors():
+    from noetl.core.projector.metrics import ProjectorMetrics, render_projector_metrics
+
+    metrics = ProjectorMetrics()
+    metrics.record_error()
+
+    snapshot = metrics.snapshot()
+    assert snapshot["errors_total"] == 1
+    assert snapshot["projection_errors_total"] == 1
+    assert snapshot["last_error_unixtime"] > 0
+
+    body = render_projector_metrics(metrics)
+    assert "noetl_projector_errors_total 1.0" in body
+    assert "noetl_projector_projection_errors_total 1.0" in body
 
 
 def test_projector_metrics_record_decode_errors():

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -33,6 +33,11 @@ class _SchemaLimitedProjectionStore(_MemoryProjectionStore):
         raise pg_errors.InsufficientPrivilege("must be owner of table projection")
 
 
+class _FailingProjectionStore(_MemoryProjectionStore):
+    async def save_projection(self, record):
+        raise RuntimeError("projection write failed")
+
+
 @pytest.mark.asyncio
 async def test_replay_state_projector_writes_grouped_projection_records():
     from noetl.core.projector import ReplayStateProjector
@@ -285,6 +290,38 @@ async def test_nats_projector_worker_counts_stale_projection_writes():
     assert snapshot["projection_records_total"] == 1
     assert snapshot["projection_stale_records_total"] == 1
     assert store.records["execution/7/all"].version == 3
+
+
+@pytest.mark.asyncio
+async def test_nats_projector_worker_counts_projection_errors():
+    from noetl.core.projector.metrics import ProjectorMetrics
+    from noetl.core.projector.nats_worker import NATSProjectorWorker, ProjectorWorkerSettings
+
+    metrics = ProjectorMetrics()
+    worker = NATSProjectorWorker(
+        projection_store=_FailingProjectionStore(),
+        settings=ProjectorWorkerSettings(shard_count=1),
+        metrics=metrics,
+    )
+
+    with pytest.raises(RuntimeError, match="projection write failed"):
+        await worker.handle_notification(
+            {
+                "event": {
+                    "event_id": 40,
+                    "stream_version": 1,
+                    "tenant_id": "tenant-a",
+                    "organization_id": "org-a",
+                    "execution_id": 7,
+                    "event_type": "workflow.completed",
+                }
+            }
+        )
+
+    snapshot = metrics.snapshot()
+    assert snapshot["errors_total"] == 1
+    assert snapshot["projection_errors_total"] == 1
+    assert snapshot["decode_errors_total"] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add noetl_projector_projection_errors_total for projection callback failures
- keep noetl_projector_errors_total as the existing aggregate compatibility counter
- cover metric rendering and worker projection-store failure accounting in tests

## Validation
- .venv/bin/python -m pytest -q tests/core/test_replay_state_projector.py tests/core/test_projector_metrics.py
- scripts/check_replay_release_gate.sh

Tracking noetl/noetl#434
Related noetl/noetl#437