### PR TITLE
feat(payload-store): add GCS adapter

### DIFF
--- a/noetl/core/payload_store/__init__.py
+++ b/noetl/core/payload_store/__init__.py
@@ -15,6 +15,7 @@ rounds.
 """
 
 from .filesystem import FilesystemPayloadStore
+from .gcs import GCSPayloadStore
 from .ports import (
     PayloadNotFound,
     PayloadReference,
@@ -30,4 +31,5 @@ __all__ = [
     "content_hash",
     "FilesystemPayloadStore",
     "S3PayloadStore",
+    "GCSPayloadStore",
 ]

--- a/noetl/core/payload_store/gcs.py
+++ b/noetl/core/payload_store/gcs.py
@@ -1,0 +1,243 @@
+"""Google Cloud Storage adapter for :class:`PayloadStore`.
+
+Implements the same Protocol contract as
+:class:`FilesystemPayloadStore` and :class:`S3PayloadStore`.
+
+Design notes:
+
+- **Key layout** mirrors the filesystem + S3 adapters:
+  ``<prefix>/<sha[0:2]>/<sha[2:4]>/<sha>``. Same sharding rationale —
+  any single GCS listing stays bounded.
+- **Atomicity** is intrinsic to GCS uploads — no temp + rename
+  ceremony.
+- **Content-addressing dedup** via ``Blob.exists()`` before
+  ``upload_from_string``.
+- **Metadata** rides as GCS custom blob metadata (the
+  ``Blob.metadata`` dict, persisted by ``Blob.patch()``). No sidecar
+  object — keeps the bucket layout flat. GCS technically tolerates
+  UTF-8 in custom metadata, but the adapter requires ASCII at the
+  boundary for portability with the S3 adapter and for predictable
+  on-wire headers.
+- **Delete** is Protocol-compliant (``True`` if a payload was
+  removed, ``False`` if already absent). Implemented as
+  ``exists`` + ``delete`` because ``Blob.delete()`` raises ``NotFound``
+  on missing keys rather than reporting a boolean.
+- **Sync google-cloud-storage + asyncio.to_thread.** The Protocol
+  exposes async methods; the implementation bridges through a thread
+  pool. The ``google-cloud-storage`` SDK has no native async client,
+  so this is the canonical pattern for cloud adapters in NoETL (same
+  shape as the S3 adapter).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+
+try:
+    from google.cloud import storage as gcs_storage  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - google-cloud-storage is a runtime dep
+    gcs_storage = None  # type: ignore[assignment]
+
+try:
+    from google.api_core import exceptions as gax_exceptions  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - google-api-core ships with google-cloud-storage
+    gax_exceptions = None  # type: ignore[assignment]
+
+from noetl.core.logger import setup_logger
+
+from .ports import (
+    PayloadNotFound,
+    PayloadReference,
+    PayloadStore,
+    content_hash,
+)
+
+logger = setup_logger(__name__, include_location=True)
+
+
+class GCSPayloadStore(PayloadStore):
+    """Async Google Cloud Storage adapter.
+
+    Constructor takes the bucket name and optional configuration:
+
+    - ``prefix`` — string prepended to every object key. Useful when
+      a single bucket hosts payloads alongside other namespaces.
+    - ``client`` — pre-configured ``google.cloud.storage.Client``.
+      When ``None``, a default client is constructed via
+      ``storage.Client(project=project, credentials=credentials)``
+      and credentials come from the standard Google auth chain (ADC).
+    - ``project`` — explicit GCP project id (used when creating the
+      default client).
+    - ``credentials`` — credentials object passed through to
+      ``storage.Client``. Pass a
+      ``google.oauth2.service_account.Credentials`` instance for
+      service-account auth. Mirrors the shape used by NoETL's existing
+      GCS tool.
+    - ``default_content_type`` — used when ``store(content_type=...)``
+      is omitted or empty.
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        prefix: str = "",
+        client: Optional[Any] = None,
+        project: Optional[str] = None,
+        credentials: Optional[Any] = None,
+        default_content_type: str = "application/octet-stream",
+    ) -> None:
+        if gcs_storage is None:  # pragma: no cover - exercised when extra missing
+            raise RuntimeError(
+                "GCSPayloadStore requires google-cloud-storage; install "
+                "noetl with the default runtime dependencies"
+            )
+        if not bucket:
+            raise ValueError("bucket name is required")
+        self.bucket_name = str(bucket)
+        self.prefix = prefix.lstrip("/").rstrip("/") if prefix else ""
+        self.project = project
+        self.default_content_type = default_content_type
+        if client is None:
+            client_kwargs: dict[str, Any] = {}
+            if project:
+                client_kwargs["project"] = project
+            if credentials is not None:
+                client_kwargs["credentials"] = credentials
+            self.client = gcs_storage.Client(**client_kwargs)
+        else:
+            self.client = client
+        self.bucket = self.client.bucket(self.bucket_name)
+
+    def _key_for(self, sha256: str) -> str:
+        """Return the GCS object key for a payload digest."""
+        if len(sha256) < 4:
+            raise ValueError(
+                f"sha256 prefix must be at least 4 chars for sharding (got {len(sha256)})"
+            )
+        sharded = f"{sha256[0:2]}/{sha256[2:4]}/{sha256}"
+        return f"{self.prefix}/{sharded}" if self.prefix else sharded
+
+    def _uri_for(self, key: str) -> str:
+        return f"gs://{self.bucket_name}/{key}"
+
+    @staticmethod
+    def _validate_metadata(metadata: dict[str, str]) -> dict[str, str]:
+        """Require ASCII-only metadata keys and values.
+
+        GCS itself tolerates UTF-8 in custom metadata, but the adapter
+        keeps the same boundary check as the S3 adapter so the
+        cross-backend contract is uniform.
+        """
+        normalized: dict[str, str] = {}
+        for raw_key, raw_value in metadata.items():
+            key = str(raw_key)
+            value = str(raw_value)
+            try:
+                key.encode("ascii")
+                value.encode("ascii")
+            except UnicodeEncodeError as exc:
+                raise ValueError(
+                    f"GCS metadata key/value must be ASCII: {raw_key!r}={raw_value!r}"
+                ) from exc
+            normalized[key] = value
+        return normalized
+
+    @staticmethod
+    def _is_not_found(exc: BaseException) -> bool:
+        """True iff the GCS client error indicates the blob is missing."""
+        if gax_exceptions is not None and isinstance(exc, gax_exceptions.NotFound):
+            return True
+        # Fallback for environments where the exception type can't be
+        # resolved — match on duck-typed status / code.
+        status = getattr(exc, "code", None) or getattr(exc, "status_code", None)
+        return status == 404
+
+    def _head_sync(self, key: str) -> bool:
+        """Sync helper — True iff the blob exists."""
+        blob = self.bucket.blob(key)
+        return bool(blob.exists())
+
+    def _store_sync(
+        self,
+        *,
+        payload: bytes,
+        key: str,
+        content_type: str,
+        metadata: dict[str, str],
+    ) -> None:
+        blob = self.bucket.blob(key)
+        if blob.exists():
+            return  # content-addressing dedup
+        if metadata:
+            blob.metadata = metadata
+        blob.upload_from_string(payload, content_type=content_type)
+
+    def _fetch_sync(self, key: str) -> bytes:
+        blob = self.bucket.blob(key)
+        try:
+            return blob.download_as_bytes()
+        except Exception as exc:
+            if self._is_not_found(exc):
+                raise PayloadNotFound(
+                    f"payload not found at gs://{self.bucket_name}/{key}"
+                ) from exc
+            raise
+
+    def _delete_sync(self, key: str) -> bool:
+        blob = self.bucket.blob(key)
+        if not blob.exists():
+            return False
+        try:
+            blob.delete()
+        except Exception as exc:
+            if self._is_not_found(exc):
+                return False
+            raise
+        return True
+
+    async def store(
+        self,
+        payload: bytes,
+        *,
+        content_type: str = "application/octet-stream",
+        metadata: Optional[dict[str, str]] = None,
+    ) -> PayloadReference:
+        if not isinstance(payload, (bytes, bytearray, memoryview)):
+            raise TypeError("payload must be bytes-like")
+        payload_bytes = bytes(payload)
+        sha = content_hash(payload_bytes)
+        key = self._key_for(sha)
+        normalized_metadata = self._validate_metadata(metadata or {})
+        effective_content_type = (
+            content_type if content_type else self.default_content_type
+        )
+
+        await asyncio.to_thread(
+            self._store_sync,
+            payload=payload_bytes,
+            key=key,
+            content_type=effective_content_type,
+            metadata=normalized_metadata,
+        )
+
+        return PayloadReference(
+            sha256=sha,
+            byte_length=len(payload_bytes),
+            content_type=effective_content_type,
+            uri=self._uri_for(key),
+            metadata=normalized_metadata,
+        )
+
+    async def fetch(self, reference: PayloadReference) -> bytes:
+        key = self._key_for(reference.sha256)
+        return await asyncio.to_thread(self._fetch_sync, key)
+
+    async def exists(self, reference: PayloadReference) -> bool:
+        key = self._key_for(reference.sha256)
+        return await asyncio.to_thread(self._head_sync, key)
+
+    async def delete(self, reference: PayloadReference) -> bool:
+        key = self._key_for(reference.sha256)
+        return await asyncio.to_thread(self._delete_sync, key)

--- a/tests/core/payload_store/test_gcs.py
+++ b/tests/core/payload_store/test_gcs.py
@@ -1,0 +1,240 @@
+"""GCS-specific tests for :class:`GCSPayloadStore`.
+
+The compliance suite in ``test_compliance.py`` does not yet cover GCS
+(there is no in-process equivalent of ``moto.mock_aws`` for GCS;
+``fake-gcs-server`` is a process-based emulator). This file exercises
+the adapter's call shape against the ``google.cloud.storage`` SDK
+surface using ``unittest.mock``.
+
+Cases:
+
+- constructor honors an injected client (no real ``Client()`` call)
+- ``store`` calls ``upload_from_string`` with the right ``content_type``
+- ``store`` writes ``blob.metadata`` before uploading
+- ``store`` dedups via ``blob.exists()`` (no second ``upload_from_string``)
+- ``fetch`` translates ``google.api_core.exceptions.NotFound`` into
+  :class:`PayloadNotFound`
+- ``exists`` passes through to ``blob.exists()``
+- ``delete`` returns ``False`` when the blob is missing
+- ``delete`` returns ``True`` when the blob existed
+- key layout matches the filesystem + S3 sharding
+- prefix normalization strips leading / trailing slashes
+- URI uses the ``gs://`` scheme
+- non-ASCII metadata raises ``ValueError``
+- a missing-bucket error from ``upload_from_string`` propagates
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from google.api_core import exceptions as gax_exceptions
+
+from noetl.core.payload_store import (
+    GCSPayloadStore,
+    PayloadNotFound,
+    PayloadReference,
+    content_hash,
+)
+
+_BUCKET = "noetl-payload-gcs"
+
+
+def _make_store(
+    *,
+    blob: MagicMock | None = None,
+    bucket: MagicMock | None = None,
+    client: MagicMock | None = None,
+    prefix: str = "",
+) -> tuple[GCSPayloadStore, MagicMock, MagicMock, MagicMock]:
+    """Build a ``GCSPayloadStore`` wired to a mocked client chain.
+
+    Returns ``(store, client, bucket, blob)``.
+    """
+    blob = blob or MagicMock(name="Blob")
+    bucket = bucket or MagicMock(name="Bucket")
+    bucket.blob.return_value = blob
+    client = client or MagicMock(name="Client")
+    client.bucket.return_value = bucket
+    store = GCSPayloadStore(_BUCKET, prefix=prefix, client=client)
+    return store, client, bucket, blob
+
+
+def test_constructor_uses_injected_client():
+    client = MagicMock(name="Client")
+    bucket = MagicMock(name="Bucket")
+    client.bucket.return_value = bucket
+
+    store = GCSPayloadStore(_BUCKET, client=client)
+
+    # bucket() was queried for our bucket name on the injected client
+    client.bucket.assert_called_once_with(_BUCKET)
+    assert store.bucket is bucket
+    assert store.client is client
+
+
+def test_constructor_rejects_empty_bucket():
+    with pytest.raises(ValueError, match="bucket name"):
+        GCSPayloadStore("")
+
+
+@pytest.mark.asyncio
+async def test_store_uploads_via_blob_with_metadata():
+    store, _, bucket, blob = _make_store()
+    blob.exists.return_value = False  # not deduped
+
+    payload = b"upload-shape"
+    metadata = {"origin": "test", "tenant": "default"}
+
+    ref = await store.store(
+        payload, content_type="application/json", metadata=metadata
+    )
+
+    # The bucket was asked for the right key
+    sha = content_hash(payload)
+    expected_key = f"{sha[:2]}/{sha[2:4]}/{sha}"
+    bucket.blob.assert_called_with(expected_key)
+
+    # Custom metadata was assigned before upload
+    assert blob.metadata == metadata
+
+    # upload_from_string carries the data + content type
+    blob.upload_from_string.assert_called_once_with(
+        payload, content_type="application/json"
+    )
+
+    # Returned reference carries the full shape
+    assert ref.sha256 == sha
+    assert ref.byte_length == len(payload)
+    assert ref.content_type == "application/json"
+    assert ref.uri == f"gs://{_BUCKET}/{expected_key}"
+    assert ref.metadata == metadata
+
+
+@pytest.mark.asyncio
+async def test_store_dedups_when_blob_exists():
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = True  # already there → dedup
+
+    await store.store(b"dedup-target")
+
+    blob.upload_from_string.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_raises_payload_not_found_on_gcs_404():
+    store, _, _, blob = _make_store()
+    blob.download_as_bytes.side_effect = gax_exceptions.NotFound("missing")
+
+    payload = b"never-stored"
+    ref = PayloadReference(
+        sha256=content_hash(payload), byte_length=len(payload)
+    )
+
+    with pytest.raises(PayloadNotFound):
+        await store.fetch(ref)
+
+
+@pytest.mark.asyncio
+async def test_fetch_returns_blob_bytes():
+    store, _, _, blob = _make_store()
+    payload = b"fetched-from-gcs"
+    blob.download_as_bytes.return_value = payload
+
+    ref = PayloadReference(
+        sha256=content_hash(payload), byte_length=len(payload)
+    )
+    assert await store.fetch(ref) == payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("present", [True, False])
+async def test_exists_passes_through_blob_exists(present: bool):
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = present
+
+    ref = PayloadReference(sha256="0" * 64, byte_length=0)
+    assert await store.exists(ref) is present
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_false_on_missing_blob():
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = False
+
+    ref = PayloadReference(sha256="0" * 64, byte_length=0)
+    assert await store.delete(ref) is False
+    blob.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_true_on_existing_blob():
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = True
+
+    ref = PayloadReference(sha256="0" * 64, byte_length=0)
+    assert await store.delete(ref) is True
+    blob.delete.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_key_layout_matches_filesystem_sharding():
+    store, _, bucket, blob = _make_store()
+    blob.exists.return_value = False
+
+    payload = b"key layout"
+    ref = await store.store(payload)
+    sha = content_hash(payload)
+
+    assert ref.uri is not None
+    assert ref.uri.endswith(f"{sha[0:2]}/{sha[2:4]}/{sha}")
+    assert ref.uri == f"gs://{_BUCKET}/{sha[0:2]}/{sha[2:4]}/{sha}"
+    bucket.blob.assert_any_call(f"{sha[0:2]}/{sha[2:4]}/{sha}")
+
+
+@pytest.mark.asyncio
+async def test_prefix_normalization():
+    store, _, bucket, blob = _make_store(prefix="/payloads/")
+    blob.exists.return_value = False
+
+    payload = b"prefixed"
+    ref = await store.store(payload)
+    sha = content_hash(payload)
+
+    expected_key = f"payloads/{sha[0:2]}/{sha[2:4]}/{sha}"
+    assert ref.uri == f"gs://{_BUCKET}/{expected_key}"
+    bucket.blob.assert_any_call(expected_key)
+
+
+@pytest.mark.asyncio
+async def test_uri_is_gs_scheme():
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = False
+
+    ref = await store.store(b"scheme-check")
+    assert ref.uri is not None
+    assert ref.uri.startswith(f"gs://{_BUCKET}/")
+
+
+@pytest.mark.asyncio
+async def test_metadata_validation_rejects_non_ascii():
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = False
+
+    with pytest.raises(ValueError, match="ASCII"):
+        await store.store(b"data", metadata={"key": "vä lue"})
+
+
+@pytest.mark.asyncio
+async def test_missing_bucket_propagates_error():
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = False
+    blob.upload_from_string.side_effect = gax_exceptions.NotFound(
+        "bucket does not exist"
+    )
+
+    with pytest.raises(gax_exceptions.NotFound):
+        await store.store(b"oops")


