### PR TITLE
feat(projector): add metrics summary helpers

### DIFF
--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -158,6 +158,28 @@ class ProjectorMetrics:
                 "termination_ratio": terminated / total if total else 0.0,
             }
 
+    def batch_summary(self) -> dict[str, float]:
+        with self._lock:
+            extracted = self._values["last_batch_extracted_events"]
+            owned = self._values["last_batch_events"]
+            unowned = self._values["last_batch_unowned_events"]
+            unshardable = self._values["last_batch_unshardable_events"]
+            projection_records = self._values["last_batch_projection_records"]
+            stale_projection_records = self._values["last_batch_stale_projection_records"]
+            return {
+                "extracted_events": extracted,
+                "owned_events": owned,
+                "unowned_events": unowned,
+                "unshardable_events": unshardable,
+                "projection_records": projection_records,
+                "stale_projection_records": stale_projection_records,
+                "owned_ratio": _safe_ratio(owned, extracted),
+                "unowned_ratio": _safe_ratio(unowned, extracted),
+                "unshardable_ratio": _safe_ratio(unshardable, extracted),
+                "projection_record_ratio": _safe_ratio(projection_records, owned),
+                "stale_projection_ratio": _safe_ratio(stale_projection_records, projection_records),
+            }
+
 
 def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapping[str, str]] = None) -> str:
     """Render projector metrics using Prometheus text exposition."""
@@ -345,6 +367,10 @@ def _format_labels(labels: Mapping[str, str]) -> str:
 
 def _escape_label(value: str) -> str:
     return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+def _safe_ratio(numerator: float, denominator: float) -> float:
+    return numerator / denominator if denominator else 0.0
 
 
 def _coerce_float(value: Any) -> Optional[float]:

--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -180,6 +180,20 @@ class ProjectorMetrics:
                 "stale_projection_ratio": _safe_ratio(stale_projection_records, projection_records),
             }
 
+    def error_summary(self) -> dict[str, float]:
+        with self._lock:
+            errors = self._values["errors_total"]
+            decode_errors = self._values["decode_errors_total"]
+            projection_errors = self._values["projection_errors_total"]
+            return {
+                "errors_total": errors,
+                "decode_errors_total": decode_errors,
+                "projection_errors_total": projection_errors,
+                "decode_error_ratio": _safe_ratio(decode_errors, errors),
+                "projection_error_ratio": _safe_ratio(projection_errors, errors),
+                "last_error_unixtime": self._values["last_error_unixtime"],
+            }
+
 
 def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapping[str, str]] = None) -> str:
     """Render projector metrics using Prometheus text exposition."""

--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -143,55 +143,37 @@ class ProjectorMetrics:
 
     def action_summary(self) -> dict[str, float]:
         with self._lock:
-            acknowledged = self._values["acknowledged_notifications_total"]
-            redelivery = self._values["redelivery_requests_total"]
-            terminated = self._values["terminated_notifications_total"]
-            total = acknowledged + redelivery + terminated
-            return {
-                "actions_total": total,
-                "acknowledged_notifications_total": acknowledged,
-                "redelivery_requests_total": redelivery,
-                "delayed_redelivery_requests_total": self._values["delayed_redelivery_requests_total"],
-                "terminated_notifications_total": terminated,
-                "ack_ratio": acknowledged / total if total else 0.0,
-                "redelivery_ratio": redelivery / total if total else 0.0,
-                "termination_ratio": terminated / total if total else 0.0,
-            }
+            return _action_summary(self._values)
 
     def batch_summary(self) -> dict[str, float]:
         with self._lock:
-            extracted = self._values["last_batch_extracted_events"]
-            owned = self._values["last_batch_events"]
-            unowned = self._values["last_batch_unowned_events"]
-            unshardable = self._values["last_batch_unshardable_events"]
-            projection_records = self._values["last_batch_projection_records"]
-            stale_projection_records = self._values["last_batch_stale_projection_records"]
-            return {
-                "extracted_events": extracted,
-                "owned_events": owned,
-                "unowned_events": unowned,
-                "unshardable_events": unshardable,
-                "projection_records": projection_records,
-                "stale_projection_records": stale_projection_records,
-                "owned_ratio": _safe_ratio(owned, extracted),
-                "unowned_ratio": _safe_ratio(unowned, extracted),
-                "unshardable_ratio": _safe_ratio(unshardable, extracted),
-                "projection_record_ratio": _safe_ratio(projection_records, owned),
-                "stale_projection_ratio": _safe_ratio(stale_projection_records, projection_records),
-            }
+            return _batch_summary(self._values)
 
     def error_summary(self) -> dict[str, float]:
         with self._lock:
