### PR TITLE
Phase 3: separate topology node id from Snowflake node id

### DIFF
--- a/noetl/core/common.py
+++ b/noetl/core/common.py
@@ -76,7 +76,22 @@ except ImportError:
 
 # Snowflake ID generator (41-bit ms timestamp, 10-bit node id, 12-bit sequence)
 _SNOWFLAKE_EPOCH_MS = int(os.environ.get("NOETL_SNOWFLAKE_EPOCH_MS", str(int(datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp() * 1000))))
-_SNOWFLAKE_NODE_ID = int(os.environ.get("NOETL_NODE_ID", os.environ.get("NOETL_SHARD_ID", "0"))) & 0x3FF  # 10 bits
+
+
+def _snowflake_node_id_from_env(env: Dict[str, str] | None = None) -> int:
+    source = env if env is not None else os.environ
+    raw = source.get("NOETL_SNOWFLAKE_NODE_ID") or source.get("NOETL_SHARD_ID") or "0"
+    try:
+        return int(raw) & 0x3FF
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid Snowflake node id %r from NOETL_SNOWFLAKE_NODE_ID/NOETL_SHARD_ID; using 0",
+            raw,
+        )
+        return 0
+
+
+_SNOWFLAKE_NODE_ID = _snowflake_node_id_from_env()  # 10 bits
 _SNOWFLAKE_LOCK = threading.Lock()
 _SNOWFLAKE_LAST_TS = 0
 _SNOWFLAKE_SEQ = 0

--- a/tests/core/test_snowflake_node_id.py
+++ b/tests/core/test_snowflake_node_id.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+
+def test_snowflake_node_id_ignores_topology_node_name():
+    from noetl.core.common import _snowflake_node_id_from_env
+
+    assert _snowflake_node_id_from_env({"NOETL_NODE_ID": "noetl-control-plane"}) == 0
+
+
+def test_snowflake_node_id_prefers_numeric_specific_env():
+    from noetl.core.common import _snowflake_node_id_from_env
+
+    assert (
+        _snowflake_node_id_from_env(
+            {
+                "NOETL_NODE_ID": "noetl-control-plane",
+                "NOETL_SHARD_ID": "2",
+                "NOETL_SNOWFLAKE_NODE_ID": "1025",
+            }
+        )
+        == 1
+    )
+
+
+def test_snowflake_node_id_falls_back_to_shard_id():
+    from noetl.core.common import _snowflake_node_id_from_env
+
+    assert _snowflake_node_id_from_env({"NOETL_SHARD_ID": "17"}) == 17


### PR DESCRIPTION
## Summary
- stop using topology `NOETL_NODE_ID` as the numeric Snowflake generator node id
- add `NOETL_SNOWFLAKE_NODE_ID` as the explicit numeric override, with `NOETL_SHARD_ID` fallback
- keep Kubernetes node names such as `noetl-control-plane` valid for IPC locality, worker metrics labels, and topology without crashing worker imports

## Validation
- `NOETL_NODE_ID=noetl-control-plane .venv/bin/python -c 'import noetl.worker; import noetl.core.common as c; print(c._SNOWFLAKE_NODE_ID)'` -> `0`
- `.venv/bin/python -m pytest tests/core/test_snowflake_node_id.py tests/core/test_runtime_topology.py tests/core/test_storage_ipc_cache.py tests/worker/test_worker_metrics.py -q` -> 17 passed, 1 warning
- `scripts/check_replay_release_gate.sh` -> 217 passed, 33 warnings
- `git diff --check`

## Local kind note
While collecting Phase 3 worker IPC evidence after #552, enabling Kubernetes `NOETL_NODE_ID` from `spec.nodeName` made workers exit during import because `noetl.core.common` parsed it as an integer Snowflake node id. This PR fixes that collision so `NOETL_NODE_ID` can remain the topology/locality identity.