### PR DESCRIPTION
## Summary

- Add `GCSPayloadStore` async adapter wrapping `google-cloud-storage`
  (sync SDK) through `asyncio.to_thread` — same canonical pattern as
  `S3PayloadStore`.
- 15 GCS-specific unit tests via `unittest.mock` stubbing the
  `Client → Bucket → Blob` chain (no emulator).
- Wiki: extend `noetl/core/payload_store.md` with a full
  `GCSPayloadStore` section + updated status / diagram /
  compliance-suite note.

## Design notes

- **Key layout** matches filesystem + S3 adapters:
  `<prefix>/<sha[:2]>/<sha[2:4]>/<sha>`.
- **Dedup** via `Blob.exists()` before `upload_from_string`.
- **Metadata** rides as GCS custom blob metadata; ASCII boundary
  check keeps the cross-backend contract uniform with the S3 adapter.
- **Delete** is Protocol-compliant (`True` if removed, `False` if
  absent) — implemented as `exists` + `delete` because
  `Blob.delete()` raises `NotFound` on missing keys.
- **Async surface, sync backend** — `google-cloud-storage` has no
  native async client; `asyncio.to_thread` bridges through a thread
  pool, matching the S3 adapter shape.

## Compliance-suite note

The parametrized compliance fixture (`test_compliance.py`) is **not**
extended to GCS in this round. There is no in-process equivalent of
`moto.mock_aws` for GCS — `fake-gcs-server` is a process-based
emulator binary. GCS gets dedicated unit tests via `unittest.mock`
this round and joins the parametrized fixture in a future round once
an emulator harness lands.

## Test plan

- [x] `pytest tests/core/payload_store/test_gcs.py -q` — 15 passed
- [x] `pytest tests/core/payload_store/ -q` — 51 passed (existing
      filesystem + S3 + compliance suites still green)
- [x] Regression sweep: `pytest tests/core/payload_store/
      tests/core/test_projector_metrics.py
      tests/core/test_replay_state_projector.py
      tests/unit/dsl/engine/test_fanout_reduce_planner.py -q`
      — 103 passed
- [x] Smoke import: `from noetl.core.payload_store import GCSPayloadStore`
- [ ] Reviewer: confirm wiki diff at
      https://github.com/noetl/noetl/wiki/payload_store

## Wiki

Paired wiki update pushed to `noetl.wiki@f064e57`:
`wiki(payload_store): document GCS adapter`.

## Follow-ups (out of scope)

- **Phase 5 round 4** — Azure Blob (`azure-storage-blob`) +
  SeaweedFS-native adapter + `EventRecord.payload_ref` typed
  binding.
- **GCS compliance leg** — wire `gcp-storage-emulator` (or Azurite
  if it co-installs) into a process-based fixture so GCS joins the
  parametrized compliance run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)