### PR TITLE
feat(payload-store): add port + filesystem reference adapter

### DIFF
--- a/noetl/core/payload_store/__init__.py
+++ b/noetl/core/payload_store/__init__.py
@@ -1,0 +1,31 @@
+"""Payload-store port + reference adapter (v2 distributed-runtime spec phase 5).
+
+Public surface:
+
+- :class:`PayloadStore` — async Protocol every adapter implements.
+- :class:`PayloadReference` — typed reference returned by ``store`` and
+  consumed by ``fetch`` / ``exists`` / ``delete``.
+- :class:`PayloadNotFound` — raised on fetch of a missing payload.
+- :func:`content_hash` — canonical SHA-256 helper.
+- :class:`FilesystemPayloadStore` — single-node / development reference
+  adapter using a sharded, atomic-write filesystem layout.
+
+Cloud adapters (S3 / GCS / Azure Blob / SeaweedFS) land in subsequent
+rounds.
+"""
+
+from .filesystem import FilesystemPayloadStore
+from .ports import (
+    PayloadNotFound,
+    PayloadReference,
+    PayloadStore,
+    content_hash,
+)
+
+__all__ = [
+    "PayloadStore",
+    "PayloadReference",
+    "PayloadNotFound",
+    "content_hash",
+    "FilesystemPayloadStore",
+]

