### PR TITLE
Phase 23 artifact path resolution

### DIFF
--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -173,16 +173,16 @@ def validate_bundle(
             )
             resolved_index_path = None
         else:
-            resolved_index_path = resolve_indexed_path(
+            resolved_index_path = resolve_manifest_artifact_path(
                 manifest_index,
-                index_path=manifest_path,
+                manifest_path=manifest_path,
             )
     else:
         resolved_index_path = artifact_index_path
         if manifest_index is not None:
-            manifest_resolved_index = resolve_indexed_path(
+            manifest_resolved_index = resolve_manifest_artifact_path(
                 manifest_index,
-                index_path=manifest_path,
+                manifest_path=manifest_path,
             )
             if manifest_resolved_index != artifact_index_path.resolve():
                 failures.append(

--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -17,10 +17,7 @@ from scripts.check_replay_fanout_reduce_report import validate_replay_fanout_red
 from scripts.check_replay_validation_manifest import _load_manifest, _validate_manifest
 from scripts.check_storage_phase5_evidence import validate_storage_phase5_evidence
 from scripts.check_worker_ipc_phase3_evidence import validate_worker_ipc_phase3_evidence
-from scripts.package_replay_validation_artifacts import (
-    resolve_indexed_path,
-    validate_artifact_index,
-)
+from scripts.package_replay_validation_artifacts import validate_artifact_index
 from scripts.replay_validation_artifacts import (
     artifact_index_path_value,
     artifact_result_entry,

--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -30,6 +30,7 @@ from scripts.replay_validation_artifacts import (
     manifest_step_names,
     missing_indexed_artifact_roles,
     phase_artifact_roles,
+    resolve_manifest_artifact_path,
     result_matched,
 )
 
@@ -282,7 +283,7 @@ def _validate_fanout_phase6_evidence(
         {"fanout_reduce_planner": reports},
         "fanout_reduce_planner",
     ):
-        path = resolve_indexed_path(path_value, index_path=manifest_path)
+        path = resolve_manifest_artifact_path(path_value, manifest_path=manifest_path)
         try:
             report = json.loads(path.read_text())
             if not isinstance(report, dict):
@@ -345,7 +346,7 @@ def _validate_replay_fanout_phase6_evidence(
             }
         )
 
-    path = resolve_indexed_path(replay_path, index_path=manifest_path)
+    path = resolve_manifest_artifact_path(replay_path, manifest_path=manifest_path)
     try:
         report = json.loads(path.read_text())
         if not isinstance(report, dict):

--- a/scripts/check_replay_validation_manifest.py
+++ b/scripts/check_replay_validation_manifest.py
@@ -21,6 +21,7 @@ from scripts.replay_validation_artifacts import (
     manifest_artifacts,
     missing_indexed_artifact_roles,
     phase_artifact_roles,
+    resolve_manifest_artifact_path,
     result_matched,
 )
 
@@ -67,10 +68,7 @@ def _valid_timestamp(value: Any) -> bool:
 
 
 def _artifact_path(value: str, manifest_path: Path | None) -> Path:
-    path = Path(value)
-    if not path.is_absolute() and manifest_path is not None:
-        return (manifest_path.parent / path).resolve()
-    return path
+    return resolve_manifest_artifact_path(value, manifest_path=manifest_path)
 
 
 def _validate_artifact_path(

--- a/scripts/check_storage_phase5_evidence.py
+++ b/scripts/check_storage_phase5_evidence.py
@@ -11,12 +11,12 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.package_replay_validation_artifacts import resolve_indexed_path
 from scripts.replay_validation_artifacts import (
     artifact_result_entry,
     indexed_artifact_paths,
     manifest_artifacts,
     manifest_step_names,
+    resolve_manifest_artifact_path,
     result_matched,
 )
 
@@ -36,9 +36,7 @@ def _load_json_object(path: Path) -> dict[str, Any]:
 
 
 def _resolve(value: str, *, manifest_path: Path | None) -> Path:
-    if manifest_path is None:
-        return Path(value)
-    return resolve_indexed_path(value, index_path=manifest_path)
+    return resolve_manifest_artifact_path(value, manifest_path=manifest_path)
 
 
 def validate_storage_phase5_report(report: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/check_worker_ipc_phase3_evidence.py
+++ b/scripts/check_worker_ipc_phase3_evidence.py
@@ -10,12 +10,12 @@ from pathlib import Path
 from typing import Any
 
 from scripts.check_worker_ipc_metrics import validate_worker_ipc_metrics
-from scripts.package_replay_validation_artifacts import resolve_indexed_path
 from scripts.replay_validation_artifacts import (
     artifact_result_entry,
     indexed_artifact_paths,
     manifest_artifacts,
     manifest_step_names,
+    resolve_manifest_artifact_path,
     result_matched,
 )
 
@@ -32,9 +32,7 @@ def _load_manifest(path: Path) -> dict[str, Any]:
 
 
 def _resolve(value: str, *, manifest_path: Path | None) -> Path:
-    if manifest_path is None:
-        return Path(value)
-    return resolve_indexed_path(value, index_path=manifest_path)
+    return resolve_manifest_artifact_path(value, manifest_path=manifest_path)
 
 
 def validate_worker_ipc_phase3_evidence(

--- a/scripts/replay_validation_artifacts.py
+++ b/scripts/replay_validation_artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 PHASE_ARTIFACT_FIELDS = (
@@ -43,6 +44,13 @@ def indexed_artifact_paths(
         if isinstance(path, str) and path:
             paths.append((index, entry, path))
     return paths
+
+
+def resolve_manifest_artifact_path(value: str, *, manifest_path: Path | None) -> Path:
+    path = Path(value)
+    if path.is_absolute() or manifest_path is None:
+        return path
+    return (manifest_path.parent / path).resolve()
 
 
 def artifact_roles(artifacts: dict[str, Any], field: str) -> list[str]:

--- a/tests/scripts/test_replay_validation_artifacts.py
+++ b/tests/scripts/test_replay_validation_artifacts.py
@@ -11,6 +11,7 @@ from scripts.replay_validation_artifacts import (
     manifest_step_names,
     missing_indexed_artifact_roles,
     phase_artifact_roles,
+    resolve_manifest_artifact_path,
     result_matched,
 )
 
@@ -88,6 +89,23 @@ def test_indexed_artifact_paths_preserves_indexes_and_path_values():
     assert indexed_artifact_paths(artifacts, "worker_metrics") == [
         (1, {"role": "worker_metrics_2", "path": "worker.prom"}, "worker.prom")
     ]
+
+
+def test_resolve_manifest_artifact_path_resolves_relative_to_manifest_dir(tmp_path):
+    manifest = tmp_path / "reports" / "manifest.json"
+    manifest.parent.mkdir()
+
+    assert resolve_manifest_artifact_path(
+        "worker.prom",
+        manifest_path=manifest,
+    ) == manifest.parent / "worker.prom"
+
+
+def test_resolve_manifest_artifact_path_preserves_absolute_or_unanchored_paths(tmp_path):
+    absolute = tmp_path / "worker.prom"
+
+    assert resolve_manifest_artifact_path(str(absolute), manifest_path=None) == absolute
+    assert resolve_manifest_artifact_path("worker.prom", manifest_path=None).as_posix() == "worker.prom"
 
 
 def test_phase_artifact_roles_collects_unique_sorted_roles():


### PR DESCRIPTION
## Summary
- add shared manifest-relative artifact path resolution
- use the helper in manifest, worker, and storage evidence validation
- use the helper in bundle fanout and replay artifact validation
- use the helper for bundle artifact-index references
- remove the now-unused bundle indexed-path import

## Validation
- PYTHONPATH=. pytest tests/scripts/test_replay_validation_artifacts.py
- PYTHONPATH=. pytest tests/scripts/test_check_replay_validation_manifest.py tests/scripts/test_check_replay_validation_bundle.py tests/scripts/test_replay_validation_artifacts.py
- scripts/check_replay_release_gate.sh