### PR TITLE
feat(validation): add phase2 projector validation runner

### DIFF
--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -14,6 +14,8 @@ fi
   tests/core/test_replay_payload_resolver.py \
   tests/scripts/test_fetch_replay_state_report.py \
   tests/scripts/test_run_replay_validation.py \
+  tests/scripts/test_run_projector_phase2_validation.py \
+  tests/scripts/test_render_projector_phase2_command.py \
   tests/scripts/test_export_live_projection_rows_postgres.py \
   tests/scripts/test_check_live_projection_rows.py \
   tests/scripts/test_package_replay_validation_artifacts.py \

--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from scripts.check_projector_phase2_evidence import validate_projector_phase2_evidence
 from scripts.check_replay_validation_manifest import _load_manifest, _validate_manifest
 from scripts.package_replay_validation_artifacts import (
     resolve_indexed_path,
@@ -31,6 +32,8 @@ def validate_bundle(
     manifest_path: Path,
     artifact_index_path: Path | None = None,
     require_matched: bool = True,
+    require_projector_phase2: bool = False,
+    require_projection_parity: bool = False,
 ) -> dict[str, Any]:
     failures: list[dict[str, Any]] = []
     manifest = _load_manifest(manifest_path)
@@ -49,6 +52,22 @@ def validate_bundle(
                 "failures": manifest_result.get("failures", []),
             }
         )
+    phase2_result: dict[str, Any] | None = None
+    if require_projector_phase2:
+        phase2_result = validate_projector_phase2_evidence(
+            manifest,
+            require_projection_parity=require_projection_parity,
+            check_artifacts=True,
+            manifest_path=manifest_path,
+        )
+        if phase2_result.get("matched") is not True:
+            failures.append(
+                {
+                    "field": "phase2_projector_evidence",
+                    "reason": "Phase 2 projector evidence validation failed",
+                    "failures": phase2_result.get("failures", []),
+                }
+            )
 
     manifest_index = _artifact_index_from_manifest(manifest)
     if artifact_index_path is None:
@@ -111,6 +130,7 @@ def validate_bundle(
         "manifest": str(manifest_path),
         "artifact_index": str(resolved_index_path) if resolved_index_path else None,
         "manifest_result": manifest_result,
+        "phase2_projector_result": phase2_result,
         "artifact_index_result": index_result,
         "failures": failures,
     }
@@ -121,12 +141,24 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--manifest", required=True, type=Path)
     parser.add_argument("--artifact-index", type=Path)
     parser.add_argument("--allow-failed", action="store_true", help="Allow matched=false manifests")
+    parser.add_argument(
+        "--require-projector-phase2",
+        action="store_true",
+        help="Require Phase 2 projector summary evidence in the manifest",
+    )
+    parser.add_argument(
+        "--require-projection-parity",
+        action="store_true",
+        help="When requiring Phase 2 projector evidence, require projection parity to run",
+    )
     args = parser.parse_args(argv)
 
     output = validate_bundle(
         manifest_path=args.manifest,
         artifact_index_path=args.artifact_index,
         require_matched=not args.allow_failed,
+        require_projector_phase2=args.require_projector_phase2,
+        require_projection_parity=args.require_projection_parity,
     )
     print(json.dumps(output, indent=2, sort_keys=True))
     return 0 if output["matched"] else 1

