### PR TITLE
feat(event-store): bind payload_ref to PayloadReference

### DIFF
--- a/noetl/core/event_store/__init__.py
+++ b/noetl/core/event_store/__init__.py
@@ -1,6 +1,13 @@
 """Event-store port and reference adapters."""
 
-from .ports import EventRecord, EventStore, ExpectedVersionConflict, canonical_event_checksum
+from .ports import (
+    PAYLOAD_REF_KIND_PAYLOAD_STORE,
+    EventRecord,
+    EventStore,
+    ExpectedVersionConflict,
+    canonical_event_checksum,
+    payload_ref_to_dict,
+)
 from .postgres import PostgresEventStore
 
 __all__ = [
@@ -8,5 +15,7 @@ __all__ = [
     "EventStore",
     "ExpectedVersionConflict",
     "PostgresEventStore",
+    "PAYLOAD_REF_KIND_PAYLOAD_STORE",
     "canonical_event_checksum",
+    "payload_ref_to_dict",
 ]

--- a/noetl/core/event_store/ports.py
+++ b/noetl/core/event_store/ports.py
@@ -4,7 +4,9 @@ import hashlib
 import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Optional, Protocol
+from typing import Any, Optional, Protocol, Union
+
+from noetl.core.payload_store.ports import PayloadReference
 
 
 class ExpectedVersionConflict(RuntimeError):
@@ -37,6 +39,54 @@ def canonical_event_checksum(value: dict[str, Any]) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
+#: Marker on serialized payload_ref dicts that originated from a
+#: :class:`noetl.core.payload_store.PayloadReference`. Consumers
+#: (replay locator, future PayloadStore-aware resolver) use this
+#: discriminator to recognize payload-store-backed references
+#: without inspecting field shapes.
+PAYLOAD_REF_KIND_PAYLOAD_STORE = "payload_store"
+
+
+def payload_ref_to_dict(
+    value: Optional[Union[PayloadReference, dict[str, Any]]],
+) -> Optional[dict[str, Any]]:
+    """Normalize an event ``payload_ref`` to a JSON-column-compatible dict.
+
+    Accepts three shapes:
+
+    - ``None`` — returned unchanged.
+    - :class:`PayloadReference` — serialized to a canonical dict with the
+      ``kind`` discriminator set to
+      :data:`PAYLOAD_REF_KIND_PAYLOAD_STORE` plus every reference field
+      (``sha256``, ``byte_length``, ``content_type``, ``uri``,
+      ``metadata``).
+    - ``dict`` — returned unchanged. Used both for legacy
+      TempStore-shaped references (``{"ref": ..., "kind": "result_ref"}``)
+      and for already-serialized PayloadReference dicts coming back off
+      the postgres ``payload_ref`` JSON column.
+
+    Any other input raises :class:`TypeError` with a clear message —
+    the envelope must never carry a non-serializable ``payload_ref``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, PayloadReference):
+        return {
+            "kind": PAYLOAD_REF_KIND_PAYLOAD_STORE,
+            "sha256": value.sha256,
+            "byte_length": value.byte_length,
+            "content_type": value.content_type,
+            "uri": value.uri,
+            "metadata": dict(value.metadata),
+        }
+    if isinstance(value, dict):
+        return value
+    raise TypeError(
+        "EventRecord.payload_ref must be None, a PayloadReference, or a "
+        f"dict; got {type(value).__name__}"
+    )
+
+
 @dataclass(frozen=True)
 class EventRecord:
     """Backend-neutral event-store record.
@@ -58,7 +108,7 @@ class EventRecord:
     causation_id: Optional[str] = None
     correlation_id: Optional[str] = None
     idempotency_key: Optional[str] = None
-    payload_ref: Optional[dict[str, Any]] = None
+    payload_ref: Optional[Union[PayloadReference, dict[str, Any]]] = None
     result: dict[str, Any] = field(default_factory=dict)
     meta: dict[str, Any] = field(default_factory=dict)
     status: Optional[str] = None
@@ -84,7 +134,7 @@ class EventRecord:
             "causation_id": self.causation_id,
             "correlation_id": self.correlation_id,
             "idempotency_key": self.idempotency_key,
-            "payload_ref": self.payload_ref,
+            "payload_ref": payload_ref_to_dict(self.payload_ref),
             "result": self.result,
             "meta": self.meta,
             "status": self.status,

--- a/noetl/server/api/replay/payload_resolver.py
+++ b/noetl/server/api/replay/payload_resolver.py
@@ -78,11 +78,33 @@ def _resolve_input(reference: Any, ref: str) -> Any:
 
 
 def replay_payload_ref_locator(reference: Any) -> str | None:
-    """Return the stable locator for a replay payload reference, when present."""
+    """Return the stable locator for a replay payload reference, when present.
+
+    Recognized shapes:
+
+    - Bare string locators (legacy).
+    - Mappings with ``kind == "payload_store"`` — extracted from
+      :class:`noetl.core.payload_store.PayloadReference` via
+      :func:`noetl.core.event_store.payload_ref_to_dict`. Prefers
+      the ``uri`` field (e.g. ``s3://``, ``gs://``, ``azure://``);
+      falls back to the ``sha256`` digest when no URI is set.
+    - Legacy mappings carrying ``ref``/``uri``/``locator`` keys,
+      including nested ``rows_ref`` sub-mappings.
+
+    Returns ``None`` when the reference has no extractable locator.
+    """
     if isinstance(reference, str):
         return reference
     if not isinstance(reference, Mapping):
         return None
+    if reference.get("kind") == "payload_store":
+        for key in ("uri", "sha256"):
+            value = reference.get(key)
+            if value:
+                return str(value)
+        # Fall through to the legacy keys for forward-compat (a
+        # PayloadReference dict with no URI and no sha256 is malformed,
+        # but the legacy path shouldn't crash on it).
     for key in ("ref", "uri", "locator"):
         value = reference.get(key)
         if value:

--- a/tests/core/event_store/test_payload_ref_binding.py
+++ b/tests/core/event_store/test_payload_ref_binding.py
@@ -1,0 +1,128 @@
+"""Tests for the :class:`EventRecord` ↔ :class:`PayloadReference`
+typed binding introduced in v2 spec Phase 5 round 5.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from noetl.core.event_store import (
+    PAYLOAD_REF_KIND_PAYLOAD_STORE,
+    EventRecord,
+    payload_ref_to_dict,
+)
+from noetl.core.payload_store import PayloadReference
+
+
+_PAYLOAD = b"hello typed binding"
+_REF = PayloadReference(
+    sha256="a" * 64,
+    byte_length=len(_PAYLOAD),
+    content_type="text/plain",
+    uri="gs://noetl-payload/aa/bb/abc",
+    metadata={"origin": "test", "tenant": "default"},
+)
+
+
+def _record(**overrides):
+    base = dict(
+        event_type="frame.committed",
+        stream_id="execution/1/stage/2",
+        execution_id=1,
+        aggregate_id="frame/3",
+        aggregate_type="frame",
+        result={"status": "COMPLETED"},
+        meta={"row_count": 2},
+        event_time=datetime(2026, 5, 22, tzinfo=timezone.utc),
+    )
+    base.update(overrides)
+    return EventRecord(**base)
+
+
+def test_envelope_serializes_payload_reference_to_canonical_dict():
+    record = _record(payload_ref=_REF)
+    envelope = record.envelope(stream_version=7)
+
+    payload_ref = envelope["payload_ref"]
+    assert payload_ref == {
+        "kind": PAYLOAD_REF_KIND_PAYLOAD_STORE,
+        "sha256": _REF.sha256,
+        "byte_length": _REF.byte_length,
+        "content_type": _REF.content_type,
+        "uri": _REF.uri,
+        "metadata": dict(_REF.metadata),
+    }
+
+
+def test_envelope_passes_through_legacy_dict_unchanged():
+    legacy = {
+        "kind": "result_ref",
+        "ref": "noetl://result_ref/some-id",
+        "scope": "execution",
+    }
+    record = _record(payload_ref=legacy)
+    envelope = record.envelope(stream_version=1)
+
+    assert envelope["payload_ref"] == legacy
+    # And the dict identity is preserved (no defensive copy)
+    assert envelope["payload_ref"] is legacy
+
+
+def test_envelope_handles_none_payload_ref():
+    record = _record(payload_ref=None)
+    envelope = record.envelope(stream_version=1)
+
+    assert "payload_ref" in envelope
+    assert envelope["payload_ref"] is None
+
+
+@pytest.mark.parametrize("bad_value", ["just a string", 42, ["list"], 3.14])
+def test_payload_ref_to_dict_rejects_invalid_input(bad_value):
+    with pytest.raises(TypeError, match="PayloadReference"):
+        payload_ref_to_dict(bad_value)
+
+
+def test_checksum_matches_between_payload_reference_and_dict_form():
+    """A PayloadReference and its serialized dict must yield identical envelopes."""
+    record_ref = _record(payload_ref=_REF)
+    record_dict = _record(payload_ref=payload_ref_to_dict(_REF))
+
+    envelope_ref = record_ref.envelope(stream_version=7)
+    envelope_dict = record_dict.envelope(stream_version=7)
+
+    assert envelope_ref["envelope_checksum"] == envelope_dict["envelope_checksum"]
+    assert envelope_ref["payload_ref"] == envelope_dict["payload_ref"]
+
+
+def test_payload_ref_metadata_preserved_in_envelope():
+    ref = PayloadReference(
+        sha256="b" * 64,
+        byte_length=10,
+        content_type="application/json",
+        uri="s3://bucket/key",
+        metadata={"origin": "frame", "tool": "python", "schema": "v1"},
+    )
+    record = _record(payload_ref=ref)
+    envelope = record.envelope(stream_version=1)
+
+    assert envelope["payload_ref"]["metadata"] == {
+        "origin": "frame",
+        "tool": "python",
+        "schema": "v1",
+    }
+
+
+def test_payload_ref_to_dict_none_returns_none():
+    assert payload_ref_to_dict(None) is None
+
+
+def test_payload_ref_to_dict_passes_through_dict():
+    legacy = {"kind": "temp_ref", "ref": "noetl://temp/x"}
+    assert payload_ref_to_dict(legacy) is legacy
+
+
+def test_payload_ref_kind_constant_value():
+    """The discriminator string is part of the wire contract — guard it."""
+    assert PAYLOAD_REF_KIND_PAYLOAD_STORE == "payload_store"

--- a/tests/core/test_replay_payload_ref_locator_kind.py
+++ b/tests/core/test_replay_payload_ref_locator_kind.py
@@ -1,0 +1,73 @@
+"""Tests for ``replay_payload_ref_locator`` with the new
+``kind: "payload_store"`` discriminator introduced in v2 spec Phase
+5 round 5.
+
+Existing legacy locator behavior (``ref`` / ``uri`` / ``locator``
+keys, bare strings, nested ``rows_ref`` mappings) is regression-
+guarded here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from noetl.server.api.replay import replay_payload_ref_locator
+
+
+def test_locator_extracts_uri_for_payload_store_kind():
+    ref = {
+        "kind": "payload_store",
+        "sha256": "a" * 64,
+        "byte_length": 7,
+        "content_type": "text/plain",
+        "uri": "gs://bucket/aa/bb/abc",
+        "metadata": {},
+    }
+    assert replay_payload_ref_locator(ref) == "gs://bucket/aa/bb/abc"
+
+
+def test_locator_falls_back_to_sha256_for_payload_store_kind_without_uri():
+    ref = {
+        "kind": "payload_store",
+        "sha256": "c" * 64,
+        "byte_length": 0,
+        "uri": None,
+        "metadata": {},
+    }
+    assert replay_payload_ref_locator(ref) == "c" * 64
+
+
+def test_locator_returns_uri_when_kind_unset_legacy():
+    ref = {"uri": "/tmp/foo"}
+    assert replay_payload_ref_locator(ref) == "/tmp/foo"
+
+
+def test_locator_returns_ref_for_legacy_temp_store_dict():
+    ref = {"kind": "temp_ref", "ref": "noetl://temp/x"}
+    assert replay_payload_ref_locator(ref) == "noetl://temp/x"
+
+
+def test_locator_returns_none_for_empty_dict():
+    assert replay_payload_ref_locator({}) is None
+
+
+def test_locator_returns_string_for_bare_string_locator():
+    assert replay_payload_ref_locator("some-ref") == "some-ref"
+
+
+def test_locator_returns_none_for_unknown_payload_store_shape():
+    """A payload_store-kind dict with no URI and no sha256 falls through
+    to the legacy lookup and returns None (legacy keys are absent)."""
+    ref = {"kind": "payload_store", "byte_length": 0, "metadata": {}}
+    assert replay_payload_ref_locator(ref) is None
+
+
+def test_locator_legacy_rows_ref_nested_mapping():
+    """Regression guard: nested ``rows_ref`` extraction still works."""
+    ref = {"rows_ref": {"ref": "noetl://rows/y"}}
+    assert replay_payload_ref_locator(ref) == "noetl://rows/y"
+
+
+@pytest.mark.parametrize("non_mapping", [None, 42, 3.14, ["a", "b"]])
+def test_locator_returns_none_for_non_mapping_non_string(non_mapping):
+    assert replay_payload_ref_locator(non_mapping) is None


### PR DESCRIPTION
## Summary

Closes out **v2 spec Phase 5** (port/adapter event/projection/payload)
by adding a typed binding so callers can pass a `PayloadReference`
directly to `EventRecord.payload_ref`. The envelope serializes the
reference to a canonical JSON-column-compatible dict with a stable
`kind: "payload_store"` discriminator. Backwards-compatible: legacy
TempStore-shaped dicts continue to flow through untouched.

## Design

- New `PAYLOAD_REF_KIND_PAYLOAD_STORE = "payload_store"` constant
  is the wire-format discriminator.
- New `payload_ref_to_dict(value)` helper normalizes the three
  accepted shapes:
  - `None` → `None`
  - `PayloadReference` → canonical dict with the discriminator +
    every reference field
  - `dict` → pass-through (legacy shapes, dicts read back off the
    postgres column)
  - anything else → `TypeError` at envelope-construction time
- `EventRecord.payload_ref` typing widens to
  `Optional[Union[PayloadReference, dict[str, Any]]]`.
- `EventRecord.envelope()` runs `self.payload_ref` through the
  helper so the canonicalization is centralized.
- `replay_payload_ref_locator` recognizes the new discriminator and
  prefers the `uri` field (falling back to `sha256` when `uri` is
  `None`). Legacy lookups (`ref` / `uri` / `locator` / nested
  `rows_ref`) remain intact.

## Wire format

```json
{
  \"kind\": \"payload_store\",
  \"sha256\": \"abcd…\",
  \"byte_length\": 1234,
  \"content_type\": \"application/json\",
  \"uri\": \"gs://bucket/aa/bb/abcd…\",
  \"metadata\": {\"origin\": \"frame-row-spill\"}
}
```

## Out of scope

- **Postgres payload_ref column unchanged.** No schema migration.
- **`TempStoreReplayPayloadResolver` routing unchanged.** Cloud URIs
  aren't yet resolved through their PayloadStore adapter — that
  needs a PayloadStore registry + router and is its own future
  round.
- **Storage tier spill path unchanged.** No caller is rewired to
  produce `PayloadReference` instances on the write side yet; this
  round just gives them a clean shape to write against when they do.

## Test plan

- [x] `pytest tests/core/event_store/test_payload_ref_binding.py
      tests/core/test_replay_payload_ref_locator_kind.py -q` —
      24 passed
- [x] Focused regression sweep:
      `pytest tests/core/event_store/ tests/core/test_event_store_ports.py
      tests/core/test_replay_payload_resolver.py
      tests/core/test_replay_payload_ref_locator_kind.py
      tests/core/test_replay_state_projector.py
      tests/core/payload_store/ -q` — 130 passed
- [x] Broader sweep:
      `pytest tests/core/ tests/api/test_replay_routes.py
      tests/server/api/ -q` — 280 passed (one pre-existing
      \`CatalogResource\` import failure on \`main\`, unrelated)
- [x] End-to-end smoke:
      \`EventRecord(payload_ref=PayloadReference(...)).envelope(1)\`
      → envelope carries the canonical dict + matches the
      checksum of the same record built from
      \`payload_ref_to_dict(ref)\`
- [ ] Reviewer: confirm wiki diffs at
      https://github.com/noetl/noetl/wiki/event_store and
      https://github.com/noetl/noetl/wiki/payload_store

## Wiki

Paired wiki update pushed to \`noetl.wiki@1549932\`:
\`wiki(event_store,payload_store): document EventRecord.payload_ref typed binding\`.

## Follow-ups (out of scope)

- **PayloadStore-aware resolver routing** — a registry + router that
  picks the right adapter (`s3://`/`gs://`/`azure://`) for replay
  payload resolution. Needs the `_resolve_input` shape in
  `payload_resolver.py` to learn about PayloadStore adapters.
- **Storage tier spill-to-payload-store** — actually route the
  TempStore's spill-on-eviction path through a registered
  `PayloadStore`. Larger change touching the storage tier.
- **Process-emulator compliance fixture** — Azurite +
  \`fake-gcs-server\` wired into a shared test-infra harness so
  the GCS + Azure cloud adapters join the parametrized compliance
  suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)