### PR TITLE
feat(engine): cache fanout/reduce plan and annotate reducer commands

### DIFF
--- a/noetl/core/dsl/engine/executor/state.py
+++ b/noetl/core/dsl/engine/executor/state.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from .common import *
 
+from noetl.core.dsl.engine.planner import FanoutReducePlan, build_fanout_reduce_plan
+
+
 class ExecutionState:
     """Tracks state of a playbook execution."""
-    
+
     def __init__(self, execution_id: str, playbook: Playbook, payload: dict[str, Any], catalog_id: Optional[int] = None, parent_execution_id: Optional[int] = None):
         self.execution_id = execution_id
         self.playbook = playbook
@@ -12,6 +15,9 @@ class ExecutionState:
         self.catalog_id = catalog_id  # Store catalog_id for event persistence
         self.parent_execution_id = parent_execution_id  # Track parent execution for sub-playbooks
         self.current_step: Optional[str] = None
+        # Phase 6: cache the static fan-out/reduce plan once per execution so
+        # transition evaluation doesn't re-run the planner on every fan-out.
+        self._fanout_reduce_plan: Optional[FanoutReducePlan] = None
         self.variables: dict[str, Any] = {}
         self.last_event_id: Optional[int] = None  # Track last persisted event ID
         self.step_event_ids: dict[str, int] = {}  # Track last event per step
@@ -156,6 +162,19 @@ class ExecutionState:
         state.pagination_state = data.get("pagination_state", {})
         state.pending_next_actions = data.get("pending_next_actions", {})
         return state
+
+    @property
+    def fanout_reduce_plan(self) -> FanoutReducePlan:
+        """Static fan-out/reduce plan derived from the playbook.
+
+        The plan is a pure function of ``self.playbook``; cache it once per
+        execution so transition evaluation doesn't re-run the planner on
+        every fan-out boundary. See
+        :func:`noetl.core.dsl.engine.planner.build_fanout_reduce_plan`.
+        """
+        if self._fanout_reduce_plan is None:
+            self._fanout_reduce_plan = build_fanout_reduce_plan(self.playbook)
+        return self._fanout_reduce_plan
 
     def get_step(self, step_name: str) -> Optional[Step]:
         """Get step by name."""

--- a/noetl/core/dsl/engine/executor/transitions.py
+++ b/noetl/core/dsl/engine/executor/transitions.py
@@ -5,7 +5,7 @@ from .outbox import drain_executor_outbox, enqueue_executor_outbox
 from .state import ExecutionState
 from .store import PlaybookRepo, StateStore
 from noetl.core.event_store.ports import canonical_event_checksum
-from noetl.core.dsl.engine.planner import build_fanout_reduce_plan
+# Plan access is now cached on ExecutionState; planner module is referenced via state.fanout_reduce_plan
 from noetl.core.dsl.render import render_template
 
 class TransitionMixin:
@@ -817,6 +817,11 @@ class TransitionMixin:
         if next_mode == "inclusive":
             self._annotate_fanout_reduce_commands(state, step_def, issued_records)
 
+        # Phase 6: reducer-bound annotation runs regardless of next.spec.mode.
+        # Reduce boundaries are static plan information — they don't depend on
+        # whether the upstream router fans out or branches conditionally.
+        self._annotate_reducer_commands(state, step_def, issued_records)
+
         return commands, any_matched, any_raised
 
     def _annotate_fanout_reduce_commands(
@@ -833,7 +838,7 @@ class TransitionMixin:
         if len(target_order) < 2:
             return
 
-        plan = build_fanout_reduce_plan(state.playbook)
+        plan = state.fanout_reduce_plan
         fanout = next(
             (item for item in plan.fanouts if item.step == source_step.step),
             None,
@@ -852,6 +857,39 @@ class TransitionMixin:
                     "target_step": target_step,
                     "target_index": target_index[target_step],
                     "reduce_steps": list(fanout.reduce_steps),
+                }
+            )
+
+    def _annotate_reducer_commands(
+        self,
+        state: ExecutionState,
+        source_step: Step,
+        issued_records: list[tuple[str, Command]],
+    ) -> None:
+        """Attach planner_reducer metadata to commands targeting a planned reducer.
+
+        Reduce boundaries are static — a step is a reducer iff the planner
+        identified it as having ≥2 upstream steps. Annotating reducer-bound
+        commands lets replay tooling, dashboards, and future scheduler
+        integration see the planned join shape without re-running the
+        planner.
+        """
+        plan = state.fanout_reduce_plan
+        if not plan.reduces:
+            return
+        reduces_by_step = {item.step: item for item in plan.reduces}
+
+        for target_step, command in issued_records:
+            reducer = reduces_by_step.get(target_step)
+            if reducer is None:
+                continue
+            command.metadata.setdefault("planner_reducer", {})
+            command.metadata["planner_reducer"].update(
+                {
+                    "planner_version": 1,
+                    "reducer_step": reducer.step,
+                    "upstream_steps": list(reducer.upstream_steps),
+                    "source_step": source_step.step,
                 }
             )
 

