### PR TITLE
feat(observability): expose IPC Tier 1.5 stats via projector metrics

### DIFF
--- a/noetl/core/projector/metrics.py
+++ b/noetl/core/projector/metrics.py
@@ -189,7 +189,67 @@ class ProjectorMetrics:
                 "actions": action_summary,
                 "batch": batch_summary,
                 "errors": error_summary,
+                "ipc": _ipc_summary(_fetch_ipc_stats()),
             }
+
+
+def _fetch_ipc_stats() -> dict[str, int]:
+    """Pull a snapshot of the default TempStore's IPC Tier 1.5 counters.
+
+    Imported lazily so the metrics module stays importable in contexts
+    that don't bootstrap the full storage stack (unit tests, lint
+    tooling). On import failure, returns zero counters.
+    """
+    try:
+        from noetl.core.storage import default_ipc_stats
+    except Exception:  # pragma: no cover - defensive
+        return _zero_ipc_stats()
+    try:
+        snapshot = default_ipc_stats() or {}
+    except Exception:  # pragma: no cover - defensive
+        return _zero_ipc_stats()
+    base = _zero_ipc_stats()
+    for key in base:
+        value = snapshot.get(key)
+        if isinstance(value, (int, float)) and value >= 0:
+            base[key] = int(value)
+    return base
+
+
+def _zero_ipc_stats() -> dict[str, int]:
+    return {
+        "admit_attempts": 0,
+        "admit_success": 0,
+        "admit_failures": 0,
+        "read_attempts": 0,
+        "read_hits": 0,
+        "read_misses": 0,
+        "fallback_reads": 0,
+    }
+
+
+def _ipc_summary(values: Mapping[str, int]) -> dict[str, float]:
+    admit_attempts = float(values.get("admit_attempts", 0))
+    admit_success = float(values.get("admit_success", 0))
+    admit_failures = float(values.get("admit_failures", 0))
+    read_attempts = float(values.get("read_attempts", 0))
+    read_hits = float(values.get("read_hits", 0))
+    read_misses = float(values.get("read_misses", 0))
+    fallback_reads = float(values.get("fallback_reads", 0))
+    return {
+        "admit_attempts": admit_attempts,
+        "admit_success": admit_success,
+        "admit_failures": admit_failures,
+        "read_attempts": read_attempts,
+        "read_hits": read_hits,
+        "read_misses": read_misses,
+        "fallback_reads": fallback_reads,
+        "admit_success_ratio": _safe_ratio(admit_success, admit_attempts),
+        "read_hit_ratio": _safe_ratio(read_hits, read_attempts),
+        "fallback_ratio": _safe_ratio(
+            fallback_reads, read_attempts + fallback_reads
+        ),
+    }
 
 
 def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapping[str, str]] = None) -> str:
