### PR TITLE
Phase 17 artifact index role contracts

### DIFF
--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -21,7 +21,11 @@ from scripts.package_replay_validation_artifacts import (
     resolve_indexed_path,
     validate_artifact_index,
 )
-from scripts.replay_validation_artifacts import indexed_artifact_entries, phase_artifact_roles
+from scripts.replay_validation_artifacts import (
+    indexed_artifact_entries,
+    missing_indexed_artifact_roles,
+    phase_artifact_roles,
+)
 
 
 def _artifact_index_from_manifest(manifest: dict[str, Any]) -> str | None:
@@ -223,11 +227,10 @@ def validate_bundle(
                 require_storage_phase5=require_storage_phase5,
                 require_fanout_phase6=require_fanout_phase6,
             )
-            indexed_roles = index_result.get("roles")
-            indexed_roles = indexed_roles if isinstance(indexed_roles, list) else []
-            missing_index_roles = [
-                role for role in required_index_roles if role not in indexed_roles
-            ]
+            missing_index_roles = missing_indexed_artifact_roles(
+                required_index_roles,
+                index_result.get("roles"),
+            )
             if missing_index_roles:
                 failures.append(
                     {

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -16,6 +16,7 @@ from scripts.package_replay_validation_artifacts import (
 )
 from scripts.replay_validation_artifacts import (
     duplicate_artifact_roles,
+    missing_indexed_artifact_roles,
     phase_artifact_roles,
 )
 
@@ -272,13 +273,10 @@ def _validate_manifest(
                                 "failures": index_output.get("failures", []),
                             }
                         )
-                    indexed_roles = index_output.get("roles")
-                    indexed_roles = indexed_roles if isinstance(indexed_roles, list) else []
-                    missing_phase_roles = [
-                        role
-                        for role in phase_artifact_roles(artifacts)
-                        if role not in indexed_roles
-                    ]
+                    missing_phase_roles = missing_indexed_artifact_roles(
+                        phase_artifact_roles(artifacts),
+                        index_output.get("roles"),
+                    )
                     if missing_phase_roles:
                         failures.append(
                             {

--- a/scripts/replay_validation_artifacts.py
+++ b/scripts/replay_validation_artifacts.py
@@ -63,6 +63,15 @@ def phase_artifact_roles(
     return sorted(set(roles))
 
 
+def missing_indexed_artifact_roles(
+    required_roles: list[str],
+    indexed_roles: Any,
+) -> list[str]:
+    if not isinstance(indexed_roles, list):
+        indexed_roles = []
+    return [role for role in required_roles if role not in indexed_roles]
+
+
 def artifact_cli_args(entries: list[dict[str, Any]]) -> list[str]:
     args: list[str] = []
     for entry in [item for item in entries if isinstance(item, dict)]:

--- a/tests/scripts/test_replay_validation_artifacts.py
+++ b/tests/scripts/test_replay_validation_artifacts.py
@@ -4,6 +4,7 @@ from scripts.replay_validation_artifacts import (
     artifact_roles,
     duplicate_artifact_roles,
     indexed_artifact_entries,
+    missing_indexed_artifact_roles,
     phase_artifact_roles,
 )
 
@@ -93,6 +94,20 @@ def test_phase_artifact_roles_can_limit_fields():
     assert phase_artifact_roles(artifacts, fields=("worker_metrics",)) == [
         "worker_metrics_1"
     ]
+
+
+def test_missing_indexed_artifact_roles_returns_unmatched_required_roles():
+    assert missing_indexed_artifact_roles(
+        ["projector_summary_1", "worker_metrics_1"],
+        ["worker_metrics_1"],
+    ) == ["projector_summary_1"]
+
+
+def test_missing_indexed_artifact_roles_treats_malformed_index_roles_as_empty():
+    assert missing_indexed_artifact_roles(
+        ["projector_summary_1"],
+        "projector_summary_1",
+    ) == ["projector_summary_1"]
 
 
 def test_artifact_cli_args_renders_role_path_pairs():


### PR DESCRIPTION
## Summary
- add a shared helper for artifact index role gap detection
- use the helper from manifest artifact-index validation
- use the helper from bundle artifact-index validation

## Validation
- PYTHONPATH=. pytest tests/scripts/test_replay_validation_artifacts.py
- PYTHONPATH=. pytest tests/scripts/test_check_replay_validation_manifest.py tests/scripts/test_replay_validation_artifacts.py
- PYTHONPATH=. pytest tests/scripts/test_check_replay_validation_bundle.py tests/scripts/test_replay_validation_artifacts.py
- scripts/check_replay_release_gate.sh