### PR TITLE
docs: link to noetl wiki and distributed-runtime component pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,35 @@ With **NoETL Gateway**, playbooks can be deployed as a **distributed backend**: 
 
 ## Documentation
 
-**https://noetl.dev**
+**https://noetl.dev** — user-facing site.
+
+**[NoETL wiki](https://github.com/noetl/noetl/wiki)** — operator and
+developer reference. Pages mirror the code tree under `noetl/noetl`.
 
 Async batch acceptance details for workers and operators:
 
 - [`noetl/server/api/BATCH_EVENTS_ASYNC.md`](noetl/server/api/BATCH_EVENTS_ASYNC.md)
 - [`noetl/server/api/RECOVERY_AUTORESUME.md`](noetl/server/api/RECOVERY_AUTORESUME.md)
+
+### Distributed runtime components
+
+Reference docs for the event-sourced, projection-backed runtime
+(implements v2 distributed-runtime spec phases 0–2; spec lives in
+`noetl/docs` at [`docs/features/noetl_distributed_runtime_spec.md`](https://github.com/noetl/docs/blob/main/docs/features/noetl_distributed_runtime_spec.md)):
+
+- **[Event Store](https://github.com/noetl/noetl/wiki/event_store)** —
+  durable append-only event log (port + Postgres adapter), `EventRecord`
+  envelope, optimistic concurrency via `expected_version`.
+- **[Projection Store](https://github.com/noetl/noetl/wiki/projection_store)**
+  — version-monotonic projection + snapshot store (port + Postgres
+  adapter), query interface for replay state.
+- **[Outbox](https://github.com/noetl/noetl/wiki/outbox)** — transactional
+  outbox publisher (`python -m noetl.outbox`) that drains `noetl.outbox`
+  to NATS with at-least-once retry/backoff.
+- **[Projector](https://github.com/noetl/noetl/wiki/projector)** —
+  out-of-process projection worker (`python -m noetl.projector`),
+  durable NATS pull consumer, shard-stable, Prometheus metrics,
+  replay-state folding shared with the in-process replay API.
 
 ## Repository model (ai-meta driven)
 


### PR DESCRIPTION
## Summary

Adds a top-level link to the [NoETL wiki](https://github.com/noetl/noetl/wiki) under Documentation, plus a new \`Distributed runtime components\` subsection that points at the four wiki pages documenting the event-sourced runtime subsystem shipped across PRs #548, #555, #561, #564, #570, etc. (event store + projection store ports, projector StatefulSet, transactional outbox, query port, strict settings).

The wiki was reset (commit \`7a28414\` on wiki master) to a layout that mirrors the noetl code tree so operators and developers can navigate from any package directory to its reference doc.

## What's added in the README

- One-line pointer to the wiki under \`## Documentation\`
- New \`### Distributed runtime components\` subsection with four wiki links:
  - [Event Store](https://github.com/noetl/noetl/wiki/event_store)
  - [Projection Store](https://github.com/noetl/noetl/wiki/projection_store)
  - [Outbox](https://github.com/noetl/noetl/wiki/outbox)
  - [Projector](https://github.com/noetl/noetl/wiki/projector)

## Why a wiki, not in-tree READMEs

Earlier #581 proposed in-tree \`README.md\` files under \`noetl/core/event_store/\`, \`noetl/outbox/\`, \`noetl/projector/\` etc. Closed in favor of keeping code-package folders code-only; reference docs live on the wiki with a mirrored folder layout.

## Test plan

- [x] All four wiki links resolve (verified on https://github.com/noetl/noetl/wiki after the wiki push)
- [x] Spec link to \`noetl/docs\` resolves
- [ ] Reviewer to spot-check rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)