### PR TITLE
feat(projector): expose redelivery metrics

### DIFF
--- a/noetl/core/messaging/nats_client.py
+++ b/noetl/core/messaging/nats_client.py
@@ -287,6 +287,7 @@ class NATSCommandSubscriber:
         fetch_heartbeat: Optional[float] = None,
         callback_timeout_seconds: Optional[float] = None,
         message_decoder: Optional[Callable[[bytes], dict[str, Any]]] = None,
+        message_action_observer: Optional[Callable[[str, Optional[float]], None]] = None,
     ):
         from noetl.core.config import get_worker_settings
         ws = get_worker_settings()
@@ -312,12 +313,21 @@ class NATSCommandSubscriber:
             min(30.0, self.callback_timeout_seconds / 4.0),
         )
         self._message_decoder = message_decoder or self._decode_json_message
+        self._message_action_observer = message_action_observer
         self._nc: Optional[NATSClient] = None
         self._js: Optional[JetStreamContext] = None
         self._subscription = None
         self._background_tasks: set = set()
         self._inflight_semaphore = asyncio.Semaphore(self.max_inflight)
         self._throttle_hits = 0
+
+    def _record_message_action(self, action: str, delay_seconds: Optional[float] = None) -> None:
+        if self._message_action_observer is None:
+            return
+        try:
+            self._message_action_observer(action, delay_seconds)
+        except Exception:
+            logger.debug("Ignoring NATS message action observer failure", exc_info=True)
 
     @staticmethod
     def _decode_json_message(payload: bytes) -> dict[str, Any]:
@@ -635,6 +645,7 @@ class NATSCommandSubscriber:
                         await msg.term()
                     else:
                         await msg.ack()
+                    self._record_message_action(callback_action, callback_nak_delay_seconds)
                 except Exception as ack_error:
                     logger.warning("Failed to send %s for message: %s", callback_action, ack_error)
                 self._inflight_semaphore.release()
@@ -704,6 +715,7 @@ class NATSCommandSubscriber:
                             logger.error(f"Error handling message: {e}")
                             try:
                                 await msg.nak()
+                                self._record_message_action("nak", None)
                             except:
                                 pass
 

--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -24,6 +24,8 @@ class ProjectorMetrics:
             "projection_stale_records_total": 0.0,
             "projection_errors_total": 0.0,
             "decode_errors_total": 0.0,
+            "redelivery_requests_total": 0.0,
+            "delayed_redelivery_requests_total": 0.0,
             "empty_or_unowned_notifications_total": 0.0,
             "errors_total": 0.0,
             "last_success_unixtime": 0.0,
@@ -73,6 +75,14 @@ class ProjectorMetrics:
             self._values["errors_total"] += 1.0
             self._values["decode_errors_total"] += 1.0
             self._values["last_error_unixtime"] = time.time()
+
+    def record_message_action(self, action: str, delay_seconds: Optional[float] = None) -> None:
+        if action != "nak":
+            return
+        with self._lock:
+            self._values["redelivery_requests_total"] += 1.0
+            if delay_seconds is not None and delay_seconds > 0:
+                self._values["delayed_redelivery_requests_total"] += 1.0
 
     def record_projection_checkpoints(self, records: Iterable[Any]) -> None:
         with self._lock:
@@ -140,6 +150,15 @@ def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapp
         "# HELP noetl_projector_decode_errors_total Projector notification payload decode failures.",
         "# TYPE noetl_projector_decode_errors_total counter",
         f"noetl_projector_decode_errors_total{label_text} {snapshot['decode_errors_total']}",
