### PR TITLE
Phase 21 manifest artifact contracts

### DIFF
--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -22,6 +22,7 @@ from scripts.package_replay_validation_artifacts import (
     validate_artifact_index,
 )
 from scripts.replay_validation_artifacts import (
+    artifact_index_path_value,
     artifact_result_entry,
     indexed_artifact_entries,
     indexed_artifact_paths,
@@ -29,16 +30,6 @@ from scripts.replay_validation_artifacts import (
     phase_artifact_roles,
     result_matched,
 )
-
-
-def _artifact_index_from_manifest(manifest: dict[str, Any]) -> str | None:
-    artifacts = manifest.get("artifacts")
-    if not isinstance(artifacts, dict):
-        return None
-    value = artifacts.get("artifact_index")
-    if not isinstance(value, str) or not value:
-        return None
-    return value
 
 
 def _required_index_roles(
@@ -168,7 +159,7 @@ def validate_bundle(
                 }
             )
 
-    manifest_index = _artifact_index_from_manifest(manifest)
+    manifest_index = artifact_index_path_value(manifest)
     if artifact_index_path is None:
         if manifest_index is None:
             failures.append(

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -15,6 +15,7 @@ from scripts.package_replay_validation_artifacts import (
     validate_artifact_index,
 )
 from scripts.replay_validation_artifacts import (
+    PHASE_ARTIFACT_FIELDS,
     duplicate_artifact_roles,
     missing_indexed_artifact_roles,
     phase_artifact_roles,
@@ -204,37 +205,10 @@ def _validate_manifest(
         failures.append({"field": "artifacts", "reason": "must be an object"})
     elif isinstance(artifacts, dict):
         for field, value in artifacts.items():
-            if field == "projector_summaries":
+            if field in PHASE_ARTIFACT_FIELDS:
                 _validate_artifact_list(
                     failures,
-                    field="artifacts.projector_summaries",
-                    value=value,
-                    manifest_path=manifest_path,
-                    check_artifacts=check_artifacts,
-                )
-                continue
-            if field == "worker_metrics":
-                _validate_artifact_list(
-                    failures,
-                    field="artifacts.worker_metrics",
-                    value=value,
-                    manifest_path=manifest_path,
-                    check_artifacts=check_artifacts,
-                )
-                continue
-            if field == "storage_backend_registry":
-                _validate_artifact_list(
-                    failures,
-                    field="artifacts.storage_backend_registry",
-                    value=value,
-                    manifest_path=manifest_path,
-                    check_artifacts=check_artifacts,
-                )
-                continue
-            if field == "fanout_reduce_planner":
-                _validate_artifact_list(
-                    failures,
-                    field="artifacts.fanout_reduce_planner",
+                    field=f"artifacts.{field}",
                     value=value,
                     manifest_path=manifest_path,
                     check_artifacts=check_artifacts,

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -16,6 +16,7 @@ from scripts.package_replay_validation_artifacts import (
 )
 from scripts.replay_validation_artifacts import (
     PHASE_ARTIFACT_FIELDS,
+    artifact_index_path_value,
     duplicate_artifact_roles,
     missing_indexed_artifact_roles,
     phase_artifact_roles,
@@ -223,8 +224,8 @@ def _validate_manifest(
                 check_artifacts=check_artifacts,
             )
 
-        artifact_index = artifacts.get("artifact_index")
-        if isinstance(artifact_index, str) and artifact_index:
+        artifact_index = artifact_index_path_value(manifest)
+        if artifact_index is not None:
             index_path = _artifact_path(artifact_index, manifest_path)
             if index_path.exists():
                 try:

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -19,6 +19,7 @@ from scripts.replay_validation_artifacts import (
     duplicate_artifact_roles,
     missing_indexed_artifact_roles,
     phase_artifact_roles,
+    result_matched,
 )
 
 REQUIRED_CONFIG_FIELDS = (
@@ -238,7 +239,7 @@ def _validate_manifest(
                         }
                     )
                 else:
-                    if index_output.get("matched") is not True:
+                    if not result_matched(index_output):
                         failures.append(
                             {
                                 "field": "artifacts.artifact_index",

--- a/scripts/replay_validation_artifacts.py
+++ b/scripts/replay_validation_artifacts.py
@@ -84,6 +84,16 @@ def missing_indexed_artifact_roles(
     return [role for role in required_roles if role not in indexed_roles]
 
 
+def artifact_index_path_value(manifest: dict[str, Any]) -> str | None:
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return None
+    value = artifacts.get("artifact_index")
+    if not isinstance(value, str) or not value:
+        return None
+    return value
+
+
 def artifact_result_entry(
     entry: dict[str, Any],
     *,

--- a/tests/scripts/test_replay_validation_artifacts.py
+++ b/tests/scripts/test_replay_validation_artifacts.py
@@ -1,6 +1,7 @@
 from scripts.replay_validation_artifacts import (
     artifact_cli_args,
     artifact_entries,
+    artifact_index_path_value,
     artifact_result_entry,
     artifact_roles,
     duplicate_artifact_roles,
@@ -126,6 +127,18 @@ def test_missing_indexed_artifact_roles_treats_malformed_index_roles_as_empty():
         ["projector_summary_1"],
         "projector_summary_1",
     ) == ["projector_summary_1"]
+
+
+def test_artifact_index_path_value_returns_non_empty_manifest_index():
+    assert artifact_index_path_value(
+        {"artifacts": {"artifact_index": "artifact-index.json"}}
+    ) == "artifact-index.json"
+
+
+def test_artifact_index_path_value_ignores_missing_or_malformed_values():
+    assert artifact_index_path_value({"artifacts": {"artifact_index": ""}}) is None
+    assert artifact_index_path_value({"artifacts": {"artifact_index": 123}}) is None
+    assert artifact_index_path_value({"artifacts": []}) is None
 
 
 def test_artifact_result_entry_preserves_role_path_and_result():


### PR DESCRIPTION
## Summary
- use the shared phase artifact field contract in manifest validation
- use the shared strict match helper for manifest artifact-index checks
- add a shared artifact-index path lookup helper
- use the helper from manifest and bundle validators

## Validation
- PYTHONPATH=. pytest tests/scripts/test_check_replay_validation_manifest.py tests/scripts/test_replay_validation_artifacts.py
- PYTHONPATH=. pytest tests/scripts/test_check_replay_validation_manifest.py tests/scripts/test_check_replay_validation_bundle.py tests/scripts/test_replay_validation_artifacts.py
- scripts/check_replay_release_gate.sh