### PR TITLE
Phase 20 validation result match contracts

### DIFF
--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -27,6 +27,7 @@ from scripts.replay_validation_artifacts import (
     indexed_artifact_paths,
     missing_indexed_artifact_roles,
     phase_artifact_roles,
+    result_matched,
 )
 
 
@@ -84,7 +85,7 @@ def validate_bundle(
         check_artifacts=True,
         manifest_path=manifest_path,
     )
-    if manifest_result.get("matched") is not True:
+    if not result_matched(manifest_result):
         failures.append(
             {
                 "field": "manifest",
@@ -100,7 +101,7 @@ def validate_bundle(
             check_artifacts=True,
             manifest_path=manifest_path,
         )
-        if phase2_result.get("matched") is not True:
+        if not result_matched(phase2_result):
             failures.append(
                 {
                     "field": "phase2_projector_evidence",
@@ -115,7 +116,7 @@ def validate_bundle(
             check_artifacts=True,
             manifest_path=manifest_path,
         )
-        if phase3_result.get("matched") is not True:
+        if not result_matched(phase3_result):
             failures.append(
                 {
                     "field": "phase3_worker_ipc_evidence",
@@ -130,7 +131,7 @@ def validate_bundle(
             check_artifacts=True,
             manifest_path=manifest_path,
         )
-        if phase5_result.get("matched") is not True:
+        if not result_matched(phase5_result):
             failures.append(
                 {
                     "field": "phase5_storage_evidence",
@@ -144,7 +145,7 @@ def validate_bundle(
             manifest,
             manifest_path=manifest_path,
         )
-        if phase6_result.get("matched") is not True:
+        if not result_matched(phase6_result):
             failures.append(
                 {
                     "field": "phase6_fanout_evidence",
@@ -158,7 +159,7 @@ def validate_bundle(
             manifest,
             manifest_path=manifest_path,
         )
-        if replay_phase6_result.get("matched") is not True:
+        if not result_matched(replay_phase6_result):
             failures.append(
                 {
                     "field": "phase6_replay_fanout_evidence",
@@ -213,7 +214,7 @@ def validate_bundle(
                 }
             )
         else:
-            if index_result.get("matched") is not True:
+            if not result_matched(index_result):
                 failures.append(
                     {
                         "field": "artifact_index",
@@ -315,7 +316,7 @@ def _validate_fanout_phase6_evidence(
             )
             continue
         report_results.append(artifact_result_entry(entry, path=str(path), result=result))
-        if result.get("matched") is not True:
+        if not result_matched(result):
             failures.append(
                 {
                     "field": f"artifacts.fanout_reduce_planner[{index}]",
@@ -380,7 +381,7 @@ def _validate_replay_fanout_phase6_evidence(
         )
         return {"matched": False, "result": None, "failures": failures}
 
-    if result.get("matched") is not True:
+    if not result_matched(result):
         failures.append(
             {
                 "field": "artifacts.replay",

--- a/scripts/check_storage_phase5_evidence.py
+++ b/scripts/check_storage_phase5_evidence.py
@@ -71,7 +71,7 @@ def validate_storage_phase5_report(report: dict[str, Any]) -> dict[str, Any]:
 
     direct_scan = report.get("direct_backend_construction")
     direct_scan = direct_scan if isinstance(direct_scan, dict) else {}
-    if direct_scan.get("matched") is not True:
+    if not result_matched(direct_scan):
         failures.append(
             {
                 "field": "direct_backend_construction",

--- a/scripts/check_storage_phase5_evidence.py
+++ b/scripts/check_storage_phase5_evidence.py
@@ -15,6 +15,7 @@ from scripts.package_replay_validation_artifacts import resolve_indexed_path
 from scripts.replay_validation_artifacts import (
     artifact_result_entry,
     indexed_artifact_paths,
+    result_matched,
 )
 
 REQUIRED_BACKENDS = {"disk", "gcs", "kv", "memory", "s3"}
@@ -140,7 +141,7 @@ def validate_storage_phase5_evidence(
                 )
                 continue
             report_results.append(artifact_result_entry(entry, path=str(path), result=result))
-            if result.get("matched") is not True:
+            if not result_matched(result):
                 failures.append(
                     {
                         "field": f"artifacts.storage_backend_registry[{index}]",

--- a/scripts/check_worker_ipc_phase3_evidence.py
+++ b/scripts/check_worker_ipc_phase3_evidence.py
@@ -14,6 +14,7 @@ from scripts.package_replay_validation_artifacts import resolve_indexed_path
 from scripts.replay_validation_artifacts import (
     artifact_result_entry,
     indexed_artifact_paths,
+    result_matched,
 )
 
 ADMISSION_ONLY_MINIMUMS = {
@@ -98,7 +99,7 @@ def validate_worker_ipc_phase3_evidence(
                 )
                 continue
             metric_results.append(artifact_result_entry(entry, path=str(path), result=result))
-            if result.get("matched") is not True:
+            if not result_matched(result):
                 failures.append(
                     {
                         "field": f"artifacts.worker_metrics[{index}]",

--- a/scripts/replay_validation_artifacts.py
+++ b/scripts/replay_validation_artifacts.py
@@ -93,6 +93,10 @@ def artifact_result_entry(
     return {"role": entry.get("role"), "path": path, "result": result}
 
 
+def result_matched(result: dict[str, Any] | None) -> bool:
+    return isinstance(result, dict) and result.get("matched") is True
+
+
 def artifact_cli_args(entries: list[dict[str, Any]]) -> list[str]:
     args: list[str] = []
     for entry in [item for item in entries if isinstance(item, dict)]:

--- a/tests/scripts/test_replay_validation_artifacts.py
+++ b/tests/scripts/test_replay_validation_artifacts.py
@@ -8,6 +8,7 @@ from scripts.replay_validation_artifacts import (
     indexed_artifact_paths,
     missing_indexed_artifact_roles,
     phase_artifact_roles,
+    result_matched,
 )
 
 
@@ -139,6 +140,13 @@ def test_artifact_result_entry_preserves_role_path_and_result():
         "path": "/tmp/worker.prom",
         "result": result,
     }
+
+
+def test_result_matched_requires_explicit_true_match():
+    assert result_matched({"matched": True}) is True
+    assert result_matched({"matched": False}) is False
+    assert result_matched({"matched": "true"}) is False
+    assert result_matched(None) is False
 
 
 def test_artifact_cli_args_renders_role_path_pairs():


### PR DESCRIPTION
## Summary
- add a shared helper for strict validation result match checks
- use the helper in worker IPC and storage evidence validators
- use the helper across bundle validation result checks
- use the helper in storage direct-scan validation

## Validation
- PYTHONPATH=. pytest tests/scripts/test_replay_validation_artifacts.py
- PYTHONPATH=. pytest tests/scripts/test_check_replay_validation_bundle.py tests/scripts/test_replay_validation_artifacts.py
- .venv/bin/python -m pytest tests/scripts/test_build_storage_phase5_report.py tests/scripts/test_check_replay_validation_bundle.py tests/scripts/test_replay_validation_artifacts.py
- scripts/check_replay_release_gate.sh