### PR TITLE
feat(projector): expose terminal action metrics

### DIFF
--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -24,8 +24,10 @@ class ProjectorMetrics:
             "projection_stale_records_total": 0.0,
             "projection_errors_total": 0.0,
             "decode_errors_total": 0.0,
+            "acknowledged_notifications_total": 0.0,
             "redelivery_requests_total": 0.0,
             "delayed_redelivery_requests_total": 0.0,
+            "terminated_notifications_total": 0.0,
             "empty_or_unowned_notifications_total": 0.0,
             "errors_total": 0.0,
             "last_success_unixtime": 0.0,
@@ -77,12 +79,15 @@ class ProjectorMetrics:
             self._values["last_error_unixtime"] = time.time()
 
     def record_message_action(self, action: str, delay_seconds: Optional[float] = None) -> None:
-        if action != "nak":
-            return
         with self._lock:
-            self._values["redelivery_requests_total"] += 1.0
-            if delay_seconds is not None and delay_seconds > 0:
-                self._values["delayed_redelivery_requests_total"] += 1.0
+            if action == "ack":
+                self._values["acknowledged_notifications_total"] += 1.0
+            elif action == "nak":
+                self._values["redelivery_requests_total"] += 1.0
+                if delay_seconds is not None and delay_seconds > 0:
+                    self._values["delayed_redelivery_requests_total"] += 1.0
+            elif action == "term":
+                self._values["terminated_notifications_total"] += 1.0
 
     def record_projection_checkpoints(self, records: Iterable[Any]) -> None:
         with self._lock:
@@ -150,6 +155,12 @@ def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapp
         "# HELP noetl_projector_decode_errors_total Projector notification payload decode failures.",
         "# TYPE noetl_projector_decode_errors_total counter",
         f"noetl_projector_decode_errors_total{label_text} {snapshot['decode_errors_total']}",
+        "# HELP noetl_projector_acknowledged_notifications_total Projector notifications ACKed after handling.",
+        "# TYPE noetl_projector_acknowledged_notifications_total counter",
+        (
+            "noetl_projector_acknowledged_notifications_total"
+            f"{label_text} {snapshot['acknowledged_notifications_total']}"
+        ),
         "# HELP noetl_projector_redelivery_requests_total Projector notifications NAKed for redelivery.",
         "# TYPE noetl_projector_redelivery_requests_total counter",
         f"noetl_projector_redelivery_requests_total{label_text} {snapshot['redelivery_requests_total']}",
@@ -158,6 +169,12 @@ def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapp
         (
             "noetl_projector_delayed_redelivery_requests_total"
             f"{label_text} {snapshot['delayed_redelivery_requests_total']}"
+        ),
+        "# HELP noetl_projector_terminated_notifications_total Projector notifications TERMed without redelivery.",
+        "# TYPE noetl_projector_terminated_notifications_total counter",
+        (
+            "noetl_projector_terminated_notifications_total"
+            f"{label_text} {snapshot['terminated_notifications_total']}"
         ),
         "# HELP noetl_projector_empty_or_unowned_notifications_total Notifications with no owned events.",
         "# TYPE noetl_projector_empty_or_unowned_notifications_total counter",

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -44,26 +44,33 @@ def test_projector_metrics_render_prometheus_labels():
     assert "noetl_projector_projection_stale_records_total" in body
     assert "noetl_projector_projection_errors_total" in body
     assert "noetl_projector_decode_errors_total" in body
+    assert "noetl_projector_acknowledged_notifications_total" in body
     assert "noetl_projector_redelivery_requests_total" in body
     assert "noetl_projector_delayed_redelivery_requests_total" in body
+    assert "noetl_projector_terminated_notifications_total" in body
     assert " 1.0" in body
 
 
-def test_projector_metrics_record_redelivery_requests():
+def test_projector_metrics_record_message_actions():
     from noetl.core.projector.metrics import ProjectorMetrics, render_projector_metrics
 
     metrics = ProjectorMetrics()
+    metrics.record_message_action("ack", None)
     metrics.record_message_action("nak", None)
     metrics.record_message_action("nak", 2.5)
-    metrics.record_message_action("ack", None)
+    metrics.record_message_action("term", None)
 
     snapshot = metrics.snapshot()
+    assert snapshot["acknowledged_notifications_total"] == 1
     assert snapshot["redelivery_requests_total"] == 2
     assert snapshot["delayed_redelivery_requests_total"] == 1
+    assert snapshot["terminated_notifications_total"] == 1
 
     body = render_projector_metrics(metrics)
+    assert "noetl_projector_acknowledged_notifications_total 1.0" in body
     assert "noetl_projector_redelivery_requests_total 2.0" in body
     assert "noetl_projector_delayed_redelivery_requests_total 1.0" in body
+    assert "noetl_projector_terminated_notifications_total 1.0" in body
 
 
 def test_projector_metrics_record_projection_errors():


### PR DESCRIPTION
## Summary
- add projector ACK and TERM counters from the existing subscriber action observer
- keep redelivery and delayed redelivery counters for NAK actions
- update metrics tests to cover ACK, NAK, delayed NAK, and TERM action accounting

## Validation
- .venv/bin/python -m pytest -q tests/core/test_nats_command_subscriber.py tests/core/test_replay_state_projector.py tests/core/test_projector_metrics.py
- scripts/check_replay_release_gate.sh

Tracking noetl/noetl#434
Related noetl/noetl#437