### PR TITLE
Phase 8 bundle index coverage hardening

### DIFF
--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -33,6 +33,44 @@ def _artifact_index_from_manifest(manifest: dict[str, Any]) -> str | None:
     return value
 
 
+def _artifact_roles(manifest: dict[str, Any], artifact_name: str) -> list[str]:
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return []
+    entries = artifacts.get(artifact_name)
+    if not isinstance(entries, list):
+        return []
+
+    roles: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        role = entry.get("role")
+        if isinstance(role, str) and role:
+            roles.append(role)
+    return roles
+
+
+def _required_index_roles(
+    manifest: dict[str, Any],
+    *,
+    require_projector_phase2: bool,
+    require_worker_ipc_phase3: bool,
+    require_storage_phase5: bool,
+    require_fanout_phase6: bool,
+) -> list[str]:
+    roles: list[str] = []
+    if require_projector_phase2:
+        roles.extend(_artifact_roles(manifest, "projector_summaries"))
+    if require_worker_ipc_phase3:
+        roles.extend(_artifact_roles(manifest, "worker_metrics"))
+    if require_storage_phase5:
+        roles.extend(_artifact_roles(manifest, "storage_backend_registry"))
+    if require_fanout_phase6:
+        roles.extend(_artifact_roles(manifest, "fanout_reduce_planner"))
+    return sorted(set(roles))
+
+
 def validate_bundle(
     *,
     manifest_path: Path,
@@ -190,6 +228,26 @@ def validate_bundle(
                         "reason": "artifact index validation failed",
                         "path": str(resolved_index_path),
                         "failures": index_result.get("failures", []),
+                    }
+                )
+            required_index_roles = _required_index_roles(
+                manifest,
+                require_projector_phase2=require_projector_phase2,
+                require_worker_ipc_phase3=require_worker_ipc_phase3,
+                require_storage_phase5=require_storage_phase5,
+                require_fanout_phase6=require_fanout_phase6,
+            )
+            indexed_roles = index_result.get("roles")
+            indexed_roles = indexed_roles if isinstance(indexed_roles, list) else []
+            missing_index_roles = [
+                role for role in required_index_roles if role not in indexed_roles
+            ]
+            if missing_index_roles:
+                failures.append(
+                    {
+                        "field": "artifact_index",
+                        "reason": "artifact index missing required phase evidence roles",
+                        "roles": missing_index_roles,
                     }
                 )
 

--- a/scripts/package_replay_validation_artifacts.py
+++ b/scripts/package_replay_validation_artifacts.py
@@ -224,7 +224,11 @@ def validate_artifact_index(index_path: Path) -> dict[str, Any]:
         for entry in artifacts
         if isinstance(entry, dict) and entry.get("required", True)
     )
-    return {"matched": matched, "failures": failures}
+    return {
+        "matched": matched,
+        "roles": sorted(roles),
+        "failures": failures,
+    }
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/scripts/test_check_replay_validation_bundle.py
+++ b/tests/scripts/test_check_replay_validation_bundle.py
@@ -3,6 +3,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_replay_validation_bundle import main
 from scripts.package_replay_validation_artifacts import build_artifact_index
 
@@ -382,6 +384,16 @@ def _add_fanout_phase6_evidence(manifest: Path, index: Path, tmp_path: Path) -> 
     )
 
 
+def _drop_index_role(index: Path, role: str) -> None:
+    payload = json.loads(index.read_text())
+    payload["artifacts"] = [
+        entry
+        for entry in payload["artifacts"]
+        if not (isinstance(entry, dict) and entry.get("role") == role)
+    ]
+    index.write_text(json.dumps(payload))
+
+
 def test_check_replay_validation_bundle_accepts_manifest_referenced_index(
     tmp_path: Path,
     capsys,
@@ -481,6 +493,23 @@ def test_check_replay_validation_bundle_rejects_missing_projector_phase2_evidenc
     output = json.loads(capsys.readouterr().out)
     assert any(
         failure["field"] == "phase2_projector_evidence"
+        for failure in output["failures"]
+    )
+
+
+def test_check_replay_validation_bundle_requires_indexed_projector_phase2_evidence(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, index = _bundle(tmp_path)
+    _add_projector_phase2_evidence(manifest, index, tmp_path)
+    _drop_index_role(index, "projector_summary_1")
+
+    assert main(["--manifest", str(manifest), "--require-projector-phase2"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any(
+        failure["reason"] == "artifact index missing required phase evidence roles"
+        and failure["roles"] == ["projector_summary_1"]
         for failure in output["failures"]
     )
 
@@ -646,5 +675,33 @@ def test_check_replay_validation_bundle_rejects_missing_replay_fanout_phase6_evi
     output = json.loads(capsys.readouterr().out)
     assert any(
         failure["field"] == "phase6_replay_fanout_evidence"
+        for failure in output["failures"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("add_evidence", "role", "flag"),
+    [
+        (_add_worker_phase3_evidence, "worker_metrics_1", "--require-worker-ipc-phase3"),
+        (_add_storage_phase5_evidence, "storage_backend_registry", "--require-storage-phase5"),
+        (_add_fanout_phase6_evidence, "fanout_reduce_planner", "--require-fanout-phase6"),
+    ],
+)
+def test_check_replay_validation_bundle_requires_indexed_phase_evidence_roles(
+    tmp_path: Path,
+    capsys,
+    add_evidence,
+    role: str,
+    flag: str,
+):
+    manifest, index = _bundle(tmp_path)
+    add_evidence(manifest, index, tmp_path)
+    _drop_index_role(index, role)
+
+    assert main(["--manifest", str(manifest), flag]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any(
+        failure["reason"] == "artifact index missing required phase evidence roles"
+        and failure["roles"] == [role]
         for failure in output["failures"]
     )

--- a/tests/scripts/test_package_replay_validation_artifacts.py
+++ b/tests/scripts/test_package_replay_validation_artifacts.py
@@ -47,7 +47,11 @@ def test_package_replay_validation_artifacts_builds_and_checks_index(tmp_path: P
     assert all(not Path(entry["path"]).is_absolute() for entry in index["artifacts"])
 
     assert main(["--check", str(output)]) == 0
-    assert json.loads(capsys.readouterr().out)["matched"] is True
+    result = json.loads(capsys.readouterr().out)
+    assert result["matched"] is True
+    assert {"manifest", "replay", "live_rows", "live_checksums", "report"} <= set(
+        result["roles"]
+    )
 
 
 def test_package_replay_validation_artifacts_checks_relative_paths_from_index_dir(


### PR DESCRIPTION
## Summary
- expose artifact roles from replay validation artifact-index checks
- require requested phase evidence roles to be present in the artifact index
- cover projector, worker IPC, storage, and fan-out phase evidence index omissions

## Validation
- scripts/check_replay_release_gate.sh (259 passed, 36 warnings)