### PR TITLE
Phase 7 replay validation hardening

### DIFF
--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -13,6 +13,7 @@ fi
   tests/core/test_replay_golden_corpus.py \
   tests/core/test_replay_payload_resolver.py \
   tests/scripts/test_fetch_replay_state_report.py \
+  tests/scripts/test_validation_stdout.py \
   tests/scripts/test_run_replay_validation.py \
   tests/scripts/test_run_projector_phase2_validation.py \
   tests/scripts/test_render_projector_phase2_command.py \

--- a/scripts/run_projector_phase2_validation.py
+++ b/scripts/run_projector_phase2_validation.py
@@ -13,30 +13,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from scripts.validation_stdout import parse_json_output
+
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def _parse_json(value: str) -> object | None:
-    text = value.strip()
-    if not text:
-        return None
-    candidates = [text]
-    for marker in ("\n{", "\n["):
-        index = text.rfind(marker)
-        if index >= 0:
-            candidates.append(text[index + 1 :])
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        pass
-    for candidate in candidates[1:]:
-        try:
-            return json.loads(candidate)
-        except json.JSONDecodeError:
-            continue
-    return None
 
 
 def _run(command: list[str]) -> tuple[int, str, str, float]:
@@ -64,7 +45,7 @@ def _step(name: str, command: list[str]) -> dict[str, Any]:
         "stdout": stdout,
         "stderr": stderr,
     }
-    stdout_json = _parse_json(stdout)
+    stdout_json = parse_json_output(stdout)
     if stdout_json is not None:
         step["stdout_json"] = stdout_json
     return step

--- a/scripts/run_projector_phase2_validation.py
+++ b/scripts/run_projector_phase2_validation.py
@@ -19,12 +19,24 @@ def _utc_now() -> str:
 
 
 def _parse_json(value: str) -> object | None:
-    if not value.strip():
+    text = value.strip()
+    if not text:
         return None
+    candidates = [text]
+    for marker in ("\n{", "\n["):
+        index = text.rfind(marker)
+        if index >= 0:
+            candidates.append(text[index + 1 :])
     try:
-        return json.loads(value)
+        return json.loads(text)
     except json.JSONDecodeError:
-        return None
+        pass
+    for candidate in candidates[1:]:
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    return None
 
 
 def _run(command: list[str]) -> tuple[int, str, str, float]:

--- a/scripts/run_projector_phase2_validation.py
+++ b/scripts/run_projector_phase2_validation.py
@@ -182,6 +182,32 @@ def main(argv: list[str] | None = None) -> int:
         )
         _emit(report, args.report_output)
         return int(steps[-1]["returncode"])
+    missing_replay_artifacts = [
+        str(path)
+        for path in (manifest_path, artifact_index_path)
+        if not path.exists()
+    ]
+    if missing_replay_artifacts:
+        steps.append(
+            {
+                "name": "replay_validation_artifacts",
+                "returncode": 1,
+                "duration_seconds": 0.0,
+                "stdout": "",
+                "stderr": "replay validation did not create required artifacts: "
+                + ", ".join(missing_replay_artifacts),
+            }
+        )
+        report = _build_report(
+            matched=False,
+            started_at=started_at,
+            manifest_path=manifest_path,
+            artifact_index_path=artifact_index_path,
+            steps=steps,
+            args=args,
+        )
+        _emit(report, args.report_output)
+        return 1
 
     phase_gate_command = [
         _validation_python(),

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -13,30 +13,11 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from scripts.validation_stdout import parse_json_output
+
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def _parse_json(value: str) -> object | None:
-    text = value.strip()
-    if not text:
-        return None
-    candidates = [text]
-    for marker in ("\n{", "\n["):
-        index = text.rfind(marker)
-        if index >= 0:
-            candidates.append(text[index + 1 :])
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        pass
-    for candidate in candidates[1:]:
-        try:
-            return json.loads(candidate)
-        except json.JSONDecodeError:
-            continue
-    return None
 
 
 def _run(command: list[str]) -> tuple[int, str, str, float]:
@@ -661,7 +642,7 @@ def main(argv: list[str] | None = None) -> int:
             "stdout": stdout,
             "stderr": stderr,
         }
