### PR TITLE
Phase 18 artifact entry path contracts

### DIFF
--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -23,6 +23,7 @@ from scripts.package_replay_validation_artifacts import (
 )
 from scripts.replay_validation_artifacts import (
     indexed_artifact_entries,
+    indexed_artifact_paths,
     missing_indexed_artifact_roles,
     phase_artifact_roles,
 )
@@ -288,13 +289,10 @@ def _validate_fanout_phase6_evidence(
         )
 
     report_results: list[dict[str, Any]] = []
-    for index, entry in indexed_artifact_entries(
+    for index, entry, path_value in indexed_artifact_paths(
         {"fanout_reduce_planner": reports},
         "fanout_reduce_planner",
     ):
-        path_value = entry.get("path")
-        if not isinstance(path_value, str) or not path_value:
-            continue
         path = resolve_indexed_path(path_value, index_path=manifest_path)
         try:
             report = json.loads(path.read_text())

--- a/scripts/check_storage_phase5_evidence.py
+++ b/scripts/check_storage_phase5_evidence.py
@@ -12,7 +12,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.package_replay_validation_artifacts import resolve_indexed_path
-from scripts.replay_validation_artifacts import indexed_artifact_entries
+from scripts.replay_validation_artifacts import indexed_artifact_paths
 
 REQUIRED_BACKENDS = {"disk", "gcs", "kv", "memory", "s3"}
 REQUIRED_CONSUMERS = {
@@ -119,13 +119,10 @@ def validate_storage_phase5_evidence(
 
     report_results: list[dict[str, Any]] = []
     if check_artifacts:
-        for index, entry in indexed_artifact_entries(
+        for index, entry, path_value in indexed_artifact_paths(
             {"storage_backend_registry": reports},
             "storage_backend_registry",
         ):
-            path_value = entry.get("path")
-            if not isinstance(path_value, str) or not path_value:
-                continue
             path = _resolve(path_value, manifest_path=manifest_path)
             try:
                 result = validate_storage_phase5_report(_load_json_object(path))

--- a/scripts/check_worker_ipc_phase3_evidence.py
+++ b/scripts/check_worker_ipc_phase3_evidence.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from scripts.check_worker_ipc_metrics import validate_worker_ipc_metrics
 from scripts.package_replay_validation_artifacts import resolve_indexed_path
-from scripts.replay_validation_artifacts import indexed_artifact_entries
+from scripts.replay_validation_artifacts import indexed_artifact_paths
 
 ADMISSION_ONLY_MINIMUMS = {
     "noetl_storage_ipc_admit_success_total": 1.0,
@@ -74,13 +74,10 @@ def validate_worker_ipc_phase3_evidence(
 
     metric_results: list[dict[str, Any]] = []
     if check_artifacts:
-        for index, entry in indexed_artifact_entries(
+        for index, entry, path_value in indexed_artifact_paths(
             {"worker_metrics": worker_metrics},
             "worker_metrics",
         ):
-            path_value = entry.get("path")
-            if not isinstance(path_value, str) or not path_value:
-                continue
             path = _resolve(path_value, manifest_path=manifest_path)
             try:
                 result = validate_worker_ipc_metrics(

--- a/scripts/replay_validation_artifacts.py
+++ b/scripts/replay_validation_artifacts.py
@@ -33,6 +33,18 @@ def indexed_artifact_entries(
     ]
 
 
+def indexed_artifact_paths(
+    artifacts: dict[str, Any],
+    field: str,
+) -> list[tuple[int, dict[str, Any], str]]:
+    paths: list[tuple[int, dict[str, Any], str]] = []
+    for index, entry in indexed_artifact_entries(artifacts, field):
+        path = entry.get("path")
+        if isinstance(path, str) and path:
+            paths.append((index, entry, path))
+    return paths
+
+
 def artifact_roles(artifacts: dict[str, Any], field: str) -> list[str]:
     roles: list[str] = []
     for entry in artifact_entries(artifacts, field):

--- a/tests/scripts/test_replay_validation_artifacts.py
+++ b/tests/scripts/test_replay_validation_artifacts.py
@@ -4,6 +4,7 @@ from scripts.replay_validation_artifacts import (
     artifact_roles,
     duplicate_artifact_roles,
     indexed_artifact_entries,
+    indexed_artifact_paths,
     missing_indexed_artifact_roles,
     phase_artifact_roles,
 )
@@ -66,6 +67,21 @@ def test_indexed_artifact_entries_preserves_original_indexes():
 
     assert indexed_artifact_entries(artifacts, "worker_metrics") == [
         (1, {"role": "worker_metrics_1", "path": "worker.prom"})
+    ]
+
+
+def test_indexed_artifact_paths_preserves_indexes_and_path_values():
+    artifacts = {
+        "worker_metrics": [
+            {"role": "worker_metrics_1", "path": ""},
+            {"role": "worker_metrics_2", "path": "worker.prom"},
+            {"role": "worker_metrics_3"},
+            "not-an-entry",
+        ]
+    }
+
+    assert indexed_artifact_paths(artifacts, "worker_metrics") == [
+        (1, {"role": "worker_metrics_2", "path": "worker.prom"}, "worker.prom")
     ]
 
 


### PR DESCRIPTION
## Summary
- add a shared helper for indexed artifact entries that carry non-empty paths
- use the helper in worker IPC and storage evidence artifact validation
- use the helper in fanout/reduce planner artifact validation

## Validation
- PYTHONPATH=. pytest tests/scripts/test_replay_validation_artifacts.py
- PYTHONPATH=. pytest tests/scripts/test_check_replay_validation_bundle.py tests/scripts/test_replay_validation_artifacts.py
- scripts/check_replay_release_gate.sh