### PR TITLE
feat(projector): enable local phase2 e2e validation

### DIFF
--- a/ci/manifests/noetl/configmap-outbox-publisher.yaml
+++ b/ci/manifests/noetl/configmap-outbox-publisher.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: noetl-outbox-publisher-config
+  namespace: noetl
+  labels:
+    app: noetl-outbox-publisher
+    component: outbox-publisher
+data:
+  TZ: "UTC"
+  LOG_LEVEL: "INFO"
+  PYTHONPATH: "/opt/noetl"
+  NOETL_RUN_MODE: "outbox-publisher"
+  NOETL_LOG_FORMAT: "json"
+  NATS_URL: "nats://noetl:noetl@nats.nats.svc.cluster.local:4222"
+  NOETL_EVENT_NATS_STREAM: "NOETL_EVENTS"
+  NOETL_EVENT_NATS_SUBJECT_PREFIX: "noetl.events"
+  NOETL_EVENT_NATS_SHARD_COUNT: "1"
+  NOETL_OUTBOX_PUBLISHER_BATCH_SIZE: "100"
+  NOETL_OUTBOX_PUBLISHER_IDLE_SLEEP_SECONDS: "1"
+  NOETL_OUTBOX_PUBLISHER_ERROR_SLEEP_SECONDS: "5"
+  POSTGRES_HOST: "postgres.postgres.svc.cluster.local"
+  POSTGRES_PORT: "5432"
+  NOETL_POSTGRES_DB: "noetl"
+  NOETL_USER: "noetl"
+  NOETL_SCHEMA: "noetl"
+  NOETL_POSTGRES_POOL_MIN_SIZE: "1"
+  NOETL_POSTGRES_POOL_MAX_SIZE: "4"
+  NOETL_POSTGRES_POOL_MAX_WAITING: "50"
+  NOETL_POSTGRES_POOL_TIMEOUT_SECONDS: "30"

--- a/ci/manifests/noetl/configmap-projector.yaml
+++ b/ci/manifests/noetl/configmap-projector.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: noetl-projector-config
+  namespace: noetl
+  labels:
+    app: noetl-projector
+    component: projector
+data:
+  TZ: "UTC"
+  LOG_LEVEL: "INFO"
+  PYTHONPATH: "/opt/noetl"
+  NOETL_RUN_MODE: "projector"
+  NOETL_LOG_FORMAT: "json"
+  NOETL_SERVER_URL: "http://noetl.noetl.svc.cluster.local:8082"
+  NOETL_SERVER: "uvicorn"
+  NOETL_SERVER_WORKERS: "1"
+  NOETL_SERVER_RELOAD: "false"
+  NATS_URL: "nats://noetl:noetl@nats.nats.svc.cluster.local:4222"
+  NOETL_PROJECTOR_NATS_STREAM: "NOETL_EVENTS"
+  NOETL_PROJECTOR_NATS_SUBJECT: "noetl.events.>"
+  NOETL_PROJECTOR_MAX_INFLIGHT: "8"
+  NOETL_PROJECTOR_NATS_MAX_ACK_PENDING: "64"
+  NOETL_PROJECTOR_NATS_FETCH_TIMEOUT_SECONDS: "30"
+  NOETL_PROJECTOR_NATS_FETCH_HEARTBEAT_SECONDS: "5"
+  NOETL_PROJECTOR_METRICS_PORT: "9090"
+  NOETL_PROJECTOR_SHARD_COUNT: "1"
+  POSTGRES_HOST: "postgres.postgres.svc.cluster.local"
+  POSTGRES_PORT: "5432"
+  NOETL_POSTGRES_DB: "noetl"
+  NOETL_USER: "noetl"
+  NOETL_SCHEMA: "noetl"
+  NOETL_POSTGRES_POOL_MIN_SIZE: "1"
+  NOETL_POSTGRES_POOL_MAX_SIZE: "4"
+  NOETL_POSTGRES_POOL_MAX_WAITING: "50"
+  NOETL_POSTGRES_POOL_TIMEOUT_SECONDS: "30"

--- a/ci/manifests/noetl/configmap-server.yaml
+++ b/ci/manifests/noetl/configmap-server.yaml
@@ -21,6 +21,11 @@ data:
   NOETL_DISABLE_METRICS: "true"
   NOETL_VICTORIALOGS_URL: "http://vmlogs-single-server.vmlogs.svc.cluster.local:9428"
   NOETL_LOG_FORMAT: ""
