### PR TITLE
test(ipc): expose worker metrics in local manifests

### DIFF
--- a/ci/manifests/noetl/configmap-worker.yaml
+++ b/ci/manifests/noetl/configmap-worker.yaml
@@ -18,7 +18,9 @@ data:
   NOETL_HTTP_MOCK_LOCAL: "false"
   PAGINATION_API_URL: "http://paginated-api.test-server.svc.cluster.local:5555"
   NOETL_SERVER_URL: "http://noetl.noetl.svc.cluster.local:8082"
-  NOETL_DISABLE_METRICS: "true"
+  NOETL_DISABLE_METRICS: "false"
+  NOETL_WORKER_METRICS_HOST: "0.0.0.0"
+  NOETL_WORKER_METRICS_PORT: "9091"
   NOETL_VICTORIALOGS_URL: "http://vmlogs-single-server.vmlogs.svc.cluster.local:9428"
   NOETL_LOG_FORMAT: ""
   # Mirror executor events to the event outbox for local projector validation.

--- a/ci/manifests/noetl/worker-deployment.yaml
+++ b/ci/manifests/noetl/worker-deployment.yaml
@@ -35,6 +35,10 @@ spec:
         - name: worker
           image: image_name:image_tag
           imagePullPolicy: Never
+          ports:
+            - name: metrics
+              containerPort: 9091
+              protocol: TCP
           command:
             - python
           args:
@@ -43,6 +47,11 @@ spec:
           envFrom:
             - configMapRef:
                 name: noetl-worker-config
+          env:
+            - name: NOETL_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           volumeMounts:
             - name: noetl-data
               mountPath: /opt/noetl/data

--- a/ci/manifests/noetl/worker-metrics-service.yaml
+++ b/ci/manifests/noetl/worker-metrics-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: noetl-worker-metrics
+  namespace: noetl
+  labels:
+    app: noetl-worker
+    component: worker
+spec:
+  clusterIP: None
+  selector:
+    app: noetl-worker
+  ports:
+    - name: metrics
+      port: 9091
+      targetPort: metrics

--- a/scripts/check_worker_ipc_phase3_evidence.py
+++ b/scripts/check_worker_ipc_phase3_evidence.py
@@ -12,6 +12,10 @@ from typing import Any
 from scripts.check_worker_ipc_metrics import validate_worker_ipc_metrics
 from scripts.package_replay_validation_artifacts import resolve_indexed_path
 
+ADMISSION_ONLY_MINIMUMS = {
+    "noetl_storage_ipc_admit_success_total": 1.0,
+}
+
 
 def _load_manifest(path: Path) -> dict[str, Any]:
     data: Any = json.loads(path.read_text())
