### PR TITLE
Phase 11 manifest index coverage

### DIFF
--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -145,6 +145,32 @@ def _validate_artifact_list(
             )
 
 
+def _artifact_roles(artifacts: dict[str, Any], field: str) -> list[str]:
+    value = artifacts.get(field)
+    if not isinstance(value, list):
+        return []
+    roles: list[str] = []
+    for entry in value:
+        if not isinstance(entry, dict):
+            continue
+        role = entry.get("role")
+        if isinstance(role, str) and role:
+            roles.append(role)
+    return roles
+
+
+def _phase_artifact_roles(artifacts: dict[str, Any]) -> list[str]:
+    roles: list[str] = []
+    for field in (
+        "projector_summaries",
+        "worker_metrics",
+        "storage_backend_registry",
+        "fanout_reduce_planner",
+    ):
+        roles.extend(_artifact_roles(artifacts, field))
+    return sorted(set(roles))
+
+
 def _validate_manifest(
     manifest: dict[str, Any],
     *,
@@ -256,6 +282,22 @@ def _validate_manifest(
                                 "reason": "artifact index validation failed",
                                 "path": artifact_index,
                                 "failures": index_output.get("failures", []),
+                            }
+                        )
+                    indexed_roles = index_output.get("roles")
+                    indexed_roles = indexed_roles if isinstance(indexed_roles, list) else []
+                    missing_phase_roles = [
+                        role
+                        for role in _phase_artifact_roles(artifacts)
+                        if role not in indexed_roles
+                    ]
+                    if missing_phase_roles:
+                        failures.append(
+                            {
+                                "field": "artifacts.artifact_index",
+                                "reason": "artifact index missing phase artifact roles",
+                                "path": artifact_index,
+                                "roles": missing_phase_roles,
                             }
                         )
                     if manifest_path is not None:

--- a/tests/scripts/test_check_replay_validation_manifest.py
+++ b/tests/scripts/test_check_replay_validation_manifest.py
@@ -255,6 +255,58 @@ def test_check_replay_validation_manifest_rejects_artifact_index_for_other_manif
     )
 
 
+def test_check_replay_validation_manifest_requires_indexed_phase_artifact_roles(
+    tmp_path: Path,
+    capsys,
+):
+    manifest = _manifest(tmp_path)
+    summary = tmp_path / "projector-summary.json"
+    summary.write_text("{}")
+    report = tmp_path / "validation-report.json"
+    report.write_text("{}")
+    index_path = tmp_path / "artifact-index.json"
+    manifest["artifacts"]["report"] = str(report)
+    manifest["artifacts"]["artifact_index"] = str(index_path)
+    manifest["artifacts"]["projector_summaries"] = [
+        {"role": "projector_summary_1", "path": str(summary)}
+    ]
+    manifest["steps"].append(
+        {
+            "name": "projector_summary_1_integrity",
+            "command": ["python", "scripts/check_projector_metrics_summary.py"],
+            "returncode": 0,
+            "duration_seconds": 0.1,
+            "stdout": "{}",
+            "stderr": "",
+        }
+    )
+    manifest["steps"].append(
+        {
+            "name": "artifact_index",
+            "command": ["python", "scripts/package_replay_validation_artifacts.py"],
+            "returncode": 0,
+            "duration_seconds": 0.1,
+            "stdout": "{}",
+            "stderr": "",
+        }
+    )
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+    index_path.write_text(
+        json.dumps(build_artifact_index(manifest_path=path, output_path=index_path))
+        + "\n"
+    )
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any(
+        failure["field"] == "artifacts.artifact_index"
+        and failure["reason"] == "artifact index missing phase artifact roles"
+        and failure["roles"] == ["projector_summary_1"]
+        for failure in output["failures"]
+    )
+
+
 def test_check_replay_validation_manifest_requires_artifact_index_step(tmp_path: Path, capsys):
     path = _write_manifest_with_artifact_index(tmp_path)
     manifest = json.loads(path.read_text())


### PR DESCRIPTION
## Summary
- make manifest validation reject artifact indexes that omit listed phase artifact roles
- align manifest-level validation with the replay bundle index coverage checks
- cover projector summary role omissions in the manifest validator tests

## Validation
- scripts/check_replay_release_gate.sh (263 passed, 36 warnings)