### PR TITLE
fix(cursor): render auth and admit IPC evidence

### DIFF
--- a/noetl/core/dsl/engine/executor/transitions.py
+++ b/noetl/core/dsl/engine/executor/transitions.py
@@ -169,6 +169,18 @@ class TransitionMixin:
 
         # Cursor spec — serialize so the worker receives a plain dict.
         cursor_spec = step_def.loop.cursor.model_dump()
+        auth_template = cursor_spec.get("auth")
+        if isinstance(auth_template, str):
+            try:
+                rendered_auth = self._render_template(auth_template, base_context)
+                if isinstance(rendered_auth, str) and rendered_auth.strip():
+                    cursor_spec["auth"] = rendered_auth.strip()
+            except Exception as exc:
+                logger.warning(
+                    "[CURSOR-LOOP] Pre-render of cursor auth for %s failed (%s); "
+                    "falling back to worker-side value",
+                    step_def.step, exc,
+                )
         # Pre-render the claim SQL against the engine's full render
         # context so any execution-scoped values (e.g. a facility id
         # resolved from a prior step's result) are baked into the

--- a/scripts/check_worker_ipc_metrics.py
+++ b/scripts/check_worker_ipc_metrics.py
@@ -27,6 +27,10 @@ DEFAULT_MINIMUMS = {
     "noetl_storage_ipc_fallback_reads_total": 1.0,
 }
 
+ADMISSION_MINIMUMS = {
+    "noetl_storage_ipc_admit_success_total": 1.0,
+}
+
 DEFAULT_REQUIRED_LABELS = ("worker_id", "node_id")
 
 METRIC_RE = re.compile(
@@ -113,6 +117,14 @@ def main(argv: list[str] | None = None) -> int:
         help="Only require metric family/labels, not non-zero hit/fallback counters",
     )
     parser.add_argument(
+        "--require-admission-only",
+        action="store_true",
+        help=(
+            "Require live cursor frame admission activity, but do not require "
+            "downstream IPC reads. Use for producer-side Phase 3 evidence."
+        ),
+    )
+    parser.add_argument(
         "--require-label",
         action="append",
         default=list(DEFAULT_REQUIRED_LABELS),
@@ -120,9 +132,15 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    minimums = DEFAULT_MINIMUMS
+    if args.allow_zero_activity:
+        minimums = {}
+    elif args.require_admission_only:
+        minimums = ADMISSION_MINIMUMS
+
     output = validate_worker_ipc_metrics(
         args.metrics.read_text(),
-        minimums={} if args.allow_zero_activity else DEFAULT_MINIMUMS,
+        minimums=minimums,
         required_labels=tuple(args.require_label),
     )
     print(json.dumps(output, indent=2, sort_keys=True))

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -108,6 +108,7 @@ def _build_report(
             "projector_summary_url": list(args.projector_summary_url),
             "worker_metrics": [str(path) for path in args.worker_metrics],
             "worker_metrics_url": list(args.worker_metrics_url),
+            "worker_metrics_admission_only": bool(args.worker_metrics_admission_only),
             "artifact_index_output": str(args.artifact_index_output) if args.artifact_index_output else None,
         },
         "steps": steps,
@@ -190,6 +191,14 @@ def main(argv: list[str] | None = None) -> int:
         default=[],
         metavar="NAME=URL",
         help="Fetch and validate a live worker metrics endpoint from NAME=URL",
+    )
+    parser.add_argument(
+        "--worker-metrics-admission-only",
+        action="store_true",
+        help=(
+            "Validate worker metrics as producer-side cursor frame admission "
+            "evidence without requiring downstream IPC reads."
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -296,15 +305,18 @@ def main(argv: list[str] | None = None) -> int:
     for idx, path in enumerate(args.worker_metrics, start=1):
         role = f"worker_metrics_{idx}"
         worker_metrics.append({"role": role, "path": str(path)})
+        check_command = [
+            _validation_python(),
+            "scripts/check_worker_ipc_metrics.py",
+            "--metrics",
+            str(path),
+        ]
+        if args.worker_metrics_admission_only:
+            check_command.append("--require-admission-only")
         worker_check_steps.append(
             (
                 f"worker_metrics_{idx}_integrity",
-                [
-                    _validation_python(),
-                    "scripts/check_worker_ipc_metrics.py",
-                    "--metrics",
-                    str(path),
-                ],
+                check_command,
             )
         )
     for idx, (name, url) in enumerate(worker_metrics_urls, start=1):
@@ -326,15 +338,18 @@ def main(argv: list[str] | None = None) -> int:
                 ],
             )
         )
+        check_command = [
+            _validation_python(),
+            "scripts/check_worker_ipc_metrics.py",
+            "--metrics",
+            str(path),
+        ]
+        if args.worker_metrics_admission_only:
+            check_command.append("--require-admission-only")
         worker_check_steps.append(
             (
                 f"{role}_integrity",
-                [
-                    _validation_python(),
-                    "scripts/check_worker_ipc_metrics.py",
-                    "--metrics",
-                    str(path),
-                ],
+                check_command,
             )
         )
     fetch_command = [

--- a/tests/core/test_frame_policy_model.py
+++ b/tests/core/test_frame_policy_model.py
@@ -82,6 +82,72 @@ def test_templated_max_in_flight_resolves_against_workload_context():
     ) == 8
 
 
