### PR TITLE
test(ipc): verify cursor frame strict reads

### DIFF
--- a/noetl/core/dsl/engine/models/workflow.py
+++ b/noetl/core/dsl/engine/models/workflow.py
@@ -62,6 +62,13 @@ class FramePolicy(BaseModel):
             "claimed row; frame runs it once per claimed frame with frame.rows"
         )
     )
+    verify_ipc: bool = Field(
+        default=False,
+        description=(
+            "When true, the cursor worker verifies captured frame rows through "
+            "an IPC read and a durable fallback read for Phase 3 evidence"
+        ),
+    )
     retry_mode: Literal["whole_frame"] = Field(
         default="whole_frame",
         description=(

--- a/noetl/core/dsl/playbook.schema.json
+++ b/noetl/core/dsl/playbook.schema.json
@@ -371,6 +371,26 @@
           ],
           "title": "Process",
           "type": "string"
+        },
+        "verify_ipc": {
+          "default": false,
+          "description": "When true, the cursor worker verifies captured frame rows through an IPC read and a durable fallback read for Phase 3 evidence",
+          "title": "Verify Ipc",
+          "type": "boolean"
+        },
+        "retry_mode": {
+          "const": "whole_frame",
+          "default": "whole_frame",
+          "description": "Frame recovery mode. Phase 1 only retries the whole frame boundary; row-split retry requires a later subframe model.",
+          "title": "Retry Mode",
+          "type": "string"
+        },
+        "max_attempts": {
+          "default": 3,
+          "description": "Maximum frame claim attempts before operator intervention is expected",
+          "minimum": 1,
+          "title": "Max Attempts",
+          "type": "integer"
         }
       },
       "title": "FramePolicy",
