### PR TITLE
feat(projector): write per-frame projections

### DIFF
--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -23,6 +23,8 @@ class ProjectorMetrics:
             "events_unshardable_total": 0.0,
             "projection_records_total": 0.0,
             "projection_stale_records_total": 0.0,
+            "frame_projection_records_total": 0.0,
+            "frame_projection_stale_records_total": 0.0,
             "projection_errors_total": 0.0,
             "decode_errors_total": 0.0,
             "acknowledged_notifications_total": 0.0,
@@ -44,6 +46,8 @@ class ProjectorMetrics:
             "last_batch_unshardable_events": 0.0,
             "last_batch_projection_records": 0.0,
             "last_batch_stale_projection_records": 0.0,
+            "last_batch_frame_projection_records": 0.0,
+            "last_batch_frame_stale_projection_records": 0.0,
             "last_projection_source_event_id": 0.0,
             "last_projection_event_time_watermark_unixtime": 0.0,
             "last_projection_projected_at_unixtime": 0.0,
@@ -60,6 +64,8 @@ class ProjectorMetrics:
         unowned_events: int = 0,
         unshardable_events: int = 0,
         stale_projection_records: int = 0,
+        frame_projection_records: int = 0,
+        frame_stale_projection_records: int = 0,
     ) -> None:
         now = time.time()
         with self._lock:
@@ -70,6 +76,10 @@ class ProjectorMetrics:
             self._values["events_unshardable_total"] += float(max(0, unshardable_events))
             self._values["projection_records_total"] += float(max(0, projection_records))
             self._values["projection_stale_records_total"] += float(max(0, stale_projection_records))
+            self._values["frame_projection_records_total"] += float(max(0, frame_projection_records))
+            self._values["frame_projection_stale_records_total"] += float(
+                max(0, frame_stale_projection_records)
+            )
             self._values["last_success_unixtime"] = now
             self._values["last_batch_extracted_events"] = float(max(0, extracted_events))
             self._values["last_batch_events"] = float(max(0, owned_events))
@@ -77,6 +87,10 @@ class ProjectorMetrics:
             self._values["last_batch_unshardable_events"] = float(max(0, unshardable_events))
             self._values["last_batch_projection_records"] = float(max(0, projection_records))
             self._values["last_batch_stale_projection_records"] = float(max(0, stale_projection_records))
+            self._values["last_batch_frame_projection_records"] = float(max(0, frame_projection_records))
+            self._values["last_batch_frame_stale_projection_records"] = float(
+                max(0, frame_stale_projection_records)
+            )
             if owned_events <= 0:
                 self._values["empty_or_unowned_notifications_total"] += 1.0
 
@@ -208,6 +222,18 @@ def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapp
             "noetl_projector_projection_stale_records_total"
             f"{label_text} {snapshot['projection_stale_records_total']}"
         ),
+        "# HELP noetl_projector_frame_projection_records_total Per-frame projection records written by this projector.",
+        "# TYPE noetl_projector_frame_projection_records_total counter",
+        (
+            "noetl_projector_frame_projection_records_total"
+            f"{label_text} {snapshot['frame_projection_records_total']}"
+        ),
+        "# HELP noetl_projector_frame_projection_stale_records_total Per-frame projection records skipped because a newer version already exists.",
+        "# TYPE noetl_projector_frame_projection_stale_records_total counter",
+        (
+            "noetl_projector_frame_projection_stale_records_total"
+            f"{label_text} {snapshot['frame_projection_stale_records_total']}"
+        ),
         "# HELP noetl_projector_projection_errors_total Projector notification projection callback failures.",
         "# TYPE noetl_projector_projection_errors_total counter",
         f"noetl_projector_projection_errors_total{label_text} {snapshot['projection_errors_total']}",
