### PR TITLE
feat(payload-store): add S3 adapter + compliance suite

### DIFF
--- a/noetl/core/payload_store/__init__.py
+++ b/noetl/core/payload_store/__init__.py
@@ -21,6 +21,7 @@ from .ports import (
     PayloadStore,
     content_hash,
 )
+from .s3 import S3PayloadStore
 
 __all__ = [
     "PayloadStore",
@@ -28,4 +29,5 @@ __all__ = [
     "PayloadNotFound",
     "content_hash",
     "FilesystemPayloadStore",
+    "S3PayloadStore",
 ]

--- a/noetl/core/payload_store/s3.py
+++ b/noetl/core/payload_store/s3.py
@@ -1,0 +1,243 @@
+"""S3 / S3-compatible adapter for :class:`PayloadStore`.
+
+Implements the same Protocol contract as
+:class:`FilesystemPayloadStore`. Works against AWS S3 and any
+S3-compatible endpoint (MinIO, SeaweedFS in S3 mode, LocalStack) via
+the optional ``endpoint_url`` constructor argument.
+
+Design notes:
+
+- **Key layout** mirrors the filesystem adapter:
+  ``<prefix>/<sha[0:2]>/<sha[2:4]>/<sha>``. Same sharding rationale —
+  any single S3 listing stays bounded.
+- **Atomicity** is intrinsic to S3 PUT — no temp + rename ceremony.
+- **Content-addressing dedup** via ``HeadObject`` before PUT.
+- **Metadata** rides as native S3 object metadata
+  (``Metadata=...`` on PutObject; surfaced in HeadObject /
+  GetObject responses). No sidecar object — keeps the bucket
+  layout flat. S3 requires ASCII metadata keys + values; the
+  adapter validates at the boundary.
+- **Delete** is Protocol-compliant (``True`` if a payload was
+  removed, ``False`` if already absent). Implemented as
+  HeadObject + DeleteObject because S3's DeleteObject is
+  idempotent and doesn't distinguish present-vs-absent.
+- **Sync boto3 + asyncio.to_thread.** The Protocol exposes async
+  methods; the implementation bridges through a thread pool. Same
+  pattern as :class:`FilesystemPayloadStore`. Trade: a per-call
+  thread vs. event-loop integration. Worth it for testability
+  (``moto.mock_aws`` only intercepts sync boto3) and operational
+  consistency with the filesystem adapter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+
+try:
+    import boto3  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - boto3 is a runtime dep
+    boto3 = None  # type: ignore[assignment]
+
+try:
+    from botocore.exceptions import ClientError  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - botocore comes with boto3 runtime dep
+    ClientError = Exception  # type: ignore[assignment,misc]
+
+from noetl.core.logger import setup_logger
+
+from .ports import (
+    PayloadNotFound,
+    PayloadReference,
+    PayloadStore,
+    content_hash,
+)
+
+logger = setup_logger(__name__, include_location=True)
+
+
+class S3PayloadStore(PayloadStore):
+    """Async S3 / S3-compatible adapter.
+
+    Constructor takes the bucket name and optional configuration:
+
+    - ``prefix`` — string prepended to every object key. Useful when
+      a single bucket hosts payloads alongside other namespaces.
+    - ``client`` — pre-configured boto3 S3 client. When ``None``, a
+      default client is constructed via
+      ``boto3.client("s3", region_name=region_name, endpoint_url=endpoint_url)``
+      and credentials come from the standard boto3 chain.
+    - ``endpoint_url`` — override for MinIO / SeaweedFS / LocalStack.
+    - ``region_name`` — explicit region (used when creating the
+      default client).
+    - ``default_content_type`` — used when ``store(content_type=...)``
+      is omitted or empty.
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        prefix: str = "",
+        client: Optional[Any] = None,
+        endpoint_url: Optional[str] = None,
+        region_name: Optional[str] = None,
+        default_content_type: str = "application/octet-stream",
+    ) -> None:
+        if boto3 is None:  # pragma: no cover - exercised when extra missing
+            raise RuntimeError(
+                "S3PayloadStore requires boto3; install noetl with the "
+                "default runtime dependencies"
+            )
+        if not bucket:
+            raise ValueError("bucket name is required")
+        self.bucket = str(bucket)
+        self.prefix = prefix.lstrip("/").rstrip("/") if prefix else ""
+        self.endpoint_url = endpoint_url
+        self.region_name = region_name
+        self.default_content_type = default_content_type
+        if client is None:
+            client_kwargs: dict[str, Any] = {}
+            if region_name:
+                client_kwargs["region_name"] = region_name
+            if endpoint_url:
+                client_kwargs["endpoint_url"] = endpoint_url
+            self.client = boto3.client("s3", **client_kwargs)
+        else:
+            self.client = client
+
+    def _key_for(self, sha256: str) -> str:
+        """Return the S3 object key for a payload digest."""
+        if len(sha256) < 4:
+            raise ValueError(
+                f"sha256 prefix must be at least 4 chars for sharding (got {len(sha256)})"
+            )
+        sharded = f"{sha256[0:2]}/{sha256[2:4]}/{sha256}"
+        return f"{self.prefix}/{sharded}" if self.prefix else sharded
+
+    def _uri_for(self, key: str) -> str:
+        return f"s3://{self.bucket}/{key}"
+
+    @staticmethod
+    def _validate_metadata(metadata: dict[str, str]) -> dict[str, str]:
+        """S3 requires ASCII-only metadata keys and values."""
+        normalized: dict[str, str] = {}
+        for raw_key, raw_value in metadata.items():
+            key = str(raw_key)
+            value = str(raw_value)
+            try:
+                key.encode("ascii")
+                value.encode("ascii")
+            except UnicodeEncodeError as exc:
+                raise ValueError(
+                    f"S3 metadata key/value must be ASCII: {raw_key!r}={raw_value!r}"
+                ) from exc
+            normalized[key] = value
+        return normalized
+
+    @staticmethod
+    def _is_not_found(exc: BaseException) -> bool:
+        """True iff the boto3 client error indicates the key is missing."""
+        if not isinstance(exc, ClientError):
+            return False
+        response = getattr(exc, "response", {}) or {}
+        error = response.get("Error", {})
+        code = str(error.get("Code") or "")
+        status = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        return code in {"404", "NoSuchKey", "NotFound"} or status == 404
+
+    def _head(self, key: str) -> bool:
+        """Sync helper — True iff the object exists; raises on other errors."""
+        try:
+            self.client.head_object(Bucket=self.bucket, Key=key)
+            return True
+        except ClientError as exc:
+            if self._is_not_found(exc):
+                return False
+            raise
+
+    def _store_sync(
+        self,
+        *,
+        payload: bytes,
+        key: str,
+        content_type: str,
+        metadata: dict[str, str],
+    ) -> None:
+        if self._head(key):
+            return  # content-addressing dedup
+        self.client.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=payload,
+            ContentType=content_type,
+            Metadata=metadata,
+        )
+
+    def _fetch_sync(self, key: str) -> bytes:
+        try:
+            response = self.client.get_object(Bucket=self.bucket, Key=key)
+        except ClientError as exc:
+            if self._is_not_found(exc):
+                raise PayloadNotFound(
+                    f"payload not found at s3://{self.bucket}/{key}"
+                ) from exc
+            raise
+        body = response["Body"]
+        try:
+            return body.read()
+        finally:
+            close = getattr(body, "close", None)
+            if close is not None:
+                close()
+
+    def _delete_sync(self, key: str) -> bool:
+        if not self._head(key):
+            return False
+        self.client.delete_object(Bucket=self.bucket, Key=key)
+        return True
+
+    async def store(
+        self,
+        payload: bytes,
+        *,
+        content_type: str = "application/octet-stream",
+        metadata: Optional[dict[str, str]] = None,
+    ) -> PayloadReference:
+        if not isinstance(payload, (bytes, bytearray, memoryview)):
+            raise TypeError("payload must be bytes-like")
+        payload_bytes = bytes(payload)
+        sha = content_hash(payload_bytes)
+        key = self._key_for(sha)
+        normalized_metadata = self._validate_metadata(metadata or {})
+        effective_content_type = (
+            content_type if content_type else self.default_content_type
+        )
+
+        await asyncio.to_thread(
+            self._store_sync,
+            payload=payload_bytes,
+            key=key,
+            content_type=effective_content_type,
+            metadata=normalized_metadata,
+        )
+
+        return PayloadReference(
+            sha256=sha,
+            byte_length=len(payload_bytes),
+            content_type=effective_content_type,
+            uri=self._uri_for(key),
+            metadata=normalized_metadata,
+        )
+
+    async def fetch(self, reference: PayloadReference) -> bytes:
+        key = self._key_for(reference.sha256)
+        return await asyncio.to_thread(self._fetch_sync, key)
+
+    async def exists(self, reference: PayloadReference) -> bool:
+        key = self._key_for(reference.sha256)
+        return await asyncio.to_thread(self._head, key)
+
+    async def delete(self, reference: PayloadReference) -> bool:
+        key = self._key_for(reference.sha256)
+        return await asyncio.to_thread(self._delete_sync, key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dev = [
     "pytest-asyncio>=0.23.6",
     "pytest-cov>=4.1.0",
     "pytest-mock>=3.14.0",
+    "moto[s3]>=5.0",
 ]
 publish = ["build>=1.2.2.post1", "twine>=6.1.0", "maturin>=1.0,<2.0"]
 # Jupyter/notebook environment and data-viz/science stack

--- a/tests/core/payload_store/test_compliance.py
+++ b/tests/core/payload_store/test_compliance.py
@@ -1,0 +1,138 @@
+"""Adapter-agnostic compliance suite for :class:`PayloadStore`.
+
+Each test is parametrized across every registered adapter. Adding a
+new adapter (GCS, Azure Blob, SeaweedFS, ...) means appending one
+fixture branch — the suite is the long-term contract gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from noetl.core.payload_store import (
+    FilesystemPayloadStore,
+    PayloadNotFound,
+    PayloadReference,
+    PayloadStore,
+    S3PayloadStore,
+    content_hash,
+)
+
+# moto + boto3 are dev deps; skip the S3 leg cleanly if either is missing
+try:
+    from moto import mock_aws  # type: ignore[import-not-found]
+    import boto3  # type: ignore[import-not-found]
+
+    _S3_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _S3_AVAILABLE = False
+    mock_aws = None  # type: ignore[assignment]
+    boto3 = None  # type: ignore[assignment]
+
+
+_S3_BUCKET = "noetl-payload-compliance"
+
+
+@pytest_asyncio.fixture(
+    params=(
+        "filesystem",
+        pytest.param(
+            "s3",
+            marks=pytest.mark.skipif(
+                not _S3_AVAILABLE,
+                reason="moto[s3] not installed; install via `uv pip install moto[s3]`",
+            ),
+        ),
+    )
+)
+async def payload_store(request, tmp_path: Path) -> AsyncIterator[PayloadStore]:
+    """Yield a configured PayloadStore for the current parameter."""
+    flavor = request.param
+    if flavor == "filesystem":
+        yield FilesystemPayloadStore(tmp_path)
+        return
+
+    # S3 leg — start the moto mock for the test's lifetime
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=_S3_BUCKET)
+        yield S3PayloadStore(_S3_BUCKET, region_name="us-east-1")
+
+
+@pytest.mark.asyncio
+async def test_store_and_fetch_round_trip(payload_store: PayloadStore):
+    payload = b"compliance: store + fetch"
+
+    ref = await payload_store.store(payload, content_type="text/plain")
+
+    assert isinstance(ref, PayloadReference)
+    assert ref.sha256 == content_hash(payload)
+    assert ref.byte_length == len(payload)
+    assert ref.content_type == "text/plain"
+    assert ref.uri is not None
+
+    fetched = await payload_store.fetch(ref)
+    assert fetched == payload
+
+
+@pytest.mark.asyncio
+async def test_content_addressing_is_deterministic(payload_store: PayloadStore):
+    payload = b"compliance: deterministic"
+    ref_a = await payload_store.store(payload)
+    ref_b = await payload_store.store(payload)
+    assert ref_a.sha256 == ref_b.sha256
+
+
+@pytest.mark.asyncio
+async def test_fetch_missing_raises_payload_not_found(payload_store: PayloadStore):
+    bogus = PayloadReference(sha256="0" * 64, byte_length=0)
+    with pytest.raises(PayloadNotFound):
+        await payload_store.fetch(bogus)
+
+
+@pytest.mark.asyncio
+async def test_exists_reflects_state(payload_store: PayloadStore):
+    payload = b"compliance: exists toggle"
+
+    pre = PayloadReference(sha256=content_hash(payload), byte_length=len(payload))
+    assert await payload_store.exists(pre) is False
+
+    ref = await payload_store.store(payload)
+    assert await payload_store.exists(ref) is True
+
+    removed = await payload_store.delete(ref)
+    assert removed is True
+    assert await payload_store.exists(ref) is False
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_false_when_missing(payload_store: PayloadStore):
+    bogus = PayloadReference(sha256="1" * 64, byte_length=0)
+    assert await payload_store.delete(bogus) is False
+
+
+@pytest.mark.asyncio
+async def test_content_type_default(payload_store: PayloadStore):
+    ref = await payload_store.store(b"compliance: default content type")
+    assert ref.content_type == "application/octet-stream"
+
+
+@pytest.mark.asyncio
+async def test_metadata_round_trip(payload_store: PayloadStore):
+    """PayloadReference.metadata returned by store(...) reflects input.
+
+    Adapter-specific persistence shape (filesystem sidecar vs S3
+    object metadata header) is tested in adapter-specific files;
+    the compliance suite only asserts the returned reference.
+    """
+    payload = b"compliance: metadata round trip"
+    metadata = {"origin": "compliance", "tool": "pytest"}
+
+    ref = await payload_store.store(
+        payload, content_type="application/json", metadata=metadata
+    )
+    assert ref.metadata == metadata
+    assert ref.content_type == "application/json"

--- a/tests/core/payload_store/test_s3.py
+++ b/tests/core/payload_store/test_s3.py
@@ -1,0 +1,139 @@
+"""S3-specific tests for :class:`S3PayloadStore`.
+
+Cross-adapter behavior is covered by the compliance suite in
+``test_compliance.py``. This file exercises shape that's specific to
+the S3 backend: key layout, prefix handling, dedup-skipping the PUT,
+non-ASCII metadata rejection, URI scheme, and missing-bucket
+propagation.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from noetl.core.payload_store import (
+    PayloadReference,
+    S3PayloadStore,
+    content_hash,
+)
+
+# Skip cleanly if moto isn't installed (CI environments without dev extras)
+moto = pytest.importorskip("moto", reason="moto[s3] is required for the S3 adapter tests")
+boto3 = pytest.importorskip("boto3", reason="boto3 is required for the S3 adapter tests")
+
+mock_aws = moto.mock_aws
+
+_BUCKET = "noetl-payload-s3"
+
+
+@pytest_asyncio.fixture
+async def s3_store() -> AsyncIterator[S3PayloadStore]:
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=_BUCKET)
+        yield S3PayloadStore(_BUCKET, region_name="us-east-1")
+
+
+@pytest.mark.asyncio
+async def test_key_layout_matches_filesystem_sharding(s3_store: S3PayloadStore):
+    payload = b"key layout"
+    ref = await s3_store.store(payload)
+    sha = content_hash(payload)
+    assert ref.uri is not None
+    assert ref.uri.endswith(f"{sha[0:2]}/{sha[2:4]}/{sha}")
+    assert ref.uri == f"s3://{_BUCKET}/{sha[0:2]}/{sha[2:4]}/{sha}"
+
+
+@pytest.mark.asyncio
+async def test_prefix_is_respected():
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=_BUCKET)
+        store = S3PayloadStore(_BUCKET, prefix="payloads/", region_name="us-east-1")
+        payload = b"prefixed"
+        ref = await store.store(payload)
+        sha = content_hash(payload)
+        # Leading + trailing slashes on the prefix are normalized away
+        expected_key = f"payloads/{sha[0:2]}/{sha[2:4]}/{sha}"
+        assert ref.uri == f"s3://{_BUCKET}/{expected_key}"
+
+        # Verify the key actually landed at the prefixed path
+        boto3.client("s3", region_name="us-east-1").head_object(
+            Bucket=_BUCKET, Key=expected_key
+        )
+
+
+@pytest.mark.asyncio
+async def test_dedup_skips_put_when_object_exists(s3_store: S3PayloadStore):
+    payload = b"dedup-target"
+    # First store admits the object
+    await s3_store.store(payload)
+
+    # Wrap put_object on the underlying client to count invocations
+    real_put = s3_store.client.put_object
+    put_calls = {"count": 0}
+
+    def _spy_put(**kwargs):
+        put_calls["count"] += 1
+        return real_put(**kwargs)
+
+    s3_store.client.put_object = _spy_put  # type: ignore[method-assign]
+
+    # Re-store the same payload — put_object should be skipped (dedup)
+    await s3_store.store(payload)
+    assert put_calls["count"] == 0, "dedup path invoked PutObject"
+
+    # Storing a different payload still PUTs
+    await s3_store.store(b"different-payload")
+    assert put_calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_metadata_validation_rejects_non_ascii(s3_store: S3PayloadStore):
+    with pytest.raises(ValueError, match="ASCII"):
+        await s3_store.store(b"data", metadata={"key": "vä lue"})
+
+
+@pytest.mark.asyncio
+async def test_uri_is_s3_scheme(s3_store: S3PayloadStore):
+    ref = await s3_store.store(b"scheme-check")
+    assert ref.uri is not None
+    assert ref.uri.startswith(f"s3://{_BUCKET}/")
+
+
+@pytest.mark.asyncio
+async def test_missing_bucket_raises():
+    """Storing against a non-existent bucket propagates boto3's ClientError."""
+    from botocore.exceptions import ClientError
+
+    with mock_aws():
+        # Intentionally do not create the bucket
+        store = S3PayloadStore("nonexistent-bucket-xyz", region_name="us-east-1")
+        with pytest.raises(ClientError):
+            await store.store(b"oops")
+
+
+def test_constructor_rejects_empty_bucket():
+    with pytest.raises(ValueError, match="bucket name"):
+        S3PayloadStore("")
+
+
+@pytest.mark.asyncio
+async def test_object_metadata_round_trips_through_s3(s3_store: S3PayloadStore):
+    """S3 stores metadata as object headers; verify they come back on HeadObject."""
+    payload = b"metadata-on-s3"
+    metadata = {"origin": "test", "tenant": "default"}
+    ref = await s3_store.store(payload, metadata=metadata)
+
+    # Round-trip via raw boto3 (mocked) — the S3 object should carry
+    # the metadata keys we passed (S3 lowercases them internally but the
+    # API surface preserves what we sent).
+    client = boto3.client("s3", region_name="us-east-1")
+    key = ref.uri.replace(f"s3://{_BUCKET}/", "")
+    head = client.head_object(Bucket=_BUCKET, Key=key)
+    returned = head["Metadata"]
+    # S3 returns metadata keys lowercased; compare case-insensitively
+    assert {k.lower(): v for k, v in returned.items()} == {
+        k.lower(): v for k, v in metadata.items()
+    }