--- a/noetl/core/payload_store/filesystem.py
+++ b/noetl/core/payload_store/filesystem.py
@@ -1,0 +1,205 @@
+"""Filesystem reference adapter for :class:`PayloadStore`.
+
+Content-addressed under a sharded directory layout. Atomic writes via
+temp-file + ``os.replace``. Optional per-blob metadata sidecar.
+
+Intended uses:
+- Single-node edge deployments.
+- Development + tests (no cloud / Postgres / NATS required).
+- The canonical reference adapter against which cloud adapters can be
+  diffed in compliance tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import tempfile
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Union
+
+from noetl.core.logger import setup_logger
+
+from .ports import (
+    PayloadNotFound,
+    PayloadReference,
+    PayloadStore,
+    content_hash,
+)
+
+logger = setup_logger(__name__, include_location=True)
+
+_DEFAULT_SHARD_DEPTH = 2
+_DEFAULT_SHARD_WIDTH = 2  # chars per shard level
+_SIDECAR_SUFFIX = ".meta.json"
+
+
+class FilesystemPayloadStore(PayloadStore):
+    """Content-addressed filesystem adapter.
+
+    Layout (with default ``shard_depth=2``, ``shard_width=2``):
+
+        <root>/<sha[0:2]>/<sha[2:4]>/<sha>
+        <root>/<sha[0:2]>/<sha[2:4]>/<sha>.meta.json   (when metadata supplied)
+
+    Two shard levels keep any single directory under ~10k entries even
+    at billions of blobs. Adjustable via the constructor.
+    """
+
+    def __init__(
+        self,
+        root: Union[str, Path],
+        *,
+        shard_depth: int = _DEFAULT_SHARD_DEPTH,
+        shard_width: int = _DEFAULT_SHARD_WIDTH,
+        default_content_type: str = "application/octet-stream",
+    ) -> None:
+        self.root = Path(root).expanduser().resolve()
+        if shard_depth < 0:
+            raise ValueError("shard_depth must be >= 0")
+        if shard_width <= 0:
+            raise ValueError("shard_width must be > 0")
+        if shard_depth * shard_width > 32:
+            raise ValueError(
+                "shard_depth * shard_width must be <= 32 (SHA-256 hex length / 2)"
+            )
+        self.shard_depth = int(shard_depth)
+        self.shard_width = int(shard_width)
+        self.default_content_type = default_content_type
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _path_for(self, sha256: str) -> Path:
+        if len(sha256) < self.shard_depth * self.shard_width:
+            raise ValueError(
+                f"sha256 prefix is shorter than the configured sharding "
+                f"({len(sha256)} < {self.shard_depth * self.shard_width})"
+            )
+        parts: list[str] = []
+        for level in range(self.shard_depth):
+            start = level * self.shard_width
+            parts.append(sha256[start : start + self.shard_width])
+        return self.root.joinpath(*parts, sha256)
+
+    def _sidecar_for(self, blob_path: Path) -> Path:
+        return blob_path.with_name(blob_path.name + _SIDECAR_SUFFIX)
+
+    async def store(
+        self,
+        payload: bytes,
+        *,
+        content_type: str = "application/octet-stream",
+        metadata: Optional[dict[str, str]] = None,
+    ) -> PayloadReference:
+        if not isinstance(payload, (bytes, bytearray, memoryview)):
+            raise TypeError("payload must be bytes-like")
+        payload_bytes = bytes(payload)
+        sha = content_hash(payload_bytes)
+        target = self._path_for(sha)
+        normalized_metadata = {str(k): str(v) for k, v in (metadata or {}).items()}
+        effective_content_type = (
+            content_type if content_type else self.default_content_type
+        )
+
+        await asyncio.to_thread(
+            self._write_atomic,
+            target=target,
+            payload=payload_bytes,
+            content_type=effective_content_type,
+            metadata=normalized_metadata,
+        )
+
+        return PayloadReference(
+            sha256=sha,
+            byte_length=len(payload_bytes),
+            content_type=effective_content_type,
+            uri=str(target),
+            metadata=normalized_metadata,
+        )
+
+    def _write_atomic(
+        self,
+        *,
+        target: Path,
+        payload: bytes,
+        content_type: str,
+        metadata: dict[str, str],
+    ) -> None:
+        """Synchronous helper — atomic write + sidecar.
+
+        Skips the rewrite if the blob already exists (content-addressing
+        dedup). The sidecar is written even on dedup hits when metadata
+        is non-empty so callers always see their metadata reflected.
+        """
+        parent = target.parent
+        parent.mkdir(parents=True, exist_ok=True)
+
+        blob_existed = target.exists()
+        if not blob_existed:
+            tmp = tempfile.NamedTemporaryFile(
+                delete=False,
+                dir=str(parent),
+                prefix=".tmp-",
+                suffix=".blob",
+            )
+            try:
+                tmp.write(payload)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+                tmp.close()
+                os.replace(tmp.name, target)
+            except BaseException:
+                # Clean up the temp file if anything went wrong before replace
+                try:
+                    os.unlink(tmp.name)
+                except FileNotFoundError:
+                    pass
+                raise
+
+        sidecar_path = self._sidecar_for(target)
+        if metadata:
+            sidecar = {
+                "content_type": content_type,
+                "metadata": metadata,
+                "byte_length": len(payload),
+                "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            }
+            sidecar_path.write_text(json.dumps(sidecar, sort_keys=True))
+        elif sidecar_path.exists() and not blob_existed:
+            # Brand-new blob with no metadata: leave any stale sidecar alone;
+            # callers that want clean metadata should pass it explicitly.
+            pass
+
+    async def fetch(self, reference: PayloadReference) -> bytes:
+        target = self._path_for(reference.sha256)
+        try:
+            return await asyncio.to_thread(target.read_bytes)
+        except FileNotFoundError as exc:
+            raise PayloadNotFound(
+                f"payload {reference.sha256} not found at {target}"
+            ) from exc
+
+    async def exists(self, reference: PayloadReference) -> bool:
+        target = self._path_for(reference.sha256)
+        return await asyncio.to_thread(target.exists)
+
+    async def delete(self, reference: PayloadReference) -> bool:
+        target = self._path_for(reference.sha256)
+        sidecar = self._sidecar_for(target)
+        return await asyncio.to_thread(self._delete_sync, target, sidecar)
+
+    @staticmethod
+    def _delete_sync(target: Path, sidecar: Path) -> bool:
+        removed = False
+        try:
+            target.unlink()
+            removed = True
+        except FileNotFoundError:
+            pass
+        try:
+            sidecar.unlink()
+        except FileNotFoundError:
+            pass
+        return removed

--- a/noetl/core/payload_store/ports.py
+++ b/noetl/core/payload_store/ports.py
@@ -1,0 +1,95 @@
+"""Payload-store port: backend-neutral interface for content-addressed blobs.
+
+Sibling of :mod:`noetl.core.event_store.ports` and
+:mod:`noetl.core.projection_store.ports`. Where the event store owns the
+durable append-only log and the projection store owns queryable read
+models, the payload store owns **immutable, content-addressed byte blobs**
+— the third leg of the v2 distributed-runtime spec's three-port shape.
+
+The port is intentionally minimal so adapters (filesystem, S3, GCS,
+Azure Blob, SeaweedFS) can be added without leaking backend-specific
+shape into callers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Optional, Protocol
+
+
+class PayloadNotFound(KeyError):
+    """Raised when a fetch / delete targets a missing payload."""
+
+
+def content_hash(payload: bytes) -> str:
+    """Return the lowercase hex SHA-256 of ``payload``.
+
+    The payload store's canonical reference id. Two byte sequences that
+    hash to the same value are considered identical — adapters MAY
+    deduplicate on this hash.
+    """
+    if not isinstance(payload, (bytes, bytearray, memoryview)):
+        raise TypeError("payload must be bytes-like")
+    return hashlib.sha256(bytes(payload)).hexdigest()
+
+
+@dataclass(frozen=True)
+class PayloadReference:
+    """Backend-neutral pointer to a stored payload.
+
+    ``sha256`` is the canonical id; ``uri`` carries the backend-specific
+    locator (filesystem path / ``s3://...`` / ``gs://...``) but is
+    optional — callers that only need to verify by hash can ignore it.
+
+    ``metadata`` is small, opaque, and meant for human-debuggable
+    annotations (originating step name, content schema digest, etc.).
+    Adapters MAY persist it in a sidecar; consumers MUST NOT depend on
+    it for correctness.
+    """
+
+    sha256: str
+    byte_length: int
+    content_type: str = "application/octet-stream"
+    uri: Optional[str] = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+class PayloadStore(Protocol):
+    """Async port for content-addressed payload storage.
+
+    Implementations are expected to be safe to call concurrently from
+    multiple coroutines in the same process. Cross-process / cross-host
+    safety is backend-specific.
+    """
+
+    async def store(
+        self,
+        payload: bytes,
+        *,
+        content_type: str = "application/octet-stream",
+        metadata: Optional[dict[str, str]] = None,
+    ) -> PayloadReference:
+        """Write ``payload`` and return a reference.
+
+        Content-addressed: storing the same bytes twice returns
+        references with the same ``sha256``. Adapters MAY skip the
+        physical write on the second call.
+        """
+
+    async def fetch(self, reference: PayloadReference) -> bytes:
+        """Return the bytes for ``reference``.
+
+        Raises :class:`PayloadNotFound` when the payload is missing.
+        """
+
+    async def exists(self, reference: PayloadReference) -> bool:
+        """Return ``True`` iff the referenced payload is present."""
+
+    async def delete(self, reference: PayloadReference) -> bool:
+        """Remove the referenced payload.
+
+        Returns ``True`` if a payload was removed; ``False`` if it was
+        already absent. Never raises for the missing-payload case
+        (mirrors :py:meth:`os.unlink` after a ``missing_ok=True`` pass).
+        """