+  # Mirror execution/core events to the event outbox for local projector validation.
+  NOETL_EVENT_MIRROR_ENABLED: "true"
+  NOETL_EVENT_NATS_STREAM: "NOETL_EVENTS"
+  NOETL_EVENT_NATS_SUBJECT_PREFIX: "noetl.events"
+  NOETL_EVENT_NATS_SHARD_COUNT: "1"
   # NATS Configuration for command publishing
   NATS_URL: "nats://noetl:noetl@nats.nats.svc.cluster.local:4222"
   NATS_USER: "noetl"

--- a/ci/manifests/noetl/configmap-worker.yaml
+++ b/ci/manifests/noetl/configmap-worker.yaml
@@ -21,6 +21,11 @@ data:
   NOETL_DISABLE_METRICS: "true"
   NOETL_VICTORIALOGS_URL: "http://vmlogs-single-server.vmlogs.svc.cluster.local:9428"
   NOETL_LOG_FORMAT: ""
+  # Mirror executor events to the event outbox for local projector validation.
+  NOETL_EVENT_MIRROR_ENABLED: "true"
+  NOETL_EVENT_NATS_STREAM: "NOETL_EVENTS"
+  NOETL_EVENT_NATS_SUBJECT_PREFIX: "noetl.events"
+  NOETL_EVENT_NATS_SHARD_COUNT: "1"
   # NATS Configuration for worker command distribution
   NATS_URL: "nats://noetl:noetl@nats.nats.svc.cluster.local:4222"
   NATS_USER: "noetl"

--- a/ci/manifests/noetl/outbox-publisher-deployment.yaml
+++ b/ci/manifests/noetl/outbox-publisher-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: noetl-outbox-publisher
+  namespace: noetl
+  labels:
+    app: noetl-outbox-publisher
+    component: outbox-publisher
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: noetl-outbox-publisher
+  template:
+    metadata:
+      labels:
+        app: noetl-outbox-publisher
+        component: outbox-publisher
+    spec:
+      serviceAccountName: noetl-worker
+      initContainers:
+        - name: wait-for-api
+          image: curlimages/curl:8.7.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - "until curl -sf http://noetl.noetl.svc.cluster.local:8082/api/health; do echo 'Waiting for NoETL API...'; sleep 3; done"
+      containers:
+        - name: outbox-publisher
+          image: image_name:image_tag
+          imagePullPolicy: Never
+          command:
+            - python
+          args:
+            - -m
+            - noetl.outbox
+          envFrom:
+            - configMapRef:
+                name: noetl-outbox-publisher-config
+            - secretRef:
+                name: noetl-secret
+          env:
+            - name: NOETL_NODE_ID
+              value: "1"
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/ci/manifests/noetl/projector-service.yaml
+++ b/ci/manifests/noetl/projector-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: noetl-projector
+  namespace: noetl
+  labels:
+    app: noetl-projector
+    component: projector
+spec:
+  clusterIP: None
+  selector:
+    app: noetl-projector
+  ports:
+    - name: metrics
+      port: 9090
+      targetPort: 9090

--- a/ci/manifests/noetl/projector-statefulset.yaml
+++ b/ci/manifests/noetl/projector-statefulset.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: noetl-projector
+  namespace: noetl
+  labels:
+    app: noetl-projector
+    component: projector
+spec:
+  serviceName: noetl-projector
+  replicas: 1
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: noetl-projector
+  template:
+    metadata:
+      labels:
+        app: noetl-projector
+        component: projector
+    spec:
+      serviceAccountName: noetl-worker
+      initContainers:
+        - name: wait-for-api
+          image: curlimages/curl:8.7.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - "until curl -sf http://noetl.noetl.svc.cluster.local:8082/api/health; do echo 'Waiting for NoETL API...'; sleep 3; done"
+      containers:
+        - name: projector
+          image: image_name:image_tag
+          imagePullPolicy: Never
+          command:
+            - python
+          args:
+            - -m
+            - noetl.projector
+          ports:
+            - name: metrics
+              containerPort: 9090
+          env:
+            - name: NOETL_PROJECTOR_SHARD_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NOETL_PROJECTOR_NATS_CONSUMER
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NOETL_NODE_ID
+              value: "0"
+          envFrom:
+            - configMapRef:
+                name: noetl-projector-config
+            - secretRef:
+                name: noetl-secret
+          volumeMounts:
+            - name: noetl-data
+              mountPath: /opt/noetl/data
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+      volumes:
+        - name: noetl-data
+          persistentVolumeClaim:
+            claimName: noetl-data-shared

