### PR TITLE
Phase 10 projector command parity

### DIFF
--- a/scripts/render_projector_phase2_command.py
+++ b/scripts/render_projector_phase2_command.py
@@ -24,17 +24,27 @@ def render_command(args: argparse.Namespace) -> list[str]:
         args.organization_id,
         "--projection",
         args.projection,
+        "--limit",
+        str(args.limit),
         "--output-dir",
         str(args.output_dir),
+        "--timeout",
+        str(args.timeout),
     ]
+    if args.resolve_payloads:
+        command.append("--resolve-payloads")
     if args.live_rows:
         command.extend(["--live-rows", str(args.live_rows)])
     if args.live_checksums:
         command.extend(["--live-checksums", str(args.live_checksums)])
     if args.export_live_rows_postgres:
         command.append("--export-live-rows-postgres")
+    if args.postgres_dsn:
+        command.extend(["--postgres-dsn", args.postgres_dsn])
     if args.require_projection_parity:
         command.append("--require-projection-parity")
+    if args.report_output:
+        command.extend(["--report-output", str(args.report_output)])
     for url in args.projector_summary_url:
         command.extend(["--projector-summary-url", url])
     for path in args.projector_summary:
@@ -49,13 +59,18 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--tenant-id", default="default")
     parser.add_argument("--organization-id", default="default")
     parser.add_argument("--projection", default="all")
+    parser.add_argument("--limit", default=100000, type=int)
     parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--timeout", default=60.0, type=float)
+    parser.add_argument("--resolve-payloads", action="store_true")
     parser.add_argument("--live-rows", type=Path)
     parser.add_argument("--live-checksums", type=Path)
     parser.add_argument("--export-live-rows-postgres", action="store_true")
+    parser.add_argument("--postgres-dsn")
     parser.add_argument("--projector-summary-url", action="append", default=[], metavar="NAME=URL")
     parser.add_argument("--projector-summary", action="append", default=[], type=Path)
     parser.add_argument("--require-projection-parity", action="store_true")
+    parser.add_argument("--report-output", type=Path)
     parser.add_argument("--json", action="store_true", help="Emit JSON with argv and shell fields")
     args = parser.parse_args(argv)
 
@@ -70,6 +85,8 @@ def main(argv: list[str] | None = None) -> int:
     )
     if live_inputs > 1:
         parser.error("use only one live parity input")
+    if args.postgres_dsn and not args.export_live_rows_postgres:
+        parser.error("--postgres-dsn requires --export-live-rows-postgres")
     if not args.projector_summary and not args.projector_summary_url:
         parser.error("provide at least one projector summary source")
 

--- a/tests/scripts/test_render_projector_phase2_command.py
+++ b/tests/scripts/test_render_projector_phase2_command.py
@@ -18,6 +18,8 @@ def test_render_projector_phase2_command_outputs_shell(capsys, tmp_path):
                 "--live-rows",
                 str(tmp_path / "live-rows.json"),
                 "--require-projection-parity",
+                "--report-output",
+                str(tmp_path / "phase2-report.json"),
             ]
         )
         == 0
@@ -26,11 +28,14 @@ def test_render_projector_phase2_command_outputs_shell(capsys, tmp_path):
     output = capsys.readouterr().out
     assert "scripts/run_projector_phase2_validation.py" in output
     assert "--projector-summary-url projector-0=http://projector-0.example:9090" in output
+    assert "--limit 100000" in output
+    assert "--timeout 60.0" in output
     assert "--live-rows" in output
     assert "--require-projection-parity" in output
+    assert "--report-output" in output
 
 
-def test_render_projector_phase2_command_outputs_json(capsys, tmp_path):
+def test_render_projector_phase2_command_outputs_json_with_runtime_options(capsys, tmp_path):
     assert (
         render_projector_phase2_command.main(
             [
@@ -40,8 +45,18 @@ def test_render_projector_phase2_command_outputs_json(capsys, tmp_path):
                 "123",
                 "--output-dir",
                 str(tmp_path),
+                "--limit",
+                "25",
+                "--timeout",
+                "12.5",
+                "--resolve-payloads",
+                "--export-live-rows-postgres",
+                "--postgres-dsn",
+                "postgresql://user@localhost/noetl",
                 "--projector-summary",
                 str(tmp_path / "projector-summary.json"),
+                "--report-output",
+                str(tmp_path / "phase2-report.json"),
                 "--json",
             ]
         )
@@ -51,6 +66,12 @@ def test_render_projector_phase2_command_outputs_json(capsys, tmp_path):
     output = json.loads(capsys.readouterr().out)
     assert output["argv"][1] == "scripts/run_projector_phase2_validation.py"
     assert "--projector-summary" in output["argv"]
+    assert output["argv"][output["argv"].index("--limit") + 1] == "25"
+    assert output["argv"][output["argv"].index("--timeout") + 1] == "12.5"
+    assert "--resolve-payloads" in output["argv"]
+    assert "--export-live-rows-postgres" in output["argv"]
+    assert output["argv"][output["argv"].index("--postgres-dsn") + 1] == "postgresql://user@localhost/noetl"
+    assert output["argv"][output["argv"].index("--report-output") + 1].endswith("phase2-report.json")
     assert "scripts/run_projector_phase2_validation.py" in output["shell"]
 
 
@@ -88,6 +109,28 @@ def test_render_projector_phase2_command_rejects_multiple_live_inputs(tmp_path):
                 str(tmp_path / "live-rows.json"),
                 "--live-checksums",
                 str(tmp_path / "live-checksums.json"),
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected parser error")
+
+
+def test_render_projector_phase2_command_rejects_postgres_dsn_without_export(tmp_path):
+    try:
+        render_projector_phase2_command.main(
+            [
+                "--base-url",
+                "http://noetl.example",
+                "--execution-id",
+                "123",
+                "--output-dir",
+                str(tmp_path),
+                "--projector-summary",
+                str(tmp_path / "projector-summary.json"),
+                "--postgres-dsn",
+                "postgresql://user@localhost/noetl",
             ]
         )
     except SystemExit as exc:


### PR DESCRIPTION
## Summary
- render Phase 2 validation commands with limit, timeout, payload-resolution, Postgres DSN, and report-output options
- keep renderer validation aligned with runner live-input constraints
- cover runtime option rendering in shell and JSON output tests

## Validation
- scripts/check_replay_release_gate.sh (262 passed, 36 warnings)