@@ -35,6 +39,9 @@ def validate_worker_ipc_phase3_evidence(
     failures: list[dict[str, Any]] = []
     artifacts = manifest.get("artifacts")
     artifacts = artifacts if isinstance(artifacts, dict) else {}
+    config = manifest.get("config")
+    config = config if isinstance(config, dict) else {}
+    admission_only = bool(config.get("worker_metrics_admission_only"))
     worker_metrics = artifacts.get("worker_metrics")
     if not isinstance(worker_metrics, list) or not worker_metrics:
         failures.append(
@@ -74,7 +81,10 @@ def validate_worker_ipc_phase3_evidence(
                 continue
             path = _resolve(path_value, manifest_path=manifest_path)
             try:
-                result = validate_worker_ipc_metrics(path.read_text())
+                result = validate_worker_ipc_metrics(
+                    path.read_text(),
+                    minimums=ADMISSION_ONLY_MINIMUMS if admission_only else None,
+                )
             except OSError as exc:
                 failures.append(
                     {
@@ -97,6 +107,7 @@ def validate_worker_ipc_phase3_evidence(
 
     return {
         "matched": not failures,
+        "worker_metrics_admission_only": admission_only,
         "metric_results": metric_results,
         "failures": failures,
     }

--- a/tests/scripts/test_check_replay_validation_bundle.py
+++ b/tests/scripts/test_check_replay_validation_bundle.py
@@ -316,6 +316,40 @@ def test_check_replay_validation_bundle_accepts_worker_ipc_phase3_evidence(
     assert output["phase3_worker_ipc_result"]["matched"] is True
 
 
+def test_check_replay_validation_bundle_accepts_worker_ipc_admission_only_evidence(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, index = _bundle(tmp_path)
+    _add_worker_phase3_evidence(manifest, index, tmp_path)
+    payload = json.loads(manifest.read_text())
+    payload["config"]["worker_metrics_admission_only"] = True
+    metrics_path = Path(payload["artifacts"]["worker_metrics"][0]["path"])
+    metrics_path.write_text(
+        _worker_metrics_body()
+        .replace("noetl_storage_ipc_read_hits_total{node_id=\"node-a\",worker_id=\"worker-a\"} 1", "noetl_storage_ipc_read_hits_total{node_id=\"node-a\",worker_id=\"worker-a\"} 0")
+        .replace("noetl_storage_ipc_fallback_reads_total{node_id=\"node-a\",worker_id=\"worker-a\"} 1", "noetl_storage_ipc_fallback_reads_total{node_id=\"node-a\",worker_id=\"worker-a\"} 0")
+    )
+    manifest.write_text(json.dumps(payload))
+    index.write_text(
+        json.dumps(
+            build_artifact_index(
+                manifest_path=manifest,
+                output_path=index,
+                extra_artifacts=[("worker_metrics_1", metrics_path)],
+            ),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+    assert main(["--manifest", str(manifest), "--require-worker-ipc-phase3"]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True
+    assert output["phase3_worker_ipc_result"]["worker_metrics_admission_only"] is True
+
+
 def test_check_replay_validation_bundle_rejects_missing_worker_ipc_phase3_evidence(
     tmp_path: Path,
     capsys,

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -424,6 +424,58 @@ def test_run_replay_validation_fetches_and_indexes_worker_metrics(
     assert metrics[0]["path"].endswith("worker_metrics_url_1_worker-0.prom")
 
 
+def test_run_replay_validation_passes_worker_metrics_admission_only_flag(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if any(str(part).endswith("fetch_replay_state_report.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
+        if any(str(part).endswith("fetch_worker_metrics.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.write_text("noetl_worker_up 1\n")
+        if any(str(part).endswith("package_replay_validation_artifacts.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.write_text(json.dumps({"schema_version": 1, "matched": True, "artifacts": []}))
+        return 0, json.dumps({"ok": True}), "", 0.01
+
+    monkeypatch.setattr(run_replay_validation, "_run", _run)
+    manifest = tmp_path / "validation.json"
+
+    assert (
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--worker-metrics-url",
+                "worker-0=http://worker-0.example:9091",
+                "--worker-metrics-admission-only",
+                "--output-dir",
+                str(tmp_path),
+                "--report-output",
+                str(manifest),
+            ]
+        )
+        == 0
+    )
+
+    assert any(
+        "scripts/check_worker_ipc_metrics.py" in call
+        and "--require-admission-only" in call
+        for call in calls
+    )
+    output = json.loads(capsys.readouterr().out)
+    assert output["config"]["worker_metrics_admission_only"] is True
+
+
 def test_run_replay_validation_rejects_invalid_worker_metrics_url(tmp_path: Path):
     try:
         run_replay_validation.main(


### PR DESCRIPTION
## Summary
- expose worker `/metrics` declaratively in local kind manifests instead of requiring manual patches
- set `NOETL_NODE_ID` from `spec.nodeName` in the local worker deployment so IPC locality labels are stable
- add `noetl-worker-metrics` headless service to local manifests
- make the Phase 3 bundle checker honor `worker_metrics_admission_only` from replay validation manifests

## Why
#554 proved producer-side cursor frame IPC admission in local kind, but the validation path still required manual Kubernetes patches for worker metrics. This makes the next redeploy produce metrics endpoints by default and keeps admission-only bundle checks consistent with the report config.

## Tests
- `python3 -m pytest tests/scripts/test_check_worker_ipc_metrics.py tests/scripts/test_check_replay_validation_bundle.py tests/scripts/test_run_replay_validation.py tests/scripts/test_fetch_worker_metrics.py -q`
- `python3 -m pytest tests/scripts/test_check_replay_validation_bundle.py tests/scripts/test_run_replay_validation.py -q`
- `python3 -m compileall scripts/check_worker_ipc_phase3_evidence.py scripts/run_replay_validation.py`
- `kubectl apply --dry-run=client -f ci/manifests/noetl/configmap-worker.yaml -f ci/manifests/noetl/worker-deployment.yaml -f ci/manifests/noetl/worker-metrics-service.yaml`
- `git diff --check`