### PR TITLE
Phase 3: add worker IPC validation evidence gate

### DIFF
--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -16,6 +16,8 @@ fi
   tests/scripts/test_run_replay_validation.py \
   tests/scripts/test_run_projector_phase2_validation.py \
   tests/scripts/test_render_projector_phase2_command.py \
+  tests/scripts/test_fetch_worker_metrics.py \
+  tests/scripts/test_check_worker_ipc_metrics.py \
   tests/scripts/test_export_live_projection_rows_postgres.py \
   tests/scripts/test_check_live_projection_rows.py \
   tests/scripts/test_package_replay_validation_artifacts.py \

--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from scripts.check_projector_phase2_evidence import validate_projector_phase2_evidence
 from scripts.check_replay_validation_manifest import _load_manifest, _validate_manifest
+from scripts.check_worker_ipc_phase3_evidence import validate_worker_ipc_phase3_evidence
 from scripts.package_replay_validation_artifacts import (
     resolve_indexed_path,
     validate_artifact_index,
@@ -34,6 +35,7 @@ def validate_bundle(
     require_matched: bool = True,
     require_projector_phase2: bool = False,
     require_projection_parity: bool = False,
+    require_worker_ipc_phase3: bool = False,
 ) -> dict[str, Any]:
     failures: list[dict[str, Any]] = []
     manifest = _load_manifest(manifest_path)
@@ -66,6 +68,21 @@ def validate_bundle(
                     "field": "phase2_projector_evidence",
                     "reason": "Phase 2 projector evidence validation failed",
                     "failures": phase2_result.get("failures", []),
+                }
+            )
+    phase3_result: dict[str, Any] | None = None
+    if require_worker_ipc_phase3:
+        phase3_result = validate_worker_ipc_phase3_evidence(
+            manifest,
+            check_artifacts=True,
+            manifest_path=manifest_path,
+        )
+        if phase3_result.get("matched") is not True:
+            failures.append(
+                {
+                    "field": "phase3_worker_ipc_evidence",
+                    "reason": "Phase 3 worker IPC evidence validation failed",
+                    "failures": phase3_result.get("failures", []),
                 }
             )
 
@@ -131,6 +148,7 @@ def validate_bundle(
         "artifact_index": str(resolved_index_path) if resolved_index_path else None,
         "manifest_result": manifest_result,
         "phase2_projector_result": phase2_result,
+        "phase3_worker_ipc_result": phase3_result,
         "artifact_index_result": index_result,
         "failures": failures,
     }
@@ -151,6 +169,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="When requiring Phase 2 projector evidence, require projection parity to run",
     )
+    parser.add_argument(
+        "--require-worker-ipc-phase3",
+        action="store_true",
+        help="Require Phase 3 worker IPC metrics evidence in the manifest",
+    )
     args = parser.parse_args(argv)
 
     output = validate_bundle(
@@ -159,6 +182,7 @@ def main(argv: list[str] | None = None) -> int:
         require_matched=not args.allow_failed,
         require_projector_phase2=args.require_projector_phase2,
         require_projection_parity=args.require_projection_parity,
+        require_worker_ipc_phase3=args.require_worker_ipc_phase3,
     )
     print(json.dumps(output, indent=2, sort_keys=True))
     return 0 if output["matched"] else 1

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -82,6 +82,56 @@ def _is_projector_summary_step(name: str) -> bool:
     )
 
 
