### PR TITLE
Phase 4: validate runtime worker locator surfaces

### DIFF
--- a/noetl/core/runtime/topology.py
+++ b/noetl/core/runtime/topology.py
@@ -4,11 +4,31 @@ from __future__ import annotations
 
 import os
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any
 
-from noetl.core.resource_locator import ResourceLocatorError, build_noetl_locator
+from noetl.core.resource_locator import ResourceLocatorError, build_noetl_locator, parse_noetl_locator
 
 LOCALITY_DISTANCES = ("node", "zone", "region", "cluster", "any")
+
+
+@dataclass(frozen=True)
+class WorkerLocatorParts:
+    """Cloud OS identity fields encoded by a worker locator."""
+
+    tenant_id: str
+    organization_id: str
+    worker_pool: str
+    cluster_id: str | None = None
+    node_id: str | None = None
+
+    def as_locality(self) -> dict[str, str]:
+        locality: dict[str, str] = {"worker_pool": self.worker_pool}
+        if self.cluster_id:
+            locality["cluster_id"] = self.cluster_id
+        if self.node_id:
+            locality["node_id"] = self.node_id
+        return locality
 
 
 def worker_locality_from_env(env: Mapping[str, str] | None = None) -> dict[str, str]:
@@ -52,6 +72,35 @@ def worker_locator(
         return build_noetl_locator(*segments)
     except (ResourceLocatorError, TypeError, ValueError):
         return None
+
+
+def parse_worker_locator(value: str) -> WorkerLocatorParts:
+    """Parse and validate a canonical Cloud OS worker locator."""
+    locator = parse_noetl_locator(value)
+    if locator.kind != "tenant":
+        raise ResourceLocatorError("worker locator must start with tenant")
+
+    try:
+        parts = locator.pairs()
+    except ResourceLocatorError as exc:
+        raise ResourceLocatorError("worker locator must use alternating key/value segments") from exc
+
+    unknown = sorted(set(parts) - {"tenant", "org", "cluster", "node", "worker"})
+    if unknown:
+        raise ResourceLocatorError(f"worker locator contains unknown segments: {', '.join(unknown)}")
+
+    required = ("tenant", "org", "worker")
+    missing = [key for key in required if not parts.get(key)]
+    if missing:
+        raise ResourceLocatorError(f"worker locator missing required segments: {', '.join(missing)}")
+
+    return WorkerLocatorParts(
+        tenant_id=parts["tenant"],
+        organization_id=parts["org"],
+        cluster_id=parts.get("cluster"),
+        node_id=parts.get("node"),
+        worker_pool=parts["worker"],
+    )
 
 
 def locality_distance(
@@ -112,6 +161,8 @@ __all__ = [
     "locality_distance",
     "locality_within",
     "placement_evaluation",
+    "parse_worker_locator",
+    "WorkerLocatorParts",
     "worker_locality_from_env",
     "worker_locator",
 ]

--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -20,6 +20,7 @@ fi
   tests/scripts/test_check_worker_ipc_metrics.py \
   tests/scripts/test_export_live_projection_rows_postgres.py \
   tests/scripts/test_check_live_projection_rows.py \
+  tests/scripts/test_check_runtime_locator_surfaces.py \
   tests/scripts/test_package_replay_validation_artifacts.py \
   tests/scripts/test_check_replay_validation_bundle.py \
   tests/scripts/test_check_replay_validation_manifest.py \

--- a/scripts/check_runtime_locator_surfaces.py
+++ b/scripts/check_runtime_locator_surfaces.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+"""Validate Cloud OS worker locators in replay and live projection artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from noetl.core.resource_locator import ResourceLocatorError
+from noetl.core.runtime.topology import WorkerLocatorParts, parse_worker_locator
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    data: Any = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _command_rows(value: Any) -> Iterable[Mapping[str, Any]]:
+    if isinstance(value, Mapping):
+        for row in value.values():
+            if isinstance(row, Mapping):
+                yield row
+        return
+    if isinstance(value, list):
+        for row in value:
+            if isinstance(row, Mapping):
+                yield row
+
+
+def _expected_context(document: Mapping[str, Any]) -> dict[str, str]:
+    context: dict[str, str] = {}
+    tenant_id = document.get("tenant_id")
+    organization_id = document.get("organization_id")
+    if isinstance(tenant_id, str) and tenant_id:
+        context["tenant_id"] = tenant_id
+    if isinstance(organization_id, str) and organization_id:
+        context["organization_id"] = organization_id
+    return context
+
+
+def _validate_parts(
+    failures: list[dict[str, Any]],
+    *,
+    surface: str,
+    index: int,
+    command_id: Any,
+    parts: WorkerLocatorParts,
+    row: Mapping[str, Any],
+    context: Mapping[str, str],
+) -> None:
+    if context.get("tenant_id") and parts.tenant_id != context["tenant_id"]:
+        failures.append(
+            {
+                "surface": surface,
+                "index": index,
+                "command_id": command_id,
+                "field": "worker_locator.tenant",
+                "reason": "does not match artifact tenant_id",
+                "expected": context["tenant_id"],
+                "actual": parts.tenant_id,
+            }
+        )
+    if context.get("organization_id") and parts.organization_id != context["organization_id"]:
+        failures.append(
+            {
+                "surface": surface,
+                "index": index,
+                "command_id": command_id,
+                "field": "worker_locator.org",
+                "reason": "does not match artifact organization_id",
+                "expected": context["organization_id"],
+                "actual": parts.organization_id,
+            }
+        )
+
+    locality = row.get("locality")
+    if not isinstance(locality, Mapping):
+        return
+    locality_checks = {
+        "cluster_id": parts.cluster_id,
+        "node_id": parts.node_id,
+        "worker_pool": parts.worker_pool,
+    }
+    for field, actual in locality_checks.items():
+        expected = locality.get(field)
+        if expected is None or expected == "" or actual is None:
+            continue
+        if str(expected) != actual:
+            failures.append(
+                {
+                    "surface": surface,
+                    "index": index,
+                    "command_id": command_id,
+                    "field": f"locality.{field}",
+                    "reason": "does not match worker_locator",
+                    "expected": str(expected),
+                    "actual": actual,
+                }
+            )
+
+
+def _validate_command_surface(
+    failures: list[dict[str, Any]],
+    *,
+    surface: str,
+    rows: Iterable[Mapping[str, Any]],
+    context: Mapping[str, str],
+) -> int:
+    locator_count = 0
+    for index, row in enumerate(rows):
+        locator = row.get("worker_locator")
+        if locator is None or locator == "":
+            continue
+        locator_count += 1
+        command_id = row.get("command_id")
+        if not isinstance(locator, str):
+            failures.append(
+                {
+                    "surface": surface,
+                    "index": index,
+                    "command_id": command_id,
+                    "field": "worker_locator",
+                    "reason": "must be a string when present",
+                    "actual": locator,
+                }
+            )
+            continue
+        try:
+            parts = parse_worker_locator(locator)
+        except ResourceLocatorError as exc:
+            failures.append(
+                {
+                    "surface": surface,
+                    "index": index,
+                    "command_id": command_id,
+                    "field": "worker_locator",
+                    "reason": str(exc),
+                    "actual": locator,
+                }
+            )
+            continue
+        _validate_parts(
+            failures,
+            surface=surface,
+            index=index,
+            command_id=command_id,
+            parts=parts,
+            row=row,
+            context=context,
+        )
+    return locator_count
+
+
+def validate_runtime_locator_surfaces(
+    *,
+    replay_report: Path | None = None,
+    live_rows: Path | None = None,
+) -> dict[str, Any]:
+    failures: list[dict[str, Any]] = []
+    surfaces: dict[str, int] = {}
+
+    if replay_report is not None:
+        replay = _load_json(replay_report)
+        count = _validate_command_surface(
+            failures,
+            surface="replay.commands",
+            rows=_command_rows(replay.get("commands")),
+            context=_expected_context(replay),
+        )
+        surfaces["replay.commands"] = count
+
+    if live_rows is not None:
+        artifact = _load_json(live_rows)
+        rows = artifact.get("rows") if isinstance(artifact.get("rows"), Mapping) else {}
+        commands = rows.get("commands") if isinstance(rows, Mapping) else None
+        count = _validate_command_surface(
+            failures,
+            surface="live_rows.commands",
+            rows=_command_rows(commands),
+            context=_expected_context(artifact),
+        )
+        surfaces["live_rows.commands"] = count
+
+    return {
+        "matched": not failures,
+        "surfaces": surfaces,
+        "locator_count": sum(surfaces.values()),
+        "failures": failures,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate NoETL runtime locator surfaces")
+    parser.add_argument("--replay-report", type=Path)
+    parser.add_argument("--live-rows", type=Path)
+    args = parser.parse_args(argv)
+
+    if args.replay_report is None and args.live_rows is None:
+        parser.error("at least one of --replay-report or --live-rows is required")
+
+    output = validate_runtime_locator_surfaces(
+        replay_report=args.replay_report,
+        live_rows=args.live_rows,
+    )
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0 if output["matched"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -392,6 +392,15 @@ def main(argv: list[str] | None = None) -> int:
             ],
         ),
         (
+            "runtime_locator_state",
+            [
+                _validation_python(),
+                "scripts/check_runtime_locator_surfaces.py",
+                "--replay-report",
+                str(replay_path),
+            ],
+        ),
+        (
             "live_rows_export",
             [
                 _validation_python(),
@@ -417,6 +426,17 @@ def main(argv: list[str] | None = None) -> int:
                 _validation_python(),
                 "scripts/check_live_projection_rows.py",
                 "--rows",
+                str(live_rows_path),
+            ]
+            if live_rows_path
+            else [],
+        ),
+        (
+            "runtime_locator_live_rows",
+            [
+                _validation_python(),
+                "scripts/check_runtime_locator_surfaces.py",
+                "--live-rows",
                 str(live_rows_path),
             ]
             if live_rows_path

--- a/tests/core/test_runtime_topology.py
+++ b/tests/core/test_runtime_topology.py
@@ -55,6 +55,38 @@ def test_worker_locator_returns_none_for_invalid_segments():
     )
 
 
+def test_parse_worker_locator_returns_cloud_os_parts():
+    from noetl.core.runtime.topology import parse_worker_locator
+
+    parts = parse_worker_locator(
+        "noetl://tenant/tenant-a/org/org-a/cluster/cluster-a/node/node-a/worker/worker-cpu-01"
+    )
+
+    assert parts.tenant_id == "tenant-a"
+    assert parts.organization_id == "org-a"
+    assert parts.cluster_id == "cluster-a"
+    assert parts.node_id == "node-a"
+    assert parts.worker_pool == "worker-cpu-01"
+    assert parts.as_locality() == {
+        "cluster_id": "cluster-a",
+        "node_id": "node-a",
+        "worker_pool": "worker-cpu-01",
+    }
+
+
+def test_parse_worker_locator_rejects_non_worker_locator():
+    import pytest
+
+    from noetl.core.resource_locator import ResourceLocatorError
+    from noetl.core.runtime.topology import parse_worker_locator
+
+    with pytest.raises(ResourceLocatorError, match="must start with tenant"):
+        parse_worker_locator("noetl://execution/123/result/load/abcd")
+
+    with pytest.raises(ResourceLocatorError, match="missing required segments"):
+        parse_worker_locator("noetl://tenant/tenant-a/org/org-a")
+
+
 def test_locality_distance_prefers_closest_match():
     from noetl.core.runtime.topology import locality_distance, locality_within, placement_evaluation
 

--- a/tests/scripts/test_check_runtime_locator_surfaces.py
+++ b/tests/scripts/test_check_runtime_locator_surfaces.py
@@ -1,0 +1,97 @@
+import json
+from pathlib import Path
+
+from scripts.check_runtime_locator_surfaces import main
+
+
+def test_check_runtime_locator_surfaces_accepts_replay_and_live_rows(tmp_path: Path, capsys):
+    command = {
+        "command_id": "cmd-1",
+        "worker_locator": "noetl://tenant/tenant-a/org/org-a/cluster/cluster-a/node/node-a/worker/worker-cpu-01",
+        "locality": {
+            "cluster_id": "cluster-a",
+            "node_id": "node-a",
+            "worker_pool": "worker-cpu-01",
+        },
+    }
+    replay = {
+        "tenant_id": "tenant-a",
+        "organization_id": "org-a",
+        "commands": {"cmd-1": command},
+    }
+    live_rows = {
+        "tenant_id": "tenant-a",
+        "organization_id": "org-a",
+        "rows": {"commands": [command]},
+    }
+    replay_path = tmp_path / "replay.json"
+    live_rows_path = tmp_path / "live-rows.json"
+    replay_path.write_text(json.dumps(replay))
+    live_rows_path.write_text(json.dumps(live_rows))
+
+    assert main(["--replay-report", str(replay_path), "--live-rows", str(live_rows_path)]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True
+    assert output["locator_count"] == 2
+    assert output["surfaces"] == {"live_rows.commands": 1, "replay.commands": 1}
+
+
+def test_check_runtime_locator_surfaces_rejects_malformed_locator(tmp_path: Path, capsys):
+    replay = {
+        "tenant_id": "tenant-a",
+        "organization_id": "org-a",
+        "commands": {
+            "cmd-1": {
+                "command_id": "cmd-1",
+                "worker_locator": "noetl://execution/123/result/load/abcd",
+            }
+        },
+    }
+    replay_path = tmp_path / "replay.json"
+    replay_path.write_text(json.dumps(replay))
+
+    assert main(["--replay-report", str(replay_path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    assert output["failures"][0]["field"] == "worker_locator"
+
+
+def test_check_runtime_locator_surfaces_rejects_tenant_mismatch(tmp_path: Path, capsys):
+    live_rows = {
+        "tenant_id": "tenant-a",
+        "organization_id": "org-a",
+        "rows": {
+            "commands": [
+                {
+                    "command_id": "cmd-1",
+                    "worker_locator": "noetl://tenant/tenant-b/org/org-a/node/node-a/worker/worker-cpu-01",
+                }
+            ]
+        },
+    }
+    live_rows_path = tmp_path / "live-rows.json"
+    live_rows_path.write_text(json.dumps(live_rows))
+
+    assert main(["--live-rows", str(live_rows_path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert "worker_locator.tenant" in {failure["field"] for failure in output["failures"]}
+
+
+def test_check_runtime_locator_surfaces_rejects_locality_mismatch(tmp_path: Path, capsys):
+    replay = {
+        "tenant_id": "tenant-a",
+        "organization_id": "org-a",
+        "commands": {
+            "cmd-1": {
+                "command_id": "cmd-1",
+                "worker_locator": "noetl://tenant/tenant-a/org/org-a/node/node-a/worker/worker-cpu-01",
+                "locality": {"node_id": "node-b"},
+            }
+        },
+    }
+    replay_path = tmp_path / "replay.json"
+    replay_path.write_text(json.dumps(replay))
+
+    assert main(["--replay-report", str(replay_path)]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert "locality.node_id" in {failure["field"] for failure in output["failures"]}

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -42,12 +42,13 @@ def test_run_replay_validation_fetches_and_runs_selected_gates(monkeypatch, tmp_
         == 0
     )
 
-    assert len(calls) == 4
+    assert len(calls) == 5
     assert "scripts/fetch_replay_state_report.py" in calls[0]
     assert "--resolve-payloads" in calls[0]
     assert "scripts/check_replay_state_report.py" in calls[1]
-    assert "scripts/check_replay_parity_report.py" in calls[2]
-    assert "scripts/check_replay_payload_resolution_report.py" in calls[3]
+    assert "scripts/check_runtime_locator_surfaces.py" in calls[2]
+    assert "scripts/check_replay_parity_report.py" in calls[3]
+    assert "scripts/check_replay_payload_resolution_report.py" in calls[4]
     output = json.loads(capsys.readouterr().out)
     assert output["matched"] is True
     assert output["replay"].endswith("replay-123.json")
@@ -190,9 +191,9 @@ def test_run_replay_validation_can_export_live_rows_from_postgres(monkeypatch, t
     assert [step["name"] for step in output["steps"][:5]] == [
         "fetch",
         "state_integrity",
+        "runtime_locator_state",
         "live_rows_export",
         "live_rows_integrity",
-        "live_checksums",
     ]
 
 


### PR DESCRIPTION
## Summary
- add a typed parser for canonical Cloud OS worker locators
- add replay/live-row validation for worker locator tenant/org/locality consistency
- wire runtime locator validation into replay validation and the replay release gate

## Validation
- python3 -m pytest tests/core/test_runtime_topology.py tests/scripts/test_check_runtime_locator_surfaces.py tests/scripts/test_run_replay_validation.py tests/scripts/test_check_live_projection_rows.py tests/scripts/test_check_replay_state_report.py -q
- python3 -m pytest tests/core/test_resource_locator.py tests/core/test_runtime_topology.py tests/core/test_runtime_events.py tests/api/test_command_claim_outbox.py tests/api/test_frame_routes.py tests/api/test_replay_routes.py tests/scripts/test_check_runtime_locator_surfaces.py tests/scripts/test_run_replay_validation.py tests/scripts/test_check_replay_validation_manifest.py tests/scripts/test_check_replay_validation_bundle.py tests/scripts/test_check_worker_ipc_metrics.py tests/core/test_storage_ipc_cache.py -q

## Phase
Phase 4 Cloud OS surfaces: validation/reporting layer adoption for runtime worker locators without changing replay checksum row shapes.