### PR TITLE
Phase 6 fanout/reduce planner and replay evidence

### DIFF
--- a/noetl/core/dsl/engine/__init__.py
+++ b/noetl/core/dsl/engine/__init__.py
@@ -24,6 +24,12 @@ from .models import (
     TaskSpec,
     ToolOutcome,
 )
+from .planner import (
+    FanoutReducePlan,
+    PlannedFanout,
+    PlannedReduce,
+    build_fanout_reduce_plan,
+)
 
 __all__ = [
     # Event & Command models
@@ -51,4 +57,8 @@ __all__ = [
     "TaskPolicy",
     "TaskSpec",
     "ToolOutcome",
+    "FanoutReducePlan",
+    "PlannedFanout",
+    "PlannedReduce",
+    "build_fanout_reduce_plan",
 ]

--- a/noetl/core/dsl/engine/executor/transitions.py
+++ b/noetl/core/dsl/engine/executor/transitions.py
@@ -5,6 +5,7 @@ from .outbox import drain_executor_outbox, enqueue_executor_outbox
 from .state import ExecutionState
 from .store import PlaybookRepo, StateStore
 from noetl.core.event_store.ports import canonical_event_checksum
+from noetl.core.dsl.engine.planner import build_fanout_reduce_plan
 from noetl.core.dsl.render import render_template
 
 class TransitionMixin:
@@ -722,6 +723,7 @@ class TransitionMixin:
 
         any_matched = False
         any_raised = False
+        issued_records: list[tuple[str, Command]] = []
 
         for idx, next_target in enumerate(next_items):
             target_step = next_target.step
@@ -787,6 +789,7 @@ class TransitionMixin:
             issued_cmds = await self._issue_loop_commands(state, target_step_def, {}, conn=conn)
             if issued_cmds:
                 commands.extend(issued_cmds)
+                issued_records.extend((target_step, command) for command in issued_cmds)
                 # Steps can be revisited in loopback workflows; clear old completion marker
                 # so pending tracking reflects the new in-flight invocation.
                 state.completed_steps.discard(target_step)
@@ -811,7 +814,46 @@ class TransitionMixin:
                 event.step,
             )
 
+        if next_mode == "inclusive":
+            self._annotate_fanout_reduce_commands(state, step_def, issued_records)
+
         return commands, any_matched, any_raised
