### PR TITLE
feat(python-tool): add hot-pluggable deps to Python tool executor

### DIFF
--- a/noetl/tools/python/executor.py
+++ b/noetl/tools/python/executor.py
@@ -5,11 +5,15 @@ Python action executor for NoETL jobs.
 import asyncio
 import uuid
 import datetime
+import glob
 import os
 import json
 import inspect
 import importlib.util
-from typing import Dict, Any, Optional, Callable
+import subprocess
+import sys
+import venv
+from typing import Dict, Any, List, Optional, Callable
 try:
     from jinja2 import Environment, BaseLoader
 except ImportError:
@@ -28,6 +32,131 @@ from noetl.core.script import resolve_script
 from noetl.worker.auth_resolver import resolve_auth
 
 logger = setup_logger(__name__, include_location=True)
+
+_TENANT_ENVS_DEFAULT = "/opt/noetl/tenant-envs"
+
+
+def _venv_site_packages(venv_dir: str) -> Optional[str]:
+    """Return the site-packages path inside a venv directory, or None if not found."""
+    pattern = os.path.join(venv_dir, "lib", "python*", "site-packages")
+    matches = glob.glob(pattern)
+    if matches:
+        return matches[0]
+    # Windows layout
+    win = os.path.join(venv_dir, "Lib", "site-packages")
+    if os.path.isdir(win):
+        return win
+    return None
+
+
+def _venv_python(venv_dir: str) -> str:
+    """Return the Python interpreter path inside a venv directory."""
+    candidates = [
+        os.path.join(venv_dir, "bin", "python"),
+        os.path.join(venv_dir, "bin", "python3"),
+        os.path.join(venv_dir, "Scripts", "python.exe"),
+    ]
+    for c in candidates:
+        if os.path.isfile(c):
+            return c
+    return os.path.join(venv_dir, "bin", "python")
+
+
+def _inject_sys_path(path: str) -> None:
+    """Prepend path to sys.path if not already present."""
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+
+def _resolve_deps(deps_config: Dict[str, Any]) -> None:
+    """Resolve and inject tenant-specific Python dependencies before code execution.
+
+    Supports three sub-keys in deps_config:
+    - sys_path: list of directory paths to inject into sys.path directly.
+    - venv_path: path to a pre-built venv whose site-packages will be injected.
+    - packages: dict of {tenant_key: [pip-spec, ...]} — creates/reuses a
+      per-tenant cached venv under NOETL_TENANT_ENVS_DIR.
+
+    Skipped entirely when NOETL_SKIP_DEPS_RESOLUTION=true.
+    """
+    if os.getenv("NOETL_SKIP_DEPS_RESOLUTION") == "true":
+        logger.debug("PYTHON.DEPS: resolution skipped (NOETL_SKIP_DEPS_RESOLUTION=true)")
+        return
+
+    if not deps_config or not isinstance(deps_config, dict):
+        return
+
+    # 1. sys_path — direct injection
+    for path in deps_config.get("sys_path") or []:
+        path = str(path)
+        if os.path.isdir(path):
+            _inject_sys_path(path)
+            logger.debug("PYTHON.DEPS: injected sys_path %s", path)
+        else:
+            logger.warning("PYTHON.DEPS: sys_path entry does not exist, skipping: %s", path)
+
+    # 2. venv_path — locate site-packages in an existing venv and inject
+    venv_path = deps_config.get("venv_path")
+    if venv_path:
+        venv_path = str(venv_path)
+        if not os.path.isdir(venv_path):
+            raise RuntimeError(
+                f"PYTHON.DEPS: venv_path does not exist: {venv_path}. "
+                "Ensure the tenant venv is created before this step runs."
+            )
+        site_pkgs = _venv_site_packages(venv_path)
+        if site_pkgs:
+            _inject_sys_path(site_pkgs)
+            logger.debug("PYTHON.DEPS: injected venv site-packages %s", site_pkgs)
+        else:
+            logger.warning("PYTHON.DEPS: no site-packages found in venv_path %s", venv_path)
+
+    # 3. packages — create/reuse a per-tenant cached venv and pip-install
+    packages_map = deps_config.get("packages")
+    if packages_map and isinstance(packages_map, dict):
+        base_dir = os.getenv("NOETL_TENANT_ENVS_DIR", _TENANT_ENVS_DEFAULT)
+        for tenant_key, pkg_list in packages_map.items():
+            if not pkg_list:
+                continue
+            pkg_list = [str(p) for p in pkg_list]
+            tenant_venv = os.path.join(base_dir, str(tenant_key))
+
+            if not os.path.isdir(tenant_venv):
+                logger.info(
+                    "PYTHON.DEPS: creating tenant venv for %s at %s", tenant_key, tenant_venv
+                )
+                venv.create(tenant_venv, with_pip=True, clear=False)
+
+            python_bin = _venv_python(tenant_venv)
+            try:
+                result = subprocess.run(
+                    [python_bin, "-m", "pip", "install", "--quiet"] + pkg_list,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                if result.stdout.strip():
+                    logger.debug("PYTHON.DEPS: pip stdout: %s", result.stdout.strip())
+            except subprocess.CalledProcessError as exc:
+                stderr = exc.stderr.strip() if exc.stderr else ""
+                raise RuntimeError(
+                    f"PYTHON.DEPS: pip install failed for tenant '{tenant_key}' "
+                    f"packages {pkg_list}: {stderr}"
+                ) from exc
+
+            site_pkgs = _venv_site_packages(tenant_venv)
+            if site_pkgs:
+                _inject_sys_path(site_pkgs)
+                logger.info(
+                    "PYTHON.DEPS: tenant '%s' venv ready, injected %s", tenant_key, site_pkgs
+                )
+            else:
+                logger.warning(
+                    "PYTHON.DEPS: tenant '%s' venv installed but no site-packages found at %s",
+                    tenant_key,
+                    tenant_venv,
+                )
+
 
 def _size_hint(value: Any) -> int:
     try:
@@ -430,6 +559,11 @@ async def execute_python_task_async(
                 logger.debug("PYTHON.EXECUTE_PYTHON_TASK: Imports block prepared (len=%s)", len(imports_block))
             else:
                 logger.warning(f"PYTHON.EXECUTE_PYTHON_TASK: 'libs' must be a dict, got {type(libs_config)}")
+
+        # Resolve tenant-specific deps (install/inject) before executing code
+        deps_config = task_config.get('deps')
+        if deps_config:
+            _resolve_deps(deps_config)
 
         logger.debug(f"PYTHON.EXECUTE_PYTHON_TASK: Python code length={len(code)} chars")
 

--- a/tests/tools/test_python_tool_deps.py
+++ b/tests/tools/test_python_tool_deps.py
@@ -1,0 +1,246 @@
+"""Tests for the _resolve_deps hot-pluggable dependency mechanism."""
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Pre-import to break circular init chain (same pattern as test_agent_executor.py).
+import noetl.worker.auth_resolver  # noqa: F401
+from noetl.tools.python.executor import _resolve_deps, _venv_site_packages, _venv_python
+
+
+# ---------------------------------------------------------------------------
+# _venv_site_packages
+# ---------------------------------------------------------------------------
+
+
+def test_venv_site_packages_unix_layout(tmp_path):
+    site = tmp_path / "lib" / "python3.12" / "site-packages"
+    site.mkdir(parents=True)
+    result = _venv_site_packages(str(tmp_path))
+    assert result == str(site)
+
+
+def test_venv_site_packages_windows_layout(tmp_path):
+    site = tmp_path / "Lib" / "site-packages"
+    site.mkdir(parents=True)
+    result = _venv_site_packages(str(tmp_path))
+    assert result == str(site)
+
+
+def test_venv_site_packages_missing(tmp_path):
+    assert _venv_site_packages(str(tmp_path)) is None
+
+
+# ---------------------------------------------------------------------------
+# _venv_python
+# ---------------------------------------------------------------------------
+
+
+def test_venv_python_returns_bin_python_when_present(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    py = bin_dir / "python"
+    py.write_text("#!/usr/bin/env python3")
+    result = _venv_python(str(tmp_path))
+    assert result == str(py)
+
+
+def test_venv_python_fallback(tmp_path):
+    result = _venv_python(str(tmp_path))
+    assert result == str(tmp_path / "bin" / "python")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_deps — skip guard
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_deps_skipped_by_env_var(monkeypatch):
+    monkeypatch.setenv("NOETL_SKIP_DEPS_RESOLUTION", "true")
+    # Should not touch sys.path at all
+    before = list(sys.path)
+    _resolve_deps({"sys_path": ["/nonexistent/path"]})
+    assert sys.path == before
+
+
+def test_resolve_deps_none_is_noop():
+    before = list(sys.path)
+    _resolve_deps(None)
+    assert sys.path == before
+
+
+def test_resolve_deps_empty_dict_is_noop():
+    before = list(sys.path)
+    _resolve_deps({})
+    assert sys.path == before
+
+
+# ---------------------------------------------------------------------------
+# _resolve_deps — sys_path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_deps_sys_path_injects_existing(tmp_path, monkeypatch):
+    monkeypatch.delenv("NOETL_SKIP_DEPS_RESOLUTION", raising=False)
+    target = str(tmp_path)
+    if target in sys.path:
+        sys.path.remove(target)
+    try:
+        _resolve_deps({"sys_path": [target]})
+        assert sys.path[0] == target
+    finally:
+        if target in sys.path:
+            sys.path.remove(target)
+
+
+def test_resolve_deps_sys_path_skips_missing(monkeypatch, caplog):
+    monkeypatch.delenv("NOETL_SKIP_DEPS_RESOLUTION", raising=False)
+    missing = "/definitely/does/not/exist/12345"
+    before = list(sys.path)
+    _resolve_deps({"sys_path": [missing]})
+    assert missing not in sys.path
+    assert sys.path == before
+
+
+def test_resolve_deps_sys_path_not_duplicated(tmp_path, monkeypatch):
+    monkeypatch.delenv("NOETL_SKIP_DEPS_RESOLUTION", raising=False)
+    target = str(tmp_path)
+    if target not in sys.path:
+        sys.path.insert(0, target)
+    original_count = sys.path.count(target)
+    try:
+        _resolve_deps({"sys_path": [target]})
+        assert sys.path.count(target) == original_count
+    finally:
+        while target in sys.path:
+            sys.path.remove(target)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_deps — venv_path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_deps_venv_path_injects_site_packages(tmp_path, monkeypatch):
+    monkeypatch.delenv("NOETL_SKIP_DEPS_RESOLUTION", raising=False)
+    site = tmp_path / "lib" / "python3.12" / "site-packages"
+    site.mkdir(parents=True)
+    site_str = str(site)
+    if site_str in sys.path:
+        sys.path.remove(site_str)
+    try:
+        _resolve_deps({"venv_path": str(tmp_path)})
+        assert site_str in sys.path
+    finally:
+        if site_str in sys.path:
+            sys.path.remove(site_str)
+
+
+def test_resolve_deps_venv_path_missing_raises(monkeypatch):
+    monkeypatch.delenv("NOETL_SKIP_DEPS_RESOLUTION", raising=False)
+    with pytest.raises(RuntimeError, match="venv_path does not exist"):
+        _resolve_deps({"venv_path": "/this/does/not/exist/at/all"})
+
+
+# ---------------------------------------------------------------------------
+# _resolve_deps — packages (mocked subprocess + venv.create)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_deps_packages_creates_venv_and_installs(tmp_path, monkeypatch):
+    monkeypatch.delenv("NOETL_SKIP_DEPS_RESOLUTION", raising=False)
+    monkeypatch.setenv("NOETL_TENANT_ENVS_DIR", str(tmp_path))
+
+    tenant_venv_dir = tmp_path / "my-tenant"
+    # site-packages will be created after venv.create mock
+    site_pkgs = tenant_venv_dir / "lib" / "python3.12" / "site-packages"
+
+    def fake_venv_create(path, **kwargs):
+        os.makedirs(str(site_pkgs), exist_ok=True)
+        py_bin = os.path.join(path, "bin", "python")
+        os.makedirs(os.path.dirname(py_bin), exist_ok=True)
+        open(py_bin, "w").close()
+
+    mock_run = MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))
+    site_str = str(site_pkgs)
+
+    with patch("noetl.tools.python.executor.venv.create", side_effect=fake_venv_create), \
+         patch("noetl.tools.python.executor.subprocess.run", mock_run):
+        if site_str in sys.path:
+            sys.path.remove(site_str)
+        try:
+            _resolve_deps({"packages": {"my-tenant": ["rdkit>=2024.03.1", "meeko>=0.5.0"]}})
+            assert site_str in sys.path
+            mock_run.assert_called_once()
+            call_args = mock_run.call_args[0][0]
+            assert "rdkit>=2024.03.1" in call_args
+            assert "meeko>=0.5.0" in call_args
+        finally:
+            if site_str in sys.path:
+                sys.path.remove(site_str)
+
+
+def test_resolve_deps_packages_reuses_existing_venv(tmp_path, monkeypatch):
+    monkeypatch.delenv("NOETL_SKIP_DEPS_RESOLUTION", raising=False)
+    monkeypatch.setenv("NOETL_TENANT_ENVS_DIR", str(tmp_path))
+
+    tenant_venv_dir = tmp_path / "cached-tenant"
+    site_pkgs = tenant_venv_dir / "lib" / "python3.12" / "site-packages"
+    site_pkgs.mkdir(parents=True)
+    py_bin = tenant_venv_dir / "bin" / "python"
+    py_bin.parent.mkdir(parents=True)
+    py_bin.write_text("")
+
+    mock_run = MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))
+    mock_venv_create = MagicMock()
+    site_str = str(site_pkgs)
+
+    with patch("noetl.tools.python.executor.venv.create", mock_venv_create), \
+         patch("noetl.tools.python.executor.subprocess.run", mock_run):
+        if site_str in sys.path:
+            sys.path.remove(site_str)
+        try:
+            _resolve_deps({"packages": {"cached-tenant": ["pandas>=2.2.3"]}})
+            mock_venv_create.assert_not_called()
+            mock_run.assert_called_once()
+            assert site_str in sys.path
+        finally:
+            if site_str in sys.path:
+                sys.path.remove(site_str)
+
+
+def test_resolve_deps_packages_pip_failure_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("NOETL_SKIP_DEPS_RESOLUTION", raising=False)
+    monkeypatch.setenv("NOETL_TENANT_ENVS_DIR", str(tmp_path))
+
+    import subprocess as _sp
+    site_pkgs = tmp_path / "bad-tenant" / "lib" / "python3.12" / "site-packages"
+
+    def fake_venv_create(path, **kwargs):
+        os.makedirs(str(site_pkgs), exist_ok=True)
+        py_bin = os.path.join(path, "bin", "python")
+        os.makedirs(os.path.dirname(py_bin), exist_ok=True)
+        open(py_bin, "w").close()
+
+    mock_run = MagicMock(
+        side_effect=_sp.CalledProcessError(1, "pip", stderr="No matching distribution")
+    )
+
+    with patch("noetl.tools.python.executor.venv.create", side_effect=fake_venv_create), \
+         patch("noetl.tools.python.executor.subprocess.run", mock_run):
+        with pytest.raises(RuntimeError, match="pip install failed for tenant 'bad-tenant'"):
+            _resolve_deps({"packages": {"bad-tenant": ["nonexistent-pkg-xyz==99.0"]}})
+
+
+def test_resolve_deps_packages_empty_list_skipped(tmp_path, monkeypatch):
+    monkeypatch.delenv("NOETL_SKIP_DEPS_RESOLUTION", raising=False)
+    monkeypatch.setenv("NOETL_TENANT_ENVS_DIR", str(tmp_path))
+    mock_run = MagicMock()
+    mock_venv_create = MagicMock()
+    with patch("noetl.tools.python.executor.venv.create", mock_venv_create), \
+         patch("noetl.tools.python.executor.subprocess.run", mock_run):
+        _resolve_deps({"packages": {"empty-tenant": []}})
+        mock_venv_create.assert_not_called()
+        mock_run.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `_resolve_deps()` to `noetl/tools/python/executor.py` so playbooks can declare tenant-specific Python packages without touching `pyproject.toml` or rebuilding the core worker image
- Three modes: `deps.sys_path` (inject dirs), `deps.venv_path` (inject existing venv), `deps.packages` (create/reuse per-tenant cached venv via pip)
- Venv cache lives under `NOETL_TENANT_ENVS_DIR` (default `/opt/noetl/tenant-envs/<tenant-key>`); first run installs, subsequent runs reuse instantly
- `NOETL_SKIP_DEPS_RESOLUTION=true` bypasses the mechanism entirely (for test environments)
- 17 new tests in `tests/tools/test_python_tool_deps.py`, all mocked — no packages are installed in CI

## Motivation

GLUT Probe Design playbooks need `rdkit` and `meeko` for ligand preparation. These are large scientific packages that must not be baked into the core NoETL worker image. This mechanism lets any tenant declare their packages in their playbook YAML.

## Usage

```yaml
tool:
  kind: python
  deps:
    packages:
      glut-probe-design:
        - "rdkit>=2024.03.1"
        - "meeko>=0.5.0"
    # or reuse an already-created venv:
    venv_path: "/opt/noetl/tenant-envs/glut-probe-design"
    # or inject a pre-built path directly:
    sys_path:
      - "/opt/noetl/tenant-envs/glut-probe-design/lib/python3.12/site-packages"
  code: |
    from rdkit import Chem
    ...
```

## Test plan

- [x] `tests/tools/test_python_tool_deps.py` — 17 tests, all green
- [x] Full `tests/tools/` suite green (36 tests)
- [x] No changes to `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)