### PR TITLE
Phase 16 artifact role integrity

### DIFF
--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -14,7 +14,10 @@ from scripts.package_replay_validation_artifacts import (
     resolve_indexed_path,
     validate_artifact_index,
 )
-from scripts.replay_validation_artifacts import phase_artifact_roles
+from scripts.replay_validation_artifacts import (
+    duplicate_artifact_roles,
+    phase_artifact_roles,
+)
 
 REQUIRED_CONFIG_FIELDS = (
     "base_url",
@@ -114,6 +117,16 @@ def _validate_artifact_list(
     if not isinstance(value, list):
         failures.append({"field": field, "reason": "must be a list"})
         return
+    artifact_field = field.removeprefix("artifacts.")
+    duplicates = duplicate_artifact_roles({artifact_field: value}, artifact_field)
+    if duplicates:
+        failures.append(
+            {
+                "field": field,
+                "reason": "artifact roles must be unique",
+                "roles": duplicates,
+            }
+        )
     for index, entry in enumerate(value):
         if not isinstance(entry, dict):
             failures.append(

--- a/scripts/replay_validation_artifacts.py
+++ b/scripts/replay_validation_artifacts.py
@@ -42,6 +42,16 @@ def artifact_roles(artifacts: dict[str, Any], field: str) -> list[str]:
     return roles
 
 
+def duplicate_artifact_roles(artifacts: dict[str, Any], field: str) -> list[str]:
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for role in artifact_roles(artifacts, field):
+        if role in seen:
+            duplicates.add(role)
+        seen.add(role)
+    return sorted(duplicates)
+
+
 def phase_artifact_roles(
     artifacts: dict[str, Any],
     *,

--- a/tests/scripts/test_check_replay_validation_bundle.py
+++ b/tests/scripts/test_check_replay_validation_bundle.py
@@ -514,6 +514,31 @@ def test_check_replay_validation_bundle_requires_indexed_projector_phase2_eviden
     )
 
 
+def test_check_replay_validation_bundle_rejects_duplicate_projector_phase2_roles(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, index = _bundle(tmp_path)
+    _add_projector_phase2_evidence(manifest, index, tmp_path)
+    payload = json.loads(manifest.read_text())
+    payload["artifacts"]["projector_summaries"].append(
+        dict(payload["artifacts"]["projector_summaries"][0])
+    )
+    manifest.write_text(json.dumps(payload))
+
+    assert main(["--manifest", str(manifest), "--require-projector-phase2"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any(
+        failure["field"] == "manifest"
+        and any(
+            nested_failure["reason"] == "artifact roles must be unique"
+            and nested_failure["roles"] == ["projector_summary_1"]
+            for nested_failure in failure.get("failures", [])
+        )
+        for failure in output["failures"]
+    )
+
+
 def test_check_replay_validation_bundle_accepts_worker_ipc_phase3_evidence(
     tmp_path: Path,
     capsys,

--- a/tests/scripts/test_check_replay_validation_manifest.py
+++ b/tests/scripts/test_check_replay_validation_manifest.py
@@ -340,6 +340,42 @@ def test_check_replay_validation_manifest_requires_indexed_phase_artifact_roles(
     )
 
 
+@pytest.mark.parametrize(
+    ("artifact_field", "role", "filename"),
+    [
+        ("projector_summaries", "projector_summary_1", "projector-summary.json"),
+        ("worker_metrics", "worker_metrics_1", "worker.prom"),
+        ("storage_backend_registry", "storage_backend_registry", "storage-phase5-report.json"),
+        ("fanout_reduce_planner", "fanout_reduce_planner", "fanout-phase6-report.json"),
+    ],
+)
+def test_check_replay_validation_manifest_rejects_duplicate_phase_artifact_roles(
+    tmp_path: Path,
+    capsys,
+    artifact_field: str,
+    role: str,
+    filename: str,
+):
+    manifest = _manifest(tmp_path)
+    artifact = tmp_path / filename
+    artifact.write_text("{}")
+    manifest["artifacts"][artifact_field] = [
+        {"role": role, "path": str(artifact)},
+        {"role": role, "path": str(artifact)},
+    ]
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert main(["--manifest", str(path), "--check-artifacts"]) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert any(
+        failure["field"] == f"artifacts.{artifact_field}"
+        and failure["reason"] == "artifact roles must be unique"
+        and failure["roles"] == [role]
+        for failure in output["failures"]
+    )
+
+
 def test_check_replay_validation_manifest_requires_artifact_index_step(tmp_path: Path, capsys):
     path = _write_manifest_with_artifact_index(tmp_path)
     manifest = json.loads(path.read_text())

--- a/tests/scripts/test_replay_validation_artifacts.py
+++ b/tests/scripts/test_replay_validation_artifacts.py
@@ -2,6 +2,7 @@ from scripts.replay_validation_artifacts import (
     artifact_cli_args,
     artifact_entries,
     artifact_roles,
+    duplicate_artifact_roles,
     indexed_artifact_entries,
     phase_artifact_roles,
 )
@@ -18,6 +19,22 @@ def test_artifact_roles_ignores_malformed_entries():
     }
 
     assert artifact_roles(artifacts, "projector_summaries") == ["projector_summary_1"]
+
+
+def test_duplicate_artifact_roles_returns_sorted_duplicates():
+    artifacts = {
+        "projector_summaries": [
+            {"role": "projector_summary_2", "path": "summary-2.json"},
+            {"role": "projector_summary_1", "path": "summary-1-a.json"},
+            {"role": "projector_summary_1", "path": "summary-1-b.json"},
+            {"role": "projector_summary_2", "path": "summary-2-b.json"},
+        ]
+    }
+
+    assert duplicate_artifact_roles(artifacts, "projector_summaries") == [
+        "projector_summary_1",
+        "projector_summary_2",
+    ]
 
 
 def test_artifact_entries_returns_only_object_entries():


### PR DESCRIPTION
## Summary
- add shared duplicate artifact-role detection for replay validation artifacts
- reject duplicate phase artifact roles at manifest validation time
- cover duplicate-role surfacing through the replay bundle gate

## Commits
- test(replay): detect duplicate artifact roles
- test(replay): reject duplicate manifest artifact roles
- test(replay): surface duplicate roles through bundle gate

## Validation
- scripts/check_replay_release_gate.sh (281 passed, 36 warnings)