--- a/noetl/core/dsl/engine/parser/core.py
+++ b/noetl/core/dsl/engine/parser/core.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from .common import *
 from .validation import ParserValidationMixin
 
+from noetl.core.dsl.engine.planner import validate_fanout_reduce_plan
+from noetl.core.logger import setup_logger
+
+_planner_logger = setup_logger("noetl.core.dsl.engine.planner", include_location=True)
+
 
 class DSLParser(ParserValidationMixin):
     """
@@ -16,6 +21,13 @@ class DSLParser(ParserValidationMixin):
     - step.spec.policy.admit.rules for admission (rejects step.when)
     - loop.spec.mode for iteration
     - Rejects case blocks, expr, eval, step.when, root vars
+
+    After structural validation + Pydantic construction succeed, runs the
+    advisory fan-out/reduce planner lint
+    (:func:`noetl.core.dsl.engine.planner.validate_fanout_reduce_plan`)
+    and surfaces warnings via the
+    ``noetl.core.dsl.engine.planner`` logger. Warnings never block
+    parsing.
     """
 
     def __init__(self):
@@ -45,11 +57,22 @@ class DSLParser(ParserValidationMixin):
 
         self._validate_canonical_v10(data)
         playbook = Playbook(**data)
+        self._emit_planner_warnings(playbook)
 
         if cache_key:
             self._cache[cache_key] = playbook
 
         return playbook