@@ -291,6 +317,18 @@ def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapp
         (
             "noetl_projector_last_batch_stale_projection_records"
             f"{label_text} {snapshot['last_batch_stale_projection_records']}"
+        ),
+        "# HELP noetl_projector_last_batch_frame_projection_records Per-frame projection records from the last handled notification.",
+        "# TYPE noetl_projector_last_batch_frame_projection_records gauge",
+        (
+            "noetl_projector_last_batch_frame_projection_records"
+            f"{label_text} {snapshot['last_batch_frame_projection_records']}"
+        ),
+        "# HELP noetl_projector_last_batch_frame_stale_projection_records Stale per-frame projection records from the last handled notification.",
+        "# TYPE noetl_projector_last_batch_frame_stale_projection_records gauge",
+        (
+            "noetl_projector_last_batch_frame_stale_projection_records"
+            f"{label_text} {snapshot['last_batch_frame_stale_projection_records']}"
         ),
         "# HELP noetl_projector_last_projection_source_event_id Last projected source event id.",
         "# TYPE noetl_projector_last_projection_source_event_id gauge",
@@ -422,6 +460,8 @@ def _batch_summary(values: Mapping[str, float]) -> dict[str, float]:
     unshardable = values["last_batch_unshardable_events"]
     projection_records = values["last_batch_projection_records"]
     stale_projection_records = values["last_batch_stale_projection_records"]
+    frame_records = values["last_batch_frame_projection_records"]
+    frame_stale_records = values["last_batch_frame_stale_projection_records"]
     return {
         "extracted_events": extracted,
         "owned_events": owned,
@@ -429,11 +469,15 @@ def _batch_summary(values: Mapping[str, float]) -> dict[str, float]:
         "unshardable_events": unshardable,
         "projection_records": projection_records,
         "stale_projection_records": stale_projection_records,
+        "frame_projection_records": frame_records,
+        "frame_stale_projection_records": frame_stale_records,
         "owned_ratio": _safe_ratio(owned, extracted),
         "unowned_ratio": _safe_ratio(unowned, extracted),
         "unshardable_ratio": _safe_ratio(unshardable, extracted),
         "projection_record_ratio": _safe_ratio(projection_records, owned),
         "stale_projection_ratio": _safe_ratio(stale_projection_records, projection_records),
+        "frame_projection_record_ratio": _safe_ratio(frame_records, owned),
+        "frame_stale_projection_ratio": _safe_ratio(frame_stale_records, frame_records),
     }
 
 

--- a/noetl/core/projector/nats_worker.py
+++ b/noetl/core/projector/nats_worker.py
@@ -181,24 +181,30 @@ class NATSProjectorWorker:
 
         try:
             projection_group_count = _projection_group_count(events)
+            frame_group_count = _frame_group_count(events)
             written = await self.projector.project(events)
         except Exception:
             self.metrics.record_error()
             raise
+        execution_records = [r for r in written if not _is_frame_record(r)]
+        frame_records = [r for r in written if _is_frame_record(r)]
         self.metrics.record_notification(
             extracted_events=len(extracted_events),
             owned_events=len(events),
-            projection_records=len(written),
+            projection_records=len(execution_records),
             unowned_events=unowned_events,
             unshardable_events=unshardable_events,
-            stale_projection_records=max(0, projection_group_count - len(written)),
+            stale_projection_records=max(0, projection_group_count - len(execution_records)),
+            frame_projection_records=len(frame_records),
+            frame_stale_projection_records=max(0, frame_group_count - len(frame_records)),
         )
         self.metrics.record_projection_checkpoints(written)
         logger.debug(
-            "Projector %s folded %s events into %s projection records",
+            "Projector %s folded %s events into %s execution + %s frame projection records",
             self.settings.shard_id,
             len(events),
-            len(written),
+            len(execution_records),
+            len(frame_records),
         )
         return "ack"
 
@@ -293,6 +299,47 @@ def _projection_group_count(events: Iterable[dict[str, Any]]) -> int:
             )
         )
     return len(groups)