### PR DESCRIPTION
## Summary

Phase 5 **round 2** of the [v2 distributed-runtime spec](https://github.com/noetl/docs/blob/main/docs/features/noetl_distributed_runtime_spec.md). Round 1 established the \`PayloadStore\` Protocol + \`FilesystemPayloadStore\` reference. This round adds the S3 / S3-compatible adapter and an adapter-agnostic compliance test suite.

Wiki: paired update on [Payload Store wiki page](https://github.com/noetl/noetl/wiki/payload_store) — new S3 adapter section + compliance suite documentation.

## What's in this PR

### S3 adapter (`noetl/core/payload_store/s3.py`)

- \`S3PayloadStore\` implementing the Protocol via sync \`boto3\` + \`asyncio.to_thread\`. Same pattern as \`FilesystemPayloadStore\`.
- Key layout mirrors filesystem: \`<prefix>/<sha[:2]>/<sha[2:4]>/<sha>\`.
- Metadata via native S3 object headers — no sidecar. ASCII validation at the boundary.
- Dedup via \`HeadObject\` before PUT.
- Delete is Protocol-compliant (\`True\` if removed, \`False\` if absent) via HeadObject + DeleteObject.
- Optional \`endpoint_url\` for MinIO / SeaweedFS / LocalStack.

### Why sync boto3 instead of aioboto3

\`moto.mock_aws\` only intercepts sync boto3 — \`aiobotocore\` triggers a \`TypeError: object bytes can't be used in 'await' expression\` (aiobotocore expects awaitable response content; moto returns sync bytes). Switching to sync boto3 + \`asyncio.to_thread\` keeps tests on moto's well-supported path and matches the filesystem adapter's pattern. Trade-off: one thread per S3 call. Acceptable for payload-store throughput.

### Compliance suite (`tests/core/payload_store/test_compliance.py`)

Adapter-agnostic tests parametrized across filesystem + S3 (via \`moto.mock_aws\`). 7 contract-level tests × 2 adapters = **14 parametrized runs**. Long-term contract gate — adding a future adapter (GCS / Azure Blob / SeaweedFS) means appending one fixture branch.

### S3-specific tests (`tests/core/payload_store/test_s3.py`)

8 tests covering key layout sharding, prefix normalization, dedup-skipping the PUT (spy on \`put_object\`), non-ASCII metadata rejection, URI scheme, missing-bucket propagation, empty-bucket rejection, object-metadata round-trip via raw boto3.

### Dev dependency

\`moto[s3]>=5.0\` added to \`[project.optional-dependencies].dev\`. No runtime-deps change.

\`pytest tests/core/payload_store/ tests/core/test_projector_metrics.py tests/core/test_replay_state_projector.py tests/unit/dsl/engine/test_fanout_reduce_planner.py -q\` → **88 passed**.

## What's intentionally NOT in this round

- **GCS / Azure Blob / SeaweedFS adapters.** Future Phase 5 rounds.
- **Migration of existing TempStore callers.**
- **\`EventRecord.payload_ref\` typed binding.**

## Coordinated change

- Wiki: noetl-wiki @ \`3638f8e\` (\"wiki(payload_store): document S3 adapter + compliance suite\")
- Handoff thread: \`ai-meta handoffs/active/2026-05-22-phase5-payload-store-s3/round-01-prompt.md\`

## Test plan

- [x] \`pytest tests/core/payload_store/\` — 36 passed (14 from filesystem, 14 parametrized compliance × 2, 8 S3-specific)
- [x] Phase 1 / 3 / 6 regression guards green (88 total in focused sweep)
- [ ] Reviewer to spot-check the \`asyncio.to_thread\` bridging pattern
- [ ] After merge: bump ai-meta pointers for noetl + noetl-wiki

🤖 Generated with [Claude Code](https://claude.com/claude-code)