+def _is_worker_metrics_step(name: str) -> bool:
+    return (
+        name.startswith("worker_metrics_")
+        and (name.endswith("_integrity") or name.endswith("_fetch"))
+    )
+
+
+def _validate_artifact_list(
+    failures: list[dict[str, Any]],
+    *,
+    field: str,
+    value: Any,
+    manifest_path: Path | None,
+    check_artifacts: bool,
+) -> None:
+    if not isinstance(value, list):
+        failures.append({"field": field, "reason": "must be a list"})
+        return
+    for index, entry in enumerate(value):
+        if not isinstance(entry, dict):
+            failures.append(
+                {
+                    "field": f"{field}[{index}]",
+                    "reason": "must be an object",
+                }
+            )
+            continue
+        if not isinstance(entry.get("role"), str) or not entry.get("role"):
+            failures.append(
+                {
+                    "field": f"{field}[{index}].role",
+                    "reason": "must be a non-empty string",
+                }
+            )
+        _validate_artifact_path(
+            failures,
+            field=f"{field}[{index}].path",
+            value=entry.get("path"),
+            manifest_path=manifest_path,
+            check_artifacts=check_artifacts,
+        )
+        if "url" in entry and (not isinstance(entry.get("url"), str) or not entry.get("url")):
+            failures.append(
+                {
+                    "field": f"{field}[{index}].url",
+                    "reason": "must be a non-empty string when present",
+                }
+            )
+
+
 def _validate_manifest(
     manifest: dict[str, Any],
     *,
@@ -127,39 +177,22 @@ def _validate_manifest(
     elif isinstance(artifacts, dict):
         for field, value in artifacts.items():
             if field == "projector_summaries":
-                if not isinstance(value, list):
-                    failures.append({"field": "artifacts.projector_summaries", "reason": "must be a list"})
-                    continue
-                for index, entry in enumerate(value):
-                    if not isinstance(entry, dict):
-                        failures.append(
-                            {
-                                "field": f"artifacts.projector_summaries[{index}]",
-                                "reason": "must be an object",
-                            }
-                        )
-                        continue
-                    if not isinstance(entry.get("role"), str) or not entry.get("role"):
-                        failures.append(
-                            {
-                                "field": f"artifacts.projector_summaries[{index}].role",
-                                "reason": "must be a non-empty string",
-                            }
-                        )
-                    _validate_artifact_path(
-                        failures,
-                        field=f"artifacts.projector_summaries[{index}].path",
-                        value=entry.get("path"),
-                        manifest_path=manifest_path,
-                        check_artifacts=check_artifacts,
-                    )
-                    if "url" in entry and (not isinstance(entry.get("url"), str) or not entry.get("url")):
-                        failures.append(
-                            {
-                                "field": f"artifacts.projector_summaries[{index}].url",
-                                "reason": "must be a non-empty string when present",
-                            }
-                        )
+                _validate_artifact_list(
+                    failures,
+                    field="artifacts.projector_summaries",
+                    value=value,
+                    manifest_path=manifest_path,
+                    check_artifacts=check_artifacts,
+                )
+                continue
+            if field == "worker_metrics":
+                _validate_artifact_list(
+                    failures,
+                    field="artifacts.worker_metrics",
+                    value=value,
+                    manifest_path=manifest_path,
+                    check_artifacts=check_artifacts,
+                )
                 continue
             _validate_artifact_path(
                 failures,
@@ -287,6 +320,16 @@ def _validate_manifest(
                     "reason": "projector summary artifacts require matching integrity steps",
                 }
             )
+    worker_metrics = artifacts.get("worker_metrics") if isinstance(artifacts, dict) else None
+    if worker_metrics:
+        integrity_steps = [name for name in step_names if _is_worker_metrics_step(name) and name.endswith("_integrity")]
+        if len(integrity_steps) < len(worker_metrics):
+            failures.append(
+                {
+                    "field": "steps",
+                    "reason": "worker metrics artifacts require matching integrity steps",
+                }
+            )
     if artifacts_index:
         if "artifact_index" not in step_names:
             failures.append(
@@ -311,6 +354,8 @@ def _validate_manifest(
         )
     for name in step_names:
         if _is_projector_summary_step(name):
+            continue
+        if _is_worker_metrics_step(name):
             continue
         if name not in (*REQUIRED_STEP_ORDER, *OPTIONAL_STEP_NAMES, "fetch_artifact"):
             failures.append({"field": "steps", "reason": "unknown validation step", "step": name})

--- a/scripts/check_worker_ipc_metrics.py
+++ b/scripts/check_worker_ipc_metrics.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+"""Validate worker Prometheus metrics for Phase 3 IPC evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REQUIRED_METRICS = {
+    "noetl_storage_ipc_admit_attempts_total",
+    "noetl_storage_ipc_admit_success_total",
+    "noetl_storage_ipc_admit_failures_total",
+    "noetl_storage_ipc_read_attempts_total",
+    "noetl_storage_ipc_read_hits_total",
+    "noetl_storage_ipc_read_misses_total",
+    "noetl_storage_ipc_fallback_reads_total",
+    "noetl_storage_ipc_read_hit_ratio",
+}
+
+DEFAULT_MINIMUMS = {
+    "noetl_storage_ipc_admit_success_total": 1.0,
+    "noetl_storage_ipc_read_hits_total": 1.0,
+    "noetl_storage_ipc_fallback_reads_total": 1.0,
+}
+
+DEFAULT_REQUIRED_LABELS = ("worker_id", "node_id")
+
+METRIC_RE = re.compile(
+    r"^(?P<name>[A-Za-z_:][A-Za-z0-9_:]*)(?:\{(?P<labels>[^}]*)\})?\s+(?P<value>[-+0-9.eE]+)\s*$"
+)
+
+
+def _parse_labels(raw: str | None) -> dict[str, str]:
+    if not raw:
+        return {}
+    labels: dict[str, str] = {}
+    for part in raw.split(","):
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        labels[key] = value.strip().strip('"')
+    return labels
+
+
+def parse_prometheus_metrics(body: str) -> list[dict[str, Any]]:
+    samples: list[dict[str, Any]] = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = METRIC_RE.match(stripped)
+        if match is None:
+            continue
+        samples.append(
+            {
+                "name": match.group("name"),
+                "labels": _parse_labels(match.group("labels")),
+                "value": float(match.group("value")),
+            }
+        )
+    return samples
+
+
+def validate_worker_ipc_metrics(
+    body: str,
+    *,
+    minimums: dict[str, float] | None = None,
+    required_labels: tuple[str, ...] = DEFAULT_REQUIRED_LABELS,
+) -> dict[str, Any]:
+    samples = parse_prometheus_metrics(body)
+    by_name: dict[str, list[dict[str, Any]]] = {}
+    for sample in samples:
+        by_name.setdefault(sample["name"], []).append(sample)
+
+    failures: list[dict[str, Any]] = []
+    for metric_name in sorted(REQUIRED_METRICS):
+        if metric_name not in by_name:
+            failures.append({"field": metric_name, "reason": "missing required IPC metric"})
+
+    for label in required_labels:
+        if not any(sample["labels"].get(label) for sample in samples if sample["name"] in REQUIRED_METRICS):
+            failures.append({"field": f"labels.{label}", "reason": "missing required IPC metric label"})
+
+    for metric_name, minimum in (minimums or DEFAULT_MINIMUMS).items():
+        total = sum(sample["value"] for sample in by_name.get(metric_name, []))
+        if total < minimum:
+            failures.append(
+                {
+                    "field": metric_name,
+                    "reason": f"sum must be >= {minimum}",
+                    "actual": total,
+                }
+            )
+
+    return {
+        "matched": not failures,
+        "metrics": sorted(by_name),
+        "sample_count": len(samples),
+        "failures": failures,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate worker IPC Prometheus metrics")
+    parser.add_argument("--metrics", required=True, type=Path, help="Worker /metrics text artifact")
+    parser.add_argument(
+        "--allow-zero-activity",
+        action="store_true",
+        help="Only require metric family/labels, not non-zero hit/fallback counters",
+    )
+    parser.add_argument(
+        "--require-label",
+        action="append",
+        default=list(DEFAULT_REQUIRED_LABELS),
+        help="IPC sample label that must be present at least once",
+    )
+    args = parser.parse_args(argv)
+
+    output = validate_worker_ipc_metrics(
+        args.metrics.read_text(),
+        minimums={} if args.allow_zero_activity else DEFAULT_MINIMUMS,
+        required_labels=tuple(args.require_label),
+    )
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0 if output["matched"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_worker_ipc_phase3_evidence.py
+++ b/scripts/check_worker_ipc_phase3_evidence.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+"""Validate Phase 3 worker IPC evidence in a replay validation manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from scripts.check_worker_ipc_metrics import validate_worker_ipc_metrics
+from scripts.package_replay_validation_artifacts import resolve_indexed_path
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    data: Any = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _resolve(value: str, *, manifest_path: Path | None) -> Path:
+    if manifest_path is None:
+        return Path(value)
+    return resolve_indexed_path(value, index_path=manifest_path)
+
+
+def validate_worker_ipc_phase3_evidence(
+    manifest: dict[str, Any],
+    *,
+    check_artifacts: bool = False,
+    manifest_path: Path | None = None,
+) -> dict[str, Any]:
+    failures: list[dict[str, Any]] = []
+    artifacts = manifest.get("artifacts")
+    artifacts = artifacts if isinstance(artifacts, dict) else {}
+    worker_metrics = artifacts.get("worker_metrics")
+    if not isinstance(worker_metrics, list) or not worker_metrics:
+        failures.append(
+            {
+                "field": "artifacts.worker_metrics",
+                "reason": "Phase 3 IPC evidence requires at least one worker metrics artifact",
+            }
+        )
+        worker_metrics = []
+
+    steps = manifest.get("steps")
+    step_names = [
+        step.get("name")
+        for step in (steps if isinstance(steps, list) else [])
+        if isinstance(step, dict)
+    ]
+    if not any(
+        isinstance(name, str)
+        and name.startswith("worker_metrics_")
+        and name.endswith("_integrity")
+        for name in step_names
+    ):
+        failures.append(
+            {
+                "field": "steps",
+                "reason": "Phase 3 IPC evidence requires worker metrics integrity checks",
+            }
+        )
+
+    metric_results: list[dict[str, Any]] = []
+    if check_artifacts:
+        for index, entry in enumerate(worker_metrics):
+            if not isinstance(entry, dict):
+                continue
+            path_value = entry.get("path")
+            if not isinstance(path_value, str) or not path_value:
+                continue
+            path = _resolve(path_value, manifest_path=manifest_path)
+            try:
+                result = validate_worker_ipc_metrics(path.read_text())
+            except OSError as exc:
+                failures.append(
+                    {
+                        "field": f"artifacts.worker_metrics[{index}].path",
+                        "reason": "worker metrics artifact could not be read",
+                        "path": path_value,
+                        "error": str(exc),
+                    }
+                )
+                continue
+            metric_results.append({"role": entry.get("role"), "path": str(path), "result": result})
+            if result.get("matched") is not True:
+                failures.append(
+                    {
+                        "field": f"artifacts.worker_metrics[{index}]",
+                        "reason": "worker metrics IPC evidence validation failed",
+                        "failures": result.get("failures", []),
+                    }
+                )
+
+    return {
+        "matched": not failures,
+        "metric_results": metric_results,
+        "failures": failures,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate Phase 3 worker IPC evidence")
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--check-artifacts", action="store_true")
+    args = parser.parse_args(argv)
+
+    output = validate_worker_ipc_phase3_evidence(
+        _load_manifest(args.manifest),
+        check_artifacts=args.check_artifacts,
+        manifest_path=args.manifest,
+    )
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0 if output["matched"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fetch_worker_metrics.py
+++ b/scripts/fetch_worker_metrics.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+"""Fetch worker Prometheus metrics from a live worker metrics endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse, urlunparse
+from urllib.request import urlopen
+
+
+def _metrics_url(raw_url: str) -> str:
+    parsed = urlparse(raw_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError("--url must be an absolute http(s) URL")
+    path = parsed.path.rstrip("/")
+    if not path:
+        path = "/metrics"
+    elif path != "/metrics":
+        path = f"{path}/metrics"
+    return urlunparse(parsed._replace(path=path, params="", query="", fragment=""))
+
+
+def fetch_worker_metrics(url: str, *, timeout: float) -> str:
+    metrics_url = _metrics_url(url)
+    try:
+        with urlopen(metrics_url, timeout=timeout) as response:
+            return response.read().decode("utf-8")
+    except (HTTPError, URLError, TimeoutError) as exc:
+        raise RuntimeError(f"failed to fetch worker metrics from {metrics_url}: {exc}") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Fetch NoETL worker /metrics text")
+    parser.add_argument("--url", required=True, help="Worker metrics server base URL or /metrics URL")
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--timeout", default=10.0, type=float)
+    args = parser.parse_args(argv)
+
+    try:
+        payload = fetch_worker_metrics(args.url, timeout=args.timeout)
+    except (RuntimeError, ValueError) as exc:
+        print(json.dumps({"matched": False, "error": str(exc)}, indent=2, sort_keys=True))
+        return 1
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(payload)
+    print(
+        json.dumps(
+            {
+                "matched": True,
+                "output": str(args.output),
+                "url": _metrics_url(args.url),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -49,7 +49,7 @@ def _validation_python() -> str:
 
 def _safe_slug(value: str) -> str:
     slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip("-")
-    return slug or "projector"
+    return slug or "endpoint"
 
 
 def _parse_named_value(raw: str, *, flag: str) -> tuple[str, str]:
@@ -71,6 +71,7 @@ def _build_report(
     live_checksums_path: Path | None,
     live_rows_path: Path | None,
     projector_summaries: list[dict[str, str]],
+    worker_metrics: list[dict[str, str]],
     steps: list[dict[str, object]],
     started_at: str,
 ) -> dict[str, object]:
@@ -85,6 +86,7 @@ def _build_report(
             "live_rows": str(live_rows_path) if live_rows_path else None,
             "live_checksums": str(live_checksums_path) if live_checksums_path else None,
             "projector_summaries": projector_summaries,
+            "worker_metrics": worker_metrics,
             "report": str(args.report_output) if args.report_output else None,
             "artifact_index": str(args.artifact_index_output) if args.artifact_index_output else None,
         },
@@ -104,6 +106,8 @@ def _build_report(
             "export_live_rows_postgres": args.export_live_rows_postgres,
             "projector_summary": [str(path) for path in args.projector_summary],
             "projector_summary_url": list(args.projector_summary_url),
+            "worker_metrics": [str(path) for path in args.worker_metrics],
+            "worker_metrics_url": list(args.worker_metrics_url),
             "artifact_index_output": str(args.artifact_index_output) if args.artifact_index_output else None,
         },
         "steps": steps,
@@ -173,6 +177,20 @@ def main(argv: list[str] | None = None) -> int:
         metavar="NAME=URL",
         help="Fetch and validate a live projector summary from NAME=URL",
     )
+    parser.add_argument(
+        "--worker-metrics",
+        action="append",
+        default=[],
+        type=Path,
+        help="Optional saved worker /metrics text artifact to validate for Phase 3 IPC evidence",
+    )
+    parser.add_argument(
+        "--worker-metrics-url",
+        action="append",
+        default=[],
+        metavar="NAME=URL",
+        help="Fetch and validate a live worker metrics endpoint from NAME=URL",
+    )
     args = parser.parse_args(argv)
 
     cutoff_count = sum(
@@ -203,6 +221,14 @@ def main(argv: list[str] | None = None) -> int:
         projector_summary_urls = [
             _parse_named_value(raw, flag="--projector-summary-url")
             for raw in args.projector_summary_url
+        ]
+    except ValueError as exc:
+        parser.error(str(exc))
+    worker_metrics_urls: list[tuple[str, str]] = []
+    try:
+        worker_metrics_urls = [
+            _parse_named_value(raw, flag="--worker-metrics-url")
+            for raw in args.worker_metrics_url
         ]
     except ValueError as exc:
         parser.error(str(exc))
@@ -260,6 +286,53 @@ def main(argv: list[str] | None = None) -> int:
                     _validation_python(),
                     "scripts/check_projector_metrics_summary.py",
                     "--report",
+                    str(path),
+                ],
+            )
+        )
+    worker_metrics: list[dict[str, str]] = []
+    worker_fetch_steps: list[tuple[str, list[str]]] = []
+    worker_check_steps: list[tuple[str, list[str]]] = []
+    for idx, path in enumerate(args.worker_metrics, start=1):
+        role = f"worker_metrics_{idx}"
+        worker_metrics.append({"role": role, "path": str(path)})
+        worker_check_steps.append(
+            (
+                f"worker_metrics_{idx}_integrity",
+                [
+                    _validation_python(),
+                    "scripts/check_worker_ipc_metrics.py",
+                    "--metrics",
+                    str(path),
+                ],
+            )
+        )
+    for idx, (name, url) in enumerate(worker_metrics_urls, start=1):
+        role = f"worker_metrics_url_{idx}_{_safe_slug(name)}"
+        path = output_dir / f"{role}.prom"
+        worker_metrics.append({"role": role, "name": name, "url": url, "path": str(path)})
+        worker_fetch_steps.append(
+            (
+                f"{role}_fetch",
+                [
+                    _validation_python(),
+                    "scripts/fetch_worker_metrics.py",
+                    "--url",
+                    url,
+                    "--output",
+                    str(path),
+                    "--timeout",
+                    str(args.timeout),
+                ],
+            )
+        )
+        worker_check_steps.append(
+            (
+                f"{role}_integrity",
+                [
+                    _validation_python(),
+                    "scripts/check_worker_ipc_metrics.py",
+                    "--metrics",
                     str(path),
                 ],
             )
@@ -374,6 +447,8 @@ def main(argv: list[str] | None = None) -> int:
     ]
     validation_steps.extend(projector_fetch_steps)
     validation_steps.extend(projector_check_steps)
+    validation_steps.extend(worker_fetch_steps)
+    validation_steps.extend(worker_check_steps)
 
     for name, command in validation_steps:
         if not command:
@@ -401,6 +476,7 @@ def main(argv: list[str] | None = None) -> int:
                     live_checksums_path=live_checksums_path,
                     live_rows_path=live_rows_path,
                     projector_summaries=projector_summaries,
+                    worker_metrics=worker_metrics,
                     steps=steps,
                     started_at=started_at,
                 ),
@@ -425,6 +501,7 @@ def main(argv: list[str] | None = None) -> int:
                     live_checksums_path=live_checksums_path,
                     live_rows_path=live_rows_path,
                     projector_summaries=projector_summaries,
+                    worker_metrics=worker_metrics,
                     steps=steps,
                     started_at=started_at,
                 ),
@@ -447,6 +524,13 @@ def main(argv: list[str] | None = None) -> int:
                 [
                     "--artifact",
                     f"{summary['role']}={summary['path']}",
+                ]
+            )
+        for metrics in worker_metrics:
+            artifact_index_command.extend(
+                [
+                    "--artifact",
+                    f"{metrics['role']}={metrics['path']}",
                 ]
             )
         steps.append(
@@ -475,6 +559,7 @@ def main(argv: list[str] | None = None) -> int:
             live_checksums_path=live_checksums_path,
             live_rows_path=live_rows_path,
             projector_summaries=projector_summaries,
+            worker_metrics=worker_metrics,
             steps=steps,
             started_at=started_at,
         ),
@@ -502,6 +587,7 @@ def main(argv: list[str] | None = None) -> int:
                     live_checksums_path=live_checksums_path,
                     live_rows_path=live_rows_path,
                     projector_summaries=projector_summaries,
+                    worker_metrics=worker_metrics,
                     steps=steps,
                     started_at=started_at,
                 ),

--- a/tests/scripts/test_check_replay_validation_bundle.py
+++ b/tests/scripts/test_check_replay_validation_bundle.py
@@ -148,6 +148,58 @@ def _add_projector_phase2_evidence(manifest: Path, index: Path, tmp_path: Path) 
     )
 
 
+def _worker_metrics_body() -> str:
+    labels = '{node_id="node-a",worker_id="worker-a"}'
+    return "\n".join(
+        [
+            f"noetl_storage_ipc_admit_attempts_total{labels} 1",
+            f"noetl_storage_ipc_admit_success_total{labels} 1",
+            f"noetl_storage_ipc_admit_failures_total{labels} 0",
+            f"noetl_storage_ipc_read_attempts_total{labels} 2",
+            f"noetl_storage_ipc_read_hits_total{labels} 1",
+            f"noetl_storage_ipc_read_misses_total{labels} 1",
+            f"noetl_storage_ipc_fallback_reads_total{labels} 1",
+            f"noetl_storage_ipc_read_hit_ratio{labels} 0.5",
+            "",
+        ]
+    )
+
+
+def _add_worker_phase3_evidence(manifest: Path, index: Path, tmp_path: Path) -> None:
+    payload = json.loads(manifest.read_text())
+    metrics = tmp_path / "worker.prom"
+    metrics.write_text(_worker_metrics_body())
+    payload["artifacts"]["worker_metrics"] = [
+        {"role": "worker_metrics_1", "path": str(metrics)}
+    ]
+    payload["config"]["worker_metrics"] = [str(metrics)]
+    payload["config"]["worker_metrics_url"] = []
+    payload["steps"].insert(
+        -1,
+        {
+            "name": "worker_metrics_1_integrity",
+            "command": ["python", "scripts/check_worker_ipc_metrics.py"],
+            "returncode": 0,
+            "duration_seconds": 0.1,
+            "stdout": "{}",
+            "stderr": "",
+        },
+    )
+    manifest.write_text(json.dumps(payload))
+    index.write_text(
+        json.dumps(
+            build_artifact_index(
+                manifest_path=manifest,
+                output_path=index,
+                extra_artifacts=[("worker_metrics_1", metrics)],
+            ),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
 def test_check_replay_validation_bundle_accepts_manifest_referenced_index(
     tmp_path: Path,
     capsys,
@@ -247,5 +299,32 @@ def test_check_replay_validation_bundle_rejects_missing_projector_phase2_evidenc
     output = json.loads(capsys.readouterr().out)
     assert any(
         failure["field"] == "phase2_projector_evidence"
+        for failure in output["failures"]
+    )
+
+
+def test_check_replay_validation_bundle_accepts_worker_ipc_phase3_evidence(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, index = _bundle(tmp_path)
+    _add_worker_phase3_evidence(manifest, index, tmp_path)
+
+    assert main(["--manifest", str(manifest), "--require-worker-ipc-phase3"]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True
+    assert output["phase3_worker_ipc_result"]["matched"] is True
+
+
+def test_check_replay_validation_bundle_rejects_missing_worker_ipc_phase3_evidence(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, _index = _bundle(tmp_path)
+
+    assert main(["--manifest", str(manifest), "--require-worker-ipc-phase3"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any(
+        failure["field"] == "phase3_worker_ipc_evidence"
         for failure in output["failures"]
     )

--- a/tests/scripts/test_check_worker_ipc_metrics.py
+++ b/tests/scripts/test_check_worker_ipc_metrics.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+from scripts.check_worker_ipc_metrics import main
+
+
+def _metrics_body() -> str:
+    labels = '{node_id="node-a",runtime="cpu",worker_id="worker-a",worker_pool="default"}'
+    return "\n".join(
+        [
+            f"noetl_storage_ipc_admit_attempts_total{labels} 2",
+            f"noetl_storage_ipc_admit_success_total{labels} 1",
+            f"noetl_storage_ipc_admit_failures_total{labels} 0",
+            f"noetl_storage_ipc_read_attempts_total{labels} 2",
+            f"noetl_storage_ipc_read_hits_total{labels} 1",
+            f"noetl_storage_ipc_read_misses_total{labels} 1",
+            f"noetl_storage_ipc_fallback_reads_total{labels} 1",
+            f"noetl_storage_ipc_read_hit_ratio{labels} 0.5",
+            "",
+        ]
+    )
+
+
+def test_check_worker_ipc_metrics_accepts_phase3_activity(tmp_path: Path, capsys):
+    path = tmp_path / "worker.prom"
+    path.write_text(_metrics_body())
+
+    assert main(["--metrics", str(path)]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True
+
+
+def test_check_worker_ipc_metrics_rejects_missing_activity(tmp_path: Path, capsys):
+    path = tmp_path / "worker.prom"
+    path.write_text(_metrics_body().replace("noetl_storage_ipc_read_hits_total", "missing_metric"))
+
+    assert main(["--metrics", str(path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    assert any(failure["field"] == "noetl_storage_ipc_read_hits_total" for failure in output["failures"])

--- a/tests/scripts/test_fetch_worker_metrics.py
+++ b/tests/scripts/test_fetch_worker_metrics.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from scripts import fetch_worker_metrics
+
+
+class _Response:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self) -> bytes:
+        return b"noetl_worker_up 1\n"
+
+
+def test_fetch_worker_metrics_appends_metrics_path(monkeypatch, tmp_path: Path):
+    seen: list[tuple[str, float]] = []
+
+    def _urlopen(url: str, timeout: float):
+        seen.append((url, timeout))
+        return _Response()
+
+    monkeypatch.setattr(fetch_worker_metrics, "urlopen", _urlopen)
+    output = tmp_path / "worker.prom"
+
+    assert fetch_worker_metrics.main(["--url", "http://worker.example", "--output", str(output), "--timeout", "1"]) == 0
+    assert seen == [("http://worker.example/metrics", 1.0)]
+    assert output.read_text() == "noetl_worker_up 1\n"

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -364,6 +364,86 @@ def test_run_replay_validation_rejects_invalid_projector_summary_url(tmp_path: P
         raise AssertionError("expected parser error")
 
 
+def test_run_replay_validation_fetches_and_indexes_worker_metrics(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if any(str(part).endswith("fetch_replay_state_report.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
+        if any(str(part).endswith("fetch_worker_metrics.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.write_text("noetl_worker_up 1\n")
+        if any(str(part).endswith("package_replay_validation_artifacts.py") for part in command):
+            artifact_args = [
+                command[idx + 1]
+                for idx, value in enumerate(command)
+                if value == "--artifact"
+            ]
+            assert any(arg.startswith("worker_metrics_url_1_worker-0=") for arg in artifact_args)
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.write_text(json.dumps({"schema_version": 1, "matched": True, "artifacts": []}))
+        return 0, json.dumps({"ok": True}), "", 0.01
+
+    monkeypatch.setattr(run_replay_validation, "_run", _run)
+    manifest = tmp_path / "validation.json"
+    artifact_index = tmp_path / "artifact-index.json"
+
+    assert (
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--worker-metrics-url",
+                "worker-0=http://worker-0.example:9091",
+                "--output-dir",
+                str(tmp_path),
+                "--report-output",
+                str(manifest),
+                "--artifact-index-output",
+                str(artifact_index),
+            ]
+        )
+        == 0
+    )
+
+    assert any("scripts/fetch_worker_metrics.py" in call for call in calls)
+    assert any("scripts/check_worker_ipc_metrics.py" in call for call in calls)
+    output = json.loads(capsys.readouterr().out)
+    metrics = output["artifacts"]["worker_metrics"]
+    assert metrics[0]["role"] == "worker_metrics_url_1_worker-0"
+    assert metrics[0]["url"] == "http://worker-0.example:9091"
+    assert metrics[0]["path"].endswith("worker_metrics_url_1_worker-0.prom")
+
+
+def test_run_replay_validation_rejects_invalid_worker_metrics_url(tmp_path: Path):
+    try:
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--worker-metrics-url",
+                "http://worker.example",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected parser error")
+
+
 def test_run_replay_validation_rejects_multiple_cutoffs(tmp_path: Path):
     try:
         run_replay_validation.main(


### PR DESCRIPTION
## Summary
- add worker `/metrics` fetching and IPC Prometheus validation for Phase 3 Arrow IPC evidence
- extend replay validation manifests, artifact indexes, and bundle checks with worker metrics artifacts
- add a `--require-worker-ipc-phase3` bundle gate so phase-sized validation can prove worker IPC hit/fallback counters before merge

## Validation
- `.venv/bin/python -m pytest tests/scripts/test_check_worker_ipc_metrics.py tests/scripts/test_fetch_worker_metrics.py tests/scripts/test_run_replay_validation.py tests/scripts/test_check_replay_validation_bundle.py tests/scripts/test_check_replay_validation_manifest.py -q` -> 45 passed
- `scripts/check_replay_release_gate.sh` -> 217 passed, 33 warnings
- `.venv/bin/python -m compileall scripts/check_worker_ipc_metrics.py scripts/check_worker_ipc_phase3_evidence.py scripts/fetch_worker_metrics.py scripts/run_replay_validation.py scripts/check_replay_validation_manifest.py scripts/check_replay_validation_bundle.py`
- `git diff --check`

## Notes
This keeps the next slice phase-sized: one PR for Phase 3 evidence plumbing instead of separate small PRs for fetch, parse, manifest, bundle, and release gate changes. Live kind/GKE validation can now attach worker metrics artifacts to the same replay validation bundle.