--- a/scripts/run_projector_phase2_validation.py
+++ b/scripts/run_projector_phase2_validation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import time
@@ -28,11 +29,15 @@ def _parse_json(value: str) -> object | None:
 
 def _run(command: list[str]) -> tuple[int, str, str, float]:
     started = time.monotonic()
+    env = os.environ.copy()
+    repo_root = str(Path.cwd())
+    env["PYTHONPATH"] = repo_root if not env.get("PYTHONPATH") else f"{repo_root}{os.pathsep}{env['PYTHONPATH']}"
     completed = subprocess.run(
         command,
         check=False,
         text=True,
         capture_output=True,
+        env=env,
     )
     return completed.returncode, completed.stdout, completed.stderr, time.monotonic() - started
 
@@ -51,6 +56,10 @@ def _step(name: str, command: list[str]) -> dict[str, Any]:
     if stdout_json is not None:
         step["stdout_json"] = stdout_json
     return step
+
+
+def _validation_python() -> str:
+    return os.environ.get("NOETL_VALIDATION_PYTHON") or sys.executable
 
 
 def _emit(report: dict[str, Any], output: Path | None) -> None:
@@ -129,7 +138,7 @@ def main(argv: list[str] | None = None) -> int:
     started_at = _utc_now()
 
     replay_command = [
-        sys.executable,
+        _validation_python(),
         "scripts/run_replay_validation.py",
         "--base-url",
         args.base_url,
@@ -182,7 +191,7 @@ def main(argv: list[str] | None = None) -> int:
         return int(steps[-1]["returncode"])
 
     phase_gate_command = [
-        sys.executable,
+        _validation_python(),
         "scripts/check_projector_phase2_evidence.py",
         "--manifest",
         str(manifest_path),

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -28,14 +29,22 @@ def _parse_json(value: str) -> object | None:
 
 def _run(command: list[str]) -> tuple[int, str, str, float]:
     started = time.monotonic()
+    env = os.environ.copy()
+    repo_root = str(Path.cwd())
+    env["PYTHONPATH"] = repo_root if not env.get("PYTHONPATH") else f"{repo_root}{os.pathsep}{env['PYTHONPATH']}"
     completed = subprocess.run(
         command,
         check=False,
         text=True,
         capture_output=True,
+        env=env,
     )
     duration = time.monotonic() - started
     return completed.returncode, completed.stdout, completed.stderr, duration
+
+
+def _validation_python() -> str:
+    return os.environ.get("NOETL_VALIDATION_PYTHON") or sys.executable
 
 
 def _safe_slug(value: str) -> str:
@@ -218,7 +227,7 @@ def main(argv: list[str] | None = None) -> int:
             (
                 f"projector_summary_{idx}_integrity",
                 [
-                    sys.executable,
+                    _validation_python(),
                     "scripts/check_projector_metrics_summary.py",
                     "--report",
                     str(path),
@@ -233,7 +242,7 @@ def main(argv: list[str] | None = None) -> int:
             (
                 f"{role}_fetch",
                 [
-                    sys.executable,
+                    _validation_python(),
                     "scripts/fetch_projector_metrics_summary.py",
                     "--url",
                     url,
@@ -248,7 +257,7 @@ def main(argv: list[str] | None = None) -> int:
             (
                 f"{role}_integrity",
                 [
-                    sys.executable,
+                    _validation_python(),
                     "scripts/check_projector_metrics_summary.py",
                     "--report",
                     str(path),
@@ -256,7 +265,7 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
     fetch_command = [
-        sys.executable,
+        _validation_python(),
         "scripts/fetch_replay_state_report.py",
         "--base-url",
         args.base_url,
@@ -288,7 +297,7 @@ def main(argv: list[str] | None = None) -> int:
         (
             "state_integrity",
             [
-                sys.executable,
+                _validation_python(),
                 "scripts/check_replay_state_report.py",
                 "--report",
                 str(replay_path),
@@ -297,7 +306,7 @@ def main(argv: list[str] | None = None) -> int:
         (
             "live_rows_export",
             [
-                sys.executable,
+                _validation_python(),
                 "scripts/export_live_projection_rows_postgres.py",
                 "--execution-id",
                 str(args.execution_id),
@@ -317,7 +326,7 @@ def main(argv: list[str] | None = None) -> int:
         (
             "live_rows_integrity",
             [
-                sys.executable,
+                _validation_python(),
                 "scripts/check_live_projection_rows.py",
                 "--rows",
                 str(live_rows_path),
@@ -328,7 +337,7 @@ def main(argv: list[str] | None = None) -> int:
         (
             "live_checksums",
             [
-                sys.executable,
+                _validation_python(),
                 "scripts/build_live_projection_checksums.py",
                 "--rows",
                 str(live_rows_path),
@@ -341,7 +350,7 @@ def main(argv: list[str] | None = None) -> int:
         (
             "projection_parity",
             [
-                sys.executable,
+                _validation_python(),
                 "scripts/check_replay_parity_report.py",
                 "--replayed",
                 str(replay_path),
@@ -354,7 +363,7 @@ def main(argv: list[str] | None = None) -> int:
         (
             "payload_resolution",
             [
-                sys.executable,
+                _validation_python(),
                 "scripts/check_replay_payload_resolution_report.py",
                 "--report",
                 str(replay_path),
@@ -426,7 +435,7 @@ def main(argv: list[str] | None = None) -> int:
     artifact_index_command: list[str] | None = None
     if args.artifact_index_output:
         artifact_index_command = [
-            sys.executable,
+            _validation_python(),
             "scripts/package_replay_validation_artifacts.py",
             "--manifest",
             str(args.report_output),


### PR DESCRIPTION
## Summary

This is the larger Phase 2 bundle requested to reduce PR churn and add real kind evidence instead of script-only validation.

- adds local kind NoETL projector manifests to the existing `ci/manifests/noetl` deploy path
- adds a local outbox publisher deployment and enables event mirroring in server/worker config
- fixes Phase 2 validation subprocesses so they run with the selected Python and repo root on `PYTHONPATH`

## Live validation

Ran against local kind using the supported ops playbook from `repos/ops` with Podman:

```bash
noetl run automation/development/noetl.yaml --runtime local --set action=redeploy --set noetl_repo_dir=../noetl
noetl run automation/development/noetl.yaml --runtime local --set action=deploy --set noetl_repo_dir=../noetl
```

Observed healthy runtime roles:

- `noetl-server`: Running
- `noetl-worker`: 3/3 Running
- `noetl-projector-0`: Running, image `localhost/local/noetl:2026-05-20-13-34`, zero restarts
- `noetl-outbox-publisher`: Running
- Postgres, NATS, and test-server: Running

Validated real event flow through the public API:

- emitted event `631181991030817600` for execution `629222780797452719`
- outbox row reached `PUBLISHED` with subject `noetl.events.default.default.629222780797452719.0`
- projector `/summary` reported `notifications_total=1`, `projection_records=1`, `ack_ratio=1.0`, `errors_total=0`

Phase 2 validation command passed:

```bash
NOETL_VALIDATION_PYTHON=/Volumes/X10/projects/noetl/ai-meta/repos/noetl/.venv/bin/python \
  .venv/bin/python scripts/run_projector_phase2_validation.py \
  --base-url http://localhost:8082 \
  --execution-id 629222780797452719 \
  --output-dir /tmp/noetl-phase2-validation-629222780797452719 \
  --projector-summary-url kind=http://127.0.0.1:19090 \
  --report-output /tmp/noetl-phase2-validation-629222780797452719/phase2-report.json
```

Result: `matched: true`; replay fetch size `28181766` bytes; projector summary fetch and integrity passed; phase2 evidence gate passed.

## Tests

```bash
.venv/bin/python -m pytest \
  tests/scripts/test_run_projector_phase2_validation.py \
  tests/scripts/test_run_replay_validation.py \
  tests/scripts/test_fetch_projector_metrics_summary.py \
  tests/scripts/test_check_projector_metrics_summary.py \
  tests/core/test_projector_metrics.py
```

Result: 35 passed.