+
+    def _annotate_fanout_reduce_commands(
+        self,
+        state: ExecutionState,
+        source_step: Step,
+        issued_records: list[tuple[str, Command]],
+    ) -> None:
+        """Attach static Phase 6 planner intent to commands from a real fan-out."""
+        target_order: list[str] = []
+        for target_step, _command in issued_records:
+            if target_step not in target_order:
+                target_order.append(target_step)
+        if len(target_order) < 2:
+            return
+
+        plan = build_fanout_reduce_plan(state.playbook)
+        fanout = next(
+            (item for item in plan.fanouts if item.step == source_step.step),
+            None,
+        )
+        if fanout is None:
+            return
+
+        target_index = {target: idx for idx, target in enumerate(target_order)}
+        for target_step, command in issued_records:
+            command.metadata.setdefault("fanout_reduce", {})
+            command.metadata["fanout_reduce"].update(
+                {
+                    "planner_version": 1,
+                    "fanout_step": source_step.step,
+                    "fanout_targets": target_order,
+                    "target_step": target_step,
+                    "target_index": target_index[target_step],
+                    "reduce_steps": list(fanout.reduce_steps),
+                }
+            )
 
     def _has_matching_next_transition(
         self,

--- a/noetl/core/dsl/engine/planner.py
+++ b/noetl/core/dsl/engine/planner.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from noetl.core.dsl.engine.models import Arc, Playbook, Step
+
+
+@dataclass(frozen=True)
+class PlannedFanout:
+    """Static fan-out boundary derived from an inclusive next router."""
+
+    step: str
+    arcs: tuple[str, ...]
+    reduce_steps: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class PlannedReduce:
+    """Static reduce boundary for a step with more than one upstream."""
+
+    step: str
+    upstream_steps: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FanoutReducePlan:
+    """Deterministic stage topology extracted from a playbook."""
+
+    fanouts: tuple[PlannedFanout, ...] = field(default_factory=tuple)
+    reduces: tuple[PlannedReduce, ...] = field(default_factory=tuple)
+
+    def is_empty(self) -> bool:
+        return not self.fanouts and not self.reduces
+
+
+def build_fanout_reduce_plan(playbook: Playbook) -> FanoutReducePlan:
+    """Build a deterministic static fan-out/reduce plan for a playbook.
+
+    Phase 6 treats canonical `next.spec.mode: inclusive` routers with multiple
+    targets as fan-out boundaries. A step targeted by multiple upstream steps is
+    a reduce boundary. The planner intentionally stays side-effect free so it can
+    be used by validation, replay tooling, and later by the runtime stage opener.
+    """
+
+    steps_by_name = {step.step: step for step in playbook.workflow}
+    workflow_order = {step.step: idx for idx, step in enumerate(playbook.workflow)}
+    graph: dict[str, tuple[str, ...]] = {}
+    incoming: dict[str, set[str]] = {step.step: set() for step in playbook.workflow}
+
+    for step in playbook.workflow:
+        targets = tuple(_arc_targets(step, steps_by_name))
+        graph[step.step] = targets
+        for target in targets:
+            incoming.setdefault(target, set()).add(step.step)
+
+    reduce_names = {
+        step_name for step_name, upstream in incoming.items()
+        if step_name in steps_by_name and len(upstream) > 1
+    }
+
+    fanouts: list[PlannedFanout] = []
+    for step in playbook.workflow:
+        router = step.next
+        if not router or not router.spec or router.spec.mode != "inclusive":
+            continue
+        targets = tuple(_arc_targets(step, steps_by_name))
+        if len(targets) < 2:
+            continue
+        fanouts.append(
+            PlannedFanout(
+                step=step.step,
+                arcs=targets,
+                reduce_steps=tuple(
+                    sorted(
+                        _reachable_reduces(graph, reduce_names, targets),
+                        key=lambda name: workflow_order.get(name, len(workflow_order)),
+                    )
+                ),
+            )
+        )
+
+    reduces = tuple(
+        PlannedReduce(
+            step=step_name,
+            upstream_steps=tuple(
+                sorted(upstream, key=lambda name: workflow_order.get(name, len(workflow_order)))
+            ),
+        )
+        for step_name, upstream in sorted(
+            incoming.items(),
+            key=lambda item: workflow_order.get(item[0], len(workflow_order)),
+        )
+        if step_name in reduce_names
+    )
+
+    return FanoutReducePlan(fanouts=tuple(fanouts), reduces=reduces)
+
+
+def _arc_targets(step: Step, steps_by_name: dict[str, Step]) -> list[str]:
+    if not step.next:
+        return []
+    targets: list[str] = []
+    seen: set[str] = set()
+    for arc in step.next.arcs:
+        target = _target_name(arc)
+        if target and target in steps_by_name and target not in seen:
+            targets.append(target)
+            seen.add(target)
+    return targets
+
+
+def _target_name(arc: Arc) -> str | None:
+    target = arc.step.strip() if isinstance(arc.step, str) else None
+    return target or None
+
+
+def _reachable_reduces(
+    graph: dict[str, tuple[str, ...]],
+    reduce_names: set[str],
+    roots: tuple[str, ...],
+) -> set[str]:
+    found: set[str] = set()
+    stack = list(reversed(roots))
+    visited: set[str] = set()
+
+    while stack:
+        step_name = stack.pop()
+        if step_name in visited:
+            continue
+        visited.add(step_name)
+        if step_name in reduce_names:
+            found.add(step_name)
+            continue
+        for target in reversed(graph.get(step_name, ())):
+            if target not in visited:
+                stack.append(target)
+
+    return found

--- a/noetl/server/api/replay/service.py
+++ b/noetl/server/api/replay/service.py
@@ -432,6 +432,7 @@ def fold_replay_state(
                     "locality": {},
                     "source_locality": {},
                     "placement": {},
+                    "fanout_reduce": {},
                     "status": "UNKNOWN",
                     "issued_event_id": None,
                     "claimed_event_id": None,
@@ -460,6 +461,8 @@ def fold_replay_state(
                 command["source_locality"] = dict(meta["source_locality"])
             if isinstance(meta.get("placement"), Mapping):
                 command["placement"] = dict(meta["placement"])
+            if isinstance(meta.get("fanout_reduce"), Mapping):
+                command["fanout_reduce"] = dict(meta["fanout_reduce"])
 
             if event_type == "command.issued":
                 command["status"] = status or "PENDING"
@@ -702,6 +705,7 @@ def _normalized_command_projection_row(row: Mapping[str, Any]) -> dict[str, Any]
         "locality": row.get("locality") or {},
         "source_locality": row.get("source_locality") or {},
         "placement": row.get("placement") or {},
+        "fanout_reduce": row.get("fanout_reduce") or {},
         "status": row.get("status"),
         "issued_event_id": (
             int(row.get("issued_event_id")) if row.get("issued_event_id") is not None else None

--- a/scripts/build_fanout_phase6_report.py
+++ b/scripts/build_fanout_phase6_report.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+"""Build a Phase 6 fan-out/reduce planner evidence report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from noetl.core.dsl.engine.parser import DSLParser
+from noetl.core.dsl.engine.planner import FanoutReducePlan, build_fanout_reduce_plan
+
+PLANNER_VERSION = 1
+
+
+def _plan_to_dict(plan: FanoutReducePlan) -> dict[str, Any]:
+    return {
+        "fanouts": [
+            {
+                "step": fanout.step,
+                "arcs": list(fanout.arcs),
+                "reduce_steps": list(fanout.reduce_steps),
+            }
+            for fanout in plan.fanouts
+        ],
+        "reduces": [
+            {
+                "step": reduce.step,
+                "upstream_steps": list(reduce.upstream_steps),
+            }
+            for reduce in plan.reduces
+        ],
+    }
+
+
+def build_fanout_phase6_report(playbook_paths: list[Path]) -> dict[str, Any]:
+    """Return a deterministic fan-out/reduce planner report."""
+    parser = DSLParser()
+    playbook_reports: list[dict[str, Any]] = []
+    total_fanouts = 0
+    total_reduces = 0
+
+    for path in sorted(playbook_paths, key=lambda item: item.as_posix()):
+        playbook = parser.parse_file(path, use_cache=False)
+        plan = build_fanout_reduce_plan(playbook)
+        plan_data = _plan_to_dict(plan)
+        total_fanouts += len(plan.fanouts)
+        total_reduces += len(plan.reduces)
+        playbook_reports.append(
+            {
+                "path": path.as_posix(),
+                "name": playbook.metadata.get("name"),
+                "planner": plan_data,
+            }
+        )
+
+    return {
+        "planner_version": PLANNER_VERSION,
+        "summary": {
+            "playbooks": len(playbook_reports),
+            "fanouts": total_fanouts,
+            "reduces": total_reduces,
+        },
+        "playbooks": playbook_reports,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a Phase 6 fan-out/reduce planner report")
+    parser.add_argument("--playbook", action="append", type=Path, required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    report = build_fanout_phase6_report(args.playbook)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(json.dumps({"matched": True, "output": str(args.output)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_fanout_phase6_evidence.py
+++ b/scripts/check_fanout_phase6_evidence.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+"""Validate Phase 6 fan-out/reduce planner evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    data: Any = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def validate_fanout_phase6_report(
+    report: dict[str, Any],
+    *,
+    require_fanout: bool = False,
+    require_reduce: bool = False,
+) -> dict[str, Any]:
+    """Validate a Phase 6 planner report artifact."""
+    failures: list[dict[str, Any]] = []
+
+    if report.get("planner_version") != 1:
+        failures.append(
+            {
+                "field": "planner_version",
+                "reason": "Phase 6 planner report requires planner_version=1",
+            }
+        )
+
+    summary = report.get("summary")
+    summary = summary if isinstance(summary, dict) else {}
+    fanout_count = int(summary.get("fanouts") or 0)
+    reduce_count = int(summary.get("reduces") or 0)
+    playbook_count = int(summary.get("playbooks") or 0)
+
+    playbooks = report.get("playbooks")
+    if not isinstance(playbooks, list) or len(playbooks) != playbook_count:
+        failures.append(
+            {
+                "field": "playbooks",
+                "reason": "playbook entries must match summary.playbooks",
+            }
+        )
+        playbooks = []
+
+    observed_fanouts = 0
+    observed_reduces = 0
+    for index, entry in enumerate(playbooks):
+        if not isinstance(entry, dict):
+            failures.append(
+                {
+                    "field": f"playbooks[{index}]",
+                    "reason": "playbook entry must be an object",
+                }
+            )
+            continue
+        planner = entry.get("planner")
+        planner = planner if isinstance(planner, dict) else {}
+        fanouts = planner.get("fanouts")
+        reduces = planner.get("reduces")
+        if not isinstance(fanouts, list) or not isinstance(reduces, list):
+            failures.append(
+                {
+                    "field": f"playbooks[{index}].planner",
+                    "reason": "planner must include fanouts and reduces lists",
+                }
+            )
+            continue
+        observed_fanouts += len(fanouts)
+        observed_reduces += len(reduces)
+        failures.extend(_validate_fanout_entries(index, fanouts))
+        failures.extend(_validate_reduce_entries(index, reduces))
+
+    if observed_fanouts != fanout_count:
+        failures.append(
+            {
+                "field": "summary.fanouts",
+                "reason": "summary fanout count does not match planner entries",
+                "expected": observed_fanouts,
+                "actual": fanout_count,
+            }
+        )
+    if observed_reduces != reduce_count:
+        failures.append(
+            {
+                "field": "summary.reduces",
+                "reason": "summary reduce count does not match planner entries",
+                "expected": observed_reduces,
+                "actual": reduce_count,
+            }
+        )
+    if require_fanout and observed_fanouts < 1:
+        failures.append(
+            {
+                "field": "summary.fanouts",
+                "reason": "at least one fanout is required",
+            }
+        )
+    if require_reduce and observed_reduces < 1:
+        failures.append(
+            {
+                "field": "summary.reduces",
+                "reason": "at least one reduce is required",
+            }
+        )
+
+    return {
+        "matched": not failures,
+        "summary": {
+            "playbooks": playbook_count,
+            "fanouts": observed_fanouts,
+            "reduces": observed_reduces,
+        },
+        "failures": failures,
+    }
+
+
+def _validate_fanout_entries(playbook_index: int, fanouts: list[Any]) -> list[dict[str, Any]]:
+    failures: list[dict[str, Any]] = []
+    for index, fanout in enumerate(fanouts):
+        if not isinstance(fanout, dict):
+            failures.append(
+                {
+                    "field": f"playbooks[{playbook_index}].planner.fanouts[{index}]",
+                    "reason": "fanout entry must be an object",
+                }
+            )
+            continue
+        arcs = fanout.get("arcs")
+        if not isinstance(fanout.get("step"), str) or not fanout["step"]:
+            failures.append(
+                {
+                    "field": f"playbooks[{playbook_index}].planner.fanouts[{index}].step",
+                    "reason": "fanout step is required",
+                }
+            )
+        if not isinstance(arcs, list) or len(arcs) < 2 or not all(isinstance(item, str) and item for item in arcs):
+            failures.append(
+                {
+                    "field": f"playbooks[{playbook_index}].planner.fanouts[{index}].arcs",
+                    "reason": "fanout arcs must include at least two target step names",
+                }
+            )
+        reduce_steps = fanout.get("reduce_steps")
+        if reduce_steps is not None and not isinstance(reduce_steps, list):
+            failures.append(
+                {
+                    "field": f"playbooks[{playbook_index}].planner.fanouts[{index}].reduce_steps",
+                    "reason": "fanout reduce_steps must be a list when present",
+                }
+            )
+    return failures
+
+
+def _validate_reduce_entries(playbook_index: int, reduces: list[Any]) -> list[dict[str, Any]]:
+    failures: list[dict[str, Any]] = []
+    for index, reduce in enumerate(reduces):
+        if not isinstance(reduce, dict):
+            failures.append(
+                {
+                    "field": f"playbooks[{playbook_index}].planner.reduces[{index}]",
+                    "reason": "reduce entry must be an object",
+                }
+            )
+            continue
+        upstream_steps = reduce.get("upstream_steps")
+        if not isinstance(reduce.get("step"), str) or not reduce["step"]:
+            failures.append(
+                {
+                    "field": f"playbooks[{playbook_index}].planner.reduces[{index}].step",
+                    "reason": "reduce step is required",
+                }
+            )
+        if (
+            not isinstance(upstream_steps, list)
+            or len(upstream_steps) < 2
+            or not all(isinstance(item, str) and item for item in upstream_steps)
+        ):
+            failures.append(
+                {
+                    "field": f"playbooks[{playbook_index}].planner.reduces[{index}].upstream_steps",
+                    "reason": "reduce upstream_steps must include at least two step names",
+                }
+            )
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate Phase 6 fan-out/reduce planner evidence")
+    parser.add_argument("--report", required=True, type=Path)
+    parser.add_argument("--require-fanout", action="store_true")
+    parser.add_argument("--require-reduce", action="store_true")
+    args = parser.parse_args(argv)
+
+    output = validate_fanout_phase6_report(
+        _load_json_object(args.report),
+        require_fanout=args.require_fanout,
+        require_reduce=args.require_reduce,
+    )
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0 if output["matched"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_replay_fanout_reduce_report.py
+++ b/scripts/check_replay_fanout_reduce_report.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+"""Validate replay evidence for Phase 6 fan-out/reduce command metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    data: Any = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def validate_replay_fanout_reduce_report(
+    report: Mapping[str, Any],
+    *,
+    require_reduce: bool = True,
+) -> dict[str, Any]:
+    """Validate fan-out/reduce metadata in a replay-state report."""
+    failures: list[dict[str, Any]] = []
+    commands = report.get("commands")
+    commands = commands if isinstance(commands, Mapping) else {}
+
+    matches: list[dict[str, Any]] = []
+    for command_id, command in sorted(commands.items(), key=lambda item: str(item[0])):
+        if not isinstance(command, Mapping):
+            continue
+        metadata = command.get("fanout_reduce")
+        if not isinstance(metadata, Mapping) or not metadata:
+            continue
+        result = _validate_metadata(command_id=str(command_id), metadata=metadata)
+        if result["failures"]:
+            failures.extend(result["failures"])
+        else:
+            matches.append(result["match"])
+
+    if not matches:
+        failures.append(
+            {
+                "field": "commands",
+                "reason": "replay report does not contain fan-out/reduce command metadata",
+            }
+        )
+
+    if require_reduce and not any(match.get("reduce_steps") for match in matches):
+        failures.append(
+            {
+                "field": "commands[*].fanout_reduce.reduce_steps",
+                "reason": "at least one fan-out command must declare a reduce step",
+            }
+        )
+
+    fanout_steps = sorted({str(match["fanout_step"]) for match in matches if match.get("fanout_step")})
+    reduce_steps = sorted(
+        {
+            str(reduce_step)
+            for match in matches
+            for reduce_step in (match.get("reduce_steps") or [])
+        }
+    )
+
+    return {
+        "matched": not failures,
+        "fanout_commands": len(matches),
+        "fanout_steps": fanout_steps,
+        "reduce_steps": reduce_steps,
+        "failures": failures,
+    }
+
+
+def _validate_metadata(command_id: str, metadata: Mapping[str, Any]) -> dict[str, Any]:
+    failures: list[dict[str, Any]] = []
+    field_prefix = f"commands.{command_id}.fanout_reduce"
+
+    planner_version = metadata.get("planner_version")
+    if planner_version != 1:
+        failures.append(
+            {
+                "field": f"{field_prefix}.planner_version",
+                "reason": "planner_version must be 1",
+                "supplied": planner_version,
+            }
+        )
+
+    fanout_step = metadata.get("fanout_step")
+    target_step = metadata.get("target_step")
+    if not isinstance(fanout_step, str) or not fanout_step:
+        failures.append({"field": f"{field_prefix}.fanout_step", "reason": "must be a non-empty string"})
+    if not isinstance(target_step, str) or not target_step:
+        failures.append({"field": f"{field_prefix}.target_step", "reason": "must be a non-empty string"})
+
+    targets = metadata.get("fanout_targets")
+    if not isinstance(targets, list) or len(targets) < 2 or not all(isinstance(item, str) and item for item in targets):
+        failures.append(
+            {
+                "field": f"{field_prefix}.fanout_targets",
+                "reason": "must include at least two target step names",
+            }
+        )
+
+    target_index = metadata.get("target_index")
+    if isinstance(target_index, bool) or not isinstance(target_index, int) or target_index < 0:
+        failures.append(
+            {
+                "field": f"{field_prefix}.target_index",
+                "reason": "must be a non-negative integer",
+                "supplied": target_index,
+            }
+        )
+    elif isinstance(targets, list) and target_index >= len(targets):
+        failures.append(
+            {
+                "field": f"{field_prefix}.target_index",
+                "reason": "must point inside fanout_targets",
+                "supplied": target_index,
+            }
+        )
+    elif isinstance(targets, list) and isinstance(target_step, str) and targets[target_index] != target_step:
+        failures.append(
+            {
+                "field": f"{field_prefix}.target_step",
+                "reason": "target_step must match fanout_targets[target_index]",
+                "target_step": target_step,
+                "target_at_index": targets[target_index],
+            }
+        )
+
+    reduce_steps = metadata.get("reduce_steps")
+    if reduce_steps is not None and (
+        not isinstance(reduce_steps, list)
+        or not all(isinstance(item, str) and item for item in reduce_steps)
+    ):
+        failures.append(
+            {
+                "field": f"{field_prefix}.reduce_steps",
+                "reason": "must be a list of step names when present",
+            }
+        )
+
+    return {
+        "match": {
+            "command_id": command_id,
+            "fanout_step": fanout_step,
+            "target_step": target_step,
+            "target_index": target_index,
+            "reduce_steps": list(reduce_steps or []) if isinstance(reduce_steps, list) else [],
+        },
+        "failures": failures,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate replay fan-out/reduce metadata evidence")
+    parser.add_argument("--report", required=True, type=Path)
+    parser.add_argument("--allow-no-reduce", action="store_true")
+    args = parser.parse_args(argv)
+
+    output = validate_replay_fanout_reduce_report(
+        _load_json_object(args.report),
+        require_reduce=not args.allow_no_reduce,
+    )
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0 if output["matched"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -24,6 +24,9 @@ fi
   tests/scripts/test_package_replay_validation_artifacts.py \
   tests/scripts/test_check_replay_validation_bundle.py \
   tests/scripts/test_check_replay_validation_manifest.py \
+  tests/scripts/test_build_fanout_phase6_report.py \
+  tests/scripts/test_check_fanout_phase6_evidence.py \
+  tests/scripts/test_check_replay_fanout_reduce_report.py \
   tests/scripts/test_check_replay_state_report.py \
   tests/scripts/test_check_replay_parity_report.py \
   tests/scripts/test_check_replay_payload_resolution_report.py \
@@ -42,4 +45,6 @@ fi
   tests/api/test_frame_routes.py \
   tests/core/test_arrow_ipc_serialization.py \
   tests/core/test_storage_ipc_hint.py \
-  tests/core/test_storage_ipc_cache.py
+  tests/core/test_storage_ipc_cache.py \
+  tests/unit/dsl/engine/test_fanout_reduce_planner.py \
+  tests/unit/dsl/engine/test_engine.py::test_inclusive_transition_commands_carry_fanout_reduce_metadata

--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -11,6 +11,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from scripts.check_fanout_phase6_evidence import validate_fanout_phase6_report
 from scripts.check_projector_phase2_evidence import validate_projector_phase2_evidence
 from scripts.check_replay_validation_manifest import _load_manifest, _validate_manifest
 from scripts.check_storage_phase5_evidence import validate_storage_phase5_evidence
@@ -40,6 +41,7 @@ def validate_bundle(
     require_projection_parity: bool = False,
     require_worker_ipc_phase3: bool = False,
     require_storage_phase5: bool = False,
+    require_fanout_phase6: bool = False,
 ) -> dict[str, Any]:
     failures: list[dict[str, Any]] = []
     manifest = _load_manifest(manifest_path)
@@ -102,6 +104,20 @@ def validate_bundle(
                     "field": "phase5_storage_evidence",
                     "reason": "Phase 5 storage registry evidence validation failed",
                     "failures": phase5_result.get("failures", []),
+                }
+            )
+    phase6_result: dict[str, Any] | None = None
+    if require_fanout_phase6:
+        phase6_result = _validate_fanout_phase6_evidence(
+            manifest,
+            manifest_path=manifest_path,
+        )
+        if phase6_result.get("matched") is not True:
+            failures.append(
+                {
+                    "field": "phase6_fanout_evidence",
+                    "reason": "Phase 6 fan-out/reduce planner evidence validation failed",
+                    "failures": phase6_result.get("failures", []),
                 }
             )
 
@@ -169,7 +185,84 @@ def validate_bundle(
         "phase2_projector_result": phase2_result,
         "phase3_worker_ipc_result": phase3_result,
         "phase5_storage_result": phase5_result,
+        "phase6_fanout_result": phase6_result,
         "artifact_index_result": index_result,
+        "failures": failures,
+    }
+
+
+def _validate_fanout_phase6_evidence(
+    manifest: dict[str, Any],
+    *,
+    manifest_path: Path,
+) -> dict[str, Any]:
+    failures: list[dict[str, Any]] = []
+    artifacts = manifest.get("artifacts")
+    artifacts = artifacts if isinstance(artifacts, dict) else {}
+    reports = artifacts.get("fanout_reduce_planner")
+    if not isinstance(reports, list) or not reports:
+        failures.append(
+            {
+                "field": "artifacts.fanout_reduce_planner",
+                "reason": "Phase 6 evidence requires at least one fan-out/reduce planner report",
+            }
+        )
+        reports = []
+
+    steps = manifest.get("steps")
+    step_names = [
+        step.get("name")
+        for step in (steps if isinstance(steps, list) else [])
+        if isinstance(step, dict)
+    ]
+    if "fanout_reduce_planner_integrity" not in step_names:
+        failures.append(
+            {
+                "field": "steps",
+                "reason": "Phase 6 evidence requires a fan-out/reduce planner integrity step",
+            }
+        )
+
+    report_results: list[dict[str, Any]] = []
+    for index, entry in enumerate(reports):
+        if not isinstance(entry, dict):
+            continue
+        path_value = entry.get("path")
+        if not isinstance(path_value, str) or not path_value:
+            continue
+        path = resolve_indexed_path(path_value, index_path=manifest_path)
+        try:
+            report = json.loads(path.read_text())
+            if not isinstance(report, dict):
+                raise ValueError(f"{path} must contain a JSON object")
+            result = validate_fanout_phase6_report(
+                report,
+                require_fanout=True,
+                require_reduce=True,
+            )
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            failures.append(
+                {
+                    "field": f"artifacts.fanout_reduce_planner[{index}].path",
+                    "reason": "fan-out/reduce planner report could not be read",
+                    "path": path_value,
+                    "error": str(exc),
+                }
+            )
+            continue
+        report_results.append({"role": entry.get("role"), "path": str(path), "result": result})
+        if result.get("matched") is not True:
+            failures.append(
+                {
+                    "field": f"artifacts.fanout_reduce_planner[{index}]",
+                    "reason": "fan-out/reduce planner report validation failed",
+                    "failures": result.get("failures", []),
+                }
+            )
+
+    return {
+        "matched": not failures,
+        "report_results": report_results,
         "failures": failures,
     }
 
@@ -199,6 +292,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Require Phase 5 storage backend registry evidence in the manifest",
     )
+    parser.add_argument(
+        "--require-fanout-phase6",
+        action="store_true",
+        help="Require Phase 6 fan-out/reduce planner evidence in the manifest",
+    )
     args = parser.parse_args(argv)
 
     output = validate_bundle(
@@ -209,6 +307,7 @@ def main(argv: list[str] | None = None) -> int:
         require_projection_parity=args.require_projection_parity,
         require_worker_ipc_phase3=args.require_worker_ipc_phase3,
         require_storage_phase5=args.require_storage_phase5,
+        require_fanout_phase6=args.require_fanout_phase6,
     )
     print(json.dumps(output, indent=2, sort_keys=True))
     return 0 if output["matched"] else 1

--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.check_fanout_phase6_evidence import validate_fanout_phase6_report
 from scripts.check_projector_phase2_evidence import validate_projector_phase2_evidence
+from scripts.check_replay_fanout_reduce_report import validate_replay_fanout_reduce_report
 from scripts.check_replay_validation_manifest import _load_manifest, _validate_manifest
 from scripts.check_storage_phase5_evidence import validate_storage_phase5_evidence
 from scripts.check_worker_ipc_phase3_evidence import validate_worker_ipc_phase3_evidence
@@ -42,6 +43,7 @@ def validate_bundle(
     require_worker_ipc_phase3: bool = False,
     require_storage_phase5: bool = False,
     require_fanout_phase6: bool = False,
+    require_replay_fanout_phase6: bool = False,
 ) -> dict[str, Any]:
     failures: list[dict[str, Any]] = []
     manifest = _load_manifest(manifest_path)
@@ -120,6 +122,20 @@ def validate_bundle(
                     "failures": phase6_result.get("failures", []),
                 }
             )
+    replay_phase6_result: dict[str, Any] | None = None
+    if require_replay_fanout_phase6:
+        replay_phase6_result = _validate_replay_fanout_phase6_evidence(
+            manifest,
+            manifest_path=manifest_path,
+        )
+        if replay_phase6_result.get("matched") is not True:
+            failures.append(
+                {
+                    "field": "phase6_replay_fanout_evidence",
+                    "reason": "Phase 6 replay fan-out/reduce evidence validation failed",
+                    "failures": replay_phase6_result.get("failures", []),
+                }
+            )
 
     manifest_index = _artifact_index_from_manifest(manifest)
     if artifact_index_path is None:
@@ -186,6 +202,7 @@ def validate_bundle(
         "phase3_worker_ipc_result": phase3_result,
         "phase5_storage_result": phase5_result,
         "phase6_fanout_result": phase6_result,
+        "phase6_replay_fanout_result": replay_phase6_result,
         "artifact_index_result": index_result,
         "failures": failures,
     }
@@ -267,6 +284,71 @@ def _validate_fanout_phase6_evidence(
     }
 
 
+def _validate_replay_fanout_phase6_evidence(
+    manifest: dict[str, Any],
+    *,
+    manifest_path: Path,
+) -> dict[str, Any]:
+    failures: list[dict[str, Any]] = []
+    artifacts = manifest.get("artifacts")
+    artifacts = artifacts if isinstance(artifacts, dict) else {}
+    replay_path = artifacts.get("replay")
+    if not isinstance(replay_path, str) or not replay_path:
+        failures.append(
+            {
+                "field": "artifacts.replay",
+                "reason": "Phase 6 replay evidence requires a replay artifact",
+            }
+        )
+        return {"matched": False, "result": None, "failures": failures}
+
+    steps = manifest.get("steps")
+    step_names = [
+        step.get("name")
+        for step in (steps if isinstance(steps, list) else [])
+        if isinstance(step, dict)
+    ]
+    if "replay_fanout_reduce_integrity" not in step_names:
+        failures.append(
+            {
+                "field": "steps",
+                "reason": "Phase 6 replay evidence requires replay_fanout_reduce_integrity step",
+            }
+        )
+
+    path = resolve_indexed_path(replay_path, index_path=manifest_path)
+    try:
+        report = json.loads(path.read_text())
+        if not isinstance(report, dict):
+            raise ValueError(f"{path} must contain a JSON object")
+        result = validate_replay_fanout_reduce_report(report)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        failures.append(
+            {
+                "field": "artifacts.replay",
+                "reason": "replay artifact could not be read for Phase 6 evidence",
+                "path": replay_path,
+                "error": str(exc),
+            }
+        )
+        return {"matched": False, "result": None, "failures": failures}
+
+    if result.get("matched") is not True:
+        failures.append(
+            {
+                "field": "artifacts.replay",
+                "reason": "replay fan-out/reduce metadata validation failed",
+                "failures": result.get("failures", []),
+            }
+        )
+
+    return {
+        "matched": not failures,
+        "result": result,
+        "failures": failures,
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Validate a replay validation evidence bundle")
     parser.add_argument("--manifest", required=True, type=Path)
@@ -297,6 +379,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Require Phase 6 fan-out/reduce planner evidence in the manifest",
     )
+    parser.add_argument(
+        "--require-replay-fanout-phase6",
+        action="store_true",
+        help="Require Phase 6 fan-out/reduce metadata in the replay artifact",
+    )
     args = parser.parse_args(argv)
 
     output = validate_bundle(
@@ -308,6 +395,7 @@ def main(argv: list[str] | None = None) -> int:
         require_worker_ipc_phase3=args.require_worker_ipc_phase3,
         require_storage_phase5=args.require_storage_phase5,
         require_fanout_phase6=args.require_fanout_phase6,
+        require_replay_fanout_phase6=args.require_replay_fanout_phase6,
     )
     print(json.dumps(output, indent=2, sort_keys=True))
     return 0 if output["matched"] else 1

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -33,6 +33,7 @@ OPTIONAL_STEP_NAMES = (
     "payload_resolution",
     "runtime_locator_live_rows",
     "runtime_locator_state",
+    "replay_fanout_reduce_integrity",
     "artifact_index",
     "storage_backend_registry_report",
     "fanout_reduce_planner_report",

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -35,6 +35,7 @@ OPTIONAL_STEP_NAMES = (
     "runtime_locator_state",
     "artifact_index",
     "storage_backend_registry_report",
+    "fanout_reduce_planner_report",
 )
 
 
@@ -94,6 +95,10 @@ def _is_worker_metrics_step(name: str) -> bool:
 
 def _is_storage_backend_registry_step(name: str) -> bool:
     return name == "storage_backend_registry_integrity"
+
+
+def _is_fanout_reduce_planner_step(name: str) -> bool:
+    return name == "fanout_reduce_planner_integrity"
 
 
 def _validate_artifact_list(
@@ -205,6 +210,15 @@ def _validate_manifest(
                 _validate_artifact_list(
                     failures,
                     field="artifacts.storage_backend_registry",
+                    value=value,
+                    manifest_path=manifest_path,
+                    check_artifacts=check_artifacts,
+                )
+                continue
+            if field == "fanout_reduce_planner":
+                _validate_artifact_list(
+                    failures,
+                    field="artifacts.fanout_reduce_planner",
                     value=value,
                     manifest_path=manifest_path,
                     check_artifacts=check_artifacts,
@@ -354,6 +368,14 @@ def _validate_manifest(
                 "reason": "storage backend registry artifacts require an integrity step",
             }
         )
+    fanout_reduce_planner = artifacts.get("fanout_reduce_planner") if isinstance(artifacts, dict) else None
+    if fanout_reduce_planner and "fanout_reduce_planner_integrity" not in step_names:
+        failures.append(
+            {
+                "field": "steps",
+                "reason": "fan-out/reduce planner artifacts require an integrity step",
+            }
+        )
     if artifacts_index:
         if "artifact_index" not in step_names:
             failures.append(
@@ -382,6 +404,8 @@ def _validate_manifest(
         if _is_worker_metrics_step(name):
             continue
         if _is_storage_backend_registry_step(name):
+            continue
+        if _is_fanout_reduce_planner_step(name):
             continue
         if name not in (*REQUIRED_STEP_ORDER, *OPTIONAL_STEP_NAMES, "fetch_artifact"):
             failures.append({"field": "steps", "reason": "unknown validation step", "step": name})

--- a/scripts/export_live_projection_rows_postgres.py
+++ b/scripts/export_live_projection_rows_postgres.py
@@ -156,6 +156,7 @@ SELECT
     COALESCE(c.meta->'locality', '{}'::jsonb) AS locality,
     COALESCE(c.meta->'source_locality', '{}'::jsonb) AS source_locality,
     COALESCE(c.meta->'placement', '{}'::jsonb) AS placement,
+    COALESCE(c.meta->'fanout_reduce', '{}'::jsonb) AS fanout_reduce,
     c.status,
     c.event_id AS issued_event_id,
     ce.claimed_event_id,

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -123,6 +123,7 @@ def _build_report(
                 str(path) for path in args.fanout_reduce_planner_report
             ],
             "fanout_reduce_playbook": [str(path) for path in args.fanout_reduce_playbook],
+            "check_replay_fanout_reduce": bool(args.check_replay_fanout_reduce),
             "artifact_index_output": str(args.artifact_index_output) if args.artifact_index_output else None,
         },
         "steps": steps,
@@ -239,6 +240,11 @@ def main(argv: list[str] | None = None) -> int:
         default=[],
         type=Path,
         help="Playbook to include in a generated Phase 6 fan-out/reduce planner report",
+    )
+    parser.add_argument(
+        "--check-replay-fanout-reduce",
+        action="store_true",
+        help="Validate Phase 6 fan-out/reduce command metadata in the fetched replay report",
     )
     args = parser.parse_args(argv)
 
@@ -607,6 +613,17 @@ def main(argv: list[str] | None = None) -> int:
                 str(replay_path),
             ]
             if args.resolve_payloads
+            else [],
+        ),
+        (
+            "replay_fanout_reduce_integrity",
+            [
+                _validation_python(),
+                "scripts/check_replay_fanout_reduce_report.py",
+                "--report",
+                str(replay_path),
+            ]
+            if args.check_replay_fanout_reduce
             else [],
         ),
     ]

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -73,6 +73,7 @@ def _build_report(
     projector_summaries: list[dict[str, str]],
     worker_metrics: list[dict[str, str]],
     storage_backend_registry: list[dict[str, str]],
+    fanout_reduce_planner: list[dict[str, str]],
     steps: list[dict[str, object]],
     started_at: str,
 ) -> dict[str, object]:
@@ -89,6 +90,7 @@ def _build_report(
             "projector_summaries": projector_summaries,
             "worker_metrics": worker_metrics,
             "storage_backend_registry": storage_backend_registry,
+            "fanout_reduce_planner": fanout_reduce_planner,
             "report": str(args.report_output) if args.report_output else None,
             "artifact_index": str(args.artifact_index_output) if args.artifact_index_output else None,
         },
@@ -117,6 +119,10 @@ def _build_report(
             "build_storage_backend_registry_report": bool(
                 args.build_storage_backend_registry_report
             ),
+            "fanout_reduce_planner_report": [
+                str(path) for path in args.fanout_reduce_planner_report
+            ],
+            "fanout_reduce_playbook": [str(path) for path in args.fanout_reduce_playbook],
             "artifact_index_output": str(args.artifact_index_output) if args.artifact_index_output else None,
         },
         "steps": steps,
@@ -219,6 +225,20 @@ def main(argv: list[str] | None = None) -> int:
         "--build-storage-backend-registry-report",
         action="store_true",
         help="Build and validate a Phase 5 storage backend registry evidence report",
+    )
+    parser.add_argument(
+        "--fanout-reduce-planner-report",
+        action="append",
+        default=[],
+        type=Path,
+        help="Optional saved Phase 6 fan-out/reduce planner evidence report",
+    )
+    parser.add_argument(
+        "--fanout-reduce-playbook",
+        action="append",
+        default=[],
+        type=Path,
+        help="Playbook to include in a generated Phase 6 fan-out/reduce planner report",
     )
     args = parser.parse_args(argv)
 
@@ -417,6 +437,51 @@ def main(argv: list[str] | None = None) -> int:
                 ],
             )
         )
+    fanout_reduce_planner: list[dict[str, str]] = []
+    fanout_report_steps: list[tuple[str, list[str]]] = []
+    fanout_check_steps: list[tuple[str, list[str]]] = []
+    for idx, path in enumerate(args.fanout_reduce_planner_report, start=1):
+        role = f"fanout_reduce_planner_{idx}"
+        fanout_reduce_planner.append({"role": role, "path": str(path)})
+        fanout_check_steps.append(
+            (
+                "fanout_reduce_planner_integrity",
+                [
+                    _validation_python(),
+                    "scripts/check_fanout_phase6_evidence.py",
+                    "--report",
+                    str(path),
+                    "--require-fanout",
+                    "--require-reduce",
+                ],
+            )
+        )
+    if args.fanout_reduce_playbook:
+        role = "fanout_reduce_planner_generated"
+        path = output_dir / "fanout-phase6-report.json"
+        fanout_reduce_planner.append({"role": role, "path": str(path)})
+        report_command = [
+            _validation_python(),
+            "scripts/build_fanout_phase6_report.py",
+            "--output",
+            str(path),
+        ]
+        for playbook_path in args.fanout_reduce_playbook:
+            report_command.extend(["--playbook", str(playbook_path)])
+        fanout_report_steps.append(("fanout_reduce_planner_report", report_command))
+        fanout_check_steps.append(
+            (
+                "fanout_reduce_planner_integrity",
+                [
+                    _validation_python(),
+                    "scripts/check_fanout_phase6_evidence.py",
+                    "--report",
+                    str(path),
+                    "--require-fanout",
+                    "--require-reduce",
+                ],
+            )
+        )
     fetch_command = [
         _validation_python(),
         "scripts/fetch_replay_state_report.py",
@@ -551,6 +616,8 @@ def main(argv: list[str] | None = None) -> int:
     validation_steps.extend(worker_check_steps)
     validation_steps.extend(storage_report_steps)
     validation_steps.extend(storage_check_steps)
+    validation_steps.extend(fanout_report_steps)
+    validation_steps.extend(fanout_check_steps)
 
     for name, command in validation_steps:
         if not command:
@@ -580,6 +647,7 @@ def main(argv: list[str] | None = None) -> int:
                     projector_summaries=projector_summaries,
                     worker_metrics=worker_metrics,
                     storage_backend_registry=storage_backend_registry,
+                    fanout_reduce_planner=fanout_reduce_planner,
                     steps=steps,
                     started_at=started_at,
                 ),
@@ -606,6 +674,7 @@ def main(argv: list[str] | None = None) -> int:
                     projector_summaries=projector_summaries,
                     worker_metrics=worker_metrics,
                     storage_backend_registry=storage_backend_registry,
+                    fanout_reduce_planner=fanout_reduce_planner,
                     steps=steps,
                     started_at=started_at,
                 ),
@@ -644,6 +713,13 @@ def main(argv: list[str] | None = None) -> int:
                     f"{report['role']}={report['path']}",
                 ]
             )
+        for report in fanout_reduce_planner:
+            artifact_index_command.extend(
+                [
+                    "--artifact",
+                    f"{report['role']}={report['path']}",
+                ]
+            )
         steps.append(
             {
                 "name": "artifact_index",
@@ -672,6 +748,7 @@ def main(argv: list[str] | None = None) -> int:
             projector_summaries=projector_summaries,
             worker_metrics=worker_metrics,
             storage_backend_registry=storage_backend_registry,
+            fanout_reduce_planner=fanout_reduce_planner,
             steps=steps,
             started_at=started_at,
         ),
@@ -701,6 +778,7 @@ def main(argv: list[str] | None = None) -> int:
                     projector_summaries=projector_summaries,
                     worker_metrics=worker_metrics,
                     storage_backend_registry=storage_backend_registry,
+                    fanout_reduce_planner=fanout_reduce_planner,
                     steps=steps,
                     started_at=started_at,
                 ),

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -802,6 +802,35 @@ def main(argv: list[str] | None = None) -> int:
                 args.report_output,
             )
             return code
+        if not args.artifact_index_output.exists():
+            steps[-1] = {
+                "name": "artifact_index",
+                "command": artifact_index_command,
+                "returncode": 1,
+                "duration_seconds": round(duration, 6),
+                "stdout": stdout,
+                "stderr": f"artifact index step did not create artifact index: {args.artifact_index_output}",
+            }
+            stdout_json = _parse_json(stdout)
+            if stdout_json is not None:
+                steps[-1]["stdout_json"] = stdout_json
+            _emit_report(
+                _build_report(
+                    matched=False,
+                    args=args,
+                    replay_path=replay_path,
+                    live_checksums_path=live_checksums_path,
+                    live_rows_path=live_rows_path,
+                    projector_summaries=projector_summaries,
+                    worker_metrics=worker_metrics,
+                    storage_backend_registry=storage_backend_registry,
+                    fanout_reduce_planner=fanout_reduce_planner,
+                    steps=steps,
+                    started_at=started_at,
+                ),
+                args.report_output,
+            )
+            return 1
     return 0
 
 

--- a/tests/api/test_replay_routes.py
+++ b/tests/api/test_replay_routes.py
@@ -394,7 +394,17 @@ def test_fold_replay_state_tracks_commands_and_topology():
                 "command_id": 900,
                 "stage_id": 7,
                 "node_name": "fetch",
-                "meta": {"parent_command_id": "899"},
+                "meta": {
+                    "parent_command_id": "899",
+                    "fanout_reduce": {
+                        "planner_version": 1,
+                        "fanout_step": "start",
+                        "fanout_targets": ["fetch", "transform"],
+                        "target_step": "fetch",
+                        "target_index": 0,
+                        "reduce_steps": ["join"],
+                    },
+                },
             },
             {
                 "event_id": 12,
@@ -448,6 +458,14 @@ def test_fold_replay_state_tracks_commands_and_topology():
     assert command["locality"] == {"node_id": "node-a", "worker_pool": "worker-cpu-01"}
     assert command["source_locality"] == {"node_id": "node-a"}
     assert command["placement"]["within_max_distance"] is True
+    assert command["fanout_reduce"] == {
+        "planner_version": 1,
+        "fanout_step": "start",
+        "fanout_targets": ["fetch", "transform"],
+        "target_step": "fetch",
+        "target_index": 0,
+        "reduce_steps": ["join"],
+    }
 
 
 def test_fold_replay_state_tracks_business_objects():
@@ -953,7 +971,17 @@ def test_command_projection_checksum_matches_live_rows_and_replayed_state():
             "command_id": 900,
             "stage_id": 7,
             "frame_id": 42,
-            "meta": {"parent_command_id": "899"},
+            "meta": {
+                "parent_command_id": "899",
+                "fanout_reduce": {
+                    "planner_version": 1,
+                    "fanout_step": "start",
+                    "fanout_targets": ["fetch", "transform"],
+                    "target_step": "fetch",
+                    "target_index": 0,
+                    "reduce_steps": ["join"],
+                },
+            },
         },
         {
             "event_id": 21,
@@ -1005,6 +1033,14 @@ def test_command_projection_checksum_matches_live_rows_and_replayed_state():
                     "distance": "node",
                     "max_distance": "node",
                     "within_max_distance": True,
+                },
+                "fanout_reduce": {
+                    "planner_version": 1,
+                    "fanout_step": "start",
+                    "fanout_targets": ["fetch", "transform"],
+                    "target_step": "fetch",
+                    "target_index": 0,
+                    "reduce_steps": ["join"],
                 },
                 "status": "COMPLETED",
                 "issued_event_id": 20,

--- a/tests/fixtures/playbooks/fanout_reduce/fanout_reduce_phase6.yaml
+++ b/tests/fixtures/playbooks/fanout_reduce/fanout_reduce_phase6.yaml
@@ -1,0 +1,50 @@
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: fanout_reduce_phase6
+  path: tests/fixtures/fanout_reduce_phase6
+
+workflow:
+  - step: start
+    tool:
+      kind: python
+      code: |
+        def main():
+            return {"status": "ok"}
+    next:
+      spec:
+        mode: inclusive
+      arcs:
+        - step: normalize_customer
+        - step: enrich_customer
+
+  - step: normalize_customer
+    tool:
+      kind: python
+      code: |
+        def main():
+            return {"normalized": True}
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: reduce_customer
+
+  - step: enrich_customer
+    tool:
+      kind: python
+      code: |
+        def main():
+            return {"enriched": True}
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: reduce_customer
+
+  - step: reduce_customer
+    tool:
+      kind: python
+      code: |
+        def main():
+            return {"reduced": True}

--- a/tests/scripts/test_build_fanout_phase6_report.py
+++ b/tests/scripts/test_build_fanout_phase6_report.py
@@ -1,6 +1,29 @@
 import json
+from pathlib import Path
 
 from scripts.build_fanout_phase6_report import build_fanout_phase6_report
+
+
+def test_build_fanout_phase6_report_from_repo_fixture():
+    playbook = Path("tests/fixtures/playbooks/fanout_reduce/fanout_reduce_phase6.yaml")
+
+    report = build_fanout_phase6_report([playbook])
+
+    assert report["summary"] == {"playbooks": 1, "fanouts": 1, "reduces": 1}
+    planner = report["playbooks"][0]["planner"]
+    assert planner["fanouts"] == [
+        {
+            "step": "start",
+            "arcs": ["normalize_customer", "enrich_customer"],
+            "reduce_steps": ["reduce_customer"],
+        }
+    ]
+    assert planner["reduces"] == [
+        {
+            "step": "reduce_customer",
+            "upstream_steps": ["normalize_customer", "enrich_customer"],
+        }
+    ]
 
 
 def test_build_fanout_phase6_report_counts_planned_boundaries(tmp_path):

--- a/tests/scripts/test_build_fanout_phase6_report.py
+++ b/tests/scripts/test_build_fanout_phase6_report.py
@@ -1,0 +1,59 @@
+import json
+
+from scripts.build_fanout_phase6_report import build_fanout_phase6_report
+
+
+def test_build_fanout_phase6_report_counts_planned_boundaries(tmp_path):
+    playbook = tmp_path / "fanout.yaml"
+    playbook.write_text(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: fanout_report
+
+workflow:
+  - step: start
+    tool:
+      kind: python
+      code: "def main(): return {}"
+    next:
+      spec:
+        mode: inclusive
+      arcs:
+        - step: a
+        - step: b
+  - step: a
+    tool:
+      kind: python
+      code: "def main(): return {}"
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: join
+  - step: b
+    tool:
+      kind: python
+      code: "def main(): return {}"
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: join
+  - step: join
+    tool:
+      kind: python
+      code: "def main(): return {}"
+""",
+        encoding="utf-8",
+    )
+
+    report = build_fanout_phase6_report([playbook])
+
+    assert json.loads(json.dumps(report))
+    assert report["planner_version"] == 1
+    assert report["summary"] == {"playbooks": 1, "fanouts": 1, "reduces": 1}
+    planner = report["playbooks"][0]["planner"]
+    assert planner["fanouts"][0]["reduce_steps"] == ["join"]
+    assert planner["reduces"][0]["upstream_steps"] == ["a", "b"]

--- a/tests/scripts/test_check_fanout_phase6_evidence.py
+++ b/tests/scripts/test_check_fanout_phase6_evidence.py
@@ -1,0 +1,79 @@
+from scripts.check_fanout_phase6_evidence import validate_fanout_phase6_report
+
+
+def test_validate_fanout_phase6_report_accepts_matching_report():
+    report = {
+        "planner_version": 1,
+        "summary": {"playbooks": 1, "fanouts": 1, "reduces": 1},
+        "playbooks": [
+            {
+                "path": "playbooks/fanout.yaml",
+                "name": "fanout",
+                "planner": {
+                    "fanouts": [
+                        {
+                            "step": "start",
+                            "arcs": ["a", "b"],
+                            "reduce_steps": ["join"],
+                        }
+                    ],
+                    "reduces": [
+                        {
+                            "step": "join",
+                            "upstream_steps": ["a", "b"],
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+
+    result = validate_fanout_phase6_report(report, require_fanout=True, require_reduce=True)
+
+    assert result["matched"] is True
+    assert result["summary"] == {"playbooks": 1, "fanouts": 1, "reduces": 1}
+    assert result["failures"] == []
+
+
+def test_validate_fanout_phase6_report_rejects_count_mismatch():
+    report = {
+        "planner_version": 1,
+        "summary": {"playbooks": 1, "fanouts": 2, "reduces": 0},
+        "playbooks": [
+            {
+                "path": "playbooks/fanout.yaml",
+                "name": "fanout",
+                "planner": {
+                    "fanouts": [{"step": "start", "arcs": ["a", "b"], "reduce_steps": []}],
+                    "reduces": [],
+                },
+            }
+        ],
+    }
+
+    result = validate_fanout_phase6_report(report)
+
+    assert result["matched"] is False
+    assert any(failure["field"] == "summary.fanouts" for failure in result["failures"])
+
+
+def test_validate_fanout_phase6_report_rejects_missing_required_reduce():
+    report = {
+        "planner_version": 1,
+        "summary": {"playbooks": 1, "fanouts": 1, "reduces": 0},
+        "playbooks": [
+            {
+                "path": "playbooks/fanout.yaml",
+                "name": "fanout",
+                "planner": {
+                    "fanouts": [{"step": "start", "arcs": ["a", "b"], "reduce_steps": []}],
+                    "reduces": [],
+                },
+            }
+        ],
+    }
+
+    result = validate_fanout_phase6_report(report, require_fanout=True, require_reduce=True)
+
+    assert result["matched"] is False
+    assert any(failure["field"] == "summary.reduces" for failure in result["failures"])

--- a/tests/scripts/test_check_replay_fanout_reduce_report.py
+++ b/tests/scripts/test_check_replay_fanout_reduce_report.py
@@ -1,0 +1,60 @@
+from scripts.check_replay_fanout_reduce_report import validate_replay_fanout_reduce_report
+
+
+def _report():
+    return {
+        "commands": {
+            "10": {
+                "command_id": "10",
+                "step": "normalize_customer",
+                "fanout_reduce": {
+                    "planner_version": 1,
+                    "fanout_step": "start",
+                    "fanout_targets": ["normalize_customer", "enrich_customer"],
+                    "target_step": "normalize_customer",
+                    "target_index": 0,
+                    "reduce_steps": ["reduce_customer"],
+                },
+            }
+        }
+    }
+
+
+def test_validate_replay_fanout_reduce_report_accepts_valid_metadata():
+    result = validate_replay_fanout_reduce_report(_report())
+
+    assert result["matched"] is True
+    assert result["fanout_commands"] == 1
+    assert result["fanout_steps"] == ["start"]
+    assert result["reduce_steps"] == ["reduce_customer"]
+    assert result["failures"] == []
+
+
+def test_validate_replay_fanout_reduce_report_rejects_missing_metadata():
+    result = validate_replay_fanout_reduce_report({"commands": {"10": {"command_id": "10"}}})
+
+    assert result["matched"] is False
+    assert result["failures"][0]["field"] == "commands"
+
+
+def test_validate_replay_fanout_reduce_report_rejects_bad_target_index():
+    report = _report()
+    report["commands"]["10"]["fanout_reduce"]["target_index"] = 1
+
+    result = validate_replay_fanout_reduce_report(report)
+
+    assert result["matched"] is False
+    assert any(
+        failure["field"] == "commands.10.fanout_reduce.target_step"
+        for failure in result["failures"]
+    )
+
+
+def test_validate_replay_fanout_reduce_report_can_allow_no_reduce():
+    report = _report()
+    report["commands"]["10"]["fanout_reduce"]["reduce_steps"] = []
+
+    result = validate_replay_fanout_reduce_report(report, require_reduce=False)
+
+    assert result["matched"] is True
+    assert result["reduce_steps"] == []

--- a/tests/scripts/test_check_replay_validation_bundle.py
+++ b/tests/scripts/test_check_replay_validation_bundle.py
@@ -94,6 +94,53 @@ def _bundle(tmp_path: Path) -> tuple[Path, Path]:
     return manifest, index
 
 
+def _add_replay_fanout_phase6_evidence(manifest: Path, index: Path) -> None:
+    payload = json.loads(manifest.read_text())
+    replay = Path(payload["artifacts"]["replay"])
+    replay.write_text(
+        json.dumps(
+            {
+                "commands": {
+                    "10": {
+                        "command_id": "10",
+                        "fanout_reduce": {
+                            "planner_version": 1,
+                            "fanout_step": "start",
+                            "fanout_targets": ["a", "b"],
+                            "target_step": "a",
+                            "target_index": 0,
+                            "reduce_steps": ["join"],
+                        },
+                    }
+                }
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    payload["config"]["check_replay_fanout_reduce"] = True
+    payload["steps"].insert(
+        -1,
+        {
+            "name": "replay_fanout_reduce_integrity",
+            "command": ["python", "scripts/check_replay_fanout_reduce_report.py"],
+            "returncode": 0,
+            "duration_seconds": 0.1,
+            "stdout": "{}",
+            "stderr": "",
+        },
+    )
+    manifest.write_text(json.dumps(payload))
+    index.write_text(
+        json.dumps(
+            build_artifact_index(manifest_path=manifest, output_path=index),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
 def _add_projector_phase2_evidence(manifest: Path, index: Path, tmp_path: Path) -> None:
     payload = json.loads(manifest.read_text())
     summary = tmp_path / "projector-summary.json"
@@ -572,5 +619,32 @@ def test_check_replay_validation_bundle_rejects_missing_fanout_phase6_evidence(
     output = json.loads(capsys.readouterr().out)
     assert any(
         failure["field"] == "phase6_fanout_evidence"
+        for failure in output["failures"]
+    )
+
+
+def test_check_replay_validation_bundle_accepts_replay_fanout_phase6_evidence(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, index = _bundle(tmp_path)
+    _add_replay_fanout_phase6_evidence(manifest, index)
+
+    assert main(["--manifest", str(manifest), "--require-replay-fanout-phase6"]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True
+    assert output["phase6_replay_fanout_result"]["matched"] is True
+
+
+def test_check_replay_validation_bundle_rejects_missing_replay_fanout_phase6_evidence(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, _index = _bundle(tmp_path)
+
+    assert main(["--manifest", str(manifest), "--require-replay-fanout-phase6"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any(
+        failure["field"] == "phase6_replay_fanout_evidence"
         for failure in output["failures"]
     )

--- a/tests/scripts/test_check_replay_validation_bundle.py
+++ b/tests/scripts/test_check_replay_validation_bundle.py
@@ -217,6 +217,34 @@ def _storage_phase5_report() -> dict:
     }
 
 
+def _fanout_phase6_report() -> dict:
+    return {
+        "planner_version": 1,
+        "summary": {"playbooks": 1, "fanouts": 1, "reduces": 1},
+        "playbooks": [
+            {
+                "path": "tests/fixtures/playbooks/fanout.yaml",
+                "name": "fanout",
+                "planner": {
+                    "fanouts": [
+                        {
+                            "step": "start",
+                            "arcs": ["a", "b"],
+                            "reduce_steps": ["join"],
+                        }
+                    ],
+                    "reduces": [
+                        {
+                            "step": "join",
+                            "upstream_steps": ["a", "b"],
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+
+
 def _add_storage_phase5_evidence(manifest: Path, index: Path, tmp_path: Path) -> None:
     payload = json.loads(manifest.read_text())
     report = tmp_path / "storage-phase5-report.json"
@@ -254,6 +282,51 @@ def _add_storage_phase5_evidence(manifest: Path, index: Path, tmp_path: Path) ->
                 manifest_path=manifest,
                 output_path=index,
                 extra_artifacts=[("storage_backend_registry", report)],
+            ),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+def _add_fanout_phase6_evidence(manifest: Path, index: Path, tmp_path: Path) -> None:
+    payload = json.loads(manifest.read_text())
+    report = tmp_path / "fanout-phase6-report.json"
+    report.write_text(json.dumps(_fanout_phase6_report(), indent=2, sort_keys=True))
+    payload["artifacts"]["fanout_reduce_planner"] = [
+        {"role": "fanout_reduce_planner", "path": str(report)}
+    ]
+    payload["config"]["fanout_reduce_planner_report"] = str(report)
+    payload["steps"].insert(
+        -1,
+        {
+            "name": "fanout_reduce_planner_report",
+            "command": ["python", "scripts/build_fanout_phase6_report.py"],
+            "returncode": 0,
+            "duration_seconds": 0.1,
+            "stdout": "{}",
+            "stderr": "",
+        },
+    )
+    payload["steps"].insert(
+        -1,
+        {
+            "name": "fanout_reduce_planner_integrity",
+            "command": ["python", "scripts/check_fanout_phase6_evidence.py"],
+            "returncode": 0,
+            "duration_seconds": 0.1,
+            "stdout": "{}",
+            "stderr": "",
+        },
+    )
+    manifest.write_text(json.dumps(payload))
+    index.write_text(
+        json.dumps(
+            build_artifact_index(
+                manifest_path=manifest,
+                output_path=index,
+                extra_artifacts=[("fanout_reduce_planner", report)],
             ),
             indent=2,
             sort_keys=True,
@@ -472,5 +545,32 @@ def test_check_replay_validation_bundle_rejects_missing_storage_phase5_evidence(
     output = json.loads(capsys.readouterr().out)
     assert any(
         failure["field"] == "phase5_storage_evidence"
+        for failure in output["failures"]
+    )
+
+
+def test_check_replay_validation_bundle_accepts_fanout_phase6_evidence(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, index = _bundle(tmp_path)
+    _add_fanout_phase6_evidence(manifest, index, tmp_path)
+
+    assert main(["--manifest", str(manifest), "--require-fanout-phase6"]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is True
+    assert output["phase6_fanout_result"]["matched"] is True
+
+
+def test_check_replay_validation_bundle_rejects_missing_fanout_phase6_evidence(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, _index = _bundle(tmp_path)
+
+    assert main(["--manifest", str(manifest), "--require-fanout-phase6"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any(
+        failure["field"] == "phase6_fanout_evidence"
         for failure in output["failures"]
     )

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -156,6 +156,7 @@ def test_run_replay_validation_can_export_live_rows_from_postgres(monkeypatch, t
         return 0, json.dumps({"ok": True}), "", 0.01
 
     monkeypatch.setattr(run_replay_validation, "_run", _run)
+    manifest = tmp_path / "validation.json"
 
     assert (
         run_replay_validation.main(
@@ -692,6 +693,7 @@ def test_run_replay_validation_can_check_replay_fanout_reduce_metadata(
         return 0, json.dumps({"ok": True}), "", 0.01
 
     monkeypatch.setattr(run_replay_validation, "_run", _run)
+    manifest = tmp_path / "validation.json"
 
     assert (
         run_replay_validation.main(
@@ -828,6 +830,7 @@ def test_run_replay_validation_fails_when_fetch_does_not_write_report(
         return 0, json.dumps({"ok": True}), "", 0.01
 
     monkeypatch.setattr(run_replay_validation, "_run", _run)
+    manifest = tmp_path / "validation.json"
 
     assert (
         run_replay_validation.main(
@@ -845,3 +848,42 @@ def test_run_replay_validation_fails_when_fetch_does_not_write_report(
     output = json.loads(capsys.readouterr().out)
     assert output["matched"] is False
     assert output["steps"][-1]["name"] == "fetch_artifact"
+
+
+def test_run_replay_validation_fails_when_artifact_index_is_not_written(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    def _run(command):
+        if any(str(part).endswith("fetch_replay_state_report.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
+        return 0, json.dumps({"ok": True}), "", 0.01
+
+    monkeypatch.setattr(run_replay_validation, "_run", _run)
+    manifest = tmp_path / "validation.json"
+
+    assert (
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--output-dir",
+                str(tmp_path),
+                "--report-output",
+                str(manifest),
+                "--artifact-index-output",
+                str(tmp_path / "artifact-index.json"),
+            ]
+        )
+        == 1
+    )
+    capsys.readouterr()
+    output = json.loads(manifest.read_text())
+    assert output["matched"] is False
+    assert output["steps"][-1]["name"] == "artifact_index"
+    assert output["steps"][-1]["stderr"].startswith("artifact index step did not create artifact index:")

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -561,6 +561,102 @@ def test_run_replay_validation_builds_and_indexes_storage_phase5_report(
     ]
 
 
+def test_run_replay_validation_builds_and_indexes_fanout_phase6_report(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if any(str(part).endswith("fetch_replay_state_report.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
+        if any(str(part).endswith("build_fanout_phase6_report.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.write_text(
+                json.dumps(
+                    {
+                        "planner_version": 1,
+                        "summary": {"playbooks": 1, "fanouts": 1, "reduces": 1},
+                        "playbooks": [
+                            {
+                                "path": "fanout.yaml",
+                                "name": "fanout",
+                                "planner": {
+                                    "fanouts": [
+                                        {
+                                            "step": "start",
+                                            "arcs": ["a", "b"],
+                                            "reduce_steps": ["join"],
+                                        }
+                                    ],
+                                    "reduces": [
+                                        {
+                                            "step": "join",
+                                            "upstream_steps": ["a", "b"],
+                                        }
+                                    ],
+                                },
+                            }
+                        ],
+                    }
+                )
+            )
+        if any(str(part).endswith("package_replay_validation_artifacts.py") for part in command):
+            artifact_args = [
+                command[idx + 1]
+                for idx, value in enumerate(command)
+                if value == "--artifact"
+            ]
+            assert any(arg.startswith("fanout_reduce_planner_generated=") for arg in artifact_args)
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.write_text(json.dumps({"schema_version": 1, "matched": True, "artifacts": []}))
+        return 0, json.dumps({"ok": True}), "", 0.01
+
+    monkeypatch.setattr(run_replay_validation, "_run", _run)
+    manifest = tmp_path / "validation.json"
+    artifact_index = tmp_path / "artifact-index.json"
+    playbook = tmp_path / "fanout.yaml"
+    playbook.write_text("apiVersion: noetl.io/v2\nkind: Playbook\nmetadata: {name: fanout}\nworkflow: []\n")
+
+    assert (
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--fanout-reduce-playbook",
+                str(playbook),
+                "--output-dir",
+                str(tmp_path),
+                "--report-output",
+                str(manifest),
+                "--artifact-index-output",
+                str(artifact_index),
+            ]
+        )
+        == 0
+    )
+
+    assert any("scripts/build_fanout_phase6_report.py" in call for call in calls)
+    assert any("scripts/check_fanout_phase6_evidence.py" in call for call in calls)
+    output = json.loads(capsys.readouterr().out)
+    reports = output["artifacts"]["fanout_reduce_planner"]
+    assert reports == [
+        {
+            "role": "fanout_reduce_planner_generated",
+            "path": str(tmp_path / "fanout-phase6-report.json"),
+        }
+    ]
+    assert "fanout_reduce_planner_integrity" in [
+        step["name"] for step in output["steps"]
+    ]
+
+
 def test_run_replay_validation_rejects_invalid_worker_metrics_url(tmp_path: Path):
     try:
         run_replay_validation.main(

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -657,6 +657,63 @@ def test_run_replay_validation_builds_and_indexes_fanout_phase6_report(
     ]
 
 
+def test_run_replay_validation_can_check_replay_fanout_reduce_metadata(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if any(str(part).endswith("fetch_replay_state_report.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(
+                json.dumps(
+                    {
+                        "projection_checksums": {"execution": "a" * 64},
+                        "commands": {
+                            "10": {
+                                "command_id": "10",
+                                "fanout_reduce": {
+                                    "planner_version": 1,
+                                    "fanout_step": "start",
+                                    "fanout_targets": ["a", "b"],
+                                    "target_step": "a",
+                                    "target_index": 0,
+                                    "reduce_steps": ["join"],
+                                },
+                            }
+                        },
+                    }
+                )
+            )
+        return 0, json.dumps({"ok": True}), "", 0.01
+
+    monkeypatch.setattr(run_replay_validation, "_run", _run)
+
+    assert (
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--check-replay-fanout-reduce",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+        == 0
+    )
+
+    assert any("scripts/check_replay_fanout_reduce_report.py" in call for call in calls)
+    output = json.loads(capsys.readouterr().out)
+    assert output["config"]["check_replay_fanout_reduce"] is True
+    assert "replay_fanout_reduce_integrity" in [step["name"] for step in output["steps"]]
+
+
 def test_run_replay_validation_rejects_invalid_worker_metrics_url(tmp_path: Path):
     try:
         run_replay_validation.main(

--- a/tests/unit/dsl/engine/test_engine.py
+++ b/tests/unit/dsl/engine/test_engine.py
@@ -140,6 +140,84 @@ workflow:
 
 
 @pytest.mark.asyncio
+async def test_inclusive_transition_commands_carry_fanout_reduce_metadata(engine_setup):
+    engine, _playbook_repo, _state_store = engine_setup
+    playbook = DSLParser().parse(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: fanout_runtime_metadata
+
+workflow:
+  - step: start
+    tool:
+      kind: python
+      code: "def main(): return {}"
+    next:
+      spec:
+        mode: inclusive
+      arcs:
+        - step: branch_a
+        - step: branch_b
+
+  - step: branch_a
+    tool:
+      kind: python
+      code: "def main(): return {}"
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: join
+
+  - step: branch_b
+    tool:
+      kind: python
+      code: "def main(): return {}"
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: join
+
+  - step: join
+    tool:
+      kind: python
+      code: "def main(): return {}"
+"""
+    )
+    state = ExecutionState(execution_id="1002", playbook=playbook, payload={})
+    start_step = state.get_step("start")
+    event = Event(
+        execution_id="1002",
+        step="start",
+        name="call.done",
+        payload={"result": {"data": {"ok": True}}},
+    )
+
+    commands, matched, raised = await engine._evaluate_next_transitions_with_status(
+        state,
+        start_step,
+        event,
+    )
+
+    assert matched is True
+    assert raised is False
+    assert [command.step for command in commands] == ["branch_a", "branch_b"]
+    assert commands[0].metadata["fanout_reduce"] == {
+        "planner_version": 1,
+        "fanout_step": "start",
+        "fanout_targets": ["branch_a", "branch_b"],
+        "target_step": "branch_a",
+        "target_index": 0,
+        "reduce_steps": ["join"],
+    }
+    assert commands[1].metadata["fanout_reduce"]["target_step"] == "branch_b"
+    assert commands[1].metadata["fanout_reduce"]["target_index"] == 1
+
+
+@pytest.mark.asyncio
 async def test_first_persisted_duplicate_call_done_still_orchestrates(engine_setup, monkeypatch):
     """Async batch ingestion may persist duplicates before orchestration; the earliest copy must still drive routing."""
     engine, playbook_repo, state_store = engine_setup

--- a/tests/unit/dsl/engine/test_fanout_reduce_planner.py
+++ b/tests/unit/dsl/engine/test_fanout_reduce_planner.py
@@ -1,0 +1,139 @@
+from noetl.core.dsl.engine.parser import DSLParser
+from noetl.core.dsl.engine.planner import build_fanout_reduce_plan
+
+
+def test_planner_detects_inclusive_fanout_and_shared_reduce():
+    playbook = DSLParser().parse(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: fanout_reduce
+
+workflow:
+  - step: start
+    tool:
+      kind: python
+      code: "def main(): return {}"
+    next:
+      spec:
+        mode: inclusive
+      arcs:
+        - step: branch_a
+        - step: branch_b
+
+  - step: branch_a
+    tool:
+      kind: python
+      code: "def main(): return {}"
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: join
+
+  - step: branch_b
+    tool:
+      kind: python
+      code: "def main(): return {}"
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: join
+
+  - step: join
+    tool:
+      kind: python
+      code: "def main(): return {}"
+"""
+    )
+
+    plan = build_fanout_reduce_plan(playbook)
+
+    assert len(plan.fanouts) == 1
+    assert plan.fanouts[0].step == "start"
+    assert plan.fanouts[0].arcs == ("branch_a", "branch_b")
+    assert plan.fanouts[0].reduce_steps == ("join",)
+    assert len(plan.reduces) == 1
+    assert plan.reduces[0].step == "join"
+    assert plan.reduces[0].upstream_steps == ("branch_a", "branch_b")
+
+
+def test_planner_keeps_exclusive_router_out_of_fanouts():
+    playbook = DSLParser().parse(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: exclusive_router
+
+workflow:
+  - step: start
+    tool:
+      kind: python
+      code: "def main(): return {}"
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: branch_a
+        - step: branch_b
+
+  - step: branch_a
+    tool:
+      kind: python
+      code: "def main(): return {}"
+
+  - step: branch_b
+    tool:
+      kind: python
+      code: "def main(): return {}"
+"""
+    )
+
+    plan = build_fanout_reduce_plan(playbook)
+
+    assert plan.fanouts == ()
+    assert plan.reduces == ()
+
+
+def test_planner_is_deterministic_for_duplicate_arcs_and_missing_targets():
+    playbook = DSLParser().parse(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: duplicate_arcs
+
+workflow:
+  - step: start
+    tool:
+      kind: python
+      code: "def main(): return {}"
+    next:
+      spec:
+        mode: inclusive
+      arcs:
+        - step: branch_b
+        - step: branch_a
+        - step: branch_b
+        - step: missing_step
+
+  - step: branch_a
+    tool:
+      kind: python
+      code: "def main(): return {}"
+
+  - step: branch_b
+    tool:
+      kind: python
+      code: "def main(): return {}"
+"""
+    )
+
+    plan = build_fanout_reduce_plan(playbook)
+
+    assert len(plan.fanouts) == 1
+    assert plan.fanouts[0].arcs == ("branch_b", "branch_a")
+    assert plan.reduces == ()


### PR DESCRIPTION
## Summary
- add a deterministic Phase 6 fanout/reduce planner for inclusive routers and shared reduce steps
- attach fanout_reduce metadata to issued runtime commands and preserve it through replay/live projections
- add static and replay evidence reports, bundle validators, and release-gate coverage for Phase 6
- harden replay validation so a successful artifact-index step must actually write the index

## Validation
- scripts/check_replay_release_gate.sh: 248 passed, 36 warnings
- static Phase 6 evidence CLI with tests/fixtures/playbooks/fanout_reduce/fanout_reduce_phase6.yaml
- synthetic replay validation bundle with real planner/checker/package scripts and mocked fetch only