+
+    def _emit_planner_warnings(self, playbook: Playbook) -> None:
+        """Log planner-derived advisory warnings (never raises)."""
+        try:
+            warnings = validate_fanout_reduce_plan(playbook)
+        except Exception:  # pragma: no cover - defensive; planner is pure
+            _planner_logger.exception("[DSL.PLANNER] validation crashed")
+            return
+        for warning in warnings:
+            _planner_logger.warning("[DSL.PLANNER] %s", warning)
 
     def parse_file(self, file_path: str | Path, use_cache: bool = True) -> Playbook:
         """

--- a/noetl/core/dsl/engine/planner.py
+++ b/noetl/core/dsl/engine/planner.py
@@ -136,3 +136,43 @@ def _reachable_reduces(
                 stack.append(target)
 
     return found
+
+
+def validate_fanout_reduce_plan(playbook: Playbook) -> list[str]:
+    """Lint a playbook's fan-out/reduce shape for register-time warnings.
+
+    Returns a list of advisory warning strings (empty for a clean plan).
+    Never raises — register-time validation should fail playbooks for
+    structural / schema errors, not for advisory plan observations.
+
+    Detected categories (stable ``[code] message`` shape so callers can
+    grep / filter):
+
+    - ``[fanout_no_reducer] fan-out '<step>' has no reachable reducer``
+      — ``next.spec.mode: inclusive`` with multiple targets but no
+      join step. Often intentional (parallel fire-and-forget) but
+      worth flagging so authors confirm.
+    - ``[reducer_orphan] reducer '<step>' has fewer than 2 upstream
+      steps`` — guard against callers that synthesize ``PlannedReduce``
+      records by hand; the planner itself only emits ``PlannedReduce``
+      when ``|upstream| > 1``.
+    """
+    plan = build_fanout_reduce_plan(playbook)
+    warnings: list[str] = []
+
+    if plan.is_empty():
+        return warnings
+
+    for fanout in plan.fanouts:
+        if not fanout.reduce_steps:
+            warnings.append(
+                f"[fanout_no_reducer] fan-out '{fanout.step}' has no reachable reducer"
+            )
+
+    for reducer in plan.reduces:
+        if len(reducer.upstream_steps) < 2:
+            warnings.append(
+                f"[reducer_orphan] reducer '{reducer.step}' has fewer than 2 upstream steps"
+            )
+
+    return warnings

--- a/tests/unit/dsl/engine/test_fanout_reduce_planner.py
+++ b/tests/unit/dsl/engine/test_fanout_reduce_planner.py
@@ -1,5 +1,13 @@
+from unittest.mock import patch
+
 from noetl.core.dsl.engine.parser import DSLParser
-from noetl.core.dsl.engine.planner import build_fanout_reduce_plan
+from noetl.core.dsl.engine.planner import (
+    PlannedFanout,
+    PlannedReduce,
+    FanoutReducePlan,
+    build_fanout_reduce_plan,
+    validate_fanout_reduce_plan,
+)
 
 
 def test_planner_detects_inclusive_fanout_and_shared_reduce():
@@ -137,3 +145,204 @@ workflow:
     assert len(plan.fanouts) == 1
     assert plan.fanouts[0].arcs == ("branch_b", "branch_a")
     assert plan.reduces == ()
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: validate_fanout_reduce_plan — register-time advisory warnings
+# ---------------------------------------------------------------------------
+
+
+def test_validate_fanout_reduce_plan_returns_empty_for_clean_playbook():
+    """Linear / well-formed playbook → no warnings."""
+    playbook = DSLParser().parse(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: clean
+workflow:
+  - step: start
+    tool: { kind: python, code: "def main(): return {}" }
+    next:
+      spec: { mode: inclusive }
+      arcs:
+        - step: branch_a
+        - step: branch_b
+  - step: branch_a
+    tool: { kind: python, code: "def main(): return {}" }
+    next:
+      spec: { mode: exclusive }
+      arcs:
+        - step: join
+  - step: branch_b
+    tool: { kind: python, code: "def main(): return {}" }
+    next:
+      spec: { mode: exclusive }
+      arcs:
+        - step: join
+  - step: join
+    tool: { kind: python, code: "def main(): return {}" }
+"""
+    )
+    assert validate_fanout_reduce_plan(playbook) == []
+
+
+def test_validate_fanout_reduce_plan_warns_when_fanout_has_no_reducer():
+    """Inclusive-mode fan-out whose targets never converge → warning."""
+    playbook = DSLParser().parse(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: fanout_no_join
+workflow:
+  - step: start
+    tool: { kind: python, code: "def main(): return {}" }
+    next:
+      spec: { mode: inclusive }
+      arcs:
+        - step: branch_a
+        - step: branch_b
+  - step: branch_a
+    tool: { kind: python, code: "def main(): return {}" }
+  - step: branch_b
+    tool: { kind: python, code: "def main(): return {}" }
+"""
+    )
+    warnings = validate_fanout_reduce_plan(playbook)
+    assert len(warnings) == 1
+    assert warnings[0].startswith("[fanout_no_reducer]")
+    assert "'start'" in warnings[0]
+
+
+def test_validate_fanout_reduce_plan_warns_for_orphan_reducer():
+    """Synthetic PlannedReduce with <2 upstream surfaces a warning.
+
+    The planner itself never emits such entries; this test exercises the
+    validator's defensive path so callers that construct plans by hand
+    (tests, fixtures) get flagged.
+    """
+    synthetic_plan = FanoutReducePlan(
+        fanouts=(),
+        reduces=(PlannedReduce(step="alone", upstream_steps=("solo",)),),
+    )
+
+    with patch(
+        "noetl.core.dsl.engine.planner.build_fanout_reduce_plan",
+        return_value=synthetic_plan,
+    ):
+        warnings = validate_fanout_reduce_plan(playbook=object())  # type: ignore[arg-type]
+
+    assert len(warnings) == 1
+    assert warnings[0].startswith("[reducer_orphan]")
+    assert "'alone'" in warnings[0]
+
+
+def test_validate_fanout_reduce_plan_empty_plan_returns_no_warnings():
+    """is_empty() short-circuits to []."""
+    synthetic_plan = FanoutReducePlan()
+    assert synthetic_plan.is_empty()
+    with patch(
+        "noetl.core.dsl.engine.planner.build_fanout_reduce_plan",
+        return_value=synthetic_plan,
+    ):
+        assert validate_fanout_reduce_plan(playbook=object()) == []  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: ExecutionState caches the plan
+# ---------------------------------------------------------------------------
+
+
+def _minimal_playbook_with_fanout():
+    return DSLParser().parse(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: cache_test
+workflow:
+  - step: start
+    tool: { kind: python, code: "def main(): return {}" }
+    next:
+      spec: { mode: inclusive }
+      arcs:
+        - step: branch_a
+        - step: branch_b
+  - step: branch_a
+    tool: { kind: python, code: "def main(): return {}" }
+    next:
+      spec: { mode: exclusive }
+      arcs:
+        - step: join
+  - step: branch_b
+    tool: { kind: python, code: "def main(): return {}" }
+    next:
+      spec: { mode: exclusive }
+      arcs:
+        - step: join
+  - step: join
+    tool: { kind: python, code: "def main(): return {}" }
+"""
+    )
+
+
+def test_execution_state_caches_fanout_reduce_plan():
+    """ExecutionState.fanout_reduce_plan runs the planner exactly once."""
+    from noetl.core.dsl.engine.executor.state import ExecutionState
+    import noetl.core.dsl.engine.executor.state as state_module
+
+    playbook = _minimal_playbook_with_fanout()
+
+    with patch.object(
+        state_module,
+        "build_fanout_reduce_plan",
+        wraps=state_module.build_fanout_reduce_plan,
+    ) as planner_spy:
+        state = ExecutionState(
+            execution_id="exec-1",
+            playbook=playbook,
+            payload={},
+        )
+        # No call until accessed
+        assert planner_spy.call_count == 0
+
+        first = state.fanout_reduce_plan
+        second = state.fanout_reduce_plan
+        third = state.fanout_reduce_plan
+
+    # Each access returns the same object; planner ran once
+    assert first is second is third
+    assert planner_spy.call_count == 1
+
+    # The cached plan is structurally correct
+    assert len(first.fanouts) == 1
+    assert first.fanouts[0].step == "start"
+    assert len(first.reduces) == 1
+    assert first.reduces[0].step == "join"
+
+
+def test_execution_state_fanout_reduce_plan_for_linear_playbook():
+    """A linear playbook (no fan-outs / reduces) returns an empty plan."""
+    from noetl.core.dsl.engine.executor.state import ExecutionState
+
+    playbook = DSLParser().parse(
+        """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: linear
+workflow:
+  - step: only_step
+    tool: { kind: python, code: "def main(): return {}" }
+"""
+    )
+    state = ExecutionState(
+        execution_id="exec-2",
+        playbook=playbook,
+        payload={},
+    )
+    plan = state.fanout_reduce_plan
+    assert plan.is_empty()
+    # Repeat access returns the same (cached) empty plan
+    assert state.fanout_reduce_plan is plan