-            errors = self._values["errors_total"]
-            decode_errors = self._values["decode_errors_total"]
-            projection_errors = self._values["projection_errors_total"]
+            return _error_summary(self._values)
+
+    def summary(self) -> dict[str, Any]:
+        with self._lock:
+            action_summary = _action_summary(self._values)
+            batch_summary = _batch_summary(self._values)
+            error_summary = _error_summary(self._values)
             return {
-                "errors_total": errors,
-                "decode_errors_total": decode_errors,
-                "projection_errors_total": projection_errors,
-                "decode_error_ratio": _safe_ratio(decode_errors, errors),
-                "projection_error_ratio": _safe_ratio(projection_errors, errors),
+                "notifications_total": self._values["notifications_total"],
+                "last_success_unixtime": self._values["last_success_unixtime"],
                 "last_error_unixtime": self._values["last_error_unixtime"],
+                "last_projection_source_event_id": self._values["last_projection_source_event_id"],
+                "last_projection_event_time_watermark_unixtime": self._values[
+                    "last_projection_event_time_watermark_unixtime"
+                ],
+                "last_projection_projected_at_unixtime": self._values[
+                    "last_projection_projected_at_unixtime"
+                ],
+                "last_projection_lag_milliseconds": self._values["last_projection_lag_milliseconds"],
+                "max_projection_lag_milliseconds": self._values["max_projection_lag_milliseconds"],
+                "actions": action_summary,
+                "batch": batch_summary,
+                "errors": error_summary,
             }
 
 
@@ -381,6 +363,59 @@ def _format_labels(labels: Mapping[str, str]) -> str:
 
 def _escape_label(value: str) -> str:
     return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+def _action_summary(values: Mapping[str, float]) -> dict[str, float]:
+    acknowledged = values["acknowledged_notifications_total"]
+    redelivery = values["redelivery_requests_total"]
+    terminated = values["terminated_notifications_total"]
+    total = acknowledged + redelivery + terminated
+    return {
+        "actions_total": total,
+        "acknowledged_notifications_total": acknowledged,
+        "redelivery_requests_total": redelivery,
+        "delayed_redelivery_requests_total": values["delayed_redelivery_requests_total"],
+        "terminated_notifications_total": terminated,
+        "ack_ratio": _safe_ratio(acknowledged, total),
+        "redelivery_ratio": _safe_ratio(redelivery, total),
+        "termination_ratio": _safe_ratio(terminated, total),
+    }
+
+
+def _batch_summary(values: Mapping[str, float]) -> dict[str, float]:
+    extracted = values["last_batch_extracted_events"]
+    owned = values["last_batch_events"]
+    unowned = values["last_batch_unowned_events"]
+    unshardable = values["last_batch_unshardable_events"]
+    projection_records = values["last_batch_projection_records"]
+    stale_projection_records = values["last_batch_stale_projection_records"]
+    return {
+        "extracted_events": extracted,
+        "owned_events": owned,
+        "unowned_events": unowned,
+        "unshardable_events": unshardable,
+        "projection_records": projection_records,
+        "stale_projection_records": stale_projection_records,
+        "owned_ratio": _safe_ratio(owned, extracted),
+        "unowned_ratio": _safe_ratio(unowned, extracted),
+        "unshardable_ratio": _safe_ratio(unshardable, extracted),
+        "projection_record_ratio": _safe_ratio(projection_records, owned),
+        "stale_projection_ratio": _safe_ratio(stale_projection_records, projection_records),
+    }
+
+
+def _error_summary(values: Mapping[str, float]) -> dict[str, float]:
+    errors = values["errors_total"]
+    decode_errors = values["decode_errors_total"]
+    projection_errors = values["projection_errors_total"]
+    return {
+        "errors_total": errors,
+        "decode_errors_total": decode_errors,
+        "projection_errors_total": projection_errors,
+        "decode_error_ratio": _safe_ratio(decode_errors, errors),
+        "projection_error_ratio": _safe_ratio(projection_errors, errors),
+        "last_error_unixtime": values["last_error_unixtime"],
+    }
 
 
 def _safe_ratio(numerator: float, denominator: float) -> float:

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -67,6 +67,33 @@ def test_projector_metrics_render_prometheus_labels():
     assert snapshot["last_batch_projection_records"] == 1
     assert snapshot["last_batch_stale_projection_records"] == 1
 
+    summary = metrics.batch_summary()
+    assert summary["extracted_events"] == 3
+    assert summary["owned_events"] == 2
+    assert summary["unowned_events"] == 1
+    assert summary["unshardable_events"] == 0
+    assert summary["projection_records"] == 1
+    assert summary["stale_projection_records"] == 1
+    assert summary["owned_ratio"] == 2 / 3
+    assert summary["unowned_ratio"] == 1 / 3
+    assert summary["unshardable_ratio"] == 0
+    assert summary["projection_record_ratio"] == 0.5
+    assert summary["stale_projection_ratio"] == 1.0
+
+
+def test_projector_metrics_batch_summary_handles_empty_batches():
+    from noetl.core.projector.metrics import ProjectorMetrics
+
+    metrics = ProjectorMetrics()
+
+    summary = metrics.batch_summary()
+    assert summary["extracted_events"] == 0
+    assert summary["owned_events"] == 0
+    assert summary["projection_records"] == 0
+    assert summary["owned_ratio"] == 0
+    assert summary["projection_record_ratio"] == 0
+    assert summary["stale_projection_ratio"] == 0
+
 
 def test_projector_metrics_record_message_actions():
     from noetl.core.projector.metrics import ProjectorMetrics, render_projector_metrics

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -144,6 +144,14 @@ def test_projector_metrics_record_projection_errors():
     assert "noetl_projector_errors_total 1.0" in body
     assert "noetl_projector_projection_errors_total 1.0" in body
 