+@pytest.mark.asyncio
+async def test_cursor_loop_dispatch_renders_cursor_auth(monkeypatch):
+    from jinja2 import Environment
+
+    from noetl.core.dsl.engine.executor.transitions import TransitionMixin
+    from noetl.core.dsl.engine.models.workflow import CursorSpec, Loop, Step
+
+    class DummyState:
+        execution_id = "42"
+        loop_state = {}
+        completed_steps = set()
+        step_results = {}
+        variables = {}
+
+        def get_render_context(self, _event):
+            return {"workload": {"pg_auth": "pg_k8s"}, "execution_id": self.execution_id}
+
+        def init_loop(self, step, collection, iterator, mode, event_id):
+            self.loop_state[step] = {
+                "collection": collection,
+                "iterator": iterator,
+                "mode": mode,
+                "event_id": event_id,
+            }
+
+    class DummyNatsCache:
+        async def set_loop_state(self, *_args, **_kwargs):
+            return None
+
+    class DummyTransitions(TransitionMixin):
+        jinja_env = Environment()
+
+        def _render_template(self, template, context):
+            return self.jinja_env.from_string(template).render(**context)
+
+        async def _open_cursor_runtime_stage(self, **_kwargs):
+            return 7
+
+    async def fake_get_nats_cache():
+        return DummyNatsCache()
+
+    monkeypatch.setattr(
+        "noetl.core.dsl.engine.executor.transitions.get_nats_cache",
+        fake_get_nats_cache,
+    )
+
+    step = Step(
+        step="fetch_rows",
+        loop=Loop(
+            cursor=CursorSpec(
+                kind="postgres",
+                auth="{{ workload.pg_auth }}",
+                claim="select {{ execution_id }}",
+            ),
+            iterator="row",
+            spec={"mode": "cursor", "max_in_flight": 1},
+        ),
+        tool={"kind": "noop"},
+    )
+
+    commands = await DummyTransitions()._issue_cursor_loop_commands(DummyState(), step, {})
+
+    assert commands[0].tool.config["cursor"]["auth"] == "pg_k8s"
+    assert commands[0].tool.config["cursor"]["claim"] == "select 42"
+
+
 def test_templated_max_in_flight_rejects_non_positive_rendered_value():
     from jinja2 import Environment
 

--- a/tests/scripts/test_check_worker_ipc_metrics.py
+++ b/tests/scripts/test_check_worker_ipc_metrics.py
@@ -38,3 +38,17 @@ def test_check_worker_ipc_metrics_rejects_missing_activity(tmp_path: Path, capsy
     output = json.loads(capsys.readouterr().out)
     assert output["matched"] is False
     assert any(failure["field"] == "noetl_storage_ipc_read_hits_total" for failure in output["failures"])
+
+
+def test_check_worker_ipc_metrics_accepts_admission_only_activity(tmp_path: Path, capsys):
+    path = tmp_path / "worker.prom"
+    body = (
+        _metrics_body()
+        .replace("noetl_storage_ipc_read_hits_total{node_id=\"node-a\",runtime=\"cpu\",worker_id=\"worker-a\",worker_pool=\"default\"} 1", "noetl_storage_ipc_read_hits_total{node_id=\"node-a\",runtime=\"cpu\",worker_id=\"worker-a\",worker_pool=\"default\"} 0")
+        .replace("noetl_storage_ipc_fallback_reads_total{node_id=\"node-a\",runtime=\"cpu\",worker_id=\"worker-a\",worker_pool=\"default\"} 1", "noetl_storage_ipc_fallback_reads_total{node_id=\"node-a\",runtime=\"cpu\",worker_id=\"worker-a\",worker_pool=\"default\"} 0")
+    )
+    path.write_text(body)
+
+    assert main(["--metrics", str(path), "--require-admission-only"]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True


### PR DESCRIPTION
## Summary
- render templated cursor auth before dispatching cursor_worker commands
- add an explicit worker IPC admission-only evidence mode for live cursor producer validation
- thread the admission-only worker metrics option through replay validation manifests

## Local kind evidence
- redeployed local kind with image local/noetl:2026-05-20-14-43 after #553
- registered temporary playbook phase3/cursor-ipc-evidence
- execution 631216669284631434 completed successfully
- cursor loop processed 12/12 rows across 3 worker slots, one frame per slot
- all three workers reported noetl_storage_ipc_admit_success_total=1
- /tmp/noetl-phase3-evidence/worker-metrics-after-cursor.prom passes scripts/check_worker_ipc_metrics.py --require-admission-only

## Tests
- python3 -m pytest tests/core/test_frame_policy_model.py tests/scripts/test_check_worker_ipc_metrics.py -q
- python3 -m compileall noetl/core/dsl/engine/executor/transitions.py scripts/check_worker_ipc_metrics.py scripts/run_replay_validation.py
- git diff --check
- scripts/check_worker_ipc_metrics.py --metrics /tmp/noetl-phase3-evidence/worker-metrics-after-cursor.prom --require-admission-only

## Notes
The strict read-hit/fallback gate remains available for consumer-side IPC evidence. The live cursor producer path admits frames but does not yet have a downstream frame reader, so admission-only mode separates that evidence cleanly instead of pretending reads happened.