+        "# HELP noetl_projector_redelivery_requests_total Projector notifications NAKed for redelivery.",
+        "# TYPE noetl_projector_redelivery_requests_total counter",
+        f"noetl_projector_redelivery_requests_total{label_text} {snapshot['redelivery_requests_total']}",
+        "# HELP noetl_projector_delayed_redelivery_requests_total Projector notifications NAKed for delayed redelivery.",
+        "# TYPE noetl_projector_delayed_redelivery_requests_total counter",
+        (
+            "noetl_projector_delayed_redelivery_requests_total"
+            f"{label_text} {snapshot['delayed_redelivery_requests_total']}"
+        ),
         "# HELP noetl_projector_empty_or_unowned_notifications_total Notifications with no owned events.",
         "# TYPE noetl_projector_empty_or_unowned_notifications_total counter",
         (

--- a/noetl/core/projector/nats_worker.py
+++ b/noetl/core/projector/nats_worker.py
@@ -131,6 +131,7 @@ class NATSProjectorWorker:
             fetch_timeout=self.settings.fetch_timeout_seconds,
             fetch_heartbeat=self.settings.fetch_heartbeat_seconds,
             message_decoder=self._decode_notification,
+            message_action_observer=self.metrics.record_message_action,
         )
         await self._subscriber.connect()
         logger.info(

--- a/tests/core/test_nats_command_subscriber.py
+++ b/tests/core/test_nats_command_subscriber.py
@@ -148,6 +148,34 @@ def test_parse_callback_action_caps_large_delayed_nak():
     assert delay == pytest.approx(3600.0)
 
 
+def test_message_action_observer_records_actions():
+    observed = []
+    subscriber = NATSCommandSubscriber(
+        consumer_name="test-consumer",
+        stream_name="NOETL_COMMANDS",
+        max_ack_pending=64,
+        max_inflight=1,
+        message_action_observer=lambda action, delay: observed.append((action, delay)),
+    )
+
+    subscriber._record_message_action("nak", 2.5)
+    subscriber._record_message_action("ack", None)
+
+    assert observed == [("nak", 2.5), ("ack", None)]
+
+
+def test_message_action_observer_failure_is_ignored():
+    subscriber = NATSCommandSubscriber(
+        consumer_name="test-consumer",
+        stream_name="NOETL_COMMANDS",
+        max_ack_pending=64,
+        max_inflight=1,
+        message_action_observer=lambda _action, _delay: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    subscriber._record_message_action("nak", None)
+
+
 class _FakeMsg:
     def __init__(self):
         self.in_progress_calls = 0

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -44,7 +44,26 @@ def test_projector_metrics_render_prometheus_labels():
     assert "noetl_projector_projection_stale_records_total" in body
     assert "noetl_projector_projection_errors_total" in body
     assert "noetl_projector_decode_errors_total" in body
+    assert "noetl_projector_redelivery_requests_total" in body
+    assert "noetl_projector_delayed_redelivery_requests_total" in body
     assert " 1.0" in body
+
+
+def test_projector_metrics_record_redelivery_requests():
+    from noetl.core.projector.metrics import ProjectorMetrics, render_projector_metrics
+
+    metrics = ProjectorMetrics()
+    metrics.record_message_action("nak", None)
+    metrics.record_message_action("nak", 2.5)
+    metrics.record_message_action("ack", None)
+
+    snapshot = metrics.snapshot()
+    assert snapshot["redelivery_requests_total"] == 2
+    assert snapshot["delayed_redelivery_requests_total"] == 1
+
+    body = render_projector_metrics(metrics)
+    assert "noetl_projector_redelivery_requests_total 2.0" in body
+    assert "noetl_projector_delayed_redelivery_requests_total 1.0" in body
 
 
 def test_projector_metrics_record_projection_errors():

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -562,6 +562,7 @@ async def test_nats_projector_worker_tolerates_projection_schema_permission(monk
         def __init__(self, **kwargs):
             calls.append(("init", kwargs["consumer_name"]))
             assert callable(kwargs["message_decoder"])
+            assert callable(kwargs["message_action_observer"])
 
         async def connect(self):
             calls.append(("connect", None))


### PR DESCRIPTION
## Summary
- add a NATS subscriber action observer hook for ack/nak/term outcomes
- wire projector subscribers to count NAK redelivery requests and delayed redelivery requests
- expose noetl_projector_redelivery_requests_total and noetl_projector_delayed_redelivery_requests_total

## Validation
- .venv/bin/python -m pytest -q tests/core/test_nats_command_subscriber.py tests/core/test_replay_state_projector.py tests/core/test_projector_metrics.py
- scripts/check_replay_release_gate.sh

Tracking noetl/noetl#434
Related noetl/noetl#437