--- a/tests/core/payload_store/test_filesystem.py
+++ b/tests/core/payload_store/test_filesystem.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from noetl.core.payload_store import (
+    FilesystemPayloadStore,
+    PayloadNotFound,
+    PayloadReference,
+    content_hash,
+)
+
+
+@pytest.mark.asyncio
+async def test_store_and_fetch_round_trip(tmp_path: Path):
+    store = FilesystemPayloadStore(tmp_path)
+    payload = b"hello chemistry cloud"
+
+    ref = await store.store(payload, content_type="text/plain")
+
+    assert ref.sha256 == content_hash(payload)
+    assert ref.byte_length == len(payload)
+    assert ref.content_type == "text/plain"
+    assert ref.uri is not None and ref.uri.endswith(ref.sha256)
+
+    fetched = await store.fetch(ref)
+    assert fetched == payload
+
+
+@pytest.mark.asyncio
+async def test_content_addressing_is_deterministic(tmp_path: Path):
+    store = FilesystemPayloadStore(tmp_path)
+    payload = b"deterministic"
+
+    ref_a = await store.store(payload)
+    ref_b = await store.store(payload)
+
+    assert ref_a.sha256 == ref_b.sha256
+    # Only one physical blob on disk
+    matches = list(tmp_path.rglob(ref_a.sha256))
+    # the blob file itself
+    blob_files = [p for p in matches if p.is_file() and not p.name.endswith(".meta.json")]
+    assert len(blob_files) == 1
+
+
+@pytest.mark.asyncio
+async def test_store_skips_write_when_blob_exists(tmp_path: Path):
+    store = FilesystemPayloadStore(tmp_path)
+    payload = b"dedup-test"
+
+    ref = await store.store(payload)
+    blob_path = Path(ref.uri)
+    first_mtime = blob_path.stat().st_mtime_ns
+
+    # Sleep beyond mtime granularity, store again — mtime must not change
+    time.sleep(0.05)
+    await store.store(payload)
+    second_mtime = blob_path.stat().st_mtime_ns
+
+    assert first_mtime == second_mtime
+
+
+@pytest.mark.asyncio
+async def test_atomic_write_temp_file_cleanup(tmp_path: Path):
+    store = FilesystemPayloadStore(tmp_path)
+    await store.store(b"atomic")
+
+    leftover = [p for p in tmp_path.rglob(".tmp-*") if p.is_file()]
+    assert leftover == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_missing_raises_payload_not_found(tmp_path: Path):
+    store = FilesystemPayloadStore(tmp_path)
+    bogus_sha = "0" * 64
+    ref = PayloadReference(
+        sha256=bogus_sha,
+        byte_length=0,
+    )
+    with pytest.raises(PayloadNotFound):
+        await store.fetch(ref)
+
+
+@pytest.mark.asyncio
+async def test_exists_reflects_state(tmp_path: Path):
+    store = FilesystemPayloadStore(tmp_path)
+    payload = b"toggle"
+
+    # Before store: reference exists() is False
+    bogus_ref = PayloadReference(
+        sha256=content_hash(payload),
+        byte_length=len(payload),
+    )
+    assert await store.exists(bogus_ref) is False
+
+    real_ref = await store.store(payload)
+    assert await store.exists(real_ref) is True
+
+    deleted = await store.delete(real_ref)
+    assert deleted is True
+    assert await store.exists(real_ref) is False
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_false_when_missing(tmp_path: Path):
+    store = FilesystemPayloadStore(tmp_path)
+    bogus_ref = PayloadReference(
+        sha256="1" * 64,
+        byte_length=0,
+    )
+    assert await store.delete(bogus_ref) is False
+
+
+@pytest.mark.asyncio
+async def test_metadata_sidecar_round_trip(tmp_path: Path):
+    store = FilesystemPayloadStore(tmp_path)
+    payload = b"with-metadata"
+    metadata = {"origin": "test", "tool": "python"}
+
+    ref = await store.store(payload, content_type="application/json", metadata=metadata)
+
+    assert ref.metadata == metadata
+    sidecar_path = Path(ref.uri + ".meta.json")
+    assert sidecar_path.exists()
+
+    parsed = json.loads(sidecar_path.read_text())
+    assert parsed["content_type"] == "application/json"
+    assert parsed["metadata"] == metadata
+    assert parsed["byte_length"] == len(payload)
+    assert isinstance(parsed["created_at"], str)
+
+
+@pytest.mark.asyncio
+async def test_content_type_default(tmp_path: Path):
+    store = FilesystemPayloadStore(tmp_path)
+    ref = await store.store(b"default-type")
+    assert ref.content_type == "application/octet-stream"
+
+
+@pytest.mark.asyncio
+async def test_delete_also_removes_sidecar(tmp_path: Path):
+    store = FilesystemPayloadStore(tmp_path)
+    payload = b"with-sidecar"
+    ref = await store.store(payload, metadata={"k": "v"})
+
+    sidecar = Path(ref.uri + ".meta.json")
+    assert sidecar.exists()
+
+    assert await store.delete(ref) is True
+    assert sidecar.exists() is False
+
+
+@pytest.mark.asyncio
+async def test_sharded_layout_uses_sha_prefix(tmp_path: Path):
+    """Default shard_depth=2, shard_width=2 → <root>/<sha[:2]>/<sha[2:4]>/<sha>."""
+    store = FilesystemPayloadStore(tmp_path)
+    ref = await store.store(b"sharded")
+    blob = Path(ref.uri)
+    relative = blob.relative_to(tmp_path)
+    parts = relative.parts
+    assert len(parts) == 3
+    assert parts[0] == ref.sha256[:2]
+    assert parts[1] == ref.sha256[2:4]
+    assert parts[2] == ref.sha256
+
+
+@pytest.mark.asyncio
+async def test_constructor_rejects_invalid_shard_config(tmp_path: Path):
+    with pytest.raises(ValueError):
+        FilesystemPayloadStore(tmp_path, shard_depth=-1)
+    with pytest.raises(ValueError):
+        FilesystemPayloadStore(tmp_path, shard_width=0)
+    with pytest.raises(ValueError):
+        FilesystemPayloadStore(tmp_path, shard_depth=20, shard_width=4)
+
+
+def test_content_hash_rejects_non_bytes():
+    with pytest.raises(TypeError):
+        content_hash("not bytes")  # type: ignore[arg-type]
+
+
+def test_content_hash_is_stable():
+    assert content_hash(b"abc") == content_hash(b"abc")
+    assert content_hash(b"abc") != content_hash(b"abd")


