### PR TITLE
Phase 25 validation harness fixes

### DIFF
--- a/noetl/server/api/catalog/service.py
+++ b/noetl/server/api/catalog/service.py
@@ -504,12 +504,24 @@ class CatalogService:
                 })
                 resource_data["workflow"] = workflow
 
-        # Get the latest version for this resource and increment it
-        latest_version = await CatalogService.get_latest_version(path)
-        new_version = latest_version + 1
-
         async with get_pool_connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cursor:
+                await cursor.execute(
+                    "SELECT pg_advisory_xact_lock(hashtext(%(path)s))",
+                    {"path": str(path)},
+                )
+
+                await cursor.execute(
+                    """
+                    SELECT COALESCE(MAX(version), 0) + 1 AS next_version
+                    FROM noetl.catalog
+                    WHERE path = %(path)s
+                    """,
+                    {"path": path},
+                )
+                version_row = await cursor.fetchone()
+                new_version = int(version_row["next_version"]) if version_row else 1
+
                 await cursor.execute(
                     """
                     INSERT INTO noetl.resource (name, meta)

--- a/tests/playwright/REAMDE.MD
+++ b/tests/playwright/REAMDE.MD
@@ -3,6 +3,12 @@ npx playwright install
 
 
 ```sh
+# API-only local kind validation skips UI specs by default.
+npx playwright test
+
+# UI validation requires the gateway/UI service.
+NOETL_RUN_UI_E2E=1 NOETL_UI_BASE_URL=http://localhost:30080 npx playwright test
+
 npx playwright test --ui  # Open mini app 
 npx playwright test --debug  # Run rebug mode, step by step run
 npx playwright test tests/newpatient.spec.ts --debug  # Run certain test
@@ -11,7 +17,7 @@ npx playwright test tests/newpatient.spec.ts --debug  # Run certain test
 uv venv
 source .venv/bin/activate   
 pip install -e .      
-noetl register ./examples/weather/weather_example.yaml --host localhost --port 8082
+noetl --host localhost --port 8082 register playbook --file ../e2e/fixtures/playbooks/hello_world/hello_world.yaml
 
 git checkout main
 git pull
@@ -22,4 +28,3 @@ noetl k8s reset
 
 cd tests/playwright
 npx playwright test --ui
-

--- a/tests/playwright/e2e/functionality/test_ui_functionality.spec.ts
+++ b/tests/playwright/e2e/functionality/test_ui_functionality.spec.ts
@@ -1,18 +1,17 @@
 import { test, expect } from '@playwright/test';
-import { execSync } from 'child_process';
+import { registerPlaybook, skipUnlessUiE2EEnabled } from '../support/noetl';
 
 test.describe('Hello World', () => {
+    skipUnlessUiE2EEnabled();
+
     test.beforeAll(() => {
         console.log('Registering hello world...');
-        execSync(
-            'noetl register tests/fixtures/playbooks/hello_world/hello_world.yaml --host localhost --port 8082',
-            { stdio: 'inherit' }
-        );
+        registerPlaybook('../e2e/fixtures/playbooks/hello_world/hello_world.yaml');
     });
 
     test('/catalog: Execute', async ({ page }) => {
         await test.step('Open Catalog', async () => {
-            await page.goto('http://localhost:8082/catalog');
+            await page.goto('/catalog');
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
@@ -36,7 +35,7 @@ test.describe('Hello World', () => {
 
     test('/catalog: Payload', async ({ page }) => {
         await test.step('Open Catalog', async () => {
-            await page.goto('http://localhost:8082/catalog');
+            await page.goto('/catalog');
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
@@ -49,7 +48,7 @@ test.describe('Hello World', () => {
 
         await test.step('Validate Payload modal UI', async () => {
             const payloadModal = page.locator(
-                '//*[@class="ant-modal-title"][text()="Execute Playbook with Payload: tests/fixtures/playbooks/hello_world"]'
+                '//*[@class="ant-modal-title"][text()="Execute Playbook with Payload: fixtures/playbooks/hello_world"]'
             );
             await expect(payloadModal).toBeVisible();
 
@@ -59,13 +58,13 @@ test.describe('Hello World', () => {
             const executeButton = page.locator('//button[span[text()="Execute with Payload"]]');
             await expect(executeButton).toBeVisible();
             //TODO: add file upload test
-            //TODO: add payload execution test, assert Executing playbook "tests/fixtures/playbooks/hello_world/hello_world"...
+            //TODO: add payload execution test, assert Executing playbook "fixtures/playbooks/hello_world/hello_world"...
         });
     });
 
     test('/catalog: Edit', async ({ page }) => {
         await test.step('Open Catalog', async () => {
-            await page.goto('http://localhost:8082/catalog');
+            await page.goto('/catalog');
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
@@ -78,13 +77,13 @@ test.describe('Hello World', () => {
 
         await test.step('Validate navigation to Editor page', async () => {
             await expect(page).toHaveURL(/\/editor/);
-            await expect(page.url()).toContain('/editor?id=tests/fixtures/playbooks/hello_world');
+            await expect(page.url()).toContain('/editor?id=fixtures/playbooks/hello_world');
         });
     });
 
     test('/catalog: View', async ({ page }) => {
         await test.step('Open Catalog', async () => {
-            await page.goto('http://localhost:8082/catalog');
+            await page.goto('/catalog');
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
@@ -107,14 +106,11 @@ test.describe('Hello World', () => {
 
     test('/catalog: Search', async ({ page }) => {
         await test.step('Register control_flow_workbook (for negative filter check)', async () => {
-            execSync(
-                'noetl register tests/fixtures/playbooks/control_flow_workbook/control_flow_workbook.yaml --host localhost --port 8082',
-                { stdio: 'inherit' }
-            );
+            registerPlaybook('../e2e/fixtures/playbooks/control_flow_workbook/control_flow_workbook.yaml');
         });
 
         await test.step('Open Catalog', async () => {
-            await page.goto('http://localhost:8082/catalog');
+            await page.goto('/catalog');
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
@@ -139,7 +135,7 @@ test.describe('Hello World', () => {
 
     test('/editor: Validate', async ({ page }) => {
         await test.step('Open Editor', async () => {
-            await page.goto('http://localhost:8082/editor');
+            await page.goto('/editor');
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
@@ -152,7 +148,7 @@ test.describe('Hello World', () => {
 
     test('/editor: Show Workflow', async ({ page }) => {
         await test.step('Open Editor', async () => {
-            await page.goto('http://localhost:8082/editor');
+            await page.goto('/editor');
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
@@ -172,7 +168,7 @@ test.describe('Hello World', () => {
 
     test('/editor: Save', async ({ page }) => {
         await test.step('Open Editor', async () => {
-            await page.goto('http://localhost:8082/editor');
+            await page.goto('/editor');
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
@@ -190,7 +186,7 @@ test.describe('Hello World', () => {
 
     test('/editor: Execute', async ({ page }) => {
         await test.step('Open Editor', async () => {
-            await page.goto('http://localhost:8082/editor');
+            await page.goto('/editor');
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 
@@ -203,7 +199,7 @@ test.describe('Hello World', () => {
 
     test('/execution: Refresh', async ({ page }) => {
         await test.step('Open Execution page', async () => {
-            await page.goto('http://localhost:8082/execution');
+            await page.goto('/execution');
             await expect(page).toHaveTitle('NoETL Dashboard');
         });
 

--- a/tests/playwright/e2e/support/noetl.ts
+++ b/tests/playwright/e2e/support/noetl.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from 'child_process';
+import path from 'path';
+import { test } from '@playwright/test';
+
+export const NOETL_HOST = process.env.NOETL_HOST ?? 'localhost';
+export const NOETL_PORT = process.env.NOETL_PORT ?? '8082';
+export const NOETL_API_BASE_URL =
+    process.env.NOETL_API_BASE_URL ?? `http://${NOETL_HOST}:${NOETL_PORT}`;
+export const NOETL_UI_BASE_URL =
+    process.env.NOETL_UI_BASE_URL ?? process.env.NOETL_BASE_URL ?? 'http://localhost:30080';
+
+const REPO_ROOT = path.resolve(process.cwd(), '..', '..');
+
+export function skipUnlessUiE2EEnabled(): void {
+    test.skip(
+        process.env.NOETL_RUN_UI_E2E !== '1',
+        'NoETL UI E2E requires the gateway/UI service; set NOETL_RUN_UI_E2E=1 and NOETL_UI_BASE_URL.'
+    );
+}
+
+export function registerPlaybook(playbookPath: string): void {
+    const resolvedPath = path.isAbsolute(playbookPath)
+        ? playbookPath
+        : path.resolve(REPO_ROOT, playbookPath);
+
+    execFileSync(
+        'noetl',
+        ['--host', NOETL_HOST, '--port', NOETL_PORT, 'register', 'playbook', '--file', resolvedPath],
+        { stdio: 'inherit' }
+    );
+}

--- a/tests/playwright/e2e/test_control_flow_workbook.spec.ts
+++ b/tests/playwright/e2e/test_control_flow_workbook.spec.ts
@@ -1,23 +1,21 @@
 import { test, expect } from '@playwright/test';
-import { execSync } from 'child_process';
+import { registerPlaybook, skipUnlessUiE2EEnabled } from './support/noetl';
 
-const NOETL_HOST = process.env.NOETL_HOST;
-const NOETL_PORT = process.env.NOETL_PORT;
-const BASE_URL = `http://${NOETL_HOST}:${NOETL_PORT}`;
-
-const CATALOG_URL = `${BASE_URL}/catalog`;
+const CATALOG_URL = `/catalog`;
 
 const PLAYBOOK_NAME = 'control_flow_workbook';
-const PLAYBOOK_PATH = `tests/fixtures/playbooks/${PLAYBOOK_NAME}/${PLAYBOOK_NAME}.yaml`;
+const PLAYBOOK_PATH = `../e2e/fixtures/playbooks/${PLAYBOOK_NAME}/${PLAYBOOK_NAME}.yaml`;
+const PLAYBOOK_CATALOG_NODE = `fixtures/playbooks/${PLAYBOOK_NAME}`;
 
 const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
 
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
 
 test.describe('Control flow workbook', () => {
+    skipUnlessUiE2EEnabled();
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register ${PLAYBOOK_PATH} --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        registerPlaybook(PLAYBOOK_PATH);
     });
 
     test('should open catalog page', async ({ page }) => {
@@ -69,7 +67,7 @@ test.describe('Control flow workbook', () => {
                     (status ? r['Status'] === status : true)
                 );
 
-            expect(hasEvent('playbook.initialized', `tests/fixtures/playbooks/${PLAYBOOK_NAME}`, 'INITIALIZED')).toBeTruthy();
+            expect(hasEvent('playbook.initialized', PLAYBOOK_CATALOG_NODE, 'INITIALIZED')).toBeTruthy();
             expect(hasEvent('workflow.initialized', 'workflow', 'INITIALIZED')).toBeTruthy();
 
             expect(hasEvent('step.enter', 'start', 'STARTED')).toBeTruthy();
@@ -87,7 +85,7 @@ test.describe('Control flow workbook', () => {
             expect(hasEvent('step.exit', 'hot_task_b', 'COMPLETED')).toBeTruthy();
 
             expect(hasEvent('workflow.completed', 'workflow', 'COMPLETED')).toBeTruthy();
-            expect(hasEvent('playbook.completed', `tests/fixtures/playbooks/${PLAYBOOK_NAME}`, 'COMPLETED')).toBeTruthy();
+            expect(hasEvent('playbook.completed', PLAYBOOK_CATALOG_NODE, 'COMPLETED')).toBeTruthy();
         });
     });
 });

--- a/tests/playwright/e2e/test_create_tables.spec.ts
+++ b/tests/playwright/e2e/test_create_tables.spec.ts
@@ -1,25 +1,22 @@
 import { test, expect } from '@playwright/test';
-import { execSync } from 'child_process';
+import { registerPlaybook, skipUnlessUiE2EEnabled } from './support/noetl';
 
-const NOETL_HOST = process.env.NOETL_HOST;
-const NOETL_PORT = process.env.NOETL_PORT;
-const BASE_URL = `http://${NOETL_HOST}:${NOETL_PORT}`;
-
-const CATALOG_URL = `${BASE_URL}/catalog`;
+const CATALOG_URL = `/catalog`;
 
 const PLAYBOOK_NAME = 'create_tables';
-const PLAYBOOK_PATH = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
+const PLAYBOOK_PATH = `../e2e/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
 
-const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
+const PLAYBOOK_CATALOG_NODE = `fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
 
 const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
 
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
 
 test.describe('Create Tables', () => {
+    skipUnlessUiE2EEnabled();
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register ${PLAYBOOK_PATH} --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        registerPlaybook(PLAYBOOK_PATH);
     });
 
     test('should open catalog page', async ({ page }) => {

--- a/tests/playwright/e2e/test_hello_world.spec.ts
+++ b/tests/playwright/e2e/test_hello_world.spec.ts
@@ -1,24 +1,21 @@
 import { test, expect, type Page } from '@playwright/test';
-import { execSync } from 'child_process';
+import { registerPlaybook, skipUnlessUiE2EEnabled } from './support/noetl';
 
-const NOETL_HOST = process.env.NOETL_HOST;
-const NOETL_PORT = process.env.NOETL_PORT;
-const BASE_URL = `http://${NOETL_HOST}:${NOETL_PORT}`;
-
-const CATALOG_URL = `${BASE_URL}/catalog`;
+const CATALOG_URL = `/catalog`;
 
 const PLAYBOOK_NAME = 'hello_world';
-const PLAYBOOK_PATH = `tests/fixtures/playbooks/${PLAYBOOK_NAME}/${PLAYBOOK_NAME}.yaml`;
-const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/${PLAYBOOK_NAME}`;
+const PLAYBOOK_PATH = `../e2e/fixtures/playbooks/${PLAYBOOK_NAME}/${PLAYBOOK_NAME}.yaml`;
+const PLAYBOOK_CATALOG_NODE = `fixtures/playbooks/${PLAYBOOK_NAME}`;
 
 const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
 
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
 
 test.describe('Hello World', () => {
+    skipUnlessUiE2EEnabled();
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register ${PLAYBOOK_PATH} --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        registerPlaybook(PLAYBOOK_PATH);
     });
 
     test('should open catalog page', async ({ page }) => {

--- a/tests/playwright/e2e/test_http_duckdb_postgres.spec.ts
+++ b/tests/playwright/e2e/test_http_duckdb_postgres.spec.ts
@@ -1,21 +1,18 @@
 import { test, expect, type Page } from '@playwright/test';
-import { execSync } from 'child_process';
+import { registerPlaybook, skipUnlessUiE2EEnabled } from './support/noetl';
 
-const NOETL_HOST = process.env.NOETL_HOST;
-const NOETL_PORT = process.env.NOETL_PORT;
-const BASE_URL = `http://${NOETL_HOST}:${NOETL_PORT}`;
-
-const CATALOG_URL = `${BASE_URL}/catalog`;
+const CATALOG_URL = `/catalog`;
 const PLAYBOOK_NAME = 'duckdb_query';
-const PLAYBOOK_PATH = `tests/retry/${PLAYBOOK_NAME}.yaml`;
+const PLAYBOOK_PATH = `../e2e/fixtures/playbooks/retry_test/duckdb_retry_query.yaml`;
 const PLAYBOOK_CATALOG_NODE = `tests/retry/${PLAYBOOK_NAME}`;
 const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
 
 test.describe('HTTP DuckDB to Postgres', () => {
+    skipUnlessUiE2EEnabled();
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register ${PLAYBOOK_PATH} --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        registerPlaybook(PLAYBOOK_PATH);
     });
 
     test('should open catalog page', async ({ page }) => {

--- a/tests/playwright/e2e/test_playbook_composition.spec.ts
+++ b/tests/playwright/e2e/test_playbook_composition.spec.ts
@@ -1,29 +1,20 @@
 import { test, expect, type Page } from '@playwright/test';
-import { execSync } from 'child_process';
-import path from 'path';
+import { registerPlaybook, skipUnlessUiE2EEnabled } from './support/noetl';
 
-const NOETL_HOST = process.env.NOETL_HOST;
-const NOETL_PORT = process.env.NOETL_PORT;
-const BASE_URL = `http://${NOETL_HOST}:${NOETL_PORT}`;
-
-const CATALOG_URL = `${BASE_URL}/catalog`;
+const CATALOG_URL = `/catalog`;
 
 const PLAYBOOK_NAME = 'playbook_composition';
-const PLAYBOOK_PATH = path.resolve(
-    process.cwd(),
-    'tests/fixtures/playbooks',
-    PLAYBOOK_NAME,
-    `${PLAYBOOK_NAME}.yaml`
-);
-const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/${PLAYBOOK_NAME}/${PLAYBOOK_NAME}`;
+const PLAYBOOK_PATH = `../e2e/fixtures/playbooks/${PLAYBOOK_NAME}/${PLAYBOOK_NAME}.yaml`;
+const PLAYBOOK_CATALOG_NODE = `fixtures/playbooks/${PLAYBOOK_NAME}/${PLAYBOOK_NAME}`;
 const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
 
 
 test.describe('Playbook Composition', () => {
+    skipUnlessUiE2EEnabled();
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register ${PLAYBOOK_PATH} --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        registerPlaybook(PLAYBOOK_PATH);
     });
 
     test('should open catalog page', async ({ page }) => {

--- a/tests/playwright/e2e/test_save_all_storage_types.spec.ts
+++ b/tests/playwright/e2e/test_save_all_storage_types.spec.ts
@@ -1,22 +1,19 @@
 import { test, expect, type Page } from '@playwright/test';
-import { execSync } from 'child_process';
+import { registerPlaybook, skipUnlessUiE2EEnabled } from './support/noetl';
 
-const NOETL_HOST = process.env.NOETL_HOST;
-const NOETL_PORT = process.env.NOETL_PORT;
-const BASE_URL = `http://${NOETL_HOST}:${NOETL_PORT}`;
-
-const CATALOG_URL = `${BASE_URL}/catalog`;
+const CATALOG_URL = `/catalog`;
 
 const PLAYBOOK_NAME = 'save_all_storage_types';
-const PLAYBOOK_PATH = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
-const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
+const PLAYBOOK_PATH = `../e2e/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
+const PLAYBOOK_CATALOG_NODE = `fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
 const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
 
 test.describe('Save all storage types', () => {
+    skipUnlessUiE2EEnabled();
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register ${PLAYBOOK_PATH} --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        registerPlaybook(PLAYBOOK_PATH);
     });
 
     test('should open catalog page', async ({ page }) => {

--- a/tests/playwright/e2e/test_save_delegation_test.spec.ts
+++ b/tests/playwright/e2e/test_save_delegation_test.spec.ts
@@ -1,24 +1,21 @@
 import { test, expect, type Page } from '@playwright/test';
-import { execSync } from 'child_process';
+import { registerPlaybook, skipUnlessUiE2EEnabled } from './support/noetl';
 
-const NOETL_HOST = process.env.NOETL_HOST;
-const NOETL_PORT = process.env.NOETL_PORT;
-const BASE_URL = `http://${NOETL_HOST}:${NOETL_PORT}`;
-
-const CATALOG_URL = `${BASE_URL}/catalog`;
+const CATALOG_URL = `/catalog`;
 const EXECUTION_URL_PATTERN = '**/execution*';
 
 const PLAYBOOK_NAME = 'save_delegation_test';
-const PLAYBOOK_PATH = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
-const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
+const PLAYBOOK_PATH = `../e2e/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
+const PLAYBOOK_CATALOG_NODE = `fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
 const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
 
 
 test.describe('Save delegation test', () => {
+    skipUnlessUiE2EEnabled();
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register "${PLAYBOOK_PATH}" --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        registerPlaybook(PLAYBOOK_PATH);
     });
 
     test('should open catalog page', async ({ page }) => {

--- a/tests/playwright/e2e/test_save_edge_cases.spec.ts
+++ b/tests/playwright/e2e/test_save_edge_cases.spec.ts
@@ -1,24 +1,21 @@
 import { test, expect } from '@playwright/test';
-import { execSync } from 'child_process';
+import { registerPlaybook, skipUnlessUiE2EEnabled } from './support/noetl';
 
-const NOETL_HOST = process.env.NOETL_HOST;
-const NOETL_PORT = process.env.NOETL_PORT;
-const BASE_URL = `http://${NOETL_HOST}:${NOETL_PORT}`;
-
-const CATALOG_URL = `${BASE_URL}/catalog`;
+const CATALOG_URL = `/catalog`;
 
 const PLAYBOOK_NAME = 'save_edge_cases';
-const PLAYBOOK_PATH = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
-const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
+const PLAYBOOK_PATH = `../e2e/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
+const PLAYBOOK_CATALOG_NODE = `fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
 
 const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
 
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
 
 test.describe('Save edge cases', () => {
+    skipUnlessUiE2EEnabled();
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register "${PLAYBOOK_PATH}" --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        registerPlaybook(PLAYBOOK_PATH);
     });
 
     test('should execute playbook and show expected events', async ({ page }) => {

--- a/tests/playwright/e2e/test_save_simple_test.spec.ts
+++ b/tests/playwright/e2e/test_save_simple_test.spec.ts
@@ -1,24 +1,21 @@
 import { test, expect } from '@playwright/test';
-import { execSync } from 'child_process';
+import { registerPlaybook, skipUnlessUiE2EEnabled } from './support/noetl';
 
-const NOETL_HOST = process.env.NOETL_HOST;
-const NOETL_PORT = process.env.NOETL_PORT;
-const BASE_URL = process.env.NOETL_BASE_URL;
-
-const CATALOG_URL = `${BASE_URL}/catalog`;
+const CATALOG_URL = `/catalog`;
 
 const PLAYBOOK_NAME = 'save_simple_test';
-const PLAYBOOK_PATH = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
-const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
+const PLAYBOOK_PATH = `../e2e/fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}.yaml`;
+const PLAYBOOK_CATALOG_NODE = `fixtures/playbooks/save_storage_test/${PLAYBOOK_NAME}`;
 
 const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
 
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
 
 test.describe('Save Simple Test', () => {
+    skipUnlessUiE2EEnabled();
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register "${PLAYBOOK_PATH}" --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        registerPlaybook(PLAYBOOK_PATH);
     });
 
     test('should execute playbook and show expected events', async ({ page }) => {

--- a/tests/playwright/e2e/test_user_profile_scorer.spec.ts
+++ b/tests/playwright/e2e/test_user_profile_scorer.spec.ts
@@ -1,24 +1,21 @@
 import { test, expect } from '@playwright/test';
-import { execSync } from 'child_process';
+import { registerPlaybook, skipUnlessUiE2EEnabled } from './support/noetl';
 
-const NOETL_HOST = process.env.NOETL_HOST ?? 'localhost';
-const NOETL_PORT = process.env.NOETL_PORT ?? '8082';
-const BASE_URL = process.env.NOETL_BASE_URL ?? `http://${NOETL_HOST}:${NOETL_PORT}`;
-
-const CATALOG_URL = `${BASE_URL}/catalog`;
+const CATALOG_URL = `/catalog`;
 
 const PLAYBOOK_NAME = 'user_profile_scorer';
-const PLAYBOOK_PATH = `tests/fixtures/playbooks/playbook_composition/${PLAYBOOK_NAME}.yaml`;
-const PLAYBOOK_CATALOG_NODE = `tests/fixtures/playbooks/playbook_composition/${PLAYBOOK_NAME}`;
+const PLAYBOOK_PATH = `../e2e/fixtures/playbooks/playbook_composition/${PLAYBOOK_NAME}.yaml`;
+const PLAYBOOK_CATALOG_NODE = `fixtures/playbooks/playbook_composition/${PLAYBOOK_NAME}`;
 
 const LOADING_EXECUTIONS_TEXT = 'Loading executions...';
 
 const viewHeaders = ['Event Type', 'Node Name', 'Status', 'Timestamp', 'Duration'] as const;
 
 test.describe('User Profile Scorer', () => {
+    skipUnlessUiE2EEnabled();
     test.beforeAll(() => {
         console.log(`Registering ${PLAYBOOK_NAME}...`);
-        execSync(`noetl register "${PLAYBOOK_PATH}" --host ${NOETL_HOST} --port ${NOETL_PORT}`, { stdio: 'inherit' });
+        registerPlaybook(PLAYBOOK_PATH);
     });
 
     test('should execute playbook and show expected events', async ({ page }) => {

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -3,12 +3,14 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   timeout: 100000,
   use: {
+    baseURL: process.env.NOETL_UI_BASE_URL ?? process.env.NOETL_BASE_URL ?? 'http://localhost:30080',
     trace: 'off',
     video: 'off',
     screenshot: 'off',
   },
 
-  fullyParallel: true,
+  fullyParallel: false,
+  workers: 1,
 
   projects: [
     {

--- a/tests/unit/server/api/catalog/test_resource_kind_resolution.py
+++ b/tests/unit/server/api/catalog/test_resource_kind_resolution.py
@@ -8,10 +8,53 @@ gate are caught without standing up Postgres.
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
+
 import pytest
 from fastapi import HTTPException
 
+from noetl.server.api.catalog import service as catalog_service_module
 from noetl.server.api.catalog.service import CatalogService
+
+
+class _FakeCursor:
+    def __init__(self):
+        self.executed = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    async def fetchone(self):
+        query = self.executed[-1][0]
+        if "next_version" in query:
+            return {"next_version": 7}
+        if "RETURNING catalog_id" in query:
+            return {"catalog_id": 123, "version": 7}
+        return None
+
+
+class _FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.commit_count = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self, **_kwargs):
+        return self._cursor
+
+    async def commit(self):
+        self.commit_count += 1
 
 
 # ---------------------------------------------------------------------------
@@ -168,6 +211,54 @@ def test_validate_payload_accepts_valid_playbook():
         payload=_valid_playbook_dict(),
         path="tests/fixtures/test_pb",
     )
+
+
+@pytest.mark.asyncio
+async def test_register_resource_allocates_version_under_catalog_path_lock(monkeypatch):
+    """Concurrent registrations for the same path must serialize version allocation."""
+    cursor = _FakeCursor()
+    conn = _FakeConnection(cursor)
+
+    @asynccontextmanager
+    async def fake_pool_connection():
+        yield conn
+
+    monkeypatch.setattr(catalog_service_module, "get_pool_connection", fake_pool_connection)
+
+    result = await CatalogService.register_resource(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: lock_test
+  path: tests/fixtures/lock_test
+workflow:
+  - step: start
+    tool:
+      kind: noop
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: end
+  - step: end
+    tool:
+      kind: noop
+""",
+        "Playbook",
+    )
+
+    queries = [query for query, _params in cursor.executed]
+    lock_index = next(i for i, query in enumerate(queries) if "pg_advisory_xact_lock" in query)
+    version_index = next(i for i, query in enumerate(queries) if "next_version" in query)
+    insert_index = next(i for i, query in enumerate(queries) if "INSERT INTO noetl.catalog" in query)
+
+    assert lock_index < version_index < insert_index
+    assert cursor.executed[lock_index][1] == {"path": "tests/fixtures/lock_test"}
+    assert cursor.executed[insert_index][1]["version"] == 7
+    assert result["version"] == 7
+    assert result["catalog_id"] == 123
+    assert conn.commit_count == 1
 
 
 def test_validate_payload_rejects_deprecated_list_form_next():


### PR DESCRIPTION
## Summary
- make catalog version allocation atomic under a path-scoped advisory lock
- make Playwright UI E2E opt-in for deployments with gateway/UI available
- update Playwright harness to use current register playbook CLI and repos/e2e fixtures
- run Playwright specs serially to avoid registration setup races

## Validation
- PYTHON_BIN=.venv/bin/python scripts/check_replay_release_gate.sh
- .venv/bin/python -m pytest -q tests/unit/server/api/catalog/test_resource_kind_resolution.py tests/scripts/test_check_replay_validation_bundle.py
- NOETL_HOST=localhost NOETL_PORT=8082 npx playwright test --project=chromium (20 skipped in API-only local kind)