### PR DESCRIPTION
## Summary

Phase 6 of the [v2 distributed-runtime spec](https://github.com/noetl/docs/blob/main/docs/features/noetl_distributed_runtime_spec.md). The planner was already wired into the engine for **fan-out** commands (\`_annotate_fanout_reduce_commands\`). This change closes three remaining gaps **without changing runtime behavior**:

1. **Plan caching** — \`ExecutionState\` gains a lazy \`fanout_reduce_plan\` property so the planner runs once per execution instead of on every fan-out transition.
2. **Reducer-bound command annotation** — new \`_annotate_reducer_commands\` attaches \`metadata[\"planner_reducer\"]\` to commands targeting a planned reducer (regardless of \`next.spec.mode\`).
3. **Register-time validation** — new \`validate_fanout_reduce_plan(playbook)\` advisory linter, called from \`DSLParser.parse\`. Emits warning codes \`[fanout_no_reducer]\` and \`[reducer_orphan]\` via the \`noetl.core.dsl.engine.planner\` logger; never raises.

Wiki coverage (per \`agents/rules/wiki-maintenance.md\`): updated [DSL Planner page](https://github.com/noetl/noetl/wiki/dsl_planner) with a new \"Engine integration\" section and shifted \"runtime stage opener\" from Planned to partially Today.

## What's intentionally not in this round

**Reducer-wait semantics** — deferring reducer scheduling until all upstream commands terminate — is a behavior change with replay implications and is deferred to a future round.

## Files changed

- \`noetl/core/dsl/engine/planner.py\` — \`validate_fanout_reduce_plan\` helper
- \`noetl/core/dsl/engine/parser/core.py\` — wire validation into \`DSLParser.parse\` (advisory log only)
- \`noetl/core/dsl/engine/executor/state.py\` — cached \`fanout_reduce_plan\` accessor
- \`noetl/core/dsl/engine/executor/transitions.py\` — use cached accessor + new \`_annotate_reducer_commands\`
- \`tests/unit/dsl/engine/test_fanout_reduce_planner.py\` — 6 new tests

\`pytest tests/unit/dsl/engine/ tests/core/test_replay_state_projector.py tests/core/test_projector_metrics.py -q\` → **122 passed**.

## Coordinated change

- Wiki: noetl-wiki @ \`1fdb8c6\` (\"wiki(dsl_planner): document Phase 6 engine integration\")
- Handoff thread: \`ai-meta handoffs/active/2026-05-22-phase6-stage-planner-wiring/round-01-prompt.md\`

## Test plan

- [x] Local pytest passes (122 tests)
- [ ] Reviewer to spot-check the metadata annotation for reducer-bound commands
- [ ] After merge: bump ai-meta pointers for noetl + noetl-wiki

🤖 Generated with [Claude Code](https://claude.com/claude-code)