### PR TITLE
Phase 22 manifest shape helpers

### DIFF
--- a/scripts/check_projector_phase2_evidence.py
+++ b/scripts/check_projector_phase2_evidence.py
@@ -10,17 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.check_replay_validation_manifest import _load_manifest, _validate_manifest
-
-
-def _step_names(manifest: dict[str, Any]) -> list[str]:
-    steps = manifest.get("steps")
-    if not isinstance(steps, list):
-        return []
-    names: list[str] = []
-    for step in steps:
-        if isinstance(step, dict) and isinstance(step.get("name"), str):
-            names.append(step["name"])
-    return names
+from scripts.replay_validation_artifacts import manifest_artifacts, manifest_step_names
 
 
 def validate_projector_phase2_evidence(
@@ -37,7 +27,7 @@ def validate_projector_phase2_evidence(
         manifest_path=manifest_path,
     )
     failures: list[dict[str, Any]] = list(base.get("failures", []))
-    artifacts = manifest.get("artifacts") if isinstance(manifest.get("artifacts"), dict) else {}
+    artifacts = manifest_artifacts(manifest)
     projector_summaries = artifacts.get("projector_summaries")
     if not isinstance(projector_summaries, list) or not projector_summaries:
         failures.append(
@@ -47,7 +37,7 @@ def validate_projector_phase2_evidence(
             }
         )
 
-    names = _step_names(manifest)
+    names = manifest_step_names(manifest)
     if not any(name.startswith("projector_summary_") and name.endswith("_integrity") for name in names):
         failures.append(
             {

--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -26,6 +26,8 @@ from scripts.replay_validation_artifacts import (
     artifact_result_entry,
     indexed_artifact_entries,
     indexed_artifact_paths,
+    manifest_artifacts,
+    manifest_step_names,
     missing_indexed_artifact_roles,
     phase_artifact_roles,
     result_matched,
@@ -40,8 +42,8 @@ def _required_index_roles(
     require_storage_phase5: bool,
     require_fanout_phase6: bool,
 ) -> list[str]:
-    artifacts = manifest.get("artifacts")
-    if not isinstance(artifacts, dict):
+    artifacts = manifest_artifacts(manifest)
+    if not artifacts:
         return []
     fields: list[str] = []
     if require_projector_phase2:
@@ -255,8 +257,7 @@ def _validate_fanout_phase6_evidence(
     manifest_path: Path,
 ) -> dict[str, Any]:
     failures: list[dict[str, Any]] = []
-    artifacts = manifest.get("artifacts")
-    artifacts = artifacts if isinstance(artifacts, dict) else {}
+    artifacts = manifest_artifacts(manifest)
     reports = artifacts.get("fanout_reduce_planner")
     if not isinstance(reports, list) or not reports:
         failures.append(
@@ -267,12 +268,7 @@ def _validate_fanout_phase6_evidence(
         )
         reports = []
 
-    steps = manifest.get("steps")
-    step_names = [
-        step.get("name")
-        for step in (steps if isinstance(steps, list) else [])
-        if isinstance(step, dict)
-    ]
+    step_names = manifest_step_names(manifest)
     if "fanout_reduce_planner_integrity" not in step_names:
         failures.append(
             {
@@ -329,8 +325,7 @@ def _validate_replay_fanout_phase6_evidence(
     manifest_path: Path,
 ) -> dict[str, Any]:
     failures: list[dict[str, Any]] = []
-    artifacts = manifest.get("artifacts")
-    artifacts = artifacts if isinstance(artifacts, dict) else {}
+    artifacts = manifest_artifacts(manifest)
     replay_path = artifacts.get("replay")
     if not isinstance(replay_path, str) or not replay_path:
         failures.append(
@@ -341,12 +336,7 @@ def _validate_replay_fanout_phase6_evidence(
         )
         return {"matched": False, "result": None, "failures": failures}
 
-    steps = manifest.get("steps")
-    step_names = [
-        step.get("name")
-        for step in (steps if isinstance(steps, list) else [])
-        if isinstance(step, dict)
-    ]
+    step_names = manifest_step_names(manifest)
     if "replay_fanout_reduce_integrity" not in step_names:
         failures.append(
             {

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -18,6 +18,7 @@ from scripts.replay_validation_artifacts import (
     PHASE_ARTIFACT_FIELDS,
     artifact_index_path_value,
     duplicate_artifact_roles,
+    manifest_artifacts,
     missing_indexed_artifact_roles,
     phase_artifact_roles,
     result_matched,
@@ -202,10 +203,11 @@ def _validate_manifest(
                 }
             )
 
-    artifacts = manifest.get("artifacts")
-    if artifacts is not None and not isinstance(artifacts, dict):
+    artifact_value = manifest.get("artifacts")
+    artifacts = manifest_artifacts(manifest)
+    if artifact_value is not None and not isinstance(artifact_value, dict):
         failures.append({"field": "artifacts", "reason": "must be an object"})
-    elif isinstance(artifacts, dict):
+    elif artifacts:
         for field, value in artifacts.items():
             if field in PHASE_ARTIFACT_FIELDS:
                 _validate_artifact_list(

--- a/scripts/check_storage_phase5_evidence.py
+++ b/scripts/check_storage_phase5_evidence.py
@@ -15,6 +15,8 @@ from scripts.package_replay_validation_artifacts import resolve_indexed_path
 from scripts.replay_validation_artifacts import (
     artifact_result_entry,
     indexed_artifact_paths,
+    manifest_artifacts,
+    manifest_step_names,
     result_matched,
 )
 
@@ -95,8 +97,7 @@ def validate_storage_phase5_evidence(
     manifest_path: Path | None = None,
 ) -> dict[str, Any]:
     failures: list[dict[str, Any]] = []
-    artifacts = manifest.get("artifacts")
-    artifacts = artifacts if isinstance(artifacts, dict) else {}
+    artifacts = manifest_artifacts(manifest)
     reports = artifacts.get("storage_backend_registry")
     if not isinstance(reports, list) or not reports:
         failures.append(
@@ -107,12 +108,7 @@ def validate_storage_phase5_evidence(
         )
         reports = []
 
-    steps = manifest.get("steps")
-    step_names = [
-        step.get("name")
-        for step in (steps if isinstance(steps, list) else [])
-        if isinstance(step, dict)
-    ]
+    step_names = manifest_step_names(manifest)
     if "storage_backend_registry_integrity" not in step_names:
         failures.append(
             {

--- a/scripts/check_worker_ipc_phase3_evidence.py
+++ b/scripts/check_worker_ipc_phase3_evidence.py
@@ -14,6 +14,8 @@ from scripts.package_replay_validation_artifacts import resolve_indexed_path
 from scripts.replay_validation_artifacts import (
     artifact_result_entry,
     indexed_artifact_paths,
+    manifest_artifacts,
+    manifest_step_names,
     result_matched,
 )
 
@@ -42,8 +44,7 @@ def validate_worker_ipc_phase3_evidence(
     manifest_path: Path | None = None,
 ) -> dict[str, Any]:
     failures: list[dict[str, Any]] = []
-    artifacts = manifest.get("artifacts")
-    artifacts = artifacts if isinstance(artifacts, dict) else {}
+    artifacts = manifest_artifacts(manifest)
     config = manifest.get("config")
     config = config if isinstance(config, dict) else {}
     admission_only = bool(config.get("worker_metrics_admission_only"))
@@ -57,12 +58,7 @@ def validate_worker_ipc_phase3_evidence(
         )
         worker_metrics = []
 
-    steps = manifest.get("steps")
-    step_names = [
-        step.get("name")
-        for step in (steps if isinstance(steps, list) else [])
-        if isinstance(step, dict)
-    ]
+    step_names = manifest_step_names(manifest)
     if not any(
         isinstance(name, str)
         and name.startswith("worker_metrics_")

--- a/scripts/replay_validation_artifacts.py
+++ b/scripts/replay_validation_artifacts.py
@@ -75,6 +75,24 @@ def phase_artifact_roles(
     return sorted(set(roles))
 
 
+def manifest_artifacts(manifest: dict[str, Any]) -> dict[str, Any]:
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return {}
+    return artifacts
+
+
+def manifest_step_names(manifest: dict[str, Any]) -> list[str]:
+    steps = manifest.get("steps")
+    if not isinstance(steps, list):
+        return []
+    return [
+        step["name"]
+        for step in steps
+        if isinstance(step, dict) and isinstance(step.get("name"), str)
+    ]
+
+
 def missing_indexed_artifact_roles(
     required_roles: list[str],
     indexed_roles: Any,
@@ -85,9 +103,7 @@ def missing_indexed_artifact_roles(
 
 
 def artifact_index_path_value(manifest: dict[str, Any]) -> str | None:
-    artifacts = manifest.get("artifacts")
-    if not isinstance(artifacts, dict):
-        return None
+    artifacts = manifest_artifacts(manifest)
     value = artifacts.get("artifact_index")
     if not isinstance(value, str) or not value:
         return None

--- a/tests/scripts/test_replay_validation_artifacts.py
+++ b/tests/scripts/test_replay_validation_artifacts.py
@@ -7,6 +7,8 @@ from scripts.replay_validation_artifacts import (
     duplicate_artifact_roles,
     indexed_artifact_entries,
     indexed_artifact_paths,
+    manifest_artifacts,
+    manifest_step_names,
     missing_indexed_artifact_roles,
     phase_artifact_roles,
     result_matched,
@@ -113,6 +115,28 @@ def test_phase_artifact_roles_can_limit_fields():
     assert phase_artifact_roles(artifacts, fields=("worker_metrics",)) == [
         "worker_metrics_1"
     ]
+
+
+def test_manifest_artifacts_returns_artifact_mapping_or_empty():
+    artifacts = {"replay": "replay.json"}
+
+    assert manifest_artifacts({"artifacts": artifacts}) == artifacts
+    assert manifest_artifacts({"artifacts": []}) == {}
+    assert manifest_artifacts({}) == {}
+
+
+def test_manifest_step_names_returns_named_steps_only():
+    assert manifest_step_names(
+        {
+            "steps": [
+                {"name": "fetch"},
+                {"name": ""},
+                {"name": 123},
+                "not-a-step",
+            ]
+        }
+    ) == ["fetch", ""]
+    assert manifest_step_names({"steps": {}}) == []
 
 
 def test_missing_indexed_artifact_roles_returns_unmatched_required_roles():


### PR DESCRIPTION
## Summary
- add shared helpers for manifest artifact and step-name extraction
- use the helpers in projector, worker, and storage evidence validators
- use the helpers in bundle fanout and artifact-index role validation
- use the artifact helper in manifest validation

## Validation
- PYTHONPATH=. pytest tests/scripts/test_replay_validation_artifacts.py
- PYTHONPATH=. pytest tests/scripts/test_check_projector_phase2_evidence.py tests/scripts/test_check_replay_validation_bundle.py tests/scripts/test_replay_validation_artifacts.py
- PYTHONPATH=. pytest tests/scripts/test_check_replay_validation_manifest.py tests/scripts/test_replay_validation_artifacts.py
- scripts/check_replay_release_gate.sh