### PR TITLE
Phase 15 validation artifact contracts

### DIFF
--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -21,7 +21,7 @@ from scripts.package_replay_validation_artifacts import (
     resolve_indexed_path,
     validate_artifact_index,
 )
-from scripts.replay_validation_artifacts import phase_artifact_roles
+from scripts.replay_validation_artifacts import indexed_artifact_entries, phase_artifact_roles
 
 
 def _artifact_index_from_manifest(manifest: dict[str, Any]) -> str | None:
@@ -285,9 +285,10 @@ def _validate_fanout_phase6_evidence(
         )
 
     report_results: list[dict[str, Any]] = []
-    for index, entry in enumerate(reports):
-        if not isinstance(entry, dict):
-            continue
+    for index, entry in indexed_artifact_entries(
+        {"fanout_reduce_planner": reports},
+        "fanout_reduce_planner",
+    ):
         path_value = entry.get("path")
         if not isinstance(path_value, str) or not path_value:
             continue

--- a/scripts/check_storage_phase5_evidence.py
+++ b/scripts/check_storage_phase5_evidence.py
@@ -12,6 +12,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.package_replay_validation_artifacts import resolve_indexed_path
+from scripts.replay_validation_artifacts import indexed_artifact_entries
 
 REQUIRED_BACKENDS = {"disk", "gcs", "kv", "memory", "s3"}
 REQUIRED_CONSUMERS = {
@@ -118,9 +119,10 @@ def validate_storage_phase5_evidence(
 
     report_results: list[dict[str, Any]] = []
     if check_artifacts:
-        for index, entry in enumerate(reports):
-            if not isinstance(entry, dict):
-                continue
+        for index, entry in indexed_artifact_entries(
+            {"storage_backend_registry": reports},
+            "storage_backend_registry",
+        ):
             path_value = entry.get("path")
             if not isinstance(path_value, str) or not path_value:
                 continue

--- a/scripts/check_worker_ipc_phase3_evidence.py
+++ b/scripts/check_worker_ipc_phase3_evidence.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from scripts.check_worker_ipc_metrics import validate_worker_ipc_metrics
 from scripts.package_replay_validation_artifacts import resolve_indexed_path
+from scripts.replay_validation_artifacts import indexed_artifact_entries
 
 ADMISSION_ONLY_MINIMUMS = {
     "noetl_storage_ipc_admit_success_total": 1.0,
@@ -73,9 +74,10 @@ def validate_worker_ipc_phase3_evidence(
 
     metric_results: list[dict[str, Any]] = []
     if check_artifacts:
-        for index, entry in enumerate(worker_metrics):
-            if not isinstance(entry, dict):
-                continue
+        for index, entry in indexed_artifact_entries(
+            {"worker_metrics": worker_metrics},
+            "worker_metrics",
+        ):
             path_value = entry.get("path")
             if not isinstance(path_value, str) or not path_value:
                 continue

--- a/scripts/replay_validation_artifacts.py
+++ b/scripts/replay_validation_artifacts.py
@@ -12,15 +12,16 @@ PHASE_ARTIFACT_FIELDS = (
 )
 
 
-def artifact_roles(artifacts: dict[str, Any], field: str) -> list[str]:
+def artifact_entries(artifacts: dict[str, Any], field: str) -> list[dict[str, Any]]:
     value = artifacts.get(field)
     if not isinstance(value, list):
         return []
+    return [entry for entry in value if isinstance(entry, dict)]
 
+
+def artifact_roles(artifacts: dict[str, Any], field: str) -> list[str]:
     roles: list[str] = []
-    for entry in value:
-        if not isinstance(entry, dict):
-            continue
+    for entry in artifact_entries(artifacts, field):
         role = entry.get("role")
         if isinstance(role, str) and role:
             roles.append(role)
@@ -40,7 +41,7 @@ def phase_artifact_roles(
 
 def artifact_cli_args(entries: list[dict[str, Any]]) -> list[str]:
     args: list[str] = []
-    for entry in entries:
+    for entry in [item for item in entries if isinstance(item, dict)]:
         role = entry.get("role")
         path = entry.get("path")
         if not isinstance(role, str) or not role:

--- a/scripts/replay_validation_artifacts.py
+++ b/scripts/replay_validation_artifacts.py
@@ -19,6 +19,20 @@ def artifact_entries(artifacts: dict[str, Any], field: str) -> list[dict[str, An
     return [entry for entry in value if isinstance(entry, dict)]
 
 
+def indexed_artifact_entries(
+    artifacts: dict[str, Any],
+    field: str,
+) -> list[tuple[int, dict[str, Any]]]:
+    value = artifacts.get(field)
+    if not isinstance(value, list):
+        return []
+    return [
+        (index, entry)
+        for index, entry in enumerate(value)
+        if isinstance(entry, dict)
+    ]
+
+
 def artifact_roles(artifacts: dict[str, Any], field: str) -> list[str]:
     roles: list[str] = []
     for entry in artifact_entries(artifacts, field):

--- a/tests/scripts/test_replay_validation_artifacts.py
+++ b/tests/scripts/test_replay_validation_artifacts.py
@@ -1,5 +1,6 @@
 from scripts.replay_validation_artifacts import (
     artifact_cli_args,
+    artifact_entries,
     artifact_roles,
     phase_artifact_roles,
 )
@@ -16,6 +17,24 @@ def test_artifact_roles_ignores_malformed_entries():
     }
 
     assert artifact_roles(artifacts, "projector_summaries") == ["projector_summary_1"]
+
+
+def test_artifact_entries_returns_only_object_entries():
+    artifacts = {
+        "worker_metrics": [
+            {"role": "worker_metrics_1", "path": "worker.prom"},
+            "not-an-entry",
+        ]
+    }
+
+    assert artifact_entries(artifacts, "worker_metrics") == [
+        {"role": "worker_metrics_1", "path": "worker.prom"}
+    ]
+
+
+def test_artifact_entries_returns_empty_for_missing_or_non_list_field():
+    assert artifact_entries({}, "worker_metrics") == []
+    assert artifact_entries({"worker_metrics": "worker.prom"}, "worker_metrics") == []
 
 
 def test_phase_artifact_roles_collects_unique_sorted_roles():

--- a/tests/scripts/test_replay_validation_artifacts.py
+++ b/tests/scripts/test_replay_validation_artifacts.py
@@ -2,6 +2,7 @@ from scripts.replay_validation_artifacts import (
     artifact_cli_args,
     artifact_entries,
     artifact_roles,
+    indexed_artifact_entries,
     phase_artifact_roles,
 )
 
@@ -35,6 +36,19 @@ def test_artifact_entries_returns_only_object_entries():
 def test_artifact_entries_returns_empty_for_missing_or_non_list_field():
     assert artifact_entries({}, "worker_metrics") == []
     assert artifact_entries({"worker_metrics": "worker.prom"}, "worker_metrics") == []
+
+
+def test_indexed_artifact_entries_preserves_original_indexes():
+    artifacts = {
+        "worker_metrics": [
+            "not-an-entry",
+            {"role": "worker_metrics_1", "path": "worker.prom"},
+        ]
+    }
+
+    assert indexed_artifact_entries(artifacts, "worker_metrics") == [
+        (1, {"role": "worker_metrics_1", "path": "worker.prom"})
+    ]
 
 
 def test_phase_artifact_roles_collects_unique_sorted_roles():


### PR DESCRIPTION
## Summary
- share artifact entry filtering helpers for replay validation evidence
- move worker IPC and storage evidence validators onto indexed artifact-entry helpers
- move bundle fan-out evidence validation onto the same shared indexed-entry helper

## Commits
- refactor(replay): share artifact entry filtering
- refactor(replay): share indexed artifact entries
- refactor(replay): share bundle fanout artifact entries

## Validation
- scripts/check_replay_release_gate.sh (275 passed, 36 warnings)