+    summary = metrics.error_summary()
+    assert summary["errors_total"] == 1
+    assert summary["projection_errors_total"] == 1
+    assert summary["decode_errors_total"] == 0
+    assert summary["projection_error_ratio"] == 1.0
+    assert summary["decode_error_ratio"] == 0
+    assert summary["last_error_unixtime"] > 0
+
 
 def test_projector_metrics_record_decode_errors():
     from noetl.core.projector.metrics import ProjectorMetrics, render_projector_metrics
@@ -160,6 +168,28 @@ def test_projector_metrics_record_decode_errors():
     body = render_projector_metrics(metrics)
     assert "noetl_projector_errors_total 1.0" in body
     assert "noetl_projector_decode_errors_total 1.0" in body
+
+    summary = metrics.error_summary()
+    assert summary["errors_total"] == 1
+    assert summary["decode_errors_total"] == 1
+    assert summary["projection_errors_total"] == 0
+    assert summary["decode_error_ratio"] == 1.0
+    assert summary["projection_error_ratio"] == 0
+    assert summary["last_error_unixtime"] > 0
+
+
+def test_projector_metrics_error_summary_handles_no_errors():
+    from noetl.core.projector.metrics import ProjectorMetrics
+
+    metrics = ProjectorMetrics()
+
+    summary = metrics.error_summary()
+    assert summary["errors_total"] == 0
+    assert summary["decode_errors_total"] == 0
+    assert summary["projection_errors_total"] == 0
+    assert summary["decode_error_ratio"] == 0
+    assert summary["projection_error_ratio"] == 0
+    assert summary["last_error_unixtime"] == 0
 
 
 def test_projector_metrics_export_projection_checkpoint_gauges():

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -220,6 +220,48 @@ def test_projector_metrics_export_projection_checkpoint_gauges():
     assert "noetl_projector_max_projection_lag_milliseconds 2000.0" in body
 
 
+def test_projector_metrics_summary_combines_current_runtime_state():
+    from noetl.core.projector.metrics import ProjectorMetrics
+
+    metrics = ProjectorMetrics()
+    metrics.record_notification(
+        extracted_events=4,
+        owned_events=3,
+        unowned_events=1,
+        projection_records=2,
+        stale_projection_records=1,
+    )
+    metrics.record_message_action("ack", None)
+    metrics.record_decode_error()
+    metrics.record_projection_checkpoints(
+        [
+            SimpleNamespace(
+                source_event_id=41,
+                meta={
+                    "event_time_watermark": "2026-05-18T18:00:00Z",
+                    "projected_at": "2026-05-18T18:00:01Z",
+                    "projection_lag_ms": 1000,
+                },
+            )
+        ]
+    )
+
+    summary = metrics.summary()
+    assert summary["notifications_total"] == 1
+    assert summary["last_success_unixtime"] > 0
+    assert summary["last_error_unixtime"] > 0
+    assert summary["last_projection_source_event_id"] == 41
+    assert summary["last_projection_lag_milliseconds"] == 1000
+    assert summary["max_projection_lag_milliseconds"] == 1000
+    assert summary["actions"]["actions_total"] == 1
+    assert summary["actions"]["ack_ratio"] == 1.0
+    assert summary["batch"]["owned_events"] == 3
+    assert summary["batch"]["owned_ratio"] == 0.75
+    assert summary["batch"]["stale_projection_ratio"] == 0.5
+    assert summary["errors"]["errors_total"] == 1
+    assert summary["errors"]["decode_error_ratio"] == 1.0
+
+
 def test_projector_metrics_server_exposes_metrics_and_health():
     from noetl.core.projector.metrics import ProjectorMetrics, start_projector_metrics_server
 


### PR DESCRIPTION
## Summary\n- add batch-shape summary helper with safe ratios for extracted, owned, unowned, unshardable, projection, and stale projection counts\n- add error summary helper for decode/projection error ratios\n- add combined projector metrics summary payload for actions, batch shape, errors, and projection lag state\n\nThis intentionally bundles three related commits into one PR to reduce origin GitHub Actions autobuild churn.\n\n## Validation\n- .venv/bin/python -m pytest -q tests/core/test_projector_metrics.py tests/core/test_nats_command_subscriber.py tests/core/test_replay_state_projector.py\n- scripts/check_replay_release_gate.sh\n\nRefs noetl/noetl#434\nRefs noetl/noetl#437