### PR TITLE
feat(validation): add phase2 projector evidence bundle

### DIFF
--- a/scripts/check_projector_phase2_evidence.py
+++ b/scripts/check_projector_phase2_evidence.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+"""Validate Phase 2 projector evidence in a replay validation manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from scripts.check_replay_validation_manifest import _load_manifest, _validate_manifest
+
+
+def _step_names(manifest: dict[str, Any]) -> list[str]:
+    steps = manifest.get("steps")
+    if not isinstance(steps, list):
+        return []
+    names: list[str] = []
+    for step in steps:
+        if isinstance(step, dict) and isinstance(step.get("name"), str):
+            names.append(step["name"])
+    return names
+
+
+def validate_projector_phase2_evidence(
+    manifest: dict[str, Any],
+    *,
+    require_projection_parity: bool,
+    check_artifacts: bool,
+    manifest_path: Path | None = None,
+) -> dict[str, Any]:
+    base = _validate_manifest(
+        manifest,
+        require_matched=True,
+        check_artifacts=check_artifacts,
+        manifest_path=manifest_path,
+    )
+    failures: list[dict[str, Any]] = list(base.get("failures", []))
+    artifacts = manifest.get("artifacts") if isinstance(manifest.get("artifacts"), dict) else {}
+    projector_summaries = artifacts.get("projector_summaries")
+    if not isinstance(projector_summaries, list) or not projector_summaries:
+        failures.append(
+            {
+                "field": "artifacts.projector_summaries",
+                "reason": "Phase 2 projector evidence requires at least one projector summary artifact",
+            }
+        )
+
+    names = _step_names(manifest)
+    if not any(name.startswith("projector_summary_") and name.endswith("_integrity") for name in names):
+        failures.append(
+            {
+                "field": "steps",
+                "reason": "Phase 2 projector evidence requires projector summary integrity checks",
+            }
+        )
+    if require_projection_parity:
+        if "projection_parity" not in names:
+            failures.append(
+                {
+                    "field": "steps",
+                    "reason": "Phase 2 projector evidence requires projection_parity step",
+                }
+            )
+        elif any(
+            isinstance(step, dict)
+            and step.get("name") == "projection_parity"
+            and step.get("skipped") is True
+            for step in manifest.get("steps", [])
+        ):
+            failures.append(
+                {
+                    "field": "steps.projection_parity",
+                    "reason": "Phase 2 projector evidence requires projection_parity to run",
+                }
+            )
+
+    return {"matched": not failures, "failures": failures}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate Phase 2 projector evidence manifest")
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument(
+        "--require-projection-parity",
+        action="store_true",
+        help="Require a non-skipped projection_parity step",
+    )
+    parser.add_argument("--check-artifacts", action="store_true")
+    args = parser.parse_args(argv)
+
+    output = validate_projector_phase2_evidence(
+        _load_manifest(args.manifest),
+        require_projection_parity=args.require_projection_parity,
+        check_artifacts=args.check_artifacts,
+        manifest_path=args.manifest,
+    )
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0 if output["matched"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -22,7 +22,9 @@ fi
   tests/scripts/test_check_replay_state_report.py \
   tests/scripts/test_check_replay_parity_report.py \
   tests/scripts/test_check_replay_payload_resolution_report.py \
+  tests/scripts/test_fetch_projector_metrics_summary.py \
   tests/scripts/test_check_projector_metrics_summary.py \
+  tests/scripts/test_check_projector_phase2_evidence.py \
   tests/api/test_replay_routes.py \
   tests/core/test_replay_upcasters.py \
   tests/core/test_replay_state_projector.py \

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -59,6 +59,29 @@ def _artifact_path(value: str, manifest_path: Path | None) -> Path:
     return path
 
 
+def _validate_artifact_path(
+    failures: list[dict[str, Any]],
+    *,
+    field: str,
+    value: Any,
+    manifest_path: Path | None,
+    check_artifacts: bool,
+) -> None:
+    if value is None:
+        return
+    if not isinstance(value, str) or not value:
+        failures.append({"field": field, "reason": "artifact path must be a string"})
+    elif check_artifacts and not _artifact_path(value, manifest_path).exists():
+        failures.append({"field": field, "reason": "artifact path does not exist", "path": value})
+
+
+def _is_projector_summary_step(name: str) -> bool:
+    return (
+        name.startswith("projector_summary_")
+        and (name.endswith("_integrity") or name.endswith("_fetch"))
+    )
+
+
 def _validate_manifest(
     manifest: dict[str, Any],
     *,
@@ -101,14 +124,50 @@ def _validate_manifest(
     artifacts = manifest.get("artifacts")
     if artifacts is not None and not isinstance(artifacts, dict):
         failures.append({"field": "artifacts", "reason": "must be an object"})
-    elif isinstance(artifacts, dict) and check_artifacts:
+    elif isinstance(artifacts, dict):
         for field, value in artifacts.items():
-            if value is None:
+            if field == "projector_summaries":
+                if not isinstance(value, list):
+                    failures.append({"field": "artifacts.projector_summaries", "reason": "must be a list"})
+                    continue
+                for index, entry in enumerate(value):
+                    if not isinstance(entry, dict):
+                        failures.append(
+                            {
+                                "field": f"artifacts.projector_summaries[{index}]",
+                                "reason": "must be an object",
+                            }
+                        )
+                        continue
+                    if not isinstance(entry.get("role"), str) or not entry.get("role"):
+                        failures.append(
+                            {
+                                "field": f"artifacts.projector_summaries[{index}].role",
+                                "reason": "must be a non-empty string",
+                            }
+                        )
+                    _validate_artifact_path(
+                        failures,
+                        field=f"artifacts.projector_summaries[{index}].path",
+                        value=entry.get("path"),
+                        manifest_path=manifest_path,
+                        check_artifacts=check_artifacts,
+                    )
+                    if "url" in entry and (not isinstance(entry.get("url"), str) or not entry.get("url")):
+                        failures.append(
+                            {
+                                "field": f"artifacts.projector_summaries[{index}].url",
+                                "reason": "must be a non-empty string when present",
+                            }
+                        )
                 continue
-            if not isinstance(value, str) or not value:
-                failures.append({"field": f"artifacts.{field}", "reason": "artifact path must be a string"})
-            elif not _artifact_path(value, manifest_path).exists():
-                failures.append({"field": f"artifacts.{field}", "reason": "artifact path does not exist", "path": value})
+            _validate_artifact_path(
+                failures,
+                field=f"artifacts.{field}",
+                value=value,
+                manifest_path=manifest_path,
+                check_artifacts=check_artifacts,
+            )
 
         artifact_index = artifacts.get("artifact_index")
         if isinstance(artifact_index, str) and artifact_index:
@@ -218,6 +277,16 @@ def _validate_manifest(
                 }
             )
     artifacts_index = artifacts.get("artifact_index") if isinstance(artifacts, dict) else None
+    projector_summaries = artifacts.get("projector_summaries") if isinstance(artifacts, dict) else None
+    if projector_summaries:
+        integrity_steps = [name for name in step_names if _is_projector_summary_step(name) and name.endswith("_integrity")]
+        if len(integrity_steps) < len(projector_summaries):
+            failures.append(
+                {
+                    "field": "steps",
+                    "reason": "projector summary artifacts require matching integrity steps",
+                }
+            )
     if artifacts_index:
         if "artifact_index" not in step_names:
             failures.append(
@@ -241,6 +310,8 @@ def _validate_manifest(
             }
         )
     for name in step_names:
+        if _is_projector_summary_step(name):
+            continue
         if name not in (*REQUIRED_STEP_ORDER, *OPTIONAL_STEP_NAMES, "fetch_artifact"):
             failures.append({"field": "steps", "reason": "unknown validation step", "step": name})
 

--- a/scripts/fetch_projector_metrics_summary.py
+++ b/scripts/fetch_projector_metrics_summary.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""Fetch projector metrics summary JSON from a live projector."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse, urlunparse
+from urllib.request import urlopen
+
+
+def _summary_url(raw_url: str) -> str:
+    parsed = urlparse(raw_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError("--url must be an absolute http(s) URL")
+    path = parsed.path.rstrip("/")
+    if not path:
+        path = "/summary"
+    elif path != "/summary":
+        path = f"{path}/summary"
+    return urlunparse(parsed._replace(path=path, params="", query="", fragment=""))
+
+
+def fetch_projector_metrics_summary(url: str, *, timeout: float) -> dict[str, Any]:
+    summary_url = _summary_url(url)
+    try:
+        with urlopen(summary_url, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+    except (HTTPError, URLError, TimeoutError) as exc:
+        raise RuntimeError(f"failed to fetch projector metrics summary from {summary_url}: {exc}") from exc
+
+    data: Any = json.loads(body)
+    if not isinstance(data, dict):
+        raise ValueError(f"{summary_url} returned non-object JSON")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Fetch NoETL projector /summary JSON")
+    parser.add_argument("--url", required=True, help="Projector metrics server base URL or /summary URL")
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--timeout", default=10.0, type=float)
+    args = parser.parse_args(argv)
+
+    try:
+        payload = fetch_projector_metrics_summary(args.url, timeout=args.timeout)
+    except (RuntimeError, ValueError, json.JSONDecodeError) as exc:
+        print(json.dumps({"matched": False, "error": str(exc)}, indent=2, sort_keys=True))
+        return 1
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(
+        json.dumps(
+            {
+                "matched": True,
+                "output": str(args.output),
+                "url": _summary_url(args.url),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import time
@@ -37,6 +38,22 @@ def _run(command: list[str]) -> tuple[int, str, str, float]:
     return completed.returncode, completed.stdout, completed.stderr, duration
 
 
+def _safe_slug(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip("-")
+    return slug or "projector"
+
+
+def _parse_named_value(raw: str, *, flag: str) -> tuple[str, str]:
+    if "=" not in raw:
+        raise ValueError(f"{flag} must use NAME=VALUE")
+    name, value = raw.split("=", 1)
+    name = name.strip()
+    value = value.strip()
+    if not name or not value:
+        raise ValueError(f"{flag} must use NAME=VALUE")
+    return name, value
+
+
 def _build_report(
     *,
     matched: bool,
@@ -44,6 +61,7 @@ def _build_report(
     replay_path: Path,
     live_checksums_path: Path | None,
     live_rows_path: Path | None,
+    projector_summaries: list[dict[str, str]],
     steps: list[dict[str, object]],
     started_at: str,
 ) -> dict[str, object]:
@@ -57,6 +75,7 @@ def _build_report(
             "replay": str(replay_path),
             "live_rows": str(live_rows_path) if live_rows_path else None,
             "live_checksums": str(live_checksums_path) if live_checksums_path else None,
+            "projector_summaries": projector_summaries,
             "report": str(args.report_output) if args.report_output else None,
             "artifact_index": str(args.artifact_index_output) if args.artifact_index_output else None,
         },
@@ -74,6 +93,8 @@ def _build_report(
             "live_checksums": str(args.live_checksums) if args.live_checksums else None,
             "live_rows": str(args.live_rows) if args.live_rows else None,
             "export_live_rows_postgres": args.export_live_rows_postgres,
+            "projector_summary": [str(path) for path in args.projector_summary],
+            "projector_summary_url": list(args.projector_summary_url),
             "artifact_index_output": str(args.artifact_index_output) if args.artifact_index_output else None,
         },
         "steps": steps,
@@ -129,6 +150,20 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         help="Optional path to write SHA-256/size index for validation artifacts",
     )
+    parser.add_argument(
+        "--projector-summary",
+        action="append",
+        default=[],
+        type=Path,
+        help="Optional saved projector /summary JSON artifact to validate",
+    )
+    parser.add_argument(
+        "--projector-summary-url",
+        action="append",
+        default=[],
+        metavar="NAME=URL",
+        help="Fetch and validate a live projector summary from NAME=URL",
+    )
     args = parser.parse_args(argv)
 
     cutoff_count = sum(
@@ -154,6 +189,14 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--postgres-dsn requires --export-live-rows-postgres")
     if args.artifact_index_output and args.report_output is None:
         parser.error("--artifact-index-output requires --report-output")
+    projector_summary_urls: list[tuple[str, str]] = []
+    try:
+        projector_summary_urls = [
+            _parse_named_value(raw, flag="--projector-summary-url")
+            for raw in args.projector_summary_url
+        ]
+    except ValueError as exc:
+        parser.error(str(exc))
 
     started_at = _utc_now()
     output_dir = args.output_dir
@@ -165,6 +208,53 @@ def main(argv: list[str] | None = None) -> int:
         live_rows_path = output_dir / f"live-rows-{args.execution_id}.json"
     if live_rows_path:
         live_checksums_path = output_dir / f"live-checksums-{args.execution_id}.json"
+    projector_summaries: list[dict[str, str]] = []
+    projector_fetch_steps: list[tuple[str, list[str]]] = []
+    projector_check_steps: list[tuple[str, list[str]]] = []
+    for idx, path in enumerate(args.projector_summary, start=1):
+        role = f"projector_summary_{idx}"
+        projector_summaries.append({"role": role, "path": str(path)})
+        projector_check_steps.append(
+            (
+                f"projector_summary_{idx}_integrity",
+                [
+                    sys.executable,
+                    "scripts/check_projector_metrics_summary.py",
+                    "--report",
+                    str(path),
+                ],
+            )
+        )
+    for idx, (name, url) in enumerate(projector_summary_urls, start=1):
+        role = f"projector_summary_url_{idx}_{_safe_slug(name)}"
+        path = output_dir / f"{role}.json"
+        projector_summaries.append({"role": role, "name": name, "url": url, "path": str(path)})
+        projector_fetch_steps.append(
+            (
+                f"{role}_fetch",
+                [
+                    sys.executable,
+                    "scripts/fetch_projector_metrics_summary.py",
+                    "--url",
+                    url,
+                    "--output",
+                    str(path),
+                    "--timeout",
+                    str(args.timeout),
+                ],
+            )
+        )
+        projector_check_steps.append(
+            (
+                f"{role}_integrity",
+                [
+                    sys.executable,
+                    "scripts/check_projector_metrics_summary.py",
+                    "--report",
+                    str(path),
+                ],
+            )
+        )
     fetch_command = [
         sys.executable,
         "scripts/fetch_replay_state_report.py",
@@ -193,7 +283,7 @@ def main(argv: list[str] | None = None) -> int:
         fetch_command.append("--resolve-payloads")
 
     steps: list[dict[str, object]] = []
-    for name, command in [
+    validation_steps = [
         ("fetch", fetch_command),
         (
             "state_integrity",
@@ -272,7 +362,11 @@ def main(argv: list[str] | None = None) -> int:
             if args.resolve_payloads
             else [],
         ),
-    ]:
+    ]
+    validation_steps.extend(projector_fetch_steps)
+    validation_steps.extend(projector_check_steps)
+
+    for name, command in validation_steps:
         if not command:
             steps.append({"name": name, "skipped": True})
             continue
@@ -297,6 +391,7 @@ def main(argv: list[str] | None = None) -> int:
                     replay_path=replay_path,
                     live_checksums_path=live_checksums_path,
                     live_rows_path=live_rows_path,
+                    projector_summaries=projector_summaries,
                     steps=steps,
                     started_at=started_at,
                 ),
@@ -320,6 +415,7 @@ def main(argv: list[str] | None = None) -> int:
                     replay_path=replay_path,
                     live_checksums_path=live_checksums_path,
                     live_rows_path=live_rows_path,
+                    projector_summaries=projector_summaries,
                     steps=steps,
                     started_at=started_at,
                 ),
@@ -337,6 +433,13 @@ def main(argv: list[str] | None = None) -> int:
             "--output",
             str(args.artifact_index_output),
         ]
+        for summary in projector_summaries:
+            artifact_index_command.extend(
+                [
+                    "--artifact",
+                    f"{summary['role']}={summary['path']}",
+                ]
+            )
         steps.append(
             {
                 "name": "artifact_index",
@@ -362,6 +465,7 @@ def main(argv: list[str] | None = None) -> int:
             replay_path=replay_path,
             live_checksums_path=live_checksums_path,
             live_rows_path=live_rows_path,
+            projector_summaries=projector_summaries,
             steps=steps,
             started_at=started_at,
         ),
@@ -388,6 +492,7 @@ def main(argv: list[str] | None = None) -> int:
                     replay_path=replay_path,
                     live_checksums_path=live_checksums_path,
                     live_rows_path=live_rows_path,
+                    projector_summaries=projector_summaries,
                     steps=steps,
                     started_at=started_at,
                 ),

--- a/tests/scripts/test_check_projector_phase2_evidence.py
+++ b/tests/scripts/test_check_projector_phase2_evidence.py
@@ -1,0 +1,133 @@
+import json
+from pathlib import Path
+
+from scripts.check_projector_phase2_evidence import main
+
+
+def _manifest(tmp_path: Path) -> dict:
+    replay = tmp_path / "replay.json"
+    replay.write_text("{}")
+    summary = tmp_path / "projector-summary.json"
+    summary.write_text("{}")
+    live = tmp_path / "live-checksums.json"
+    live.write_text("{}")
+    return {
+        "matched": True,
+        "started_at": "2026-05-20T00:00:00Z",
+        "finished_at": "2026-05-20T00:00:01Z",
+        "replay": str(replay),
+        "artifacts": {
+            "replay": str(replay),
+            "live_rows": None,
+            "live_checksums": str(live),
+            "projector_summaries": [
+                {"role": "projector_summary_1", "path": str(summary)}
+            ],
+            "report": None,
+            "artifact_index": None,
+        },
+        "config": {
+            "base_url": "http://noetl.example",
+            "execution_id": 123,
+            "tenant_id": "tenant-a",
+            "organization_id": "org-a",
+            "projection": "all",
+            "limit": 100000,
+            "as_of_event_id": None,
+            "as_of_position": None,
+            "as_of_time": None,
+            "resolve_payloads": False,
+            "live_checksums": str(live),
+            "live_rows": None,
+            "export_live_rows_postgres": False,
+            "projector_summary": [str(summary)],
+            "projector_summary_url": [],
+        },
+        "steps": [
+            {
+                "name": "fetch",
+                "command": ["python", "scripts/fetch_replay_state_report.py"],
+                "returncode": 0,
+                "duration_seconds": 0.1,
+                "stdout": "{}",
+                "stderr": "",
+            },
+            {
+                "name": "state_integrity",
+                "command": ["python", "scripts/check_replay_state_report.py"],
+                "returncode": 0,
+                "duration_seconds": 0.1,
+                "stdout": "{}",
+                "stderr": "",
+            },
+            {"name": "live_rows_export", "skipped": True},
+            {"name": "live_rows_integrity", "skipped": True},
+            {"name": "live_checksums", "skipped": True},
+            {
+                "name": "projection_parity",
+                "command": ["python", "scripts/check_replay_parity_report.py"],
+                "returncode": 0,
+                "duration_seconds": 0.1,
+                "stdout": "{}",
+                "stderr": "",
+            },
+            {"name": "payload_resolution", "skipped": True},
+            {
+                "name": "projector_summary_1_integrity",
+                "command": ["python", "scripts/check_projector_metrics_summary.py"],
+                "returncode": 0,
+                "duration_seconds": 0.1,
+                "stdout": "{}",
+                "stderr": "",
+            },
+        ],
+    }
+
+
+def test_check_projector_phase2_evidence_accepts_projector_manifest(tmp_path: Path, capsys):
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(_manifest(tmp_path)))
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 0
+    assert json.loads(capsys.readouterr().out)["matched"] is True
+
+
+def test_check_projector_phase2_evidence_requires_projector_summary(tmp_path: Path, capsys):
+    manifest = _manifest(tmp_path)
+    manifest["artifacts"]["projector_summaries"] = []
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert "artifacts.projector_summaries" in {failure["field"] for failure in output["failures"]}
+
+
+def test_check_projector_phase2_evidence_requires_integrity_step(tmp_path: Path, capsys):
+    manifest = _manifest(tmp_path)
+    manifest["steps"] = [
+        step for step in manifest["steps"] if step["name"] != "projector_summary_1_integrity"
+    ]
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any("projector summary integrity" in failure["reason"] for failure in output["failures"])
+
+
+def test_check_projector_phase2_evidence_can_require_projection_parity(
+    tmp_path: Path,
+    capsys,
+):
+    manifest = _manifest(tmp_path)
+    for step in manifest["steps"]:
+        if step["name"] == "projection_parity":
+            step.clear()
+            step.update({"name": "projection_parity", "skipped": True})
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path), "--require-projection-parity"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert "steps.projection_parity" in {failure["field"] for failure in output["failures"]}

--- a/tests/scripts/test_check_replay_validation_manifest.py
+++ b/tests/scripts/test_check_replay_validation_manifest.py
@@ -17,6 +17,7 @@ def _manifest(tmp_path: Path) -> dict:
             "replay": str(replay),
             "live_rows": None,
             "live_checksums": None,
+            "projector_summaries": [],
             "report": None,
             "artifact_index": None,
         },
@@ -34,6 +35,8 @@ def _manifest(tmp_path: Path) -> dict:
             "live_checksums": None,
             "live_rows": None,
             "export_live_rows_postgres": False,
+            "projector_summary": [],
+            "projector_summary_url": [],
         },
         "steps": [
             {
@@ -290,3 +293,76 @@ def test_check_replay_validation_manifest_rejects_orphan_artifact_index_step(
     assert main(["--manifest", str(path), "--check-artifacts"]) == 1
     output = json.loads(capsys.readouterr().out)
     assert "artifacts.artifact_index" in {failure["field"] for failure in output["failures"]}
+
+
+def test_check_replay_validation_manifest_accepts_projector_summary_artifact(
+    tmp_path: Path,
+    capsys,
+):
+    manifest = _manifest(tmp_path)
+    summary = tmp_path / "projector-summary.json"
+    summary.write_text("{}")
+    manifest["artifacts"]["projector_summaries"] = [
+        {"role": "projector_summary_1", "path": str(summary)}
+    ]
+    manifest["steps"].append(
+        {
+            "name": "projector_summary_1_integrity",
+            "command": ["python", "scripts/check_projector_metrics_summary.py"],
+            "returncode": 0,
+            "duration_seconds": 0.1,
+            "stdout": "{}",
+            "stderr": "",
+        }
+    )
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 0
+    assert json.loads(capsys.readouterr().out)["matched"] is True
+
+
+def test_check_replay_validation_manifest_requires_projector_summary_integrity(
+    tmp_path: Path,
+    capsys,
+):
+    manifest = _manifest(tmp_path)
+    summary = tmp_path / "projector-summary.json"
+    summary.write_text("{}")
+    manifest["artifacts"]["projector_summaries"] = [
+        {"role": "projector_summary_1", "path": str(summary)}
+    ]
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any("projector summary artifacts" in failure["reason"] for failure in output["failures"])
+
+
+def test_check_replay_validation_manifest_rejects_bad_projector_summary_artifact(
+    tmp_path: Path,
+    capsys,
+):
+    manifest = _manifest(tmp_path)
+    manifest["artifacts"]["projector_summaries"] = [
+        {"role": "", "path": str(tmp_path / "missing-summary.json")}
+    ]
+    manifest["steps"].append(
+        {
+            "name": "projector_summary_1_integrity",
+            "command": ["python", "scripts/check_projector_metrics_summary.py"],
+            "returncode": 0,
+            "duration_seconds": 0.1,
+            "stdout": "{}",
+            "stderr": "",
+        }
+    )
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    fields = {failure["field"] for failure in output["failures"]}
+    assert "artifacts.projector_summaries[0].role" in fields
+    assert "artifacts.projector_summaries[0].path" in fields

--- a/tests/scripts/test_fetch_projector_metrics_summary.py
+++ b/tests/scripts/test_fetch_projector_metrics_summary.py
@@ -1,0 +1,95 @@
+import json
+from pathlib import Path
+
+from scripts import fetch_projector_metrics_summary
+
+
+class _Response:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self):
+        return self._body
+
+
+def test_fetch_projector_metrics_summary_appends_summary_path(monkeypatch):
+    seen = []
+
+    def _urlopen(url, timeout):
+        seen.append((url, timeout))
+        return _Response(b'{"labels":{},"summary":{"notifications_total":1}}')
+
+    monkeypatch.setattr(fetch_projector_metrics_summary, "urlopen", _urlopen)
+
+    payload = fetch_projector_metrics_summary.fetch_projector_metrics_summary(
+        "http://127.0.0.1:9090",
+        timeout=2.5,
+    )
+
+    assert payload["summary"]["notifications_total"] == 1
+    assert seen == [("http://127.0.0.1:9090/summary", 2.5)]
+
+
+def test_fetch_projector_metrics_summary_keeps_existing_summary_path(monkeypatch):
+    seen = []
+
+    def _urlopen(url, timeout):
+        seen.append((url, timeout))
+        return _Response(b'{"labels":{},"summary":{}}')
+
+    monkeypatch.setattr(fetch_projector_metrics_summary, "urlopen", _urlopen)
+
+    fetch_projector_metrics_summary.fetch_projector_metrics_summary(
+        "http://projector.example/summary",
+        timeout=1.0,
+    )
+
+    assert seen == [("http://projector.example/summary", 1.0)]
+
+
+def test_fetch_projector_metrics_summary_writes_output(monkeypatch, tmp_path: Path, capsys):
+    def _urlopen(_url, timeout):
+        return _Response(b'{"labels":{"shard_id":"p0"},"summary":{"notifications_total":1}}')
+
+    monkeypatch.setattr(fetch_projector_metrics_summary, "urlopen", _urlopen)
+    output_path = tmp_path / "summary.json"
+
+    assert (
+        fetch_projector_metrics_summary.main(
+            [
+                "--url",
+                "http://projector.example",
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+
+    assert json.loads(output_path.read_text())["labels"]["shard_id"] == "p0"
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True
+    assert output["output"] == str(output_path)
+
+
+def test_fetch_projector_metrics_summary_rejects_relative_url(capsys, tmp_path: Path):
+    assert (
+        fetch_projector_metrics_summary.main(
+            [
+                "--url",
+                "localhost:9090",
+                "--output",
+                str(tmp_path / "summary.json"),
+            ]
+        )
+        == 1
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -244,6 +244,126 @@ def test_run_replay_validation_can_write_artifact_index(monkeypatch, tmp_path: P
     assert json.loads(capsys.readouterr().out)["artifacts"]["artifact_index"] == str(artifact_index)
 
 
+def test_run_replay_validation_validates_saved_projector_summary(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if any(str(part).endswith("fetch_replay_state_report.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
+        return 0, json.dumps({"ok": True}), "", 0.01
+
+    monkeypatch.setattr(run_replay_validation, "_run", _run)
+    projector_summary = tmp_path / "projector-summary.json"
+    projector_summary.write_text(json.dumps({"labels": {}, "summary": {}}))
+
+    assert (
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--projector-summary",
+                str(projector_summary),
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+        == 0
+    )
+
+    assert any("scripts/check_projector_metrics_summary.py" in call for call in calls)
+    output = json.loads(capsys.readouterr().out)
+    assert output["artifacts"]["projector_summaries"] == [
+        {"role": "projector_summary_1", "path": str(projector_summary)}
+    ]
+    assert output["steps"][-1]["name"] == "projector_summary_1_integrity"
+
+
+def test_run_replay_validation_fetches_and_indexes_projector_summary(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if any(str(part).endswith("fetch_replay_state_report.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
+        if any(str(part).endswith("fetch_projector_metrics_summary.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.write_text(json.dumps({"labels": {}, "summary": {}}))
+        if any(str(part).endswith("package_replay_validation_artifacts.py") for part in command):
+            assert "--artifact" in command
+            artifact_arg = command[command.index("--artifact") + 1]
+            assert artifact_arg.startswith("projector_summary_url_1_projector-0=")
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.write_text(json.dumps({"schema_version": 1, "matched": True, "artifacts": []}))
+        return 0, json.dumps({"ok": True}), "", 0.01
+
+    monkeypatch.setattr(run_replay_validation, "_run", _run)
+    manifest = tmp_path / "validation.json"
+    artifact_index = tmp_path / "artifact-index.json"
+
+    assert (
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--projector-summary-url",
+                "projector-0=http://projector-0.example:9090",
+                "--output-dir",
+                str(tmp_path),
+                "--report-output",
+                str(manifest),
+                "--artifact-index-output",
+                str(artifact_index),
+            ]
+        )
+        == 0
+    )
+
+    assert any("scripts/fetch_projector_metrics_summary.py" in call for call in calls)
+    assert any("scripts/check_projector_metrics_summary.py" in call for call in calls)
+    output = json.loads(capsys.readouterr().out)
+    summaries = output["artifacts"]["projector_summaries"]
+    assert summaries[0]["role"] == "projector_summary_url_1_projector-0"
+    assert summaries[0]["url"] == "http://projector-0.example:9090"
+    assert summaries[0]["path"].endswith("projector_summary_url_1_projector-0.json")
+
+
+def test_run_replay_validation_rejects_invalid_projector_summary_url(tmp_path: Path):
+    try:
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--projector-summary-url",
+                "http://projector.example",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected parser error")
+
+
 def test_run_replay_validation_rejects_multiple_cutoffs(tmp_path: Path):
     try:
         run_replay_validation.main(


### PR DESCRIPTION
## Summary\n- add a fetcher for live projector /summary JSON artifacts\n- let run_replay_validation fetch or validate projector summaries and include them in manifests/artifact indexes\n- extend replay validation manifest checks for projector summary artifacts and integrity steps\n- add a Phase 2 projector evidence gate that requires projector summary evidence and can require projection parity\n- include the new Phase 2 projector evidence tests in the replay release gate\n\nThis is intentionally a phase-sized NoETL bundle with five related commits in one PR to reduce origin GitHub Actions autobuild churn.\n\n## Validation\n- .venv/bin/python -m pytest -q tests/scripts/test_fetch_projector_metrics_summary.py tests/scripts/test_check_projector_metrics_summary.py tests/scripts/test_run_replay_validation.py tests/scripts/test_check_replay_validation_manifest.py tests/scripts/test_check_projector_phase2_evidence.py tests/core/test_projector_metrics.py tests/core/test_nats_command_subscriber.py tests/core/test_replay_state_projector.py\n- scripts/check_replay_release_gate.sh\n\nRefs noetl/noetl#434\nRefs noetl/noetl#437