@@ -352,6 +412,32 @@ def render_projector_metrics(metrics: ProjectorMetrics, *, labels: Optional[Mapp
         "# TYPE noetl_projector_max_projection_lag_milliseconds gauge",
         f"noetl_projector_max_projection_lag_milliseconds{label_text} {snapshot['max_projection_lag_milliseconds']}",
     ]
+    ipc = _fetch_ipc_stats()
+    lines.extend(
+        [
+            "# HELP noetl_ipc_admit_attempts_total IPC Tier 1.5 admit attempts (producer writes to shared memory).",
+            "# TYPE noetl_ipc_admit_attempts_total counter",
+            f"noetl_ipc_admit_attempts_total{label_text} {ipc['admit_attempts']}",
+            "# HELP noetl_ipc_admit_success_total IPC Tier 1.5 successful admits.",
+            "# TYPE noetl_ipc_admit_success_total counter",
+            f"noetl_ipc_admit_success_total{label_text} {ipc['admit_success']}",
+            "# HELP noetl_ipc_admit_failures_total IPC Tier 1.5 admit failures (budget exceeded, write error).",
+            "# TYPE noetl_ipc_admit_failures_total counter",
+            f"noetl_ipc_admit_failures_total{label_text} {ipc['admit_failures']}",
+            "# HELP noetl_ipc_read_attempts_total IPC Tier 1.5 read attempts (consumer tries shared memory first).",
+            "# TYPE noetl_ipc_read_attempts_total counter",
+            f"noetl_ipc_read_attempts_total{label_text} {ipc['read_attempts']}",
+            "# HELP noetl_ipc_read_hits_total IPC Tier 1.5 cache hits.",
+            "# TYPE noetl_ipc_read_hits_total counter",
+            f"noetl_ipc_read_hits_total{label_text} {ipc['read_hits']}",
+            "# HELP noetl_ipc_read_misses_total IPC Tier 1.5 cache misses (segment evicted, expired, or cross-node).",
+            "# TYPE noetl_ipc_read_misses_total counter",
+            f"noetl_ipc_read_misses_total{label_text} {ipc['read_misses']}",
+            "# HELP noetl_ipc_fallback_reads_total Reads that fell through to the durable tier (no hint or miss).",
+            "# TYPE noetl_ipc_fallback_reads_total counter",
+            f"noetl_ipc_fallback_reads_total{label_text} {ipc['fallback_reads']}",
+        ]
+    )
     return "\n".join(lines) + "\n"
 
 

--- a/noetl/core/storage/__init__.py
+++ b/noetl/core/storage/__init__.py
@@ -53,6 +53,7 @@ from noetl.core.storage.router import (
 from noetl.core.storage.result_store import (
     TempStore,
     default_store,
+    default_ipc_stats,
 )
 
 from noetl.core.storage.ipc_cache import (
@@ -126,6 +127,7 @@ __all__ = [
     'default_router',
     # Store (both names)
     'TempStore',
+    'default_ipc_stats',
     'ResultStore',
     'default_store',
     'default_result_store',

--- a/noetl/core/storage/result_store.py
+++ b/noetl/core/storage/result_store.py
@@ -1065,7 +1065,26 @@ class TempStore:
 default_store = TempStore()
 
 
+def default_ipc_stats() -> Dict[str, int]:
+    """Return a snapshot of the default TempStore's IPC Tier 1.5 counters.
+
+    Exposed at module scope so callers without a direct ``TempStore``
+    reference (the projector metrics exporter, ops tooling) can read
+    counters without coupling to the singleton. Returns a fresh dict;
+    callers can mutate the result without affecting future calls.
+
+    Counter keys (see :class:`ArrowIpcSharedMemoryCache` for the producer
+    side and :meth:`TempStore.get_ipc_bytes` for the consumer side):
+
+    - ``admit_attempts`` / ``admit_success`` / ``admit_failures``
+    - ``read_attempts`` / ``read_hits`` / ``read_misses``
+    - ``fallback_reads``
+    """
+    return default_store.ipc_stats()
+
+
 __all__ = [
     "TempStore",
+    "default_ipc_stats",
     "default_store",
 ]

--- a/tests/core/test_projector_metrics.py
+++ b/tests/core/test_projector_metrics.py
@@ -90,6 +90,83 @@ def test_projector_metrics_render_prometheus_labels():
     assert summary["frame_stale_projection_ratio"] == 0
 
 
+def test_projector_metrics_render_includes_ipc_counters():
+    """Prometheus export pulls IPC Tier 1.5 stats from the default store."""
+    from noetl.core.projector.metrics import ProjectorMetrics, render_projector_metrics
+
+    metrics = ProjectorMetrics()
+    body = render_projector_metrics(metrics)
+    # All seven counters appear in the body (values may be zero on a
+    # fresh process — assertion is on the metric name being exported).
+    assert "noetl_ipc_admit_attempts_total" in body
+    assert "noetl_ipc_admit_success_total" in body
+    assert "noetl_ipc_admit_failures_total" in body
+    assert "noetl_ipc_read_attempts_total" in body
+    assert "noetl_ipc_read_hits_total" in body
+    assert "noetl_ipc_read_misses_total" in body
+    assert "noetl_ipc_fallback_reads_total" in body
+    assert "# HELP noetl_ipc_read_hits_total" in body
+
+
+def test_projector_metrics_summary_includes_ipc_block():
+    """summary()['ipc'] always present with zero-value counters."""
+    from noetl.core.projector.metrics import ProjectorMetrics
+
+    metrics = ProjectorMetrics()
+    summary = metrics.summary()
+    assert "ipc" in summary
+    ipc = summary["ipc"]
+    for key in [
+        "admit_attempts",
+        "admit_success",
+        "admit_failures",
+        "read_attempts",
+        "read_hits",
+        "read_misses",
+        "fallback_reads",
+        "admit_success_ratio",
+        "read_hit_ratio",
+        "fallback_ratio",
+    ]:
+        assert key in ipc, f"missing ipc.{key}"
+
+
+def test_projector_metrics_summary_ipc_ratios_when_default_store_active(monkeypatch):
+    """When TempStore tracks IPC activity, summary ratios reflect it."""
+    from noetl.core.projector.metrics import ProjectorMetrics
+    from noetl.core.storage import default_store
+
+    snapshot = {
+        "admit_attempts": 5,
+        "admit_success": 4,
+        "admit_failures": 1,
+        "read_attempts": 10,
+        "read_hits": 7,
+        "read_misses": 3,
+        "fallback_reads": 2,
+    }
+    monkeypatch.setattr(default_store, "_ipc_stats", dict(snapshot))
+
+    metrics = ProjectorMetrics()
+    ipc = metrics.summary()["ipc"]
+    assert ipc["admit_success_ratio"] == 4 / 5
+    assert ipc["read_hit_ratio"] == 0.7
+    # fallback_ratio = fallback_reads / (read_attempts + fallback_reads)
+    assert ipc["fallback_ratio"] == 2 / 12
+
+
+def test_default_ipc_stats_returns_independent_snapshot():
+    """default_ipc_stats() returns a copy — mutating it doesn't leak back."""
+    from noetl.core.storage import default_ipc_stats, default_store
+
+    first = default_ipc_stats()
+    first["read_hits"] = 99999  # mutate the returned dict
+    second = default_ipc_stats()
+    # default_store's internal counter wasn't affected
+    assert second["read_hits"] != 99999
+    assert second["read_hits"] == default_store.ipc_stats()["read_hits"]
+
+
 def test_projector_metrics_record_notification_tracks_frame_counters():
     """Frame-specific counters increment when record_notification is called with them."""
     from noetl.core.projector.metrics import ProjectorMetrics, render_projector_metrics


### PR DESCRIPTION
## Summary

Phase 3 of the [v2 distributed-runtime spec](https://github.com/noetl/docs/blob/main/docs/features/noetl_distributed_runtime_spec.md). After re-surveying \`main\`, the IPC Tier 1.5 **data plane** is already live (\`ArrowIpcSharedMemoryCache\` + \`IpcHint\` + \`TempStore.get_ipc_bytes\` fast-path with graceful fallback to the durable tier). What was missing: **observability**. This change closes that gap by surfacing TempStore's internal IPC counters through the projector's Prometheus metrics endpoint.

Wiki coverage (per \`agents/rules/wiki-maintenance.md\`): updated [Storage page](https://github.com/noetl/noetl/wiki/storage) — Tier 1.5 subsection reframed from \"still in flight\" to \"live as of v2.91.x\", new observability + configuration tables. [Projector page](https://github.com/noetl/noetl/wiki/projector) metrics table extended with the new \`noetl_ipc_*_total\` counters.

## What's new

- \`default_ipc_stats()\` module-level helper in \`noetl/core/storage/result_store.py\` — exposed via \`from noetl.core.storage import default_ipc_stats\`.
- 7 new Prometheus counters on the projector endpoint:
  - \`noetl_ipc_admit_attempts_total\` / \`_admit_success_total\` / \`_admit_failures_total\`
  - \`noetl_ipc_read_attempts_total\` / \`_read_hits_total\` / \`_read_misses_total\` / \`_fallback_reads_total\`
- New \`summary[\"ipc\"]\` block in \`/summary\` JSON with raw counters + 3 derived ratios (\`admit_success_ratio\`, \`read_hit_ratio\`, \`fallback_ratio\`).

## What's intentionally NOT in this round

- **Wider producer adoption** — only \`cursor_worker.py\` stages results in IPC today. Promoting other tools (python, http) to stage in IPC is a separate adoption pass.
- **Cross-system payload-ref-with-IPC round-trip test** at the integration level — unit tests cover the metrics surface; full kind-deployed round-trip is a follow-up before declaring Phase 3 wholly closed.

## Test plan

- [x] \`pytest tests/core/test_projector_metrics.py tests/core/test_replay_state_projector.py tests/unit/dsl/engine/test_fanout_reduce_planner.py -q\` → **52 passed**
- [ ] Reviewer to spot-check the lazy-import pattern in \`_fetch_ipc_stats\`
- [ ] After merge: bump ai-meta pointers for noetl + noetl-wiki

## Coordinated change

- Wiki: noetl-wiki @ \`a096134\` (\"wiki(storage, projector): document IPC Tier 1.5 observability\")
- Handoff thread: \`ai-meta handoffs/active/2026-05-22-phase3-ipc-observability/round-01-prompt.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)