@@ -465,11 +485,14 @@
               "type": "integer"
             },
             {
+              "type": "string"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Maximum concurrent iterations (parallel) / workers (cursor)",
+          "description": "Maximum concurrent iterations (parallel) / workers (cursor). May be an integer or a renderable expression resolved before dispatch.",
           "title": "Max In Flight"
         },
         "policy": {

--- a/noetl/worker/cursor_worker.py
+++ b/noetl/worker/cursor_worker.py
@@ -28,6 +28,7 @@ from noetl.core.runtime.topology import worker_locality_from_env
 from noetl.core.storage import (
     ARROW_STREAM_MEDIA_TYPE,
     ArrowIpcSharedMemoryCache,
+    IpcHint,
     Scope,
     StoreTier,
     default_store,
@@ -127,6 +128,18 @@ def _estimate_row_bytes(row: dict[str, Any]) -> int:
         return 1024
 
 
+def _truthy_policy(value: Any, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    return bool(value)
+
+
 async def _store_claimed_frame(
     *,
     execution_id: Any,
@@ -177,6 +190,49 @@ async def _store_claimed_frame(
             "capture_failed": True,
             "capture_error": str(exc)[:300],
         }
+
+
+async def _verify_claimed_frame_ipc(
+    *,
+    frame_meta: dict[str, Any],
+    expected_rows: list[dict[str, Any]],
+    frame_policy: dict[str, Any],
+) -> Optional[dict[str, Any]]:
+    if not _truthy_policy(frame_policy.get("verify_ipc"), default=False):
+        return None
+
+    rows_ref = frame_meta.get("rows_ref")
+    if not isinstance(rows_ref, dict):
+        return {"enabled": True, "verified": False, "reason": "missing rows_ref"}
+
+    result: dict[str, Any] = {
+        "enabled": True,
+        "verified": False,
+        "row_count": len(expected_rows),
+        "ipc_hint_present": isinstance(rows_ref.get("ipc"), dict),
+    }
+    try:
+        ipc_rows = await default_store.resolve(rows_ref)
+        result["ipc_read_row_count"] = len(ipc_rows) if isinstance(ipc_rows, list) else None
+        result["ipc_read_matches"] = ipc_rows == expected_rows
+
+        ipc_hint = rows_ref.get("ipc")
+        if isinstance(ipc_hint, dict):
+            cache = _frame_ipc_cache()
+            if cache is not None:
+                cache.delete(IpcHint.model_validate(ipc_hint))
+                result["ipc_hint_evicted"] = True
+            else:
+                result["ipc_hint_evicted"] = False
+
+        fallback_rows = await default_store.resolve(rows_ref)
+        result["fallback_read_row_count"] = len(fallback_rows) if isinstance(fallback_rows, list) else None
+        result["fallback_read_matches"] = fallback_rows == expected_rows
+        result["verified"] = bool(result["ipc_read_matches"] and result["fallback_read_matches"])
+        return result
+    except Exception as exc:
+        result["error"] = str(exc)[:300]
+        return result
 
 
 def _runtime_api_base(context: dict[str, Any]) -> str:
@@ -699,6 +755,13 @@ async def execute_cursor_worker(
                 frame_policy=frame_policy,
             )
             if frame_meta is not None:
+                verification = await _verify_claimed_frame_ipc(
+                    frame_meta=frame_meta,
+                    expected_rows=frame_rows,
+                    frame_policy=frame_policy,
+                )
+                if verification is not None:
+                    frame_meta["ipc_verification"] = verification
                 frames.append(frame_meta)
 
             stop_after_frame = False

--- a/tests/worker/test_cursor_worker_frames.py
+++ b/tests/worker/test_cursor_worker_frames.py
@@ -31,12 +31,14 @@ class _FakeCursorDriver:
 class _FakeStore:
     def __init__(self):
         self.puts = []
+        self.payloads = {}
+        self.resolved = []
 
     async def put_ipc_bytes(self, **kwargs):
-        from noetl.core.storage import Scope, StoreTier, TempRef, TempRefMeta
+        from noetl.core.storage import IpcHint, Scope, StoreTier, TempRef, TempRefMeta
 
         self.puts.append(kwargs)
-        return TempRef.create(
+        ref = TempRef.create(
             execution_id=kwargs["execution_id"],
             name=kwargs["name"],
             store=kwargs.get("store") or StoreTier.KV,
@@ -50,6 +52,29 @@ class _FakeStore:
                 encoding="binary",
             ),
         )
+        ref.ipc = IpcHint(
+            shm_name=f"fake-{kwargs['name']}",
+            schema_digest=kwargs["schema_digest"],
+            byte_length=len(kwargs["data_bytes"]),
+            row_count=kwargs["row_count"],
+            node_id="node-a",
+        )
+        self.payloads[ref.ref] = kwargs["data_bytes"]
+        return ref
+
+    async def resolve(self, rows_ref):
+        from noetl.core.storage import arrow_ipc_to_rows
+
+        self.resolved.append(rows_ref)
+        return arrow_ipc_to_rows(self.payloads[rows_ref["ref"]])
+
+
+class _FakeIpcCache:
+    def __init__(self):
+        self.deleted = []
+
+    def delete(self, hint):
+        self.deleted.append(hint)
 
 
 class _FakeBatchCursorDriver(_FakeCursorDriver):
@@ -262,6 +287,72 @@ async def test_cursor_worker_claims_and_serializes_bounded_frames(monkeypatch):
     assert fake_store.puts[0]["media_type"] == "application/vnd.apache.arrow.stream"
     assert driver.claim_contexts[0]["frame_index"] == 0
     assert driver.claim_contexts[1]["frame_row_index"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cursor_worker_can_verify_frame_ipc_hit_and_fallback(monkeypatch):
+    from noetl.core.cursor_drivers import register_driver
+    from noetl.worker import cursor_worker
+
+    driver = _FakeBatchCursorDriver(
+        [
+            {"id": 1, "status": "pending"},
+            {"id": 2, "status": "pending"},
+        ]
+    )
+    register_driver(driver.kind, driver)
+    fake_store = _FakeStore()
+    fake_cache = _FakeIpcCache()
+    monkeypatch.setattr(cursor_worker, "default_store", fake_store)
+    monkeypatch.setattr(cursor_worker, "_frame_ipc_cache", lambda: fake_cache)
+
+    async def fetch_credential(auth_key):
+        return {"dsn": "memory"}
+
+    monkeypatch.setattr(cursor_worker, "fetch_credential_by_key_async", fetch_credential)
+
+    async def tool_executor(kind, cfg, ctx):
+        return {"status": "ok"}
+
+    result = await cursor_worker.execute_cursor_worker(
+        config={
+            "cursor": {
+                "kind": driver.kind,
+                "auth": "pg",
+                "claim": "select next limit {{ __frame_max_rows }}",
+                "options": {"max_iterations": 10},
+            },
+            "iterator": "item",
+            "tasks": [{"name": "process_item", "kind": "noop"}],
+            "frame_policy": {
+                "max_rows": 2,
+                "max_seconds": 30,
+                "max_bytes": 4096,
+                "verify_ipc": True,
+            },
+        },
+        context={"execution_id": 42},
+        jinja_env=Environment(),
+        tool_executor=tool_executor,
+        render_template=lambda template, ctx: template.replace("{{ __frame_max_rows }}", str(ctx["__frame_max_rows"])),
+        render_dict=lambda data, ctx: data,
+        worker_slot_id="slot-1",
+    )
+
+    verification = result["frames"][0]["ipc_verification"]
+    assert verification == {
+        "enabled": True,
+        "verified": True,
+        "row_count": 2,
+        "ipc_hint_present": True,
+        "ipc_read_row_count": 2,
+        "ipc_read_matches": True,
+        "ipc_hint_evicted": True,
+        "fallback_read_row_count": 2,
+        "fallback_read_matches": True,
+    }
+    assert len(fake_store.resolved) == 2
+    assert len(fake_cache.deleted) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- add a cursor frame policy flag to verify captured Arrow IPC frames inside the worker\n- verify each captured frame through an IPC read, evict the IPC hint, then verify durable fallback read\n- record bounded frame-level ipc_verification evidence and regenerate the playbook schema\n\n## Validation\n- python3 -m pytest tests/worker/test_cursor_worker_frames.py tests/core/test_storage_ipc_cache.py tests/scripts/test_check_worker_ipc_metrics.py tests/scripts/test_run_replay_validation.py tests/scripts/test_check_replay_validation_bundle.py tests/api/test_replay_routes.py -q\n- ops local kind redeploy: local/noetl:2026-05-20-15-35\n- registered phase3/cursor-ipc-evidence version 3 with frame.verify_ipc=true\n- local kind execution 631239401665724650 completed: 3 frame.committed events, all ipc_verification.verified=true\n- strict metrics gate passed: python3 scripts/check_worker_ipc_metrics.py --metrics /tmp/noetl-phase3-strict-evidence/worker-metrics.prom\n\n## Evidence\n- each of 3 workers reported admit_success=1, read_hits=1, read_misses=1, fallback_reads=1\n- no manual worker metrics service patching was needed; service/endpoints came from merged manifests\n\nRefs #438