### PR TITLE
feat(resource-locator): URN extension for data resources, locality, and NATS subjects

### DIFF
--- a/noetl/core/resource_locator.py
+++ b/noetl/core/resource_locator.py
@@ -4,16 +4,73 @@ NoETL locators are durable identities, not transport URLs. They use the
 ``noetl://`` scheme followed by slash-separated resource segments, for example:
 
 ``noetl://tenant/t1/org/o1/cluster/prod/node/node-a/worker/cpu-01``.
+
+The locator is intentionally minimal and stable: alternating key/value
+segments, URL-safe per-segment encoding, no query / fragment / params.
+It is the **portable** identity used across the event store
+(``payload_ref``), the storage tier (``ResultRef.ref``), the runtime
+topology (worker identity), and — starting with Phase 4 — the catalog
+and NATS supercluster routing layers.
+
+Beyond the parser, this module exposes:
+
+- :data:`KNOWN_RESOURCE_KINDS` — advisory taxonomy of recognized
+  top-level ``kind`` segments. Unknown kinds parse without error;
+  the taxonomy is for catalog / router dispatch + warning paths.
+- :meth:`NoetlResourceLocator.to_nats_subject` /
+  :meth:`NoetlResourceLocator.from_nats_subject` — canonical
+  derivation of a NATS-safe subject from a locator. Phase 4
+  round 3 (NATS supercluster) leans on this.
+- :meth:`NoetlResourceLocator.locality` — extract the locality
+  segments (``region`` / ``zone`` / ``cluster`` / ``node``) into a
+  plain dict, without callers having to know the schema.
+- :func:`dataset_locator` / :func:`stream_locator` /
+  :func:`partition_locator` — data-resource URN builders for the
+  future catalog routing work.
 """
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Iterable, Mapping, Optional
 from urllib.parse import quote, unquote, urlparse
 
 
 SCHEME = "noetl"
+
+#: NATS subject root for every NoETL-derived subject. All subjects
+#: produced by :meth:`NoetlResourceLocator.to_nats_subject` start
+#: with this prefix so NATS subject-permission rules can match
+#: ``noetl.>``.
+NATS_SUBJECT_ROOT = "noetl"
+
+#: Regex matching characters that are NOT allowed in a NATS subject
+#: segment. NATS accepts ``[a-zA-Z0-9_-]`` plus the wildcards ``*``
+#: and ``>``; concrete subjects (what the locator emits) keep only
+#: the alphanumerics + ``_`` and ``-``.
+_NATS_SAFE_RE = re.compile(r"[^a-zA-Z0-9_-]")
+
+#: Advisory taxonomy of recognized top-level locator ``kind``
+#: segments. The set is intentionally extensible: parsing an
+#: unknown kind does not raise. Catalog / router code should check
+#: :attr:`NoetlResourceLocator.is_known_kind` and decide its own
+#: policy (log, warn, route to a default, etc.).
+KNOWN_RESOURCE_KINDS = frozenset(
+    {
+        "tenant",  # worker / runtime identity
+        "execution",  # playbook execution
+        "dataset",  # logical dataset for catalog routing
+        "stream",  # event / data stream
+        "partition",  # physical partition of a stream
+        "payload",  # content-addressed payload (pairs with payload_store URIs)
+    }
+)
+
+#: Locality segments recognized by :meth:`NoetlResourceLocator.locality`,
+#: in coarse-to-fine order. Builders emit them in this order so URN
+#: prefixes sort naturally by geographic scope.
+LOCALITY_KEYS = ("region", "zone", "cluster", "node")
 
 
 class ResourceLocatorError(ValueError):
@@ -60,6 +117,29 @@ class NoetlResourceLocator:
             segments.extend((str(key), str(value)))
         return cls.from_segments(segments)
 
+    @classmethod
+    def from_nats_subject(cls, subject: str) -> "NoetlResourceLocator":
+        """Parse a NATS subject produced by :meth:`to_nats_subject`.
+
+        Strips the :data:`NATS_SUBJECT_ROOT` prefix, splits on ``.``,
+        and rebuilds the locator from the resulting segments. Because
+        :meth:`to_nats_subject` is **lossy** (URL-quoted bytes collapse
+        to ``_``), round-trip is only guaranteed when every original
+        segment is already NATS-safe.
+        """
+        if not isinstance(subject, str) or not subject.strip():
+            raise ResourceLocatorError("nats subject must be a non-empty string")
+        cleaned = subject.strip()
+        prefix = f"{NATS_SUBJECT_ROOT}."
+        if not cleaned.startswith(prefix):
+            raise ResourceLocatorError(
+                f"nats subject must start with {prefix!r}: {subject!r}"
+            )
+        body = cleaned[len(prefix) :]
+        if not body:
+            raise ResourceLocatorError("nats subject has no segments after the root prefix")
+        return cls.from_segments(body.split("."))
+
     @property
     def kind(self) -> str:
         return self.segments[0]
@@ -67,6 +147,16 @@ class NoetlResourceLocator:
     @property
     def identity(self) -> Optional[str]:
         return self.segments[1] if len(self.segments) > 1 else None
+
+    @property
+    def is_known_kind(self) -> bool:
+        """``True`` iff :attr:`kind` is in :data:`KNOWN_RESOURCE_KINDS`.
+
+        Advisory only — the parser never rejects unknown kinds.
+        Catalog / router code should branch on this and decide its
+        own policy.
+        """
+        return self.kind in KNOWN_RESOURCE_KINDS
 
     def value_after(self, key: str) -> Optional[str]:
         """Return the first segment immediately following ``key``."""
@@ -90,6 +180,44 @@ class NoetlResourceLocator:
     def child(self, *segments: object) -> "NoetlResourceLocator":
         return NoetlResourceLocator.from_segments((*self.segments, *(str(segment) for segment in segments)))
 
+    def locality(self) -> dict[str, str]:
+        """Return locality segments (``region``/``zone``/``cluster``/``node``).
+
+        Returns an empty dict when no locality segments are present.
+        The returned dict's keys preserve the coarse-to-fine order
+        from :data:`LOCALITY_KEYS`.
+        """
+        result: dict[str, str] = {}
+        for key in LOCALITY_KEYS:
+            value = self.value_after(key)
+            if value:
+                result[key] = value
+        return result
+
+    def to_nats_subject(self) -> str:
+        """Derive a canonical NATS-safe subject from the locator.
+
+        Mapping rules:
+
+        - Strip the ``noetl://`` scheme.
+        - For each segment: keep ``[a-zA-Z0-9_-]`` characters; replace
+          any other byte with ``_``. URL-quoted segments (e.g.
+          ``r%26d``) thus collapse to underscores; the mapping is
+          **lossy** for non-NATS-safe segments.
+        - Prefix with :data:`NATS_SUBJECT_ROOT` (``noetl``) so NATS
+          subject-permission rules can match ``noetl.>``.
+        - Join with ``.`` (the NATS segment separator).
+
+        Example::
+
+            >>> NoetlResourceLocator.from_segments(
+            ...     ["tenant", "acme", "org", "research", "cluster", "us-east-1"]
+            ... ).to_nats_subject()
+            'noetl.tenant.acme.org.research.cluster.us-east-1'
+        """
+        safe_segments = [_NATS_SAFE_RE.sub("_", segment) for segment in self.segments]
+        return ".".join((NATS_SUBJECT_ROOT, *safe_segments))
+
     def __str__(self) -> str:
         return f"{SCHEME}://" + "/".join(quote(segment, safe="") for segment in self.segments)
 
@@ -111,9 +239,111 @@ def _normalize_segment(segment: object) -> str:
     return value
 
 
+def _locality_pairs(
+    *,
+    region: Optional[str],
+    zone: Optional[str],
+    cluster_id: Optional[str],
+    node_id: Optional[str] = None,
+) -> list[tuple[str, str]]:
+    """Build alternating-pair tuples for the locality segments that are set."""
+    pairs: list[tuple[str, str]] = []
+    if region:
+        pairs.append(("region", str(region)))
+    if zone:
+        pairs.append(("zone", str(zone)))
+    if cluster_id:
+        pairs.append(("cluster", str(cluster_id)))
+    if node_id:
+        pairs.append(("node", str(node_id)))
+    return pairs
+
+
+def dataset_locator(
+    tenant_id: str,
+    organization_id: str,
+    dataset_id: str,
+    *,
+    region: Optional[str] = None,
+    zone: Optional[str] = None,
+    cluster_id: Optional[str] = None,
+) -> str:
+    """Build a canonical dataset URN.
+
+    Shape::
+
+        noetl://tenant/<t>/org/<o>[/region/<r>][/zone/<z>][/cluster/<c>]/dataset/<id>
+
+    Locality segments are included only when their argument is set.
+    """
+    pairs: list[tuple[str, str]] = [
+        ("tenant", str(tenant_id)),
+        ("org", str(organization_id)),
+    ]
+    pairs.extend(_locality_pairs(region=region, zone=zone, cluster_id=cluster_id))
+    pairs.append(("dataset", str(dataset_id)))
+    return str(NoetlResourceLocator.from_pairs(pairs))
+
+
+def stream_locator(
+    tenant_id: str,
+    organization_id: str,
+    stream_id: str,
+    *,
+    region: Optional[str] = None,
+    zone: Optional[str] = None,
+    cluster_id: Optional[str] = None,
+) -> str:
+    """Build a canonical stream URN.
+
+    Shape::
+
+        noetl://tenant/<t>/org/<o>[/region/<r>][/zone/<z>][/cluster/<c>]/stream/<id>
+    """
+    pairs: list[tuple[str, str]] = [
+        ("tenant", str(tenant_id)),
+        ("org", str(organization_id)),
+    ]
+    pairs.extend(_locality_pairs(region=region, zone=zone, cluster_id=cluster_id))
+    pairs.append(("stream", str(stream_id)))
+    return str(NoetlResourceLocator.from_pairs(pairs))
+
+
+def partition_locator(
+    tenant_id: str,
+    organization_id: str,
+    stream_id: str,
+    partition_index: int | str,
+    *,
+    region: Optional[str] = None,
+    zone: Optional[str] = None,
+    cluster_id: Optional[str] = None,
+) -> str:
+    """Build a canonical partition URN.
+
+    Shape::
+
+        noetl://tenant/<t>/org/<o>[/region/<r>][/zone/<z>][/cluster/<c>]/stream/<sid>/partition/<idx>
+    """
+    pairs: list[tuple[str, str]] = [
+        ("tenant", str(tenant_id)),
+        ("org", str(organization_id)),
+    ]
+    pairs.extend(_locality_pairs(region=region, zone=zone, cluster_id=cluster_id))
+    pairs.append(("stream", str(stream_id)))
+    pairs.append(("partition", str(partition_index)))
+    return str(NoetlResourceLocator.from_pairs(pairs))
+
+
 __all__ = [
+    "KNOWN_RESOURCE_KINDS",
+    "LOCALITY_KEYS",
+    "NATS_SUBJECT_ROOT",
     "NoetlResourceLocator",
     "ResourceLocatorError",
     "build_noetl_locator",
+    "dataset_locator",
     "parse_noetl_locator",
+    "partition_locator",
+    "stream_locator",
 ]

--- a/noetl/core/runtime/topology.py
+++ b/noetl/core/runtime/topology.py
@@ -21,9 +21,15 @@ class WorkerLocatorParts:
     worker_pool: str
     cluster_id: str | None = None
     node_id: str | None = None
+    region: str | None = None
+    zone: str | None = None
 
     def as_locality(self) -> dict[str, str]:
         locality: dict[str, str] = {"worker_pool": self.worker_pool}
+        if self.region:
+            locality["region"] = self.region
+        if self.zone:
+            locality["zone"] = self.zone
         if self.cluster_id:
             locality["cluster_id"] = self.cluster_id
         if self.node_id:
@@ -61,9 +67,16 @@ def worker_locator(
             "org",
             organization_id or "default",
         ]
+        region = locality.get("region")
+        zone = locality.get("zone")
         cluster_id = locality.get("cluster_id")
         node_id = locality.get("node_id")
         worker_pool = locality.get("worker_pool") or worker_id
+        # Coarse-to-fine: region → zone → cluster → node → worker.
+        if region:
+            segments.extend(["region", region])
+        if zone:
+            segments.extend(["zone", zone])
         if cluster_id:
             segments.extend(["cluster", cluster_id])
         if node_id:
@@ -85,7 +98,9 @@ def parse_worker_locator(value: str) -> WorkerLocatorParts:
     except ResourceLocatorError as exc:
         raise ResourceLocatorError("worker locator must use alternating key/value segments") from exc
 
-    unknown = sorted(set(parts) - {"tenant", "org", "cluster", "node", "worker"})
+    unknown = sorted(
+        set(parts) - {"tenant", "org", "region", "zone", "cluster", "node", "worker"}
+    )
     if unknown:
         raise ResourceLocatorError(f"worker locator contains unknown segments: {', '.join(unknown)}")
 
@@ -99,6 +114,8 @@ def parse_worker_locator(value: str) -> WorkerLocatorParts:
         organization_id=parts["org"],
         cluster_id=parts.get("cluster"),
         node_id=parts.get("node"),
+        region=parts.get("region"),
+        zone=parts.get("zone"),
         worker_pool=parts["worker"],
     )
 

--- a/tests/core/test_resource_locator.py
+++ b/tests/core/test_resource_locator.py
@@ -57,3 +57,238 @@ def test_resource_locator_rejects_query_and_slash_segments():
 
     with pytest.raises(ResourceLocatorError, match="must not contain"):
         NoetlResourceLocator.from_segments(["execution", "bad/id"])
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 round 1 — URN extension
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["tenant", "execution", "dataset", "stream", "partition", "payload"])
+def test_known_kind_taxonomy_recognizes_each_kind(kind: str):
+    from noetl.core.resource_locator import NoetlResourceLocator
+
+    locator = NoetlResourceLocator.from_segments([kind, "some-id"])
+    assert locator.is_known_kind is True
+
+
+def test_known_kind_taxonomy_reports_unknown_without_error():
+    """Unknown kinds parse cleanly; is_known_kind reports False without raising."""
+    from noetl.core.resource_locator import NoetlResourceLocator
+
+    locator = NoetlResourceLocator.from_segments(["spaceship", "enterprise-d"])
+    assert locator.is_known_kind is False
+    # The locator itself remains usable
+    assert str(locator) == "noetl://spaceship/enterprise-d"
+    assert locator.kind == "spaceship"
+
+
+def test_known_kind_taxonomy_exports_expected_set():
+    from noetl.core.resource_locator import KNOWN_RESOURCE_KINDS
+
+    assert KNOWN_RESOURCE_KINDS == frozenset(
+        {"tenant", "execution", "dataset", "stream", "partition", "payload"}
+    )
+
+
+@pytest.mark.parametrize(
+    "segments",
+    [
+        ["tenant", "acme", "org", "research", "cluster", "us-east-1", "worker", "cpu-01"],
+        ["execution", "12345"],
+        ["payload", "sha256-abc"],
+        ["tenant", "acme", "org", "research", "stream", "orders-v1", "partition", "7"],
+    ],
+)
+def test_to_nats_subject_round_trip_for_nats_safe_segments(segments):
+    from noetl.core.resource_locator import NoetlResourceLocator
+
+    locator = NoetlResourceLocator.from_segments(segments)
+    subject = locator.to_nats_subject()
+    round_tripped = NoetlResourceLocator.from_nats_subject(subject)
+
+    # Round-trip identity for NATS-safe segments
+    assert tuple(round_tripped.segments) == tuple(segments)
+    # And the string form survives
+    assert str(round_tripped) == str(locator)
+
+
+def test_to_nats_subject_collapses_unsafe_chars():
+    """Non-NATS-safe characters in a segment collapse to underscores. Lossy."""
+    from noetl.core.resource_locator import NoetlResourceLocator
+
+    locator = NoetlResourceLocator.from_segments(["tenant", "r&d", "org", "team alpha"])
+    subject = locator.to_nats_subject()
+    assert subject == "noetl.tenant.r_d.org.team_alpha"
+
+    # Round-trip is lossy when the original was unsafe — what we get back
+    # is the collapsed form, not the original.
+    round_tripped = NoetlResourceLocator.from_nats_subject(subject)
+    assert tuple(round_tripped.segments) == ("tenant", "r_d", "org", "team_alpha")
+
+
+def test_to_nats_subject_prefix_is_noetl():
+    from noetl.core.resource_locator import NoetlResourceLocator
+
+    locator = NoetlResourceLocator.from_segments(["execution", "abc"])
+    subject = locator.to_nats_subject()
+    assert subject.startswith("noetl.")
+
+
+def test_to_nats_subject_does_not_emit_nats_forbidden_chars():
+    """The subject string only contains NATS-safe chars plus '.'.
+
+    Segments are limited to ``[a-zA-Z0-9_-]`` by the lossy mapping
+    (``/`` is impossible to land in a segment because the parser
+    rejects it before we ever reach ``to_nats_subject``).
+    """
+    import re
+
+    from noetl.core.resource_locator import NoetlResourceLocator
+
+    locator = NoetlResourceLocator.from_segments(
+        ["tenant", "ten?ant", "org", "team alpha", "cluster", "us east", "wild", "ca*re>t"]
+    )
+    subject = locator.to_nats_subject()
+    # Segments must be [a-zA-Z0-9_-], joined by '.'
+    assert re.fullmatch(r"[a-zA-Z0-9_.-]+", subject)
+    # And explicitly: no NATS-wildcard or query-style chars survived
+    for forbidden in ("?", "*", ">", " "):
+        assert forbidden not in subject
+
+
+def test_from_nats_subject_rejects_missing_prefix():
+    from noetl.core.resource_locator import NoetlResourceLocator, ResourceLocatorError
+
+    with pytest.raises(ResourceLocatorError, match="must start with 'noetl."):
+        NoetlResourceLocator.from_nats_subject("foo.bar.baz")
+
+
+def test_from_nats_subject_rejects_empty_body():
+    from noetl.core.resource_locator import NoetlResourceLocator, ResourceLocatorError
+
+    with pytest.raises(ResourceLocatorError, match="no segments after the root prefix"):
+        NoetlResourceLocator.from_nats_subject("noetl.")
+
+
+def test_from_nats_subject_rejects_empty_input():
+    from noetl.core.resource_locator import NoetlResourceLocator, ResourceLocatorError
+
+    with pytest.raises(ResourceLocatorError, match="non-empty string"):
+        NoetlResourceLocator.from_nats_subject("")
+
+
+def test_locality_extracts_present_segments():
+    from noetl.core.resource_locator import parse_noetl_locator
+
+    locator = parse_noetl_locator(
+        "noetl://tenant/acme/org/research/region/us-east1/zone/us-east1-b"
+        "/cluster/prod/node/node-a/worker/cpu-01"
+    )
+
+    assert locator.locality() == {
+        "region": "us-east1",
+        "zone": "us-east1-b",
+        "cluster": "prod",
+        "node": "node-a",
+    }
+
+
+def test_locality_returns_empty_for_no_locality_segments():
+    from noetl.core.resource_locator import parse_noetl_locator
+
+    locator = parse_noetl_locator("noetl://execution/123/result/load/abc")
+    assert locator.locality() == {}
+
+
+def test_locality_returns_only_set_segments():
+    from noetl.core.resource_locator import parse_noetl_locator
+
+    locator = parse_noetl_locator("noetl://tenant/acme/org/research/region/us-east1/dataset/x")
+    assert locator.locality() == {"region": "us-east1"}
+
+
+def test_dataset_locator_builds_canonical_shape():
+    from noetl.core.resource_locator import dataset_locator
+
+    # Without locality
+    assert (
+        dataset_locator("acme", "research", "sales-2026")
+        == "noetl://tenant/acme/org/research/dataset/sales-2026"
+    )
+
+    # With full locality
+    assert (
+        dataset_locator(
+            "acme",
+            "research",
+            "sales-2026",
+            region="us-east1",
+            zone="us-east1-b",
+            cluster_id="prod",
+        )
+        == "noetl://tenant/acme/org/research/region/us-east1/zone/us-east1-b"
+        "/cluster/prod/dataset/sales-2026"
+    )
+
+
+def test_dataset_locator_skips_unset_locality_fields():
+    from noetl.core.resource_locator import dataset_locator
+
+    # Only region set — zone / cluster omitted
+    assert (
+        dataset_locator("acme", "research", "ds-1", region="us-east1")
+        == "noetl://tenant/acme/org/research/region/us-east1/dataset/ds-1"
+    )
+
+
+def test_stream_locator_builds_canonical_shape():
+    from noetl.core.resource_locator import stream_locator
+
+    assert (
+        stream_locator("acme", "research", "orders-v1")
+        == "noetl://tenant/acme/org/research/stream/orders-v1"
+    )
+
+    assert (
+        stream_locator("acme", "research", "orders-v1", cluster_id="prod-1")
+        == "noetl://tenant/acme/org/research/cluster/prod-1/stream/orders-v1"
+    )
+
+
+def test_partition_locator_includes_stream_id_and_index():
+    from noetl.core.resource_locator import partition_locator
+
+    assert (
+        partition_locator("acme", "research", "orders-v1", 7)
+        == "noetl://tenant/acme/org/research/stream/orders-v1/partition/7"
+    )
+
+    # Integer index renders as string
+    assert (
+        partition_locator("acme", "research", "orders-v1", 0, region="us-east1")
+        == "noetl://tenant/acme/org/research/region/us-east1/stream/orders-v1/partition/0"
+    )
+
+
+def test_data_resource_locators_round_trip_through_parser():
+    """The data-resource builders produce URNs that the parser accepts."""
+    from noetl.core.resource_locator import (
+        dataset_locator,
+        parse_noetl_locator,
+        partition_locator,
+        stream_locator,
+    )
+
+    for builder, args in (
+        (dataset_locator, ("acme", "research", "sales-2026")),
+        (stream_locator, ("acme", "research", "orders-v1")),
+        (partition_locator, ("acme", "research", "orders-v1", 3)),
+    ):
+        uri = builder(*args, region="us-east1", cluster_id="prod")
+        locator = parse_noetl_locator(uri)
+        # Tenant + org + locality are present
+        assert locator.value_after("tenant") == "acme"
+        assert locator.value_after("org") == "research"
+        assert locator.value_after("region") == "us-east1"
+        assert locator.value_after("cluster") == "prod"

--- a/tests/core/test_runtime_topology.py
+++ b/tests/core/test_runtime_topology.py
@@ -87,6 +87,131 @@ def test_parse_worker_locator_rejects_non_worker_locator():
         parse_worker_locator("noetl://tenant/tenant-a/org/org-a")
 
 
+def test_worker_locator_emits_region_and_zone_in_coarse_to_fine_order():
+    from noetl.core.runtime.topology import worker_locator
+
+    uri = worker_locator(
+        tenant_id="acme",
+        organization_id="research",
+        worker_id="worker-cpu-01",
+        locality={
+            "region": "us-east1",
+            "zone": "us-east1-b",
+            "cluster_id": "prod",
+            "node_id": "node-a",
+            "worker_pool": "worker-cpu-01",
+        },
+    )
+
+    # Coarse-to-fine: region → zone → cluster → node → worker
+    assert (
+        uri
+        == "noetl://tenant/acme/org/research/region/us-east1/zone/us-east1-b"
+        "/cluster/prod/node/node-a/worker/worker-cpu-01"
+    )
+
+
+def test_worker_locator_emits_region_only_when_zone_unset():
+    from noetl.core.runtime.topology import worker_locator
+
+    uri = worker_locator(
+        tenant_id="acme",
+        organization_id="research",
+        worker_id="worker-cpu-01",
+        locality={"region": "us-east1", "worker_pool": "worker-cpu-01"},
+    )
+
+    assert (
+        uri
+        == "noetl://tenant/acme/org/research/region/us-east1/worker/worker-cpu-01"
+    )
+
+
+def test_worker_locator_without_region_or_zone_is_back_compat():
+    """Existing call shape produces the pre-round-1 URN unchanged."""
+    from noetl.core.runtime.topology import worker_locator
+
+    uri = worker_locator(
+        tenant_id="tenant-a",
+        organization_id="org-a",
+        worker_id="worker-a",
+        locality={
+            "cluster_id": "cluster-a",
+            "node_id": "node-a",
+            "worker_pool": "worker-cpu-01",
+        },
+    )
+
+    # Pre-round-1 canonical form — no region/zone segments.
+    assert (
+        uri
+        == "noetl://tenant/tenant-a/org/org-a/cluster/cluster-a/node/node-a/worker/worker-cpu-01"
+    )
+
+
+def test_parse_worker_locator_populates_region_and_zone():
+    from noetl.core.runtime.topology import parse_worker_locator
+
+    parts = parse_worker_locator(
+        "noetl://tenant/acme/org/research/region/us-east1/zone/us-east1-b"
+        "/cluster/prod/node/node-a/worker/worker-cpu-01"
+    )
+
+    assert parts.region == "us-east1"
+    assert parts.zone == "us-east1-b"
+    assert parts.cluster_id == "prod"
+    assert parts.node_id == "node-a"
+    assert parts.worker_pool == "worker-cpu-01"
+
+
+def test_parse_worker_locator_back_compat_without_region_zone():
+    from noetl.core.runtime.topology import parse_worker_locator
+
+    parts = parse_worker_locator(
+        "noetl://tenant/acme/org/research/cluster/prod/worker/worker-cpu-01"
+    )
+
+    assert parts.region is None
+    assert parts.zone is None
+    assert parts.cluster_id == "prod"
+    assert parts.worker_pool == "worker-cpu-01"
+
+
+def test_worker_locator_parts_as_locality_includes_region_zone():
+    from noetl.core.runtime.topology import WorkerLocatorParts
+
+    parts = WorkerLocatorParts(
+        tenant_id="acme",
+        organization_id="research",
+        worker_pool="cpu-01",
+        cluster_id="prod",
+        node_id="node-a",
+        region="us-east1",
+        zone="us-east1-b",
+    )
+
+    assert parts.as_locality() == {
+        "worker_pool": "cpu-01",
+        "region": "us-east1",
+        "zone": "us-east1-b",
+        "cluster_id": "prod",
+        "node_id": "node-a",
+    }
+
+
+def test_parse_worker_locator_rejects_unknown_segment():
+    """The allowlist still bars segments outside the known schema."""
+    import pytest
+
+    from noetl.core.resource_locator import ResourceLocatorError
+    from noetl.core.runtime.topology import parse_worker_locator
+
+    with pytest.raises(ResourceLocatorError, match="unknown segments: country"):
+        parse_worker_locator(
+            "noetl://tenant/acme/org/research/country/uk/worker/worker-cpu-01"
+        )
+
+
 def test_locality_distance_prefers_closest_match():
     from noetl.core.runtime.topology import locality_distance, locality_within, placement_evaluation
 


### PR DESCRIPTION
## Summary

v2 spec **Phase 4 round 1** — extends the `noetl://` URN scheme so
the upcoming **KEDA scaler** (round 2), **NATS supercluster**
(round 3), and future **catalog routing** work all have a stable
shape to lean on.

This round is **pure URN-surface extension**. No KEDA. No NATS
configuration. No catalog routing. No consumer rewiring. Existing
17+ URN call sites continue to work unchanged; the new surface is
additive.

## Architectural context (from the user's direction)

> Data flows through the service domain via Cloudflare. Small
> workers enrich with URN and route to KEDA-managed NATS
> supercluster. Queries get redirected to data locality via the
> catalog. The catalog work comes later — let's have URN + KEDA
> + NATS first.

The URN now encodes enough locality + kind discrimination + NATS
mapping that the later rounds + the future catalog can route
deterministically.

## What changed

### `noetl/core/resource_locator.py`

- **`KNOWN_RESOURCE_KINDS`** — advisory taxonomy of recognized
  top-level kinds (`tenant`, `execution`, `dataset`, `stream`,
  `partition`, `payload`). Parsing an unknown kind never raises;
  callers branch on `is_known_kind`. Mirrors the
  `payload_ref` `kind` discriminator pattern from Phase 5 round 5.

- **`NATS_SUBJECT_ROOT`** + **`to_nats_subject()`** / **`from_nats_subject()`** —
  canonical NATS-safe subject derivation:

  ```
  noetl://tenant/acme/org/research/cluster/us-east-1/worker/cpu-01
       ↓ to_nats_subject()
  noetl.tenant.acme.org.research.cluster.us-east-1.worker.cpu-01
  ```

  Lossy for non-NATS-safe characters (collapsed to `_`); round-trip
  identity guaranteed only when every segment is already
  `[a-zA-Z0-9_-]`. Phase 4 round 3 (NATS supercluster) keys subjects
  off this mapping.

- **`locality()`** — extract `{region?, zone?, cluster?, node?}` in
  coarse-to-fine order without callers having to know the schema.

- **`dataset_locator` / `stream_locator` / `partition_locator`** —
  data-resource URN builders for the future catalog routing work.
  Optional `region` / `zone` / `cluster_id` keyword args; empty
  values drop out.

### `noetl/core/runtime/topology.py`

- `WorkerLocatorParts` gains `region` and `zone` fields.
- `worker_locator()` emits `region` / `zone` segments in
  coarse-to-fine order: `tenant → org → region → zone → cluster
  → node → worker`.
- `parse_worker_locator()` extends the allowlist; back-compat is
  load-bearing (existing URNs without those segments parse
  identically and report `None`).
- `worker_locality_from_env()` already harvested
  `NOETL_REGION` / `NOETL_ZONE`; the URN now actually emits them.

## URN reference

```
noetl://tenant/<t>/org/<o>[/region/<r>][/zone/<z>][/cluster/<c>][/node/<n>]/worker/<pool>
noetl://tenant/<t>/org/<o>[/...locality...]/dataset/<id>
noetl://tenant/<t>/org/<o>[/...locality...]/stream/<id>
noetl://tenant/<t>/org/<o>[/...locality...]/stream/<sid>/partition/<idx>
```

NATS subject form:

```
noetl.<segments-joined-by-dot-with-non-safe-chars-as-underscore>
```

## Test plan

- [x] `pytest tests/core/test_resource_locator.py
      tests/core/test_runtime_topology.py -q` — **44 passed**
- [x] Focused regression sweep:
      `pytest tests/core/test_resource_locator.py
      tests/core/test_runtime_topology.py
      tests/core/test_event_store_ports.py
      tests/core/event_store/
      tests/core/payload_store/
      tests/core/test_replay_payload_ref_locator_kind.py -q`
      — **144 passed**
- [x] End-to-end smoke: build worker URN with region/zone, derive
      NATS subject, round-trip parse → identical URN
- [ ] Reviewer: confirm wiki diffs at
      https://github.com/noetl/noetl/wiki/resource_locator and
      https://github.com/noetl/noetl/wiki/topology

## Wiki

- **New page:** `noetl/core/resource_locator.md` — full URN
  documentation with scheme, API table, known-kind taxonomy, NATS
  subject derivation rules + lossiness caveat, data-resource
  builders, cross-links.
- **Updated:** `noetl/core/runtime/topology.md` — `region` + `zone`
  fields documented; coarse-to-fine emission order; cross-link to
  the new resource_locator page.
- **Updated:** `Home.md` + `_Sidebar.md` to list the new page.

Paired wiki commit: `noetl.wiki@e7e4842`.

## Follow-ups (round 2 + 3 of Phase 4)

- **Round 2 — KEDA scaler.** Worker-pool autoscaler keyed off NATS
  subject metrics; subjects derived via `to_nats_subject()` from
  this round.
- **Round 3 — NATS supercluster.** Multi-cluster NATS topology.
  Subjects + stream patterns derive deterministically from URNs.
- **Out-of-phase — catalog-driven query routing.** Per the user's
  architectural direction: queries redirect to data locality. The
  locality segments + dataset/stream/partition builders from this
  round are the shape the catalog will route on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)