### PR TITLE
feat(projector): include decode failures in aggregate errors

### DIFF
--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -70,6 +70,7 @@ class ProjectorMetrics:
 
     def record_decode_error(self) -> None:
         with self._lock:
+            self._values["errors_total"] += 1.0
             self._values["decode_errors_total"] += 1.0
             self._values["last_error_unixtime"] = time.time()
 

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -70,10 +70,13 @@ def test_projector_metrics_record_decode_errors():
     metrics.record_decode_error()
 
     snapshot = metrics.snapshot()
+    assert snapshot["errors_total"] == 1
     assert snapshot["decode_errors_total"] == 1
+    assert snapshot["projection_errors_total"] == 0
     assert snapshot["last_error_unixtime"] > 0
 
     body = render_projector_metrics(metrics)
+    assert "noetl_projector_errors_total 1.0" in body
     assert "noetl_projector_decode_errors_total 1.0" in body
 
 

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -428,7 +428,9 @@ def test_nats_projector_worker_records_decode_errors():
         worker._decode_notification(b"not-json-or-arrow")
 
     snapshot = metrics.snapshot()
+    assert snapshot["errors_total"] == 1
     assert snapshot["decode_errors_total"] == 1
+    assert snapshot["projection_errors_total"] == 0
     assert snapshot["last_error_unixtime"] > 0
 
 


### PR DESCRIPTION
## Summary
- make noetl_projector_errors_total include projector decode failures as well as projection callback failures
- keep noetl_projector_decode_errors_total and noetl_projector_projection_errors_total as the split counters
- update metrics and worker tests to cover the aggregate/split counter contract

## Validation
- .venv/bin/python -m pytest -q tests/core/test_replay_state_projector.py tests/core/test_projector_metrics.py
- scripts/check_replay_release_gate.sh

Tracking noetl/noetl#434
Related noetl/noetl#437