### PR DESCRIPTION
## Summary

Phase 5 **round 1** of the [v2 distributed-runtime spec](https://github.com/noetl/docs/blob/main/docs/features/noetl_distributed_runtime_spec.md). Establishes NoETL's third port-and-adapter family, parallel to [Event Store](https://github.com/noetl/noetl/wiki/event_store) and [Projection Store](https://github.com/noetl/noetl/wiki/projection_store).

Cloud adapters (S3 / GCS / Azure Blob / SeaweedFS) land in **subsequent rounds**. This round establishes the contract and ships a usable single-node / development reference.

## What's in this PR

### Port (`noetl/core/payload_store/ports.py`)

- \`PayloadStore\` async Protocol — \`store\` / \`fetch\` / \`exists\` / \`delete\`.
- \`PayloadReference\` frozen dataclass: \`sha256\` / \`byte_length\` / \`content_type\` / \`uri\` / \`metadata\`.
- \`PayloadNotFound\` (KeyError subclass) for missing-payload fetch.
- \`content_hash(payload)\` module helper for canonical SHA-256.

### Reference adapter (`noetl/core/payload_store/filesystem.py`)

- Content-addressed sharded layout: \`<root>/<sha[0:2]>/<sha[2:4]>/<sha>\` (configurable, up to 32 hex chars total).
- **Atomic writes** via \`tempfile.NamedTemporaryFile(dir=parent) + fsync + os.replace\`. Mid-write crashes never produce visible partial blobs.
- **Content-addressing dedup** — second \`store(payload)\` for the same bytes is a no-op for the blob file.
- Optional **metadata sidecar** at \`<blob>.meta.json\` with content_type / metadata / byte_length / created_at.
- \`delete()\` returns \`False\` for missing payloads (never raises) — mirrors \`os.unlink(missing_ok=True)\`.

### Tests

14 new tests in \`tests/core/payload_store/test_filesystem.py\` covering round-trip, dedup, atomic-write cleanup, missing-fetch behavior, exists/delete toggle, metadata sidecar JSON shape, default content type, sharded layout, constructor validation, content_hash determinism + type guard.

\`pytest tests/core/payload_store/ tests/core/test_projector_metrics.py tests/core/test_replay_state_projector.py tests/unit/dsl/engine/test_fanout_reduce_planner.py -q\` → **66 passed**.

## What's intentionally NOT in this round

- **No migration of existing callers.** \`TempStore\` and the [storage](https://github.com/noetl/noetl/wiki/storage) tier continue to work unchanged. The port establishes the contract; future rounds wire callers through it where it makes sense.
- **No cloud adapters.** S3 / GCS / Azure Blob / SeaweedFS land as separate rounds.
- **No event-envelope integration.** \`EventRecord.payload_ref\` stays an opaque dict for now; binding it to \`PayloadReference\` is a follow-up.

## Coordinated change

- Wiki: noetl-wiki @ \`acd5c68\` (\"wiki: add Payload Store page\") — new [Payload Store wiki page](https://github.com/noetl/noetl/wiki/payload_store)
- Handoff thread: \`ai-meta handoffs/active/2026-05-22-phase5-payload-store-port/round-01-prompt.md\`

## Test plan

- [x] \`pytest tests/core/payload_store/\` — 14 passed
- [x] Regression: Phase 1 + Phase 3 + Phase 6 test suites — all green
- [ ] Reviewer to confirm the atomic-write semantics in \`_write_atomic\`
- [ ] After merge: bump ai-meta pointers for noetl + noetl-wiki

🤖 Generated with [Claude Code](https://claude.com/claude-code)