+
+
+def _frame_group_count(events: Iterable[dict[str, Any]]) -> int:
+    """Count distinct frames represented in the event batch.
+
+    Mirrors the projector's frame-fold grouping so the worker can report
+    a stale-frame metric (frames present in the batch but skipped by the
+    monotonic upsert).
+    """
+    from .service import _extract_frame_id  # local import to avoid a cycle
+
+    groups: set[tuple[str, str, int, str]] = set()
+    for event in events:
+        execution_id = event.get("execution_id")
+        if execution_id is None:
+            continue
+        frame_id = _extract_frame_id(event)
+        if not frame_id:
+            continue
+        try:
+            parsed_execution_id = int(execution_id)
+        except (TypeError, ValueError):
+            continue
+        groups.add(
+            (
+                str(event.get("tenant_id") or "default"),
+                str(event.get("organization_id") or "default"),
+                parsed_execution_id,
+                frame_id,
+            )
+        )
+    return len(groups)
+
+
+def _is_frame_record(record: Any) -> bool:
+    """Return True if the projection record was written by the frame fan-out path."""
+    projection_id = getattr(record, "projection_id", None)
+    if isinstance(projection_id, str) and projection_id.startswith("frame/"):
+        return True
+    projection_type = getattr(record, "projection_type", None)
+    return isinstance(projection_type, str) and projection_type.startswith("replay_state:frame")
 
 
 def decode_projector_notification(payload: bytes) -> dict[str, Any]:

--- a/noetl/core/projector/service.py
+++ b/noetl/core/projector/service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
 from noetl.core.projection_store import ProjectionRecord, ProjectionStore
 from noetl.server.api.replay.service import fold_replay_state
@@ -17,6 +17,15 @@ class ReplayStateProjector:
     feed the same projector, and tests can call it directly.  The event log and
     immutable payload references remain authoritative; projection rows are
     rebuildable serving state.