--- a/scripts/render_projector_phase2_command.py
+++ b/scripts/render_projector_phase2_command.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+"""Render a reproducible Phase 2 projector validation command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import sys
+from pathlib import Path
+
+
+def render_command(args: argparse.Namespace) -> list[str]:
+    command = [
+        sys.executable,
+        "scripts/run_projector_phase2_validation.py",
+        "--base-url",
+        args.base_url,
+        "--execution-id",
+        str(args.execution_id),
+        "--tenant-id",
+        args.tenant_id,
+        "--organization-id",
+        args.organization_id,
+        "--projection",
+        args.projection,
+        "--output-dir",
+        str(args.output_dir),
+    ]
+    if args.live_rows:
+        command.extend(["--live-rows", str(args.live_rows)])
+    if args.live_checksums:
+        command.extend(["--live-checksums", str(args.live_checksums)])
+    if args.export_live_rows_postgres:
+        command.append("--export-live-rows-postgres")
+    if args.require_projection_parity:
+        command.append("--require-projection-parity")
+    for url in args.projector_summary_url:
+        command.extend(["--projector-summary-url", url])
+    for path in args.projector_summary:
+        command.extend(["--projector-summary", str(path)])
+    return command
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Render a Phase 2 projector validation command")
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--execution-id", required=True, type=int)
+    parser.add_argument("--tenant-id", default="default")
+    parser.add_argument("--organization-id", default="default")
+    parser.add_argument("--projection", default="all")
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--live-rows", type=Path)
+    parser.add_argument("--live-checksums", type=Path)
+    parser.add_argument("--export-live-rows-postgres", action="store_true")
+    parser.add_argument("--projector-summary-url", action="append", default=[], metavar="NAME=URL")
+    parser.add_argument("--projector-summary", action="append", default=[], type=Path)
+    parser.add_argument("--require-projection-parity", action="store_true")
+    parser.add_argument("--json", action="store_true", help="Emit JSON with argv and shell fields")
+    args = parser.parse_args(argv)
+
+    live_inputs = sum(
+        1
+        for enabled in (
+            bool(args.live_rows),
+            bool(args.live_checksums),
+            bool(args.export_live_rows_postgres),
+        )
+        if enabled
+    )
+    if live_inputs > 1:
+        parser.error("use only one live parity input")
+    if not args.projector_summary and not args.projector_summary_url:
+        parser.error("provide at least one projector summary source")
+
+    command = render_command(args)
+    shell = " ".join(shlex.quote(part) for part in command)
+    if args.json:
+        print(json.dumps({"argv": command, "shell": shell}, indent=2, sort_keys=True))
+    else:
+        print(shell)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_projector_phase2_validation.py
+++ b/scripts/run_projector_phase2_validation.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+"""Run the Phase 2 projector evidence validation workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_json(value: str) -> object | None:
+    if not value.strip():
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return None
+
+
+def _run(command: list[str]) -> tuple[int, str, str, float]:
+    started = time.monotonic()
+    completed = subprocess.run(
+        command,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    return completed.returncode, completed.stdout, completed.stderr, time.monotonic() - started
+
+
+def _step(name: str, command: list[str]) -> dict[str, Any]:
+    code, stdout, stderr, duration = _run(command)
+    step: dict[str, Any] = {
+        "name": name,
+        "command": command,
+        "returncode": code,
+        "duration_seconds": round(duration, 6),
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+    stdout_json = _parse_json(stdout)
+    if stdout_json is not None:
+        step["stdout_json"] = stdout_json
+    return step
+
+
+def _emit(report: dict[str, Any], output: Path | None) -> None:
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered + "\n")
+    print(rendered)
+
+
+def _build_report(
+    *,
+    matched: bool,
+    started_at: str,
+    manifest_path: Path,
+    artifact_index_path: Path,
+    steps: list[dict[str, Any]],
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    return {
+        "matched": matched,
+        "started_at": started_at,
+        "finished_at": _utc_now(),
+        "artifacts": {
+            "manifest": str(manifest_path),
+            "artifact_index": str(artifact_index_path),
+            "report": str(args.report_output) if args.report_output else None,
+        },
+        "config": {
+            "base_url": args.base_url,
+            "execution_id": args.execution_id,
+            "tenant_id": args.tenant_id,
+            "organization_id": args.organization_id,
+            "projection": args.projection,
+            "limit": args.limit,
+            "resolve_payloads": args.resolve_payloads,
+            "live_checksums": str(args.live_checksums) if args.live_checksums else None,
+            "live_rows": str(args.live_rows) if args.live_rows else None,
+            "export_live_rows_postgres": args.export_live_rows_postgres,
+            "projector_summary": [str(path) for path in args.projector_summary],
+            "projector_summary_url": list(args.projector_summary_url),
+            "require_projection_parity": args.require_projection_parity,
+        },
+        "steps": steps,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run NoETL Phase 2 projector validation")
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--execution-id", required=True, type=int)
+    parser.add_argument("--tenant-id", default="default")
+    parser.add_argument("--organization-id", default="default")
+    parser.add_argument("--projection", default="all")
+    parser.add_argument("--limit", default=100000, type=int)
+    parser.add_argument("--resolve-payloads", action="store_true")
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--timeout", default=60.0, type=float)
+    parser.add_argument("--live-checksums", type=Path)
+    parser.add_argument("--live-rows", type=Path)
+    parser.add_argument("--export-live-rows-postgres", action="store_true")
+    parser.add_argument("--postgres-dsn")
+    parser.add_argument("--projector-summary", action="append", default=[], type=Path)
+    parser.add_argument("--projector-summary-url", action="append", default=[], metavar="NAME=URL")
+    parser.add_argument("--require-projection-parity", action="store_true")
+    parser.add_argument("--report-output", type=Path)
+    args = parser.parse_args(argv)
+
+    if not args.projector_summary and not args.projector_summary_url:
+        parser.error("provide at least one --projector-summary or --projector-summary-url")
+
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = output_dir / f"phase2-replay-validation-{args.execution_id}.json"
+    artifact_index_path = output_dir / f"phase2-artifact-index-{args.execution_id}.json"
+    started_at = _utc_now()
+
+    replay_command = [
+        sys.executable,
+        "scripts/run_replay_validation.py",
+        "--base-url",
+        args.base_url,
+        "--execution-id",
+        str(args.execution_id),
+        "--tenant-id",
+        args.tenant_id,
+        "--organization-id",
+        args.organization_id,
+        "--projection",
+        args.projection,
+        "--limit",
+        str(args.limit),
+        "--output-dir",
+        str(output_dir),
+        "--timeout",
+        str(args.timeout),
+        "--report-output",
+        str(manifest_path),
+        "--artifact-index-output",
+        str(artifact_index_path),
+    ]
+    if args.resolve_payloads:
+        replay_command.append("--resolve-payloads")
+    if args.live_checksums:
+        replay_command.extend(["--live-checksums", str(args.live_checksums)])
+    if args.live_rows:
+        replay_command.extend(["--live-rows", str(args.live_rows)])
+    if args.export_live_rows_postgres:
+        replay_command.append("--export-live-rows-postgres")
+    if args.postgres_dsn:
+        replay_command.extend(["--postgres-dsn", args.postgres_dsn])
+    for path in args.projector_summary:
+        replay_command.extend(["--projector-summary", str(path)])
+    for value in args.projector_summary_url:
+        replay_command.extend(["--projector-summary-url", value])
+
+    steps: list[dict[str, Any]] = []
+    steps.append(_step("replay_validation", replay_command))
+    if steps[-1]["returncode"] != 0:
+        report = _build_report(
+            matched=False,
+            started_at=started_at,
+            manifest_path=manifest_path,
+            artifact_index_path=artifact_index_path,
+            steps=steps,
+            args=args,
+        )
+        _emit(report, args.report_output)
+        return int(steps[-1]["returncode"])
+
+    phase_gate_command = [
+        sys.executable,
+        "scripts/check_projector_phase2_evidence.py",
+        "--manifest",
+        str(manifest_path),
+        "--check-artifacts",
+    ]
+    if args.require_projection_parity:
+        phase_gate_command.append("--require-projection-parity")
+    steps.append(_step("phase2_evidence", phase_gate_command))
+
+    matched = steps[-1]["returncode"] == 0
+    report = _build_report(
+        matched=matched,
+        started_at=started_at,
+        manifest_path=manifest_path,
+        artifact_index_path=artifact_index_path,
+        steps=steps,
+        args=args,
+    )
+    _emit(report, args.report_output)
+    return 0 if matched else int(steps[-1]["returncode"])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_check_replay_validation_bundle.py
+++ b/tests/scripts/test_check_replay_validation_bundle.py
@@ -10,6 +10,8 @@ def _bundle(tmp_path: Path) -> tuple[Path, Path]:
     replay.write_text("{}")
     report = tmp_path / "validation-report.json"
     report.write_text("{}")
+    summary = tmp_path / "projector-summary.json"
+    summary.write_text("{}")
     index = tmp_path / "artifact-index.json"
     manifest = tmp_path / "validation.json"
     manifest.write_text(
@@ -23,6 +25,7 @@ def _bundle(tmp_path: Path) -> tuple[Path, Path]:
                     "replay": str(replay),
                     "live_rows": None,
                     "live_checksums": None,
+                    "projector_summaries": [],
                     "report": str(report),
                     "artifact_index": str(index),
                 },
@@ -40,6 +43,8 @@ def _bundle(tmp_path: Path) -> tuple[Path, Path]:
                     "live_checksums": None,
                     "live_rows": None,
                     "export_live_rows_postgres": False,
+                    "projector_summary": [],
+                    "projector_summary_url": [],
                     "artifact_index_output": str(index),
                 },
                 "steps": [
@@ -85,6 +90,62 @@ def _bundle(tmp_path: Path) -> tuple[Path, Path]:
         + "\n"
     )
     return manifest, index
+
+
+def _add_projector_phase2_evidence(manifest: Path, index: Path, tmp_path: Path) -> None:
+    payload = json.loads(manifest.read_text())
+    summary = tmp_path / "projector-summary.json"
+    summary.write_text("{}")
+    live_rows = tmp_path / "live-rows.json"
+    live_rows.write_text("{}")
+    live = tmp_path / "live-checksums.json"
+    live.write_text("{}")
+    payload["artifacts"]["live_rows"] = str(live_rows)
+    payload["artifacts"]["live_checksums"] = str(live)
+    payload["config"]["live_rows"] = str(live_rows)
+    payload["artifacts"]["projector_summaries"] = [
+        {"role": "projector_summary_1", "path": str(summary)}
+    ]
+    payload["config"]["live_checksums"] = None
+    payload["config"]["projector_summary"] = [str(summary)]
+    payload["steps"] = [
+        step for step in payload["steps"] if step["name"] != "projection_parity"
+    ]
+    payload["steps"].insert(
+        5,
+        {
+            "name": "projection_parity",
+            "command": ["python", "scripts/check_replay_parity_report.py"],
+            "returncode": 0,
+            "duration_seconds": 0.1,
+            "stdout": "{}",
+            "stderr": "",
+        },
+    )
+    payload["steps"].insert(
+        -1,
+        {
+            "name": "projector_summary_1_integrity",
+            "command": ["python", "scripts/check_projector_metrics_summary.py"],
+            "returncode": 0,
+            "duration_seconds": 0.1,
+            "stdout": "{}",
+            "stderr": "",
+        },
+    )
+    manifest.write_text(json.dumps(payload))
+    index.write_text(
+        json.dumps(
+            build_artifact_index(
+                manifest_path=manifest,
+                output_path=index,
+                extra_artifacts=[("projector_summary_1", summary)],
+            ),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
 
 
 def test_check_replay_validation_bundle_accepts_manifest_referenced_index(
@@ -149,5 +210,42 @@ def test_check_replay_validation_bundle_rejects_missing_index_reference(
     output = json.loads(capsys.readouterr().out)
     assert any(
         failure["field"] == "artifacts.artifact_index"
+        for failure in output["failures"]
+    )
+
+
+def test_check_replay_validation_bundle_accepts_projector_phase2_evidence(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, index = _bundle(tmp_path)
+    _add_projector_phase2_evidence(manifest, index, tmp_path)
+
+    assert (
+        main(
+            [
+                "--manifest",
+                str(manifest),
+                "--require-projector-phase2",
+                "--require-projection-parity",
+            ]
+        )
+        == 0
+    )
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True
+    assert output["phase2_projector_result"]["matched"] is True
+
+
+def test_check_replay_validation_bundle_rejects_missing_projector_phase2_evidence(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, _index = _bundle(tmp_path)
+
+    assert main(["--manifest", str(manifest), "--require-projector-phase2"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any(
+        failure["field"] == "phase2_projector_evidence"
         for failure in output["failures"]
     )

--- a/tests/scripts/test_render_projector_phase2_command.py
+++ b/tests/scripts/test_render_projector_phase2_command.py
@@ -1,0 +1,96 @@
+import json
+
+from scripts import render_projector_phase2_command
+
+
+def test_render_projector_phase2_command_outputs_shell(capsys, tmp_path):
+    assert (
+        render_projector_phase2_command.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--output-dir",
+                str(tmp_path),
+                "--projector-summary-url",
+                "projector-0=http://projector-0.example:9090",
+                "--live-rows",
+                str(tmp_path / "live-rows.json"),
+                "--require-projection-parity",
+            ]
+        )
+        == 0
+    )
+
+    output = capsys.readouterr().out
+    assert "scripts/run_projector_phase2_validation.py" in output
+    assert "--projector-summary-url projector-0=http://projector-0.example:9090" in output
+    assert "--live-rows" in output
+    assert "--require-projection-parity" in output
+
+
+def test_render_projector_phase2_command_outputs_json(capsys, tmp_path):
+    assert (
+        render_projector_phase2_command.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--output-dir",
+                str(tmp_path),
+                "--projector-summary",
+                str(tmp_path / "projector-summary.json"),
+                "--json",
+            ]
+        )
+        == 0
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["argv"][1] == "scripts/run_projector_phase2_validation.py"
+    assert "--projector-summary" in output["argv"]
+    assert "scripts/run_projector_phase2_validation.py" in output["shell"]
+
+
+def test_render_projector_phase2_command_requires_projector_source(tmp_path):
+    try:
+        render_projector_phase2_command.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected parser error")
+
+
+def test_render_projector_phase2_command_rejects_multiple_live_inputs(tmp_path):
+    try:
+        render_projector_phase2_command.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--output-dir",
+                str(tmp_path),
+                "--projector-summary",
+                str(tmp_path / "projector-summary.json"),
+                "--live-rows",
+                str(tmp_path / "live-rows.json"),
+                "--live-checksums",
+                str(tmp_path / "live-checksums.json"),
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected parser error")

--- a/tests/scripts/test_run_projector_phase2_validation.py
+++ b/tests/scripts/test_run_projector_phase2_validation.py
@@ -1,0 +1,152 @@
+import json
+from pathlib import Path
+
+from scripts import run_projector_phase2_validation
+
+
+def test_run_projector_phase2_validation_runs_replay_then_phase_gate(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if "scripts/run_replay_validation.py" in command:
+            manifest_path = Path(command[command.index("--report-output") + 1])
+            artifact_index_path = Path(command[command.index("--artifact-index-output") + 1])
+            manifest_path.write_text(json.dumps({"matched": True}))
+            artifact_index_path.write_text(json.dumps({"matched": True}))
+        return 0, json.dumps({"matched": True}), "", 0.01
+
+    monkeypatch.setattr(run_projector_phase2_validation, "_run", _run)
+    summary = tmp_path / "projector-summary.json"
+    summary.write_text("{}")
+
+    assert (
+        run_projector_phase2_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--projector-summary",
+                str(summary),
+                "--live-checksums",
+                str(tmp_path / "live.json"),
+                "--require-projection-parity",
+                "--output-dir",
+                str(tmp_path),
+                "--report-output",
+                str(tmp_path / "phase2-report.json"),
+            ]
+        )
+        == 0
+    )
+
+    replay_call = calls[0]
+    assert "scripts/run_replay_validation.py" in replay_call
+    assert "--projector-summary" in replay_call
+    assert str(summary) in replay_call
+    assert "--artifact-index-output" in replay_call
+    phase_gate_call = calls[1]
+    assert "scripts/check_projector_phase2_evidence.py" in phase_gate_call
+    assert "--require-projection-parity" in phase_gate_call
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True
+    assert output["artifacts"]["manifest"].endswith("phase2-replay-validation-123.json")
+    assert output["steps"][0]["name"] == "replay_validation"
+    assert output["steps"][1]["name"] == "phase2_evidence"
+
+
+def test_run_projector_phase2_validation_passes_projector_summary_urls(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        return 0, json.dumps({"matched": True}), "", 0.01
+
+    monkeypatch.setattr(run_projector_phase2_validation, "_run", _run)
+
+    assert (
+        run_projector_phase2_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--projector-summary-url",
+                "projector-0=http://projector-0.example:9090",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+        == 0
+    )
+
+    assert "--projector-summary-url" in calls[0]
+    assert "projector-0=http://projector-0.example:9090" in calls[0]
+    output = json.loads(capsys.readouterr().out)
+    assert output["config"]["projector_summary_url"] == [
+        "projector-0=http://projector-0.example:9090"
+    ]
+
+
+def test_run_projector_phase2_validation_stops_when_replay_validation_fails(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        return 2, "", "failed", 0.01
+
+    monkeypatch.setattr(run_projector_phase2_validation, "_run", _run)
+    summary = tmp_path / "projector-summary.json"
+    summary.write_text("{}")
+
+    assert (
+        run_projector_phase2_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--projector-summary",
+                str(summary),
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+        == 2
+    )
+
+    assert len(calls) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    assert output["steps"][0]["stderr"] == "failed"
+
+
+def test_run_projector_phase2_validation_requires_projector_evidence(tmp_path: Path):
+    try:
+        run_projector_phase2_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected parser error")


### PR DESCRIPTION
## Summary\n- add scripts/run_projector_phase2_validation.py as the operator runner for Phase 2 projector evidence\n- let replay validation bundles require Phase 2 projector evidence and optional projection parity\n- add scripts/render_projector_phase2_command.py to render reproducible validation commands for projector replicas\n- include the runner and command renderer in the replay release gate\n\nThis is intentionally a phase-sized NoETL bundle with four related commits in one PR to reduce origin GitHub Actions autobuild churn.\n\n## Validation\n- .venv/bin/python -m pytest -q tests/scripts/test_run_projector_phase2_validation.py tests/scripts/test_check_replay_validation_bundle.py tests/scripts/test_render_projector_phase2_command.py tests/scripts/test_run_replay_validation.py tests/scripts/test_check_projector_phase2_evidence.py tests/scripts/test_check_replay_validation_manifest.py\n- scripts/check_replay_release_gate.sh\n\nRefs noetl/noetl#434\nRefs noetl/noetl#437