### PR TITLE
Phase 14 validation evidence consolidation

### DIFF
--- a/scripts/check_replay_release_gate.sh
+++ b/scripts/check_replay_release_gate.sh
@@ -22,6 +22,7 @@ fi
   tests/scripts/test_export_live_projection_rows_postgres.py \
   tests/scripts/test_check_live_projection_rows.py \
   tests/scripts/test_check_runtime_locator_surfaces.py \
+  tests/scripts/test_replay_validation_artifacts.py \
   tests/scripts/test_package_replay_validation_artifacts.py \
   tests/scripts/test_check_replay_validation_bundle.py \
   tests/scripts/test_check_replay_validation_manifest.py \

--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -21,6 +21,7 @@ from scripts.package_replay_validation_artifacts import (
     resolve_indexed_path,
     validate_artifact_index,
 )
+from scripts.replay_validation_artifacts import phase_artifact_roles
 
 
 def _artifact_index_from_manifest(manifest: dict[str, Any]) -> str | None:
@@ -33,24 +34,6 @@ def _artifact_index_from_manifest(manifest: dict[str, Any]) -> str | None:
     return value
 
 
-def _artifact_roles(manifest: dict[str, Any], artifact_name: str) -> list[str]:
-    artifacts = manifest.get("artifacts")
-    if not isinstance(artifacts, dict):
-        return []
-    entries = artifacts.get(artifact_name)
-    if not isinstance(entries, list):
-        return []
-
-    roles: list[str] = []
-    for entry in entries:
-        if not isinstance(entry, dict):
-            continue
-        role = entry.get("role")
-        if isinstance(role, str) and role:
-            roles.append(role)
-    return roles
-
-
 def _required_index_roles(
     manifest: dict[str, Any],
     *,
@@ -59,16 +42,19 @@ def _required_index_roles(
     require_storage_phase5: bool,
     require_fanout_phase6: bool,
 ) -> list[str]:
-    roles: list[str] = []
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return []
+    fields: list[str] = []
     if require_projector_phase2:
-        roles.extend(_artifact_roles(manifest, "projector_summaries"))
+        fields.append("projector_summaries")
     if require_worker_ipc_phase3:
-        roles.extend(_artifact_roles(manifest, "worker_metrics"))
+        fields.append("worker_metrics")
     if require_storage_phase5:
-        roles.extend(_artifact_roles(manifest, "storage_backend_registry"))
+        fields.append("storage_backend_registry")
     if require_fanout_phase6:
-        roles.extend(_artifact_roles(manifest, "fanout_reduce_planner"))
-    return sorted(set(roles))
+        fields.append("fanout_reduce_planner")
+    return phase_artifact_roles(artifacts, fields=tuple(fields))
 
 
 def validate_bundle(

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -14,6 +14,7 @@ from scripts.package_replay_validation_artifacts import (
     resolve_indexed_path,
     validate_artifact_index,
 )
+from scripts.replay_validation_artifacts import phase_artifact_roles
 
 REQUIRED_CONFIG_FIELDS = (
     "base_url",
@@ -145,32 +146,6 @@ def _validate_artifact_list(
             )
 
 
-def _artifact_roles(artifacts: dict[str, Any], field: str) -> list[str]:
-    value = artifacts.get(field)
-    if not isinstance(value, list):
-        return []
-    roles: list[str] = []
-    for entry in value:
-        if not isinstance(entry, dict):
-            continue
-        role = entry.get("role")
-        if isinstance(role, str) and role:
-            roles.append(role)
-    return roles
-
-
-def _phase_artifact_roles(artifacts: dict[str, Any]) -> list[str]:
-    roles: list[str] = []
-    for field in (
-        "projector_summaries",
-        "worker_metrics",
-        "storage_backend_registry",
-        "fanout_reduce_planner",
-    ):
-        roles.extend(_artifact_roles(artifacts, field))
-    return sorted(set(roles))
-
-
 def _validate_manifest(
     manifest: dict[str, Any],
     *,
@@ -288,7 +263,7 @@ def _validate_manifest(
                     indexed_roles = indexed_roles if isinstance(indexed_roles, list) else []
                     missing_phase_roles = [
                         role
-                        for role in _phase_artifact_roles(artifacts)
+                        for role in phase_artifact_roles(artifacts)
                         if role not in indexed_roles
                     ]
                     if missing_phase_roles:

--- a/scripts/replay_validation_artifacts.py
+++ b/scripts/replay_validation_artifacts.py
@@ -36,3 +36,16 @@ def phase_artifact_roles(
     for field in fields:
         roles.extend(artifact_roles(artifacts, field))
     return sorted(set(roles))
+
+
+def artifact_cli_args(entries: list[dict[str, Any]]) -> list[str]:
+    args: list[str] = []
+    for entry in entries:
+        role = entry.get("role")
+        path = entry.get("path")
+        if not isinstance(role, str) or not role:
+            continue
+        if not isinstance(path, str) or not path:
+            continue
+        args.extend(["--artifact", f"{role}={path}"])
+    return args

--- a/scripts/replay_validation_artifacts.py
+++ b/scripts/replay_validation_artifacts.py
@@ -1,0 +1,38 @@
+"""Shared helpers for replay validation artifact metadata."""
+
+from __future__ import annotations
+
+from typing import Any
+
+PHASE_ARTIFACT_FIELDS = (
+    "projector_summaries",
+    "worker_metrics",
+    "storage_backend_registry",
+    "fanout_reduce_planner",
+)
+
+
+def artifact_roles(artifacts: dict[str, Any], field: str) -> list[str]:
+    value = artifacts.get(field)
+    if not isinstance(value, list):
+        return []
+
+    roles: list[str] = []
+    for entry in value:
+        if not isinstance(entry, dict):
+            continue
+        role = entry.get("role")
+        if isinstance(role, str) and role:
+            roles.append(role)
+    return roles
+
+
+def phase_artifact_roles(
+    artifacts: dict[str, Any],
+    *,
+    fields: tuple[str, ...] = PHASE_ARTIFACT_FIELDS,
+) -> list[str]:
+    roles: list[str] = []
+    for field in fields:
+        roles.extend(artifact_roles(artifacts, field))
+    return sorted(set(roles))

--- a/scripts/run_replay_validation.py
+++ b/scripts/run_replay_validation.py
@@ -13,6 +13,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from scripts.replay_validation_artifacts import artifact_cli_args
 from scripts.validation_stdout import parse_json_output
 
 
@@ -702,34 +703,10 @@ def main(argv: list[str] | None = None) -> int:
             "--output",
             str(args.artifact_index_output),
         ]
-        for summary in projector_summaries:
-            artifact_index_command.extend(
-                [
-                    "--artifact",
-                    f"{summary['role']}={summary['path']}",
-                ]
-            )
-        for metrics in worker_metrics:
-            artifact_index_command.extend(
-                [
-                    "--artifact",
-                    f"{metrics['role']}={metrics['path']}",
-                ]
-            )
-        for report in storage_backend_registry:
-            artifact_index_command.extend(
-                [
-                    "--artifact",
-                    f"{report['role']}={report['path']}",
-                ]
-            )
-        for report in fanout_reduce_planner:
-            artifact_index_command.extend(
-                [
-                    "--artifact",
-                    f"{report['role']}={report['path']}",
-                ]
-            )
+        artifact_index_command.extend(artifact_cli_args(projector_summaries))
+        artifact_index_command.extend(artifact_cli_args(worker_metrics))
+        artifact_index_command.extend(artifact_cli_args(storage_backend_registry))
+        artifact_index_command.extend(artifact_cli_args(fanout_reduce_planner))
         steps.append(
             {
                 "name": "artifact_index",

--- a/tests/scripts/test_replay_validation_artifacts.py
+++ b/tests/scripts/test_replay_validation_artifacts.py
@@ -1,0 +1,41 @@
+from scripts.replay_validation_artifacts import artifact_roles, phase_artifact_roles
+
+
+def test_artifact_roles_ignores_malformed_entries():
+    artifacts = {
+        "projector_summaries": [
+            {"role": "projector_summary_1", "path": "summary.json"},
+            {"role": "", "path": "missing-role.json"},
+            {"path": "no-role.json"},
+            "not-an-entry",
+        ]
+    }
+
+    assert artifact_roles(artifacts, "projector_summaries") == ["projector_summary_1"]
+
+
+def test_phase_artifact_roles_collects_unique_sorted_roles():
+    artifacts = {
+        "projector_summaries": [{"role": "projector_summary_1"}],
+        "worker_metrics": [{"role": "worker_metrics_1"}],
+        "storage_backend_registry": [{"role": "storage_backend_registry"}],
+        "fanout_reduce_planner": [{"role": "fanout_reduce_planner"}],
+    }
+
+    assert phase_artifact_roles(artifacts) == [
+        "fanout_reduce_planner",
+        "projector_summary_1",
+        "storage_backend_registry",
+        "worker_metrics_1",
+    ]
+
+
+def test_phase_artifact_roles_can_limit_fields():
+    artifacts = {
+        "projector_summaries": [{"role": "projector_summary_1"}],
+        "worker_metrics": [{"role": "worker_metrics_1"}],
+    }
+
+    assert phase_artifact_roles(artifacts, fields=("worker_metrics",)) == [
+        "worker_metrics_1"
+    ]

--- a/tests/scripts/test_replay_validation_artifacts.py
+++ b/tests/scripts/test_replay_validation_artifacts.py
@@ -1,4 +1,8 @@
-from scripts.replay_validation_artifacts import artifact_roles, phase_artifact_roles
+from scripts.replay_validation_artifacts import (
+    artifact_cli_args,
+    artifact_roles,
+    phase_artifact_roles,
+)
 
 
 def test_artifact_roles_ignores_malformed_entries():
@@ -39,3 +43,27 @@ def test_phase_artifact_roles_can_limit_fields():
     assert phase_artifact_roles(artifacts, fields=("worker_metrics",)) == [
         "worker_metrics_1"
     ]
+
+
+def test_artifact_cli_args_renders_role_path_pairs():
+    assert artifact_cli_args(
+        [
+            {"role": "projector_summary_1", "path": "summary.json"},
+            {"role": "worker_metrics_1", "path": "worker.prom"},
+        ]
+    ) == [
+        "--artifact",
+        "projector_summary_1=summary.json",
+        "--artifact",
+        "worker_metrics_1=worker.prom",
+    ]
+
+
+def test_artifact_cli_args_ignores_incomplete_entries():
+    assert artifact_cli_args(
+        [
+            {"role": "projector_summary_1"},
+            {"path": "worker.prom"},
+            {"role": "", "path": "missing-role.json"},
+        ]
+    ) == []


### PR DESCRIPTION
## Summary
- share phase artifact role extraction between manifest and bundle validators
- include the shared artifact helper tests in the replay release gate
- share artifact-index CLI argument rendering from the replay validation runner

## Commits
- refactor(replay): share phase artifact role helpers
- test(replay): include artifact helper in release gate
- refactor(replay): share artifact index cli args

## Validation
- scripts/check_replay_release_gate.sh (272 passed, 36 warnings)