### PR TITLE
feat(payload-store): add Azure Blob adapter + SeaweedFS docs

### DIFF
--- a/noetl/core/payload_store/__init__.py
+++ b/noetl/core/payload_store/__init__.py
@@ -14,6 +14,7 @@ Cloud adapters (S3 / GCS / Azure Blob / SeaweedFS) land in subsequent
 rounds.
 """
 
+from .azure import AzureBlobPayloadStore
 from .filesystem import FilesystemPayloadStore
 from .gcs import GCSPayloadStore
 from .ports import (
@@ -32,4 +33,5 @@ __all__ = [
     "FilesystemPayloadStore",
     "S3PayloadStore",
     "GCSPayloadStore",
+    "AzureBlobPayloadStore",
 ]

--- a/noetl/core/payload_store/azure.py
+++ b/noetl/core/payload_store/azure.py
@@ -1,0 +1,272 @@
+"""Azure Blob Storage adapter for :class:`PayloadStore`.
+
+Implements the same Protocol contract as
+:class:`FilesystemPayloadStore`, :class:`S3PayloadStore`, and
+:class:`GCSPayloadStore`.
+
+Design notes:
+
+- **Key layout** mirrors the other adapters:
+  ``<prefix>/<sha[0:2]>/<sha[2:4]>/<sha>``. Same sharding rationale —
+  any single container listing stays bounded.
+- **Atomicity** is intrinsic to Azure Blob ``upload_blob`` — no temp +
+  rename ceremony.
+- **Content-addressing dedup** via ``BlobClient.exists()`` before
+  ``upload_blob``.
+- **Metadata** rides as Azure Blob custom metadata (``x-ms-meta-*``
+  headers), passed via the ``metadata=`` kwarg on ``upload_blob``.
+  Azure requires metadata keys to be valid **C# identifiers**
+  (ASCII letters / digits / underscore; must start with a letter or
+  underscore). Values must be ASCII for portability. The adapter
+  validates at the boundary.
+- **Content type** is conveyed through
+  ``ContentSettings(content_type=...)``.
+- **Delete** is Protocol-compliant (``True`` if a payload was
+  removed, ``False`` if already absent). Implemented as
+  ``BlobClient.exists()`` + ``BlobClient.delete_blob()`` because
+  ``delete_blob`` raises ``ResourceNotFoundError`` on missing keys
+  rather than reporting a boolean.
+- **Sync azure-storage-blob + asyncio.to_thread.** The SDK ships an
+  ``aio`` submodule, but using it would force aio-aware testing
+  infrastructure and risk a repeat of the round-2 aioboto3/moto
+  trap. Sync + thread bridging is the canonical cloud-adapter
+  pattern in NoETL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Any, Optional
+
+try:
+    from azure.storage.blob import (  # type: ignore[import-not-found]
+        BlobServiceClient,
+        ContentSettings,
+    )
+except ImportError:  # pragma: no cover - azure-storage-blob is a runtime dep
+    BlobServiceClient = None  # type: ignore[assignment,misc]
+    ContentSettings = None  # type: ignore[assignment,misc]
+
+try:
+    from azure.core.exceptions import ResourceNotFoundError  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - azure-core ships with azure-storage-blob
+    ResourceNotFoundError = Exception  # type: ignore[assignment,misc]
+
+from noetl.core.logger import setup_logger
+
+from .ports import (
+    PayloadNotFound,
+    PayloadReference,
+    PayloadStore,
+    content_hash,
+)
+
+logger = setup_logger(__name__, include_location=True)
+
+_CSHARP_IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+class AzureBlobPayloadStore(PayloadStore):
+    """Async Azure Blob Storage adapter.
+
+    Constructor takes the container name and optional configuration:
+
+    - ``prefix`` — string prepended to every blob name. Useful when
+      a single container hosts payloads alongside other namespaces.
+    - ``account_url`` — e.g.
+      ``https://<account>.blob.core.windows.net``. Required when
+      ``connection_string`` is not provided and ``client`` is
+      ``None``.
+    - ``credential`` — ``TokenCredential`` (typically
+      ``DefaultAzureCredential``), account-key string, or SAS token.
+      Used when constructing the default ``BlobServiceClient`` from
+      ``account_url``.
+    - ``connection_string`` — full Azure storage connection string.
+      Preferred for local / Azurite work. When set, takes precedence
+      over ``account_url`` + ``credential`` for building the default
+      client.
+    - ``client`` — pre-configured ``BlobServiceClient``. When
+      ``None``, the adapter builds one from
+      ``connection_string`` or ``account_url`` + ``credential``.
+    - ``default_content_type`` — used when ``store(content_type=...)``
+      is omitted or empty.
+    """
+
+    def __init__(
+        self,
+        container: str,
+        *,
+        prefix: str = "",
+        account_url: Optional[str] = None,
+        credential: Optional[Any] = None,
+        connection_string: Optional[str] = None,
+        client: Optional[Any] = None,
+        default_content_type: str = "application/octet-stream",
+    ) -> None:
+        if BlobServiceClient is None:  # pragma: no cover - exercised when extra missing
+            raise RuntimeError(
+                "AzureBlobPayloadStore requires azure-storage-blob; install "
+                "noetl with the default runtime dependencies"
+            )
+        if not container:
+            raise ValueError("container name is required")
+        self.container_name = str(container)
+        self.prefix = prefix.lstrip("/").rstrip("/") if prefix else ""
+        self.default_content_type = default_content_type
+        if client is None:
+            if connection_string:
+                self.client = BlobServiceClient.from_connection_string(
+                    connection_string
+                )
+            elif account_url:
+                self.client = BlobServiceClient(
+                    account_url=account_url, credential=credential
+                )
+            else:
+                raise ValueError(
+                    "AzureBlobPayloadStore requires one of: client, "
+                    "connection_string, or account_url"
+                )
+        else:
+            self.client = client
+        self.container_client = self.client.get_container_client(self.container_name)
+
+    def _key_for(self, sha256: str) -> str:
+        """Return the blob name for a payload digest."""
+        if len(sha256) < 4:
+            raise ValueError(
+                f"sha256 prefix must be at least 4 chars for sharding (got {len(sha256)})"
+            )
+        sharded = f"{sha256[0:2]}/{sha256[2:4]}/{sha256}"
+        return f"{self.prefix}/{sharded}" if self.prefix else sharded
+
+    def _uri_for(self, key: str) -> str:
+        account = getattr(self.client, "account_name", None)
+        if account:
+            return f"azure://{account}/{self.container_name}/{key}"
+        return f"azure://{self.container_name}/{key}"
+
+    @staticmethod
+    def _validate_metadata(metadata: dict[str, str]) -> dict[str, str]:
+        """Azure requires C#-identifier keys + ASCII values."""
+        normalized: dict[str, str] = {}
+        for raw_key, raw_value in metadata.items():
+            key = str(raw_key)
+            value = str(raw_value)
+            if not _CSHARP_IDENT.fullmatch(key):
+                raise ValueError(
+                    f"Azure metadata key must be a valid C# identifier "
+                    f"(letters / digits / underscore, starting with a letter "
+                    f"or underscore): {raw_key!r}"
+                )
+            try:
+                value.encode("ascii")
+            except UnicodeEncodeError as exc:
+                raise ValueError(
+                    f"Azure metadata value must be ASCII: {raw_key!r}={raw_value!r}"
+                ) from exc
+            normalized[key] = value
+        return normalized
+
+    @staticmethod
+    def _is_not_found(exc: BaseException) -> bool:
+        """True iff the Azure client error indicates the blob is missing."""
+        if isinstance(exc, ResourceNotFoundError):
+            return True
+        status = getattr(exc, "status_code", None)
+        return status == 404
+
+    def _blob_client(self, key: str) -> Any:
+        return self.container_client.get_blob_client(key)
+
+    def _head_sync(self, key: str) -> bool:
+        """Sync helper — True iff the blob exists."""
+        return bool(self._blob_client(key).exists())
+
+    def _store_sync(
+        self,
+        *,
+        payload: bytes,
+        key: str,
+        content_type: str,
+        metadata: dict[str, str],
+    ) -> None:
+        blob = self._blob_client(key)
+        if blob.exists():
+            return  # content-addressing dedup
+        content_settings = ContentSettings(content_type=content_type)
+        blob.upload_blob(
+            payload,
+            content_settings=content_settings,
+            metadata=metadata or None,
+        )
+
+    def _fetch_sync(self, key: str) -> bytes:
+        blob = self._blob_client(key)
+        try:
+            stream = blob.download_blob()
+            return stream.readall()
+        except Exception as exc:
+            if self._is_not_found(exc):
+                raise PayloadNotFound(
+                    f"payload not found at azure://{self.container_name}/{key}"
+                ) from exc
+            raise
+
+    def _delete_sync(self, key: str) -> bool:
+        blob = self._blob_client(key)
+        if not blob.exists():
+            return False
+        try:
+            blob.delete_blob()
+        except Exception as exc:
+            if self._is_not_found(exc):
+                return False
+            raise
+        return True
+
+    async def store(
+        self,
+        payload: bytes,
+        *,
+        content_type: str = "application/octet-stream",
+        metadata: Optional[dict[str, str]] = None,
+    ) -> PayloadReference:
+        if not isinstance(payload, (bytes, bytearray, memoryview)):
+            raise TypeError("payload must be bytes-like")
+        payload_bytes = bytes(payload)
+        sha = content_hash(payload_bytes)
+        key = self._key_for(sha)
+        normalized_metadata = self._validate_metadata(metadata or {})
+        effective_content_type = (
+            content_type if content_type else self.default_content_type
+        )
+
+        await asyncio.to_thread(
+            self._store_sync,
+            payload=payload_bytes,
+            key=key,
+            content_type=effective_content_type,
+            metadata=normalized_metadata,
+        )
+
+        return PayloadReference(
+            sha256=sha,
+            byte_length=len(payload_bytes),
+            content_type=effective_content_type,
+            uri=self._uri_for(key),
+            metadata=normalized_metadata,
+        )
+
+    async def fetch(self, reference: PayloadReference) -> bytes:
+        key = self._key_for(reference.sha256)
+        return await asyncio.to_thread(self._fetch_sync, key)
+
+    async def exists(self, reference: PayloadReference) -> bool:
+        key = self._key_for(reference.sha256)
+        return await asyncio.to_thread(self._head_sync, key)
+
+    async def delete(self, reference: PayloadReference) -> bool:
+        key = self._key_for(reference.sha256)
+        return await asyncio.to_thread(self._delete_sync, key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dependencies = [
     "aioboto3>=13.0.0",
     "azure-identity>=1.23.0",
     "azure-keyvault-secrets>=4.8.0",
+    "azure-storage-blob>=12.20.0",
     "ortools>=9.10",
     "kubernetes>=31.0.0",
     "nats-py>=2.10.0",

--- a/tests/core/payload_store/test_azure.py
+++ b/tests/core/payload_store/test_azure.py
@@ -1,0 +1,283 @@
+"""Azure Blob–specific tests for :class:`AzureBlobPayloadStore`.
+
+The compliance suite in ``test_compliance.py`` does not yet cover
+Azure (Azurite is a process-based emulator, not an in-process
+mock library). This file exercises the adapter's call shape
+against the ``azure-storage-blob`` SDK surface using
+``unittest.mock``.
+
+Cases:
+
+- constructor honors an injected client (no real ``BlobServiceClient`` call)
+- constructor rejects an empty container name
+- constructor requires one of: client / connection_string / account_url
+- ``store`` calls ``upload_blob`` with the right
+  ``ContentSettings(content_type=...)`` and metadata
+- ``store`` dedups via ``BlobClient.exists()``
+- ``fetch`` translates ``ResourceNotFoundError`` into
+  :class:`PayloadNotFound`
+- ``fetch`` returns the underlying blob bytes on the happy path
+- ``exists`` passes through to ``BlobClient.exists()``
+- ``delete`` returns ``False`` when the blob is missing
+- ``delete`` returns ``True`` when the blob existed
+- key layout matches the filesystem + S3 + GCS sharding
+- prefix normalization strips leading / trailing slashes
+- URI uses the ``azure://`` scheme
+- non-ASCII metadata values raise ``ValueError``
+- non-identifier metadata keys raise ``ValueError``
+- a missing-container error from ``upload_blob`` propagates
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from azure.core.exceptions import ResourceNotFoundError
+from azure.storage.blob import ContentSettings
+
+from noetl.core.payload_store import (
+    AzureBlobPayloadStore,
+    PayloadNotFound,
+    PayloadReference,
+    content_hash,
+)
+
+_CONTAINER = "noetl-payload-azure"
+_ACCOUNT = "noetlacct"
+
+
+def _make_store(
+    *,
+    blob: MagicMock | None = None,
+    container_client: MagicMock | None = None,
+    client: MagicMock | None = None,
+    prefix: str = "",
+) -> tuple[AzureBlobPayloadStore, MagicMock, MagicMock, MagicMock]:
+    """Build an ``AzureBlobPayloadStore`` wired to a mocked client chain.
+
+    Returns ``(store, client, container_client, blob)``.
+    """
+    blob = blob or MagicMock(name="BlobClient")
+    container_client = container_client or MagicMock(name="ContainerClient")
+    container_client.get_blob_client.return_value = blob
+    client = client or MagicMock(name="BlobServiceClient")
+    client.get_container_client.return_value = container_client
+    client.account_name = _ACCOUNT
+    store = AzureBlobPayloadStore(_CONTAINER, prefix=prefix, client=client)
+    return store, client, container_client, blob
+
+
+def test_constructor_uses_injected_client():
+    client = MagicMock(name="BlobServiceClient")
+    container_client = MagicMock(name="ContainerClient")
+    client.get_container_client.return_value = container_client
+
+    store = AzureBlobPayloadStore(_CONTAINER, client=client)
+
+    client.get_container_client.assert_called_once_with(_CONTAINER)
+    assert store.container_client is container_client
+    assert store.client is client
+
+
+def test_constructor_rejects_empty_container():
+    with pytest.raises(ValueError, match="container name"):
+        AzureBlobPayloadStore("")
+
+
+def test_constructor_requires_auth_source():
+    with pytest.raises(ValueError, match="connection_string"):
+        AzureBlobPayloadStore(_CONTAINER)
+
+
+@pytest.mark.asyncio
+async def test_store_uploads_via_blob_with_metadata():
+    store, _, container_client, blob = _make_store()
+    blob.exists.return_value = False  # not deduped
+
+    payload = b"upload-shape"
+    metadata = {"origin": "test", "tenant": "default"}
+
+    ref = await store.store(
+        payload, content_type="application/json", metadata=metadata
+    )
+
+    sha = content_hash(payload)
+    expected_key = f"{sha[:2]}/{sha[2:4]}/{sha}"
+    container_client.get_blob_client.assert_called_with(expected_key)
+
+    blob.upload_blob.assert_called_once()
+    call = blob.upload_blob.call_args
+    # First positional argument is the payload bytes
+    assert call.args[0] == payload
+    # ContentSettings carries the content type
+    content_settings = call.kwargs["content_settings"]
+    assert isinstance(content_settings, ContentSettings)
+    assert content_settings.content_type == "application/json"
+    # Metadata dict is passed through
+    assert call.kwargs["metadata"] == metadata
+
+    # Returned reference carries the full shape
+    assert ref.sha256 == sha
+    assert ref.byte_length == len(payload)
+    assert ref.content_type == "application/json"
+    assert ref.uri == f"azure://{_ACCOUNT}/{_CONTAINER}/{expected_key}"
+    assert ref.metadata == metadata
+
+
+@pytest.mark.asyncio
+async def test_store_dedups_when_blob_exists():
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = True  # already there → dedup
+
+    await store.store(b"dedup-target")
+
+    blob.upload_blob.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_raises_payload_not_found_on_azure_404():
+    store, _, _, blob = _make_store()
+    blob.download_blob.side_effect = ResourceNotFoundError("missing")
+
+    payload = b"never-stored"
+    ref = PayloadReference(
+        sha256=content_hash(payload), byte_length=len(payload)
+    )
+
+    with pytest.raises(PayloadNotFound):
+        await store.fetch(ref)
+
+
+@pytest.mark.asyncio
+async def test_fetch_returns_blob_bytes():
+    store, _, _, blob = _make_store()
+    payload = b"fetched-from-azure"
+    stream = MagicMock(name="StorageStreamDownloader")
+    stream.readall.return_value = payload
+    blob.download_blob.return_value = stream
+
+    ref = PayloadReference(
+        sha256=content_hash(payload), byte_length=len(payload)
+    )
+    assert await store.fetch(ref) == payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("present", [True, False])
+async def test_exists_passes_through_blob_exists(present: bool):
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = present
+
+    ref = PayloadReference(sha256="0" * 64, byte_length=0)
+    assert await store.exists(ref) is present
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_false_on_missing_blob():
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = False
+
+    ref = PayloadReference(sha256="0" * 64, byte_length=0)
+    assert await store.delete(ref) is False
+    blob.delete_blob.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_true_on_existing_blob():
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = True
+
+    ref = PayloadReference(sha256="0" * 64, byte_length=0)
+    assert await store.delete(ref) is True
+    blob.delete_blob.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_key_layout_matches_filesystem_sharding():
+    store, _, container_client, blob = _make_store()
+    blob.exists.return_value = False
+
+    payload = b"key layout"
+    ref = await store.store(payload)
+    sha = content_hash(payload)
+
+    assert ref.uri is not None
+    assert ref.uri.endswith(f"{sha[0:2]}/{sha[2:4]}/{sha}")
+    assert ref.uri == f"azure://{_ACCOUNT}/{_CONTAINER}/{sha[0:2]}/{sha[2:4]}/{sha}"
+    container_client.get_blob_client.assert_any_call(
+        f"{sha[0:2]}/{sha[2:4]}/{sha}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prefix_normalization():
+    store, _, container_client, blob = _make_store(prefix="/payloads/")
+    blob.exists.return_value = False
+
+    payload = b"prefixed"
+    ref = await store.store(payload)
+    sha = content_hash(payload)
+
+    expected_key = f"payloads/{sha[0:2]}/{sha[2:4]}/{sha}"
+    assert ref.uri == f"azure://{_ACCOUNT}/{_CONTAINER}/{expected_key}"
+    container_client.get_blob_client.assert_any_call(expected_key)
+
+
+@pytest.mark.asyncio
+async def test_uri_is_azure_scheme():
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = False
+
+    ref = await store.store(b"scheme-check")
+    assert ref.uri is not None
+    assert ref.uri.startswith(f"azure://{_ACCOUNT}/{_CONTAINER}/")
+
+
+@pytest.mark.asyncio
+async def test_uri_falls_back_when_account_name_missing():
+    client = MagicMock(name="BlobServiceClient")
+    container_client = MagicMock(name="ContainerClient")
+    blob = MagicMock(name="BlobClient")
+    blob.exists.return_value = False
+    container_client.get_blob_client.return_value = blob
+    client.get_container_client.return_value = container_client
+    # Explicitly drop account_name attribute
+    client.account_name = None
+
+    store = AzureBlobPayloadStore(_CONTAINER, client=client)
+    ref = await store.store(b"no-account")
+    assert ref.uri is not None
+    assert ref.uri.startswith(f"azure://{_CONTAINER}/")
+
+
+@pytest.mark.asyncio
+async def test_metadata_validation_rejects_non_ascii_value():
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = False
+
+    with pytest.raises(ValueError, match="ASCII"):
+        await store.store(b"data", metadata={"key": "vä lue"})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_key", ["my-key", "1bad", "bad.key", "with space"])
+async def test_metadata_key_rejects_invalid_identifier(bad_key: str):
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = False
+
+    with pytest.raises(ValueError, match="C# identifier"):
+        await store.store(b"data", metadata={bad_key: "value"})
+
+
+@pytest.mark.asyncio
+async def test_missing_container_propagates_error():
+    store, _, _, blob = _make_store()
+    blob.exists.return_value = False
+    blob.upload_blob.side_effect = ResourceNotFoundError(
+        "container does not exist"
+    )
+
+    with pytest.raises(ResourceNotFoundError):
+        await store.store(b"oops")

--- a/uv.lock
+++ b/uv.lock
@@ -279,16 +279,15 @@ wheels = [
 
 [[package]]
 name = "azure-core"
-version = "1.35.0"
+version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
-    { name = "six" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/89/f53968635b1b2e53e4aad2dd641488929fef4ca9dfb0b97927fa7697ddf3/azure_core-1.35.0.tar.gz", hash = "sha256:c0be528489485e9ede59b6971eb63c1eaacf83ef53001bfe3904e475e972be5c", size = 339689, upload-time = "2025-07-03T00:55:23.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz", hash = "sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a", size = 381042, upload-time = "2026-05-07T23:30:54.302Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/78/bf94897361fdd650850f0f2e405b2293e2f12808239046232bdedf554301/azure_core-1.35.0-py3-none-any.whl", hash = "sha256:8db78c72868a58f3de8991eb4d22c4d368fae226dac1002998d6c50437e7dad1", size = 210708, upload-time = "2025-07-03T00:55:25.238Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/db/325c6d7312d2200251c52323878281045aaffcb5586612296484e4280eaa/azure_core-1.41.0-py3-none-any.whl", hash = "sha256:522b4011e8180b1a3dcd2024396a4e7fe9ac37fb8597db47163d230b5efe892d", size = 220920, upload-time = "2026-05-07T23:30:56.357Z" },
 ]
 
 [[package]]
@@ -319,6 +318,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/97/e5/3074e581b6e8923c4a1f2e42192ea6f390bb52de3600c68baaaed529ef05/azure_keyvault_secrets-4.10.0.tar.gz", hash = "sha256:666fa42892f9cee749563e551a90f060435ab878977c95265173a8246d546a36", size = 129695, upload-time = "2025-06-16T22:52:20.986Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/94/7c902e966b28e7cb5080a8e0dd6bffc22ba44bc907f09c4c633d2b7c4f6a/azure_keyvault_secrets-4.10.0-py3-none-any.whl", hash = "sha256:9dbde256077a4ee1a847646671580692e3f9bea36bcfc189c3cf2b9a94eb38b9", size = 125237, upload-time = "2025-06-16T22:52:22.489Z" },
+]
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/25/fdcf1e381922dbab8ba23d6fd78d397fe6cbac6b480310218834b7bc91fe/azure_storage_blob-12.29.0.tar.gz", hash = "sha256:2824ddd7ebc9056034ebc76b17971a38e9aa5835abb0d565b9700493f2a6c657", size = 611359, upload-time = "2026-05-15T03:34:59.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2c/6ddee6a3e42d0236ba9259e4df7fa97fdc415ff0802b736c634baaf4b285/azure_storage_blob-12.29.0-py3-none-any.whl", hash = "sha256:ccf8a1bcd5e49df83ab85aab793b579e5ba2eeea2ad8900b2f62ca3a37dc391f", size = 434823, upload-time = "2026-05-15T03:35:01.837Z" },
 ]
 
 [[package]]
@@ -2161,6 +2175,7 @@ dependencies = [
     { name = "authlib" },
     { name = "azure-identity" },
     { name = "azure-keyvault-secrets" },
+    { name = "azure-storage-blob" },
     { name = "boto3" },
     { name = "click" },
     { name = "connectorx" },
@@ -2235,6 +2250,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.6.5" },
     { name = "azure-identity", specifier = ">=1.23.0" },
     { name = "azure-keyvault-secrets", specifier = ">=4.8.0" },
+    { name = "azure-storage-blob", specifier = ">=12.20.0" },
     { name = "boto3", specifier = ">=1.38.45" },
     { name = "build", marker = "extra == 'publish'", specifier = ">=1.2.2.post1" },
     { name = "click", specifier = ">=8.1.0,<8.2.1" },


### PR DESCRIPTION
## Summary

- Add `AzureBlobPayloadStore` async adapter wrapping
  `azure-storage-blob` (sync SDK) through `asyncio.to_thread` —
  same canonical pattern as `S3PayloadStore` and
  `GCSPayloadStore`.
- 21 Azure-specific unit tests via `unittest.mock` stubbing the
  `BlobServiceClient → ContainerClient → BlobClient` chain (no
  Azurite emulator).
- Add `azure-storage-blob>=12.20.0` to runtime deps alongside the
  existing `azure-identity` / `azure-keyvault-secrets`.
- Wiki: extend `noetl/core/payload_store.md` with full
  `## AzureBlobPayloadStore` section + `## SeaweedFS` subsection
  (S3-mode recipe; no dedicated adapter needed) + status /
  diagram / compliance-suite-deferral note.

This closes out the cloud-adapter rollout for v2 spec Phase 5.
The remaining piece — wiring the `EventRecord.payload_ref` field
to `PayloadReference` shape — lands in a separate round 5 since
it touches the event-store envelope, postgres insert path,
frames endpoint, and replay service.

## Design notes

- **Key layout** matches filesystem + S3 + GCS adapters:
  `<prefix>/<sha[:2]>/<sha[2:4]>/<sha>`.
- **URI shape:** `azure://<account>/<container>/<key>` when the
  account name is derivable from the `BlobServiceClient`, else
  `azure://<container>/<key>`.
- **Dedup** via `BlobClient.exists()` before `upload_blob`.
- **Metadata** rides as Azure custom metadata (`x-ms-meta-*`).
  Boundary check requires C#-identifier keys and ASCII values
  (Azure's documented constraints).
- **Content type** via `ContentSettings(content_type=...)`.
- **Delete** is Protocol-compliant (`True` if removed, `False`
  if absent) — implemented as `exists` + `delete_blob` because
  `delete_blob()` raises `ResourceNotFoundError` on missing keys.
- **Async surface, sync backend** — the SDK ships an `aio`
  submodule but using it would force aio-aware testing
  infrastructure and risk a repeat of the round-2 aioboto3/moto
  trap.

## SeaweedFS

Documented as doc-only path. SeaweedFS exposes an S3-compatible
API on its filer / S3 gateway port; the existing `S3PayloadStore`
covers it via `endpoint_url`. A dedicated SeaweedFS-native HTTP
adapter is mentioned as future work but not built.

## Compliance-suite note

The parametrized compliance fixture (`test_compliance.py`) is
**not** extended to Azure (same reason as GCS in round 3 —
Azurite is a process-based emulator binary, not a Python
decorator). Both legs can join once a process-emulator harness
lands in a dedicated test-infra round.

## Test plan

- [x] `pytest tests/core/payload_store/test_azure.py -q` —
      21 passed
- [x] `pytest tests/core/payload_store/ -q` — 72 passed
      (filesystem + S3 + GCS + compliance suites still green)
- [x] Regression sweep:
      `pytest tests/core/payload_store/
      tests/core/test_projector_metrics.py
      tests/core/test_replay_state_projector.py
      tests/unit/dsl/engine/test_fanout_reduce_planner.py -q`
      — 124 passed
- [x] Smoke import:
      `from noetl.core.payload_store import AzureBlobPayloadStore`
- [ ] Reviewer: confirm wiki diff at
      https://github.com/noetl/noetl/wiki/payload_store

## Wiki

Paired wiki update pushed to `noetl.wiki@e201549`:
`wiki(payload_store): document Azure Blob adapter + SeaweedFS via S3 mode`.

## Follow-ups (out of scope)

- **Phase 5 round 5** — `EventRecord.payload_ref` typed binding:
  switch the event-store envelope's `payload_ref` field from
  `Optional[dict[str, Any]]` to a `PayloadReference` shape, and
  wire the storage tier's spill-to-payload-store path through it.
  Touches `noetl/core/event_store/ports.py`, `postgres.py`,
  `noetl/server/api/frames/endpoint.py`, and
  `noetl/server/api/replay/service.py`.
- **Compliance leg for GCS + Azure** — process-emulator test
  fixture (`gcp-storage-emulator` + Azurite). Shared infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)