### PR TITLE
Phase 9 projector validation bundle gate

### DIFF
--- a/scripts/run_projector_phase2_validation.py
+++ b/scripts/run_projector_phase2_validation.py
@@ -219,6 +219,19 @@ def main(argv: list[str] | None = None) -> int:
     if args.require_projection_parity:
         phase_gate_command.append("--require-projection-parity")
     steps.append(_step("phase2_evidence", phase_gate_command))
+    if steps[-1]["returncode"] == 0:
+        bundle_gate_command = [
+            _validation_python(),
+            "scripts/check_replay_validation_bundle.py",
+            "--manifest",
+            str(manifest_path),
+            "--artifact-index",
+            str(artifact_index_path),
+            "--require-projector-phase2",
+        ]
+        if args.require_projection_parity:
+            bundle_gate_command.append("--require-projection-parity")
+        steps.append(_step("bundle_evidence", bundle_gate_command))
 
     matched = steps[-1]["returncode"] == 0
     report = _build_report(

--- a/tests/scripts/test_run_projector_phase2_validation.py
+++ b/tests/scripts/test_run_projector_phase2_validation.py
@@ -53,11 +53,17 @@ def test_run_projector_phase2_validation_runs_replay_then_phase_gate(
     phase_gate_call = calls[1]
     assert "scripts/check_projector_phase2_evidence.py" in phase_gate_call
     assert "--require-projection-parity" in phase_gate_call
+    bundle_gate_call = calls[2]
+    assert "scripts/check_replay_validation_bundle.py" in bundle_gate_call
+    assert "--artifact-index" in bundle_gate_call
+    assert "--require-projector-phase2" in bundle_gate_call
+    assert "--require-projection-parity" in bundle_gate_call
     output = json.loads(capsys.readouterr().out)
     assert output["matched"] is True
     assert output["artifacts"]["manifest"].endswith("phase2-replay-validation-123.json")
     assert output["steps"][0]["name"] == "replay_validation"
     assert output["steps"][1]["name"] == "phase2_evidence"
+    assert output["steps"][2]["name"] == "bundle_evidence"
 
 
 def test_run_projector_phase2_validation_captures_log_prefixed_step_json(
@@ -99,6 +105,7 @@ def test_run_projector_phase2_validation_captures_log_prefixed_step_json(
     output = json.loads(capsys.readouterr().out)
     assert output["steps"][0]["stdout_json"] == {"matched": True}
     assert output["steps"][1]["stdout_json"] == {"matched": True}
+    assert output["steps"][2]["stdout_json"] == {"matched": True}
 
 
 def test_run_projector_phase2_validation_passes_projector_summary_urls(
@@ -141,6 +148,98 @@ def test_run_projector_phase2_validation_passes_projector_summary_urls(
     assert output["config"]["projector_summary_url"] == [
         "projector-0=http://projector-0.example:9090"
     ]
+
+
+def test_run_projector_phase2_validation_stops_when_phase_gate_fails(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if "scripts/run_replay_validation.py" in command:
+            manifest_path = Path(command[command.index("--report-output") + 1])
+            artifact_index_path = Path(command[command.index("--artifact-index-output") + 1])
+            manifest_path.write_text(json.dumps({"matched": True}))
+            artifact_index_path.write_text(json.dumps({"matched": True}))
+            return 0, json.dumps({"matched": True}), "", 0.01
+        if "scripts/check_projector_phase2_evidence.py" in command:
+            return 1, json.dumps({"matched": False}), "phase failed", 0.01
+        return 0, json.dumps({"matched": True}), "", 0.01
+
+    monkeypatch.setattr(run_projector_phase2_validation, "_run", _run)
+    summary = tmp_path / "projector-summary.json"
+    summary.write_text("{}")
+
+    assert (
+        run_projector_phase2_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--projector-summary",
+                str(summary),
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+        == 1
+    )
+
+    assert len(calls) == 2
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    assert output["steps"][-1]["name"] == "phase2_evidence"
+    assert output["steps"][-1]["stderr"] == "phase failed"
+
+
+def test_run_projector_phase2_validation_fails_when_bundle_gate_fails(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    calls = []
+
+    def _run(command):
+        calls.append(command)
+        if "scripts/run_replay_validation.py" in command:
+            manifest_path = Path(command[command.index("--report-output") + 1])
+            artifact_index_path = Path(command[command.index("--artifact-index-output") + 1])
+            manifest_path.write_text(json.dumps({"matched": True}))
+            artifact_index_path.write_text(json.dumps({"matched": True}))
+            return 0, json.dumps({"matched": True}), "", 0.01
+        if "scripts/check_replay_validation_bundle.py" in command:
+            return 1, json.dumps({"matched": False}), "bundle failed", 0.01
+        return 0, json.dumps({"matched": True}), "", 0.01
+
+    monkeypatch.setattr(run_projector_phase2_validation, "_run", _run)
+    summary = tmp_path / "projector-summary.json"
+    summary.write_text("{}")
+
+    assert (
+        run_projector_phase2_validation.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--projector-summary",
+                str(summary),
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+        == 1
+    )
+
+    assert len(calls) == 3
+    output = json.loads(capsys.readouterr().out)
+    assert output["matched"] is False
+    assert output["steps"][-1]["name"] == "bundle_evidence"
+    assert output["steps"][-1]["stderr"] == "bundle failed"
 
 
 def test_run_projector_phase2_validation_stops_when_replay_validation_fails(


### PR DESCRIPTION
## Summary
- run the full replay validation bundle checker from the Phase 2 projector validation workflow
- require projector Phase 2 evidence and artifact-index coverage in the generated bundle
- preserve clear failure reporting for replay, phase evidence, and bundle evidence steps

## Validation
- scripts/check_replay_release_gate.sh (261 passed, 36 warnings)