### PR TITLE
feat(projector): expose metrics summary endpoint

### DIFF
--- a/noetl/core/projector/__init__.py
+++ b/noetl/core/projector/__init__.py
@@ -1,11 +1,17 @@
 """Deterministic projection helpers for decentralized projectors."""
 
-from .metrics import ProjectorMetrics, render_projector_metrics, start_projector_metrics_server
+from .metrics import (
+    ProjectorMetrics,
+    projector_metrics_summary,
+    render_projector_metrics,
+    start_projector_metrics_server,
+)
 from .service import ReplayStateProjector
 
 __all__ = [
     "ProjectorMetrics",
     "ReplayStateProjector",
+    "projector_metrics_summary",
     "render_projector_metrics",
     "start_projector_metrics_server",
 ]

--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -345,6 +346,21 @@ def start_projector_metrics_server(
                 self.send_header("Content-Type", "text/plain; charset=utf-8")
                 self.end_headers()
                 self.wfile.write(b"ok\n")
+                return
+            if self.path == "/summary":
+                body = (
+                    json.dumps(
+                        projector_metrics_summary(metrics, labels=labels),
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                ).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
                 return
             if self.path != "/metrics":
                 self.send_response(404)

--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -316,6 +316,19 @@ def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapp
     return "\n".join(lines) + "\n"
 
 
+def projector_metrics_summary(
+    metrics: ProjectorMetrics,
+    *,
+    labels: Optional[Mapping[str, str]] = None,
+) -> dict[str, Any]:
+    """Return a JSON-friendly projector metrics summary payload."""
+
+    return {
+        "labels": _filtered_labels(labels or {}),
+        "summary": metrics.summary(),
+    }
+
+
 def start_projector_metrics_server(
     metrics: ProjectorMetrics,
     *,
@@ -354,11 +367,15 @@ def start_projector_metrics_server(
 
 
 def _format_labels(labels: Mapping[str, str]) -> str:
-    filtered = {key: value for key, value in labels.items() if value}
+    filtered = _filtered_labels(labels)
     if not filtered:
         return ""
     body = ",".join(f'{key}="{_escape_label(value)}"' for key, value in sorted(filtered.items()))
     return "{" + body + "}"
+
+
+def _filtered_labels(labels: Mapping[str, str]) -> dict[str, str]:
+    return {str(key): str(value) for key, value in labels.items() if value}
 
 
 def _escape_label(value: str) -> str:
@@ -453,6 +470,7 @@ def _coerce_datetime_unixtime(value: Any) -> Optional[float]:
 
 __all__ = [
     "ProjectorMetrics",
+    "projector_metrics_summary",
     "render_projector_metrics",
     "start_projector_metrics_server",
 ]

--- a/scripts/check_projector_metrics_summary.py
+++ b/scripts/check_projector_metrics_summary.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+"""Validate projector metrics summary JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+REQUIRED_ACTION_FIELDS = (
+    "actions_total",
+    "acknowledged_notifications_total",
+    "redelivery_requests_total",
+    "delayed_redelivery_requests_total",
+    "terminated_notifications_total",
+    "ack_ratio",
+    "redelivery_ratio",
+    "termination_ratio",
+)
+
+REQUIRED_BATCH_FIELDS = (
+    "extracted_events",
+    "owned_events",
+    "unowned_events",
+    "unshardable_events",
+    "projection_records",
+    "stale_projection_records",
+    "owned_ratio",
+    "unowned_ratio",
+    "unshardable_ratio",
+    "projection_record_ratio",
+    "stale_projection_ratio",
+)
+
+REQUIRED_ERROR_FIELDS = (
+    "errors_total",
+    "decode_errors_total",
+    "projection_errors_total",
+    "decode_error_ratio",
+    "projection_error_ratio",
+    "last_error_unixtime",
+)
+
+REQUIRED_SUMMARY_FIELDS = (
+    "notifications_total",
+    "last_success_unixtime",
+    "last_error_unixtime",
+    "last_projection_source_event_id",
+    "last_projection_event_time_watermark_unixtime",
+    "last_projection_projected_at_unixtime",
+    "last_projection_lag_milliseconds",
+    "max_projection_lag_milliseconds",
+    "actions",
+    "batch",
+    "errors",
+)
+
+
+def _load_report(path: Path) -> dict[str, Any]:
+    data: Any = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _validate_number(
+    failures: list[dict[str, Any]],
+    *,
+    field: str,
+    value: Any,
+    minimum: float | None = 0.0,
+) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        failures.append({"field": field, "reason": "must be a number", "supplied": value})
+        return None
+    parsed = float(value)
+    if minimum is not None and parsed < minimum:
+        failures.append({"field": field, "reason": f"must be >= {minimum}", "supplied": value})
+    return parsed
+
+
+def _validate_ratio(
+    failures: list[dict[str, Any]],
+    *,
+    field: str,
+    value: Any,
+) -> float | None:
+    parsed = _validate_number(failures, field=field, value=value, minimum=0.0)
+    if parsed is not None and parsed > 1.0:
+        failures.append({"field": field, "reason": "must be <= 1.0", "supplied": value})
+    return parsed
+
+
+def _validate_object(
+    failures: list[dict[str, Any]],
+    *,
+    field: str,
+    value: Any,
+) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        failures.append({"field": field, "reason": "must be an object", "supplied": value})
+        return None
+    return value
+
+
+def _validate_required_fields(
+    failures: list[dict[str, Any]],
+    *,
+    prefix: str,
+    value: Mapping[str, Any],
+    fields: tuple[str, ...],
+) -> None:
+    for field in fields:
+        if field not in value:
+            failures.append({"field": f"{prefix}.{field}", "reason": "missing required field"})
+
+
+def _validate_labels(failures: list[dict[str, Any]], labels: Any) -> None:
+    labels_obj = _validate_object(failures, field="labels", value=labels)
+    if labels_obj is None:
+        return
+    for key, value in labels_obj.items():
+        if not isinstance(key, str) or not key:
+            failures.append({"field": "labels", "reason": "label keys must be non-empty strings"})
+        if not isinstance(value, str) or not value:
+            failures.append(
+                {
+                    "field": f"labels.{key}",
+                    "reason": "label values must be non-empty strings",
+                    "supplied": value,
+                }
+            )
+
+
+def _validate_action_summary(failures: list[dict[str, Any]], actions: Mapping[str, Any]) -> None:
+    _validate_required_fields(failures, prefix="summary.actions", value=actions, fields=REQUIRED_ACTION_FIELDS)
+    for field in REQUIRED_ACTION_FIELDS:
+        if field.endswith("_ratio"):
+            _validate_ratio(failures, field=f"summary.actions.{field}", value=actions.get(field))
+        else:
+            _validate_number(failures, field=f"summary.actions.{field}", value=actions.get(field))
+
+
+def _validate_batch_summary(failures: list[dict[str, Any]], batch: Mapping[str, Any]) -> None:
+    _validate_required_fields(failures, prefix="summary.batch", value=batch, fields=REQUIRED_BATCH_FIELDS)
+    for field in REQUIRED_BATCH_FIELDS:
+        if field.endswith("_ratio"):
+            _validate_ratio(failures, field=f"summary.batch.{field}", value=batch.get(field))
+        else:
+            _validate_number(failures, field=f"summary.batch.{field}", value=batch.get(field))
+
+
+def _validate_error_summary(failures: list[dict[str, Any]], errors: Mapping[str, Any]) -> None:
+    _validate_required_fields(failures, prefix="summary.errors", value=errors, fields=REQUIRED_ERROR_FIELDS)
+    for field in REQUIRED_ERROR_FIELDS:
+        if field.endswith("_ratio"):
+            _validate_ratio(failures, field=f"summary.errors.{field}", value=errors.get(field))
+        else:
+            _validate_number(failures, field=f"summary.errors.{field}", value=errors.get(field))
+
+
+def validate_projector_metrics_summary(report: dict[str, Any]) -> dict[str, Any]:
+    failures: list[dict[str, Any]] = []
+    _validate_labels(failures, report.get("labels"))
+
+    summary = _validate_object(failures, field="summary", value=report.get("summary"))
+    if summary is None:
+        return {"matched": False, "failures": failures}
+
+    _validate_required_fields(failures, prefix="summary", value=summary, fields=REQUIRED_SUMMARY_FIELDS)
+    for field in REQUIRED_SUMMARY_FIELDS:
+        if field in {"actions", "batch", "errors"}:
+            continue
+        _validate_number(failures, field=f"summary.{field}", value=summary.get(field))
+
+    actions = _validate_object(failures, field="summary.actions", value=summary.get("actions"))
+    if actions is not None:
+        _validate_action_summary(failures, actions)
+
+    batch = _validate_object(failures, field="summary.batch", value=summary.get("batch"))
+    if batch is not None:
+        _validate_batch_summary(failures, batch)
+
+    errors = _validate_object(failures, field="summary.errors", value=summary.get("errors"))
+    if errors is not None:
+        _validate_error_summary(failures, errors)
+
+    return {"matched": not failures, "failures": failures}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate NoETL projector /summary JSON",
+    )
+    parser.add_argument(
+        "--report",
+        required=True,
+        type=Path,
+        help="Projector metrics summary JSON returned by /summary",
+    )
+    args = parser.parse_args(argv)
+
+    output = validate_projector_metrics_summary(_load_report(args.report))
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0 if output["matched"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -22,6 +22,7 @@ fi
   tests/scripts/test_check_replay_state_report.py \
   tests/scripts/test_check_replay_parity_report.py \
   tests/scripts/test_check_replay_payload_resolution_report.py \
+  tests/scripts/test_check_projector_metrics_summary.py \
   tests/api/test_replay_routes.py \
   tests/core/test_replay_upcasters.py \
   tests/core/test_replay_state_projector.py \

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -262,6 +262,31 @@ def test_projector_metrics_summary_combines_current_runtime_state():
     assert summary["errors"]["decode_error_ratio"] == 1.0
 
 
+def test_projector_metrics_summary_payload_filters_labels():
+    from noetl.core.projector.metrics import ProjectorMetrics, projector_metrics_summary
+
+    metrics = ProjectorMetrics()
+    metrics.record_notification(extracted_events=2, owned_events=1, projection_records=1)
+    metrics.record_message_action("ack", None)
+
+    payload = projector_metrics_summary(
+        metrics,
+        labels={
+            "shard_id": "noetl-projector-0",
+            "shard_index": "0",
+            "empty": "",
+        },
+    )
+
+    assert payload["labels"] == {
+        "shard_id": "noetl-projector-0",
+        "shard_index": "0",
+    }
+    assert payload["summary"]["notifications_total"] == 1
+    assert payload["summary"]["actions"]["ack_ratio"] == 1.0
+    assert payload["summary"]["batch"]["owned_ratio"] == 0.5
+
+
 def test_projector_metrics_server_exposes_metrics_and_health():
     from noetl.core.projector.metrics import ProjectorMetrics, start_projector_metrics_server
 

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from urllib.request import urlopen
 
@@ -302,11 +303,16 @@ def test_projector_metrics_server_exposes_metrics_and_health():
     try:
         with urlopen(f"http://{host}:{port}/health", timeout=2) as response:
             assert response.read() == b"ok\n"
+        with urlopen(f"http://{host}:{port}/summary", timeout=2) as response:
+            summary = json.loads(response.read().decode("utf-8"))
         with urlopen(f"http://{host}:{port}/metrics", timeout=2) as response:
             body = response.read().decode("utf-8")
     finally:
         server.shutdown()
         server.server_close()
 
+    assert summary["labels"] == {"shard_id": "test-shard"}
+    assert summary["summary"]["notifications_total"] == 1
+    assert summary["summary"]["batch"]["owned_events"] == 0
     assert "noetl_projector_empty_or_unowned_notifications_total" in body
     assert 'shard_id="test-shard"' in body

--- a/tests/scripts/test_check_projector_metrics_summary.py
+++ b/tests/scripts/test_check_projector_metrics_summary.py
@@ -1,0 +1,111 @@
+import json
+from pathlib import Path
+
+from scripts.check_projector_metrics_summary import main
+
+
+def _summary_payload():
+    return {
+        "labels": {
+            "shard_id": "noetl-projector-0",
+            "shard_index": "0",
+            "shard_count": "2",
+        },
+        "summary": {
+            "notifications_total": 2.0,
+            "last_success_unixtime": 1779312000.0,
+            "last_error_unixtime": 0.0,
+            "last_projection_source_event_id": 41.0,
+            "last_projection_event_time_watermark_unixtime": 1779311999.0,
+            "last_projection_projected_at_unixtime": 1779312000.0,
+            "last_projection_lag_milliseconds": 1000.0,
+            "max_projection_lag_milliseconds": 1000.0,
+            "actions": {
+                "actions_total": 2.0,
+                "acknowledged_notifications_total": 1.0,
+                "redelivery_requests_total": 1.0,
+                "delayed_redelivery_requests_total": 0.0,
+                "terminated_notifications_total": 0.0,
+                "ack_ratio": 0.5,
+                "redelivery_ratio": 0.5,
+                "termination_ratio": 0.0,
+            },
+            "batch": {
+                "extracted_events": 3.0,
+                "owned_events": 2.0,
+                "unowned_events": 1.0,
+                "unshardable_events": 0.0,
+                "projection_records": 2.0,
+                "stale_projection_records": 0.0,
+                "owned_ratio": 2 / 3,
+                "unowned_ratio": 1 / 3,
+                "unshardable_ratio": 0.0,
+                "projection_record_ratio": 1.0,
+                "stale_projection_ratio": 0.0,
+            },
+            "errors": {
+                "errors_total": 0.0,
+                "decode_errors_total": 0.0,
+                "projection_errors_total": 0.0,
+                "decode_error_ratio": 0.0,
+                "projection_error_ratio": 0.0,
+                "last_error_unixtime": 0.0,
+            },
+        },
+    }
+
+
+def _write_payload(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "projector-summary.json"
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def test_check_projector_metrics_summary_accepts_valid_payload(tmp_path: Path, capsys):
+    path = _write_payload(tmp_path, _summary_payload())
+
+    assert main(["--report", str(path)]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True
+
+
+def test_check_projector_metrics_summary_rejects_missing_required_field(
+    tmp_path: Path,
+    capsys,
+):
+    payload = _summary_payload()
+    payload["summary"]["batch"].pop("owned_ratio")
+    path = _write_payload(tmp_path, payload)
+
+    assert main(["--report", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    fields = {failure["field"] for failure in output["failures"]}
+    assert "summary.batch.owned_ratio" in fields
+
+
+def test_check_projector_metrics_summary_rejects_invalid_ratio(tmp_path: Path, capsys):
+    payload = _summary_payload()
+    payload["summary"]["actions"]["ack_ratio"] = 1.5
+    path = _write_payload(tmp_path, payload)
+
+    assert main(["--report", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    fields = {failure["field"] for failure in output["failures"]}
+    assert "summary.actions.ack_ratio" in fields
+
+
+def test_check_projector_metrics_summary_rejects_invalid_label_value(
+    tmp_path: Path,
+    capsys,
+):
+    payload = _summary_payload()
+    payload["labels"]["shard_id"] = ""
+    path = _write_payload(tmp_path, payload)
+
+    assert main(["--report", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    fields = {failure["field"] for failure in output["failures"]}
+    assert "labels.shard_id" in fields


### PR DESCRIPTION
## Summary\n- add a JSON-friendly projector metrics summary payload with filtered labels\n- expose the payload from the projector metrics server at /summary alongside /health and /metrics\n- add a projector summary validation script for saved /summary JSON\n- include the new summary gate in the replay release checks\n\nThis intentionally bundles four related commits into one NoETL PR to reduce origin GitHub Actions autobuild churn.\n\n## Validation\n- .venv/bin/python -m pytest -q tests/core/test_projector_metrics.py tests/scripts/test_check_projector_metrics_summary.py tests/core/test_nats_command_subscriber.py tests/core/test_replay_state_projector.py\n- scripts/check_replay_release_gate.sh\n\nRefs noetl/noetl#434\nRefs noetl/noetl#437