### PR TITLE
Phase 19 artifact result entry contracts

### DIFF
--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -22,6 +22,7 @@ from scripts.package_replay_validation_artifacts import (
     validate_artifact_index,
 )
 from scripts.replay_validation_artifacts import (
+    artifact_result_entry,
     indexed_artifact_entries,
     indexed_artifact_paths,
     missing_indexed_artifact_roles,
@@ -313,7 +314,7 @@ def _validate_fanout_phase6_evidence(
                 }
             )
             continue
-        report_results.append({"role": entry.get("role"), "path": str(path), "result": result})
+        report_results.append(artifact_result_entry(entry, path=str(path), result=result))
         if result.get("matched") is not True:
             failures.append(
                 {

--- a/scripts/check_storage_phase5_evidence.py
+++ b/scripts/check_storage_phase5_evidence.py
@@ -12,7 +12,10 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.package_replay_validation_artifacts import resolve_indexed_path
-from scripts.replay_validation_artifacts import indexed_artifact_paths
+from scripts.replay_validation_artifacts import (
+    artifact_result_entry,
+    indexed_artifact_paths,
+)
 
 REQUIRED_BACKENDS = {"disk", "gcs", "kv", "memory", "s3"}
 REQUIRED_CONSUMERS = {
@@ -136,7 +139,7 @@ def validate_storage_phase5_evidence(
                     }
                 )
                 continue
-            report_results.append({"role": entry.get("role"), "path": str(path), "result": result})
+            report_results.append(artifact_result_entry(entry, path=str(path), result=result))
             if result.get("matched") is not True:
                 failures.append(
                     {

--- a/scripts/check_worker_ipc_phase3_evidence.py
+++ b/scripts/check_worker_ipc_phase3_evidence.py
@@ -11,7 +11,10 @@ from typing import Any
 
 from scripts.check_worker_ipc_metrics import validate_worker_ipc_metrics
 from scripts.package_replay_validation_artifacts import resolve_indexed_path
-from scripts.replay_validation_artifacts import indexed_artifact_paths
+from scripts.replay_validation_artifacts import (
+    artifact_result_entry,
+    indexed_artifact_paths,
+)
 
 ADMISSION_ONLY_MINIMUMS = {
     "noetl_storage_ipc_admit_success_total": 1.0,
@@ -94,7 +97,7 @@ def validate_worker_ipc_phase3_evidence(
                     }
                 )
                 continue
-            metric_results.append({"role": entry.get("role"), "path": str(path), "result": result})
+            metric_results.append(artifact_result_entry(entry, path=str(path), result=result))
             if result.get("matched") is not True:
                 failures.append(
                     {

--- a/scripts/replay_validation_artifacts.py
+++ b/scripts/replay_validation_artifacts.py
@@ -84,6 +84,15 @@ def missing_indexed_artifact_roles(
     return [role for role in required_roles if role not in indexed_roles]
 
 
+def artifact_result_entry(
+    entry: dict[str, Any],
+    *,
+    path: str,
+    result: dict[str, Any],
+) -> dict[str, Any]:
+    return {"role": entry.get("role"), "path": path, "result": result}
+
+
 def artifact_cli_args(entries: list[dict[str, Any]]) -> list[str]:
     args: list[str] = []
     for entry in [item for item in entries if isinstance(item, dict)]:

--- a/tests/scripts/test_replay_validation_artifacts.py
+++ b/tests/scripts/test_replay_validation_artifacts.py
@@ -1,6 +1,7 @@
 from scripts.replay_validation_artifacts import (
     artifact_cli_args,
     artifact_entries,
+    artifact_result_entry,
     artifact_roles,
     duplicate_artifact_roles,
     indexed_artifact_entries,
@@ -124,6 +125,20 @@ def test_missing_indexed_artifact_roles_treats_malformed_index_roles_as_empty():
         ["projector_summary_1"],
         "projector_summary_1",
     ) == ["projector_summary_1"]
+
+
+def test_artifact_result_entry_preserves_role_path_and_result():
+    result = {"matched": True}
+
+    assert artifact_result_entry(
+        {"role": "worker_metrics_1"},
+        path="/tmp/worker.prom",
+        result=result,
+    ) == {
+        "role": "worker_metrics_1",
+        "path": "/tmp/worker.prom",
+        "result": result,
+    }
 
 
 def test_artifact_cli_args_renders_role_path_pairs():


### PR DESCRIPTION
## Summary
- add a shared helper for artifact evidence result entries
- use the helper in worker IPC and storage evidence result payloads
- use the helper in fanout/reduce planner result payloads

## Validation
- PYTHONPATH=. pytest tests/scripts/test_replay_validation_artifacts.py
- PYTHONPATH=. pytest tests/scripts/test_check_replay_validation_bundle.py tests/scripts/test_replay_validation_artifacts.py
- scripts/check_replay_release_gate.sh