+
+    Writes two record families:
+
+    - Per-execution records keyed ``execution/<id>/<projection>`` — the
+      original behaviour.
+    - Per-frame records keyed ``frame/<frame_id>/<projection>`` — written
+      additively whenever the folded state's ``frames`` surface is
+      non-empty. Lets dashboards and replay tooling read individual frame
+      state without fanning out from the execution record.
     """
 
     def __init__(self, projection_store: ProjectionStore, *, projection: str = "all") -> None:
@@ -78,7 +87,124 @@ class ReplayStateProjector:
             )
             if await self.projection_store.save_projection(record):
                 written.append(record)
+
+            frame_records = self._build_frame_records(
+                state=state,
+                events=ordered,
+                tenant_id=tenant_id,
+                organization_id=organization_id,
+                execution_id=execution_id,
+                projected_at=projected_at,
+            )
+            for frame_record in frame_records:
+                if await self.projection_store.save_projection(frame_record):
+                    written.append(frame_record)
         return written
+
+    def _build_frame_records(
+        self,
+        *,
+        state: Mapping[str, Any],
+        events: list[dict[str, Any]],
+        tenant_id: str,
+        organization_id: str,
+        execution_id: int,
+        projected_at: datetime,
+    ) -> list[ProjectionRecord]:
+        """Materialize per-frame projection records from a folded state.
+
+        Each entry in ``state['frames']`` becomes one
+        ``frame/<frame_id>/<projection>`` row. Versions and source event
+        ids are computed against the subset of input events touching the
+        same frame so the monotonic upsert in the projection store stays
+        coherent even when batches arrive out of order.
+        """
+        frames = state.get("frames") if isinstance(state, Mapping) else None
+        if not isinstance(frames, Mapping) or not frames:
+            return []
+
+        events_by_frame: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for event in events:
+            frame_id = _extract_frame_id(event)
+            if frame_id:
+                events_by_frame[frame_id].append(event)
+
+        records: list[ProjectionRecord] = []
+        for frame_id, frame_state in frames.items():
+            if not isinstance(frame_state, Mapping):
+                continue
+            frame_events = events_by_frame.get(str(frame_id), [])
+            version = _projection_version(frame_events)
+            source_event_id = _last_event_id(frame_events)
+            event_watermark = _event_time_watermark(frame_events)
+            frame_payload = dict(frame_state)
+            frame_payload.setdefault("frame_id", str(frame_id))
+            record_state = {
+                "tenant_id": tenant_id,
+                "organization_id": organization_id,
+                "execution_id": execution_id,
+                "frame_id": str(frame_id),
+                "stage_id": frame_payload.get("stage_id"),
+                "parent_frame_id": frame_payload.get("parent_frame_id"),
+                "projection": self.projection,
+                "frame": frame_payload,
+                "projection_checksums": state.get("projection_checksums"),
+                "upcaster_registry_digest": state.get("upcaster_registry_digest"),
+            }
+            meta = {
+                "event_count": len(frame_events),
+                "event_time_watermark": _format_dt(event_watermark),
+                "projected_at": _format_dt(projected_at),
+                "projection_lag_ms": _projection_lag_ms(event_watermark, projected_at),
+                "projector": "replay_state",
+                "projection": self.projection,
+                "projection_checksums": state.get("projection_checksums"),
+                "source_event_id": source_event_id,
+                "frame_id": str(frame_id),
+                "stage_id": frame_payload.get("stage_id"),
+                "command_id": frame_payload.get("command_id"),
+                "parent_frame_id": frame_payload.get("parent_frame_id"),
+                "frame_status": frame_payload.get("status"),
+                "upcaster_registry_digest": state.get("upcaster_registry_digest"),
+            }
+            records.append(
+                ProjectionRecord(
+                    projection_id=f"frame/{frame_id}/{self.projection}",
+                    projection_type=f"replay_state:frame:{self.projection}",
+                    tenant_id=tenant_id,
+                    organization_id=organization_id,
+                    execution_id=execution_id,
+                    version=version,
+                    source_event_id=source_event_id,
+                    state=record_state,
+                    meta=meta,
+                )
+            )
+        return records
+
+
+def _extract_frame_id(event: Mapping[str, Any]) -> str | None:
+    """Return the frame_id an event belongs to, or ``None``.
+
+    Mirrors the resolution order used by
+    :func:`noetl.server.api.replay.service._frame_id` so projector and
+    replay agree on which events fold into which frame.
+    """
+    if not isinstance(event, Mapping):
+        return None
+    column_value = event.get("frame_id")
+    if column_value is not None:
+        return str(column_value)
+    aggregate_type = event.get("aggregate_type")
+    aggregate_id = event.get("aggregate_id")
+    if aggregate_type == "frame" and aggregate_id:
+        return str(aggregate_id).removeprefix("frame/")
+    meta = event.get("meta")
+    if isinstance(meta, Mapping):
+        value = meta.get("frame_id")
+        if value is not None:
+            return str(value)
+    return None
 
 
 def _projection_version(events: list[dict[str, Any]]) -> int:

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -58,6 +58,10 @@ def test_projector_metrics_render_prometheus_labels():
     assert "noetl_projector_last_batch_unowned_events" in body
     assert "noetl_projector_last_batch_unshardable_events" in body
     assert "noetl_projector_last_batch_stale_projection_records" in body
+    assert "noetl_projector_frame_projection_records_total" in body
+    assert "noetl_projector_frame_projection_stale_records_total" in body
+    assert "noetl_projector_last_batch_frame_projection_records" in body
+    assert "noetl_projector_last_batch_frame_stale_projection_records" in body
     assert " 1.0" in body
 
     snapshot = metrics.snapshot()
@@ -75,11 +79,48 @@ def test_projector_metrics_render_prometheus_labels():
     assert summary["unshardable_events"] == 0
     assert summary["projection_records"] == 1
     assert summary["stale_projection_records"] == 1
+    assert summary["frame_projection_records"] == 0
+    assert summary["frame_stale_projection_records"] == 0
     assert summary["owned_ratio"] == 2 / 3
     assert summary["unowned_ratio"] == 1 / 3
     assert summary["unshardable_ratio"] == 0
     assert summary["projection_record_ratio"] == 0.5
     assert summary["stale_projection_ratio"] == 1.0
+    assert summary["frame_projection_record_ratio"] == 0
+    assert summary["frame_stale_projection_ratio"] == 0
+
+
+def test_projector_metrics_record_notification_tracks_frame_counters():
+    """Frame-specific counters increment when record_notification is called with them."""
+    from noetl.core.projector.metrics import ProjectorMetrics, render_projector_metrics
+
+    metrics = ProjectorMetrics()
+    metrics.record_notification(
+        extracted_events=5,
+        owned_events=4,
+        projection_records=1,
+        stale_projection_records=0,
+        frame_projection_records=3,
+        frame_stale_projection_records=1,
+    )
+
+    snapshot = metrics.snapshot()
+    assert snapshot["frame_projection_records_total"] == 3
+    assert snapshot["frame_projection_stale_records_total"] == 1
+    assert snapshot["last_batch_frame_projection_records"] == 3
+    assert snapshot["last_batch_frame_stale_projection_records"] == 1
+
+    body = render_projector_metrics(metrics)
+    assert "noetl_projector_frame_projection_records_total 3.0" in body
+    assert "noetl_projector_frame_projection_stale_records_total 1.0" in body
+    assert "noetl_projector_last_batch_frame_projection_records 3.0" in body
+    assert "noetl_projector_last_batch_frame_stale_projection_records 1.0" in body
+
+    summary = metrics.batch_summary()
+    assert summary["frame_projection_records"] == 3
+    assert summary["frame_stale_projection_records"] == 1
+    assert summary["frame_projection_record_ratio"] == 0.75
+    assert summary["frame_stale_projection_ratio"] == 1 / 3
 
 
 def test_projector_metrics_batch_summary_handles_empty_batches():

--- a/tests/core/test_replay_state_projector.py
+++ b/tests/core/test_replay_state_projector.py
@@ -79,7 +79,8 @@ async def test_replay_state_projector_writes_grouped_projection_records():
         ]
     )
 
-    assert len(written) == 2
+    # 2 execution records + 1 frame record from execution 7 (frame "1")
+    assert len(written) == 3
     first = store.records["execution/7/all"]
     assert first.tenant_id == "tenant-a"
     assert first.organization_id == "org-a"
@@ -98,6 +99,177 @@ async def test_replay_state_projector_writes_grouped_projection_records():
     assert first.meta["projector"] == "replay_state"
     assert first.meta["projection_checksums"] == first.state["projection_checksums"]
     assert first.meta["source_event_id"] == 10
+
+    # Per-frame record was emitted for frame "1" in execution 7
+    frame_record = store.records["frame/1/all"]
+    assert frame_record.tenant_id == "tenant-a"
+    assert frame_record.organization_id == "org-a"
+    assert frame_record.execution_id == 7
+    assert frame_record.version == 2
+    assert frame_record.source_event_id == 10
+    assert frame_record.projection_type == "replay_state:frame:all"
+    assert frame_record.state["frame_id"] == "1"
+    assert frame_record.state["frame"]["status"] == "COMPLETED"
+    assert frame_record.meta["frame_id"] == "1"
+    assert frame_record.meta["frame_status"] == "COMPLETED"
+    assert frame_record.meta["event_count"] == 1
+    assert frame_record.meta["projector"] == "replay_state"
+
+
+@pytest.mark.asyncio
+async def test_replay_state_projector_writes_per_frame_projection_records():
+    """Two distinct frames in one execution → two per-frame projection rows."""
+    from noetl.core.projector import ReplayStateProjector
+
+    store = _MemoryProjectionStore()
+    projector = ReplayStateProjector(store)
+
+    written = await projector.project(
+        [
+            {
+                "event_id": 100,
+                "stream_version": 1,
+                "tenant_id": "tenant-a",
+                "organization_id": "org-a",
+                "execution_id": 12,
+                "event_type": "frame.dispatched",
+                "aggregate_type": "frame",
+                "aggregate_id": "frame/11",
+                "meta": {"frame_id": "11", "stage_id": "1"},
+            },
+            {
+                "event_id": 101,
+                "stream_version": 2,
+                "tenant_id": "tenant-a",
+                "organization_id": "org-a",
+                "execution_id": 12,
+                "event_type": "frame.committed",
+                "aggregate_type": "frame",
+                "aggregate_id": "frame/11",
+                "result": {"status": "COMPLETED"},
+                "meta": {"frame_id": "11", "stage_id": "1", "row_count": 5},
+            },
+            {
+                "event_id": 102,
+                "stream_version": 1,
+                "tenant_id": "tenant-a",
+                "organization_id": "org-a",
+                "execution_id": 12,
+                "event_type": "frame.dispatched",
+                "aggregate_type": "frame",
+                "aggregate_id": "frame/22",
+                "meta": {"frame_id": "22", "stage_id": "1"},
+            },
+            {
+                "event_id": 103,
+                "stream_version": 2,
+                "tenant_id": "tenant-a",
+                "organization_id": "org-a",
+                "execution_id": 12,
+                "event_type": "frame.committed",
+                "aggregate_type": "frame",
+                "aggregate_id": "frame/22",
+                "result": {"status": "COMPLETED"},
+                "meta": {"frame_id": "22", "stage_id": "1", "row_count": 7},
+            },
+        ]
+    )
+
+    # 1 execution record + 2 frame records
+    assert len(written) == 3
+    assert {r.projection_id for r in written} == {
+        "execution/12/all",
+        "frame/11/all",
+        "frame/22/all",
+    }
+    assert store.records["frame/11/all"].state["frame"]["row_count"] == 5
+    assert store.records["frame/22/all"].state["frame"]["row_count"] == 7
+    # Frames share the same execution_id but have independent versions
+    assert store.records["frame/11/all"].version == 2
+    assert store.records["frame/22/all"].version == 2
+
+
+@pytest.mark.asyncio
+async def test_replay_state_projector_skips_per_frame_when_no_frame_events():
+    """Execution-only events produce only execution records — no frame writes."""
+    from noetl.core.projector import ReplayStateProjector
+
+    store = _MemoryProjectionStore()
+    projector = ReplayStateProjector(store)
+
+    written = await projector.project(
+        [
+            {
+                "event_id": 200,
+                "stream_version": 1,
+                "tenant_id": "tenant-a",
+                "organization_id": "org-a",
+                "execution_id": 30,
+                "event_type": "execution.started",
+            },
+            {
+                "event_id": 201,
+                "stream_version": 2,
+                "tenant_id": "tenant-a",
+                "organization_id": "org-a",
+                "execution_id": 30,
+                "event_type": "workflow.completed",
+            },
+        ]
+    )
+
+    assert len(written) == 1
+    assert written[0].projection_id == "execution/30/all"
+    assert not any(pid.startswith("frame/") for pid in store.records)
+
+
+@pytest.mark.asyncio
+async def test_replay_state_projector_frame_records_respect_monotonic_upsert():
+    """A stale (lower-version) frame event must not overwrite the existing row."""
+    from noetl.core.projector import ReplayStateProjector
+
+    store = _MemoryProjectionStore()
+    projector = ReplayStateProjector(store)
+
+    newer = await projector.project(
+        [
+            {
+                "event_id": 300,
+                "stream_version": 3,
+                "tenant_id": "tenant-a",
+                "organization_id": "org-a",
+                "execution_id": 42,
+                "event_type": "frame.committed",
+                "aggregate_type": "frame",
+                "aggregate_id": "frame/99",
+                "result": {"status": "COMPLETED"},
+                "meta": {"frame_id": "99", "stage_id": "9", "row_count": 11},
+            }
+        ]
+    )
+
+    stale = await projector.project(
+        [
+            {
+                "event_id": 290,
+                "stream_version": 1,
+                "tenant_id": "tenant-a",
+                "organization_id": "org-a",
+                "execution_id": 42,
+                "event_type": "frame.dispatched",
+                "aggregate_type": "frame",
+                "aggregate_id": "frame/99",
+                "meta": {"frame_id": "99", "stage_id": "9"},
+            }
+        ]
+    )
+
+    assert any(r.projection_id == "frame/99/all" for r in newer)
+    # Stale projection-store write is a no-op (returns False from save_projection)
+    assert not any(r.projection_id == "frame/99/all" for r in stale)
+    # Stored record stays at the newer version
+    assert store.records["frame/99/all"].version == 3
+    assert store.records["frame/99/all"].state["frame"]["status"] == "COMPLETED"
 
 
 @pytest.mark.asyncio
@@ -371,6 +543,97 @@ async def test_nats_projector_worker_does_not_count_same_execution_batch_as_stal
     assert snapshot["events_owned_total"] == 2
     assert snapshot["projection_records_total"] == 1
     assert snapshot["projection_stale_records_total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_nats_projector_worker_counts_frame_projection_writes():
+    """Worker should count per-frame projection writes separately from per-execution."""
+    from noetl.core.projector.metrics import ProjectorMetrics
+    from noetl.core.projector.nats_worker import NATSProjectorWorker, ProjectorWorkerSettings
+
+    metrics = ProjectorMetrics()
+    store = _MemoryProjectionStore()
+    worker = NATSProjectorWorker(
+        projection_store=store,
+        settings=ProjectorWorkerSettings(shard_count=1),
+        metrics=metrics,
+    )
+
+    action = await worker.handle_notification(
+        {
+            "events": [
+                {
+                    "event_id": 700,
+                    "stream_version": 1,
+                    "tenant_id": "tenant-a",
+                    "organization_id": "org-a",
+                    "execution_id": 50,
+                    "event_type": "frame.dispatched",
+                    "aggregate_type": "frame",
+                    "aggregate_id": "frame/55",
+                    "meta": {"frame_id": "55", "stage_id": "1"},
+                },
+                {
+                    "event_id": 701,
+                    "stream_version": 2,
+                    "tenant_id": "tenant-a",
+                    "organization_id": "org-a",
+                    "execution_id": 50,
+                    "event_type": "frame.committed",
+                    "aggregate_type": "frame",
+                    "aggregate_id": "frame/55",
+                    "result": {"status": "COMPLETED"},
+                    "meta": {"frame_id": "55", "stage_id": "1", "row_count": 3},
+                },
+            ]
+        }
+    )
+
+    assert action == "ack"
+    assert "execution/50/all" in store.records
+    assert "frame/55/all" in store.records
+
+    snapshot = metrics.snapshot()
+    assert snapshot["projection_records_total"] == 1
+    assert snapshot["projection_stale_records_total"] == 0
+    assert snapshot["frame_projection_records_total"] == 1
+    assert snapshot["frame_projection_stale_records_total"] == 0
+    assert snapshot["last_batch_frame_projection_records"] == 1
+    assert snapshot["last_batch_frame_stale_projection_records"] == 0
+
+
+@pytest.mark.asyncio
+async def test_nats_projector_worker_reports_zero_frame_metrics_for_non_frame_batch():
+    """Per-frame metrics stay at zero when no frame events are in the batch."""
+    from noetl.core.projector.metrics import ProjectorMetrics
+    from noetl.core.projector.nats_worker import NATSProjectorWorker, ProjectorWorkerSettings
+
+    metrics = ProjectorMetrics()
+    store = _MemoryProjectionStore()
+    worker = NATSProjectorWorker(
+        projection_store=store,
+        settings=ProjectorWorkerSettings(shard_count=1),
+        metrics=metrics,
+    )
+
+    await worker.handle_notification(
+        {
+            "event": {
+                "event_id": 800,
+                "stream_version": 1,
+                "tenant_id": "tenant-a",
+                "organization_id": "org-a",
+                "execution_id": 60,
+                "event_type": "workflow.completed",
+            }
+        }
+    )
+
+    snapshot = metrics.snapshot()
+    assert snapshot["projection_records_total"] == 1
+    assert snapshot["frame_projection_records_total"] == 0
+    assert snapshot["frame_projection_stale_records_total"] == 0
+    assert snapshot["last_batch_frame_projection_records"] == 0
 
 
 def test_projector_notification_decoder_accepts_json_and_arrow_feather():


### PR DESCRIPTION
## Summary

Phase 1 of the [v2 distributed-runtime spec](https://github.com/noetl/docs/blob/main/docs/features/noetl_distributed_runtime_spec.md) (frame-shaped cursor loops). The projector worker previously wrote one \`ProjectionRecord\` per execution_id even when the batch carried frame events. This change adds an **additive** per-frame write path so dashboards, the [Frames API](https://github.com/noetl/noetl/wiki/frames), and replay tooling can read individual frame state directly.

Wiki coverage (per the new \`agents/rules/wiki-maintenance.md\` rule in ai-meta): updated [Projector page](https://github.com/noetl/noetl/wiki/projector) with the new \"Frame projections\" subsection and metrics table entries.

## Implementation

- \`noetl/core/projector/service.py\` — extract frame slices from \`state[\"frames\"]\` after the existing \`fold_replay_state\` call; build one record per frame keyed \`frame/<frame_id>/<projection>\`. Version + source_event_id computed against the per-frame subset so the monotonic upsert stays coherent across out-of-order batches.
- \`noetl/core/projector/nats_worker.py\` — split written records into per-execution vs per-frame; pass separate counts to \`ProjectorMetrics.record_notification\`. Add \`_frame_group_count\` helper.
- \`noetl/core/projector/metrics.py\` — add \`frame_projection_records_total\` + \`frame_projection_stale_records_total\` counters; matching last-batch gauges; export in both Prometheus text and \`/summary\` JSON.

## Tests

- Updated \`test_replay_state_projector_writes_grouped_projection_records\` for the new 3-record expectation (1 execution + 1 frame + 1 execution-only from a separate execution).
- Added \`test_replay_state_projector_writes_per_frame_projection_records\` — two frames in one execution → two records.
- Added \`test_replay_state_projector_skips_per_frame_when_no_frame_events\` — execution-only events produce no frame records.
- Added \`test_replay_state_projector_frame_records_respect_monotonic_upsert\` — stale frame writes are no-ops.
- Added \`test_nats_projector_worker_counts_frame_projection_writes\` — worker metrics increment for frame writes.
- Added \`test_nats_projector_worker_reports_zero_frame_metrics_for_non_frame_batch\` — frame counters stay at zero when no frame events.
- Extended Prometheus-export test in \`test_projector_metrics.py\` to assert the new metric names.
- Added \`test_projector_metrics_record_notification_tracks_frame_counters\`.

\`pytest tests/core/test_replay_state_projector.py tests/core/test_projector_metrics.py\` → 39 passed.

## Coordinated change

- Wiki: noetl-wiki @ \`03886a8\` (\"wiki(projector): document per-frame projection writes\")
- Handoff thread: \`ai-meta handoffs/active/2026-05-22-phase1-frame-projections/round-01-prompt.md\`

## Test plan

- [x] Local pytest passes for the two touched test files
- [ ] Reviewer to spot-check the frame-slice fold extraction logic
- [ ] After merge: bump ai-meta pointers for noetl + noetl-wiki

🤖 Generated with [Claude Code](https://claude.com/claude-code)