### PR TITLE
Phase 24 validation path normalization

### DIFF
--- a/scripts/check_replay_validation_bundle.py
+++ b/scripts/check_replay_validation_bundle.py
@@ -181,7 +181,7 @@ def validate_bundle(
                 manifest_index,
                 manifest_path=manifest_path,
             )
-            if manifest_resolved_index != artifact_index_path.resolve():
+            if manifest_resolved_index.resolve() != artifact_index_path.resolve():
                 failures.append(
                     {
                         "field": "artifact_index",

--- a/tests/scripts/test_check_replay_validation_bundle.py
+++ b/tests/scripts/test_check_replay_validation_bundle.py
@@ -416,6 +416,32 @@ def test_check_replay_validation_bundle_accepts_explicit_matching_index(
     assert json.loads(capsys.readouterr().out)["matched"] is True
 
 
+def test_check_replay_validation_bundle_accepts_equivalent_resolved_index_path(
+    tmp_path: Path,
+    capsys,
+):
+    manifest, index = _bundle(tmp_path)
+    link = tmp_path.parent / f"{tmp_path.name}-link"
+    try:
+        link.symlink_to(tmp_path, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable: {exc}")
+    payload = json.loads(manifest.read_text())
+    payload["artifacts"]["artifact_index"] = str(link / index.name)
+    manifest.write_text(json.dumps(payload))
+    index.write_text(
+        json.dumps(
+            build_artifact_index(manifest_path=manifest, output_path=index),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+    assert main(["--manifest", str(manifest), "--artifact-index", str(index)]) == 0
+    assert json.loads(capsys.readouterr().out)["matched"] is True
+
+
 def test_check_replay_validation_bundle_rejects_different_explicit_index(
     tmp_path: Path,
     capsys,


### PR DESCRIPTION
## Summary
- normalize both manifest and explicit artifact-index paths before comparing them
- add a regression test for equivalent resolved artifact-index paths, such as /tmp vs /private/tmp on macOS

## Validation
- redeployed local kind with automation/development/noetl.yaml
- registered and ran distributed hello_world execution: 631392818300191126
- PYTHONPATH=. .venv/bin/python scripts/run_replay_validation.py --base-url http://localhost:8082 --execution-id 631392818300191126 --output-dir /tmp/noetl-validation-631392818300191126 --report-output /tmp/noetl-validation-631392818300191126/manifest.json --artifact-index-output /tmp/noetl-validation-631392818300191126/artifact-index.json
- PYTHONPATH=. .venv/bin/python scripts/check_replay_validation_bundle.py --manifest /tmp/noetl-validation-631392818300191126/manifest.json --artifact-index /tmp/noetl-validation-631392818300191126/artifact-index.json
- scripts/check_replay_release_gate.sh