-        stdout_json = _parse_json(stdout)
+        stdout_json = parse_json_output(stdout)
         if stdout_json is not None:
             step["stdout_json"] = stdout_json
         steps.append(step)
@@ -794,7 +775,7 @@ def main(argv: list[str] | None = None) -> int:
                 "stdout": stdout,
                 "stderr": stderr,
             }
-            stdout_json = _parse_json(stdout)
+            stdout_json = parse_json_output(stdout)
             if stdout_json is not None:
                 steps[-1]["stdout_json"] = stdout_json
             _emit_report(
@@ -823,7 +804,7 @@ def main(argv: list[str] | None = None) -> int:
                 "stdout": stdout,
                 "stderr": f"artifact index step did not create artifact index: {args.artifact_index_output}",
             }
-            stdout_json = _parse_json(stdout)
+            stdout_json = parse_json_output(stdout)
             if stdout_json is not None:
                 steps[-1]["stdout_json"] = stdout_json
             _emit_report(

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -19,12 +19,24 @@ def _utc_now() -> str:
 
 
 def _parse_json(value: str) -> object | None:
-    if not value.strip():
+    text = value.strip()
+    if not text:
         return None
+    candidates = [text]
+    for marker in ("\n{", "\n["):
+        index = text.rfind(marker)
+        if index >= 0:
+            candidates.append(text[index + 1 :])
     try:
-        return json.loads(value)
+        return json.loads(text)
     except json.JSONDecodeError:
-        return None
+        pass
+    for candidate in candidates[1:]:
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    return None
 
 
 def _run(command: list[str]) -> tuple[int, str, str, float]:

--- a/scripts/validation_stdout.py
+++ b/scripts/validation_stdout.py
@@ -1,0 +1,28 @@
+"""Helpers for parsing machine-readable validation command output."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def parse_json_output(value: str) -> Any | None:
+    """Parse JSON stdout that may include a log preface before the payload."""
+    text = value.strip()
+    if not text:
+        return None
+    candidates = [text]
+    for marker in ("\n{", "\n["):
+        index = text.rfind(marker)
+        if index >= 0:
+            candidates.append(text[index + 1 :])
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    for candidate in candidates[1:]:
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    return None

--- a/tests/scripts/test_run_projector_phase2_validation.py
+++ b/tests/scripts/test_run_projector_phase2_validation.py
@@ -4,6 +4,12 @@ from pathlib import Path
 from scripts import run_projector_phase2_validation
 
 
+def test_projector_phase2_parse_json_accepts_log_prefixed_output():
+    output = "INFO warmed projector gate\n{\"matched\": true}\n"
+
+    assert run_projector_phase2_validation._parse_json(output) == {"matched": True}
+
+
 def test_run_projector_phase2_validation_runs_replay_then_phase_gate(
     monkeypatch,
     tmp_path: Path,
@@ -58,6 +64,47 @@ def test_run_projector_phase2_validation_runs_replay_then_phase_gate(
     assert output["artifacts"]["manifest"].endswith("phase2-replay-validation-123.json")
     assert output["steps"][0]["name"] == "replay_validation"
     assert output["steps"][1]["name"] == "phase2_evidence"
+
+
+def test_run_projector_phase2_validation_captures_log_prefixed_step_json(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if "scripts/run_replay_validation.py" in command:
+            manifest_path = Path(command[command.index("--report-output") + 1])
+            artifact_index_path = Path(command[command.index("--artifact-index-output") + 1])
+            manifest_path.write_text(json.dumps({"matched": True}))
+            artifact_index_path.write_text(json.dumps({"matched": True}))
+        return 0, 'INFO gate emitted a preface\n{"matched": true}\n', "", 0.01
+
+    monkeypatch.setattr(run_projector_phase2_validation, "_run", _run)
+    summary = tmp_path / "projector-summary.json"
+    summary.write_text("{}")
+
+    assert (
+        run_projector_phase2_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--projector-summary",
+                str(summary),
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+        == 0
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["steps"][0]["stdout_json"] == {"matched": True}
+    assert output["steps"][1]["stdout_json"] == {"matched": True}
 
 
 def test_run_projector_phase2_validation_passes_projector_summary_urls(

--- a/tests/scripts/test_run_projector_phase2_validation.py
+++ b/tests/scripts/test_run_projector_phase2_validation.py
@@ -4,12 +4,6 @@ from pathlib import Path
 from scripts import run_projector_phase2_validation
 
 
-def test_projector_phase2_parse_json_accepts_log_prefixed_output():
-    output = "INFO warmed projector gate\n{\"matched\": true}\n"
-
-    assert run_projector_phase2_validation._parse_json(output) == {"matched": True}
-
-
 def test_run_projector_phase2_validation_runs_replay_then_phase_gate(
     monkeypatch,
     tmp_path: Path,

--- a/tests/scripts/test_run_projector_phase2_validation.py
+++ b/tests/scripts/test_run_projector_phase2_validation.py
@@ -110,6 +110,11 @@ def test_run_projector_phase2_validation_passes_projector_summary_urls(
 
     def _run(command):
         calls.append(command)
+        if "scripts/run_replay_validation.py" in command:
+            manifest_path = Path(command[command.index("--report-output") + 1])
+            artifact_index_path = Path(command[command.index("--artifact-index-output") + 1])
+            manifest_path.write_text(json.dumps({"matched": True}))
+            artifact_index_path.write_text(json.dumps({"matched": True}))
         return 0, json.dumps({"matched": True}), "", 0.01
 
     monkeypatch.setattr(run_projector_phase2_validation, "_run", _run)
@@ -173,6 +178,46 @@ def test_run_projector_phase2_validation_stops_when_replay_validation_fails(
     output = json.loads(capsys.readouterr().out)
     assert output["matched"] is False
     assert output["steps"][0]["stderr"] == "failed"
+
+
+def test_run_projector_phase2_validation_fails_when_replay_artifacts_are_missing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        return 0, json.dumps({"matched": True}), "", 0.01
+
+    monkeypatch.setattr(run_projector_phase2_validation, "_run", _run)
+    summary = tmp_path / "projector-summary.json"
+    summary.write_text("{}")
+
+    assert (
+        run_projector_phase2_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--projector-summary",
+                str(summary),
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+        == 1
+    )
+
+    assert len(calls) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    assert output["steps"][-1]["name"] == "replay_validation_artifacts"
+    assert output["steps"][-1]["stderr"].startswith(
+        "replay validation did not create required artifacts:"
+    )
 
 
 def test_run_projector_phase2_validation_requires_projector_evidence(tmp_path: Path):

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -4,6 +4,26 @@ from pathlib import Path
 from scripts import run_replay_validation
 
 
+def test_parse_json_accepts_plain_json():
+    assert run_replay_validation._parse_json('{"matched": true}') == {"matched": True}
+
+
+def test_parse_json_accepts_log_prefixed_json_object():
+    output = "2026-05-20T20:48:51 [INFO] config validated\n{\"matched\": true, \"failures\": []}\n"
+
+    assert run_replay_validation._parse_json(output) == {"matched": True, "failures": []}
+
+
+def test_parse_json_accepts_log_prefixed_json_array():
+    output = "INFO warmup complete\n[{\"name\": \"fetch\"}]\n"
+
+    assert run_replay_validation._parse_json(output) == [{"name": "fetch"}]
+
+
+def test_parse_json_rejects_non_json_output():
+    assert run_replay_validation._parse_json("INFO only\nnot-json") is None
+
+
 def test_run_replay_validation_fetches_and_runs_selected_gates(monkeypatch, tmp_path: Path, capsys):
     calls = []
 
@@ -60,6 +80,40 @@ def test_run_replay_validation_fetches_and_runs_selected_gates(monkeypatch, tmp_
     assert output["steps"][0]["duration_seconds"] == 0.01
     manifest_path = tmp_path / "reports" / "manifest.json"
     assert json.loads(manifest_path.read_text())["matched"] is True
+
+
+def test_run_replay_validation_captures_log_prefixed_step_json(monkeypatch, tmp_path: Path, capsys):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if any(str(part).endswith("fetch_replay_state_report.py") for part in command):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps({"projection_checksums": {"execution": "a" * 64}}))
+        if any(str(part).endswith("check_replay_state_report.py") for part in command):
+            return 0, 'INFO validated env\n{"matched": true, "failures": []}\n', "", 0.01
+        return 0, json.dumps({"ok": True}), "", 0.01
+
+    monkeypatch.setattr(run_replay_validation, "_run", _run)
+
+    assert (
+        run_replay_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+        == 0
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["steps"][1]["name"] == "state_integrity"
+    assert output["steps"][1]["stdout_json"] == {"matched": True, "failures": []}
 
 
 def test_run_replay_validation_stops_on_gate_failure(monkeypatch, tmp_path: Path, capsys):

--- a/tests/scripts/test_run_replay_validation.py
+++ b/tests/scripts/test_run_replay_validation.py
@@ -4,26 +4,6 @@ from pathlib import Path
 from scripts import run_replay_validation
 
 
-def test_parse_json_accepts_plain_json():
-    assert run_replay_validation._parse_json('{"matched": true}') == {"matched": True}
-
-
-def test_parse_json_accepts_log_prefixed_json_object():
-    output = "2026-05-20T20:48:51 [INFO] config validated\n{\"matched\": true, \"failures\": []}\n"
-
-    assert run_replay_validation._parse_json(output) == {"matched": True, "failures": []}
-
-
-def test_parse_json_accepts_log_prefixed_json_array():
-    output = "INFO warmup complete\n[{\"name\": \"fetch\"}]\n"
-
-    assert run_replay_validation._parse_json(output) == [{"name": "fetch"}]
-
-
-def test_parse_json_rejects_non_json_output():
-    assert run_replay_validation._parse_json("INFO only\nnot-json") is None
-
-
 def test_run_replay_validation_fetches_and_runs_selected_gates(monkeypatch, tmp_path: Path, capsys):
     calls = []
 

--- a/tests/scripts/test_validation_stdout.py
+++ b/tests/scripts/test_validation_stdout.py
@@ -1,0 +1,21 @@
+from scripts.validation_stdout import parse_json_output
+
+
+def test_parse_json_output_accepts_plain_json():
+    assert parse_json_output('{"matched": true}') == {"matched": True}
+
+
+def test_parse_json_output_accepts_log_prefixed_json_object():
+    output = "2026-05-20T20:48:51 [INFO] config validated\n{\"matched\": true, \"failures\": []}\n"
+
+    assert parse_json_output(output) == {"matched": True, "failures": []}
+
+
+def test_parse_json_output_accepts_log_prefixed_json_array():
+    output = "INFO warmup complete\n[{\"name\": \"fetch\"}]\n"
+
+    assert parse_json_output(output) == [{"name": "fetch"}]
+
+
+def test_parse_json_output_rejects_non_json_output():
+    assert parse_json_output("INFO only\nnot-json") is None


### PR DESCRIPTION
## Summary
- preserve parsed stdout_json for validation commands that emit log-prefixed JSON
- share validation stdout parsing between replay and projector validation runners
- fail projector Phase 2 validation immediately when replay validation does not produce its manifest/artifact index
- include the stdout parser tests in the replay release gate

## Validation
- scripts/check_replay_release_gate.sh: 255 passed, 36 warnings
