### PR TITLE
fix(runtime): NATS supercluster — server_name, healthz, headless DNS (live-kind validation)

### DIFF
--- a/ci/manifests/nats-supercluster/cluster-a.yaml
+++ b/ci/manifests/nats-supercluster/cluster-a.yaml
@@ -85,23 +85,37 @@ spec:
         - containerPort: 7222
           name: gateway
           protocol: TCP
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         args:
         - -c
         - /etc/nats/nats.conf
+        - --name
+        - $(POD_NAME)
         volumeMounts:
         - name: nats-config
           mountPath: /etc/nats
         - name: nats-storage
           mountPath: /data
+        startupProbe:
+          httpGet:
+            path: /healthz?js-server-only=true
+            port: 8222
+          periodSeconds: 5
+          failureThreshold: 60
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /healthz?js-server-only=true
             port: 8222
           initialDelaySeconds: 30
           periodSeconds: 10
+          failureThreshold: 5
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /healthz?js-enabled-only=true
             port: 8222
           initialDelaySeconds: 10
           periodSeconds: 5
@@ -139,6 +153,7 @@ metadata:
     region: us-east-1
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   selector: *id001
   ports:
   - name: client

--- a/ci/manifests/nats-supercluster/cluster-b.yaml
+++ b/ci/manifests/nats-supercluster/cluster-b.yaml
@@ -68,23 +68,37 @@ spec:
         - containerPort: 7222
           name: gateway
           protocol: TCP
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         args:
         - -c
         - /etc/nats/nats.conf
+        - --name
+        - $(POD_NAME)
         volumeMounts:
         - name: nats-config
           mountPath: /etc/nats
         - name: nats-storage
           mountPath: /data
+        startupProbe:
+          httpGet:
+            path: /healthz?js-server-only=true
+            port: 8222
+          periodSeconds: 5
+          failureThreshold: 60
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /healthz?js-server-only=true
             port: 8222
           initialDelaySeconds: 30
           periodSeconds: 10
+          failureThreshold: 5
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /healthz?js-enabled-only=true
             port: 8222
           initialDelaySeconds: 10
           periodSeconds: 5
@@ -122,6 +136,7 @@ metadata:
     region: us-west-2
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   selector: *id001
   ports:
   - name: client

--- a/noetl/core/runtime/nats_topology.py
+++ b/noetl/core/runtime/nats_topology.py
@@ -355,18 +355,63 @@ def _build_statefulset(
                                 {"containerPort": DEFAULT_CLUSTER_PORT, "name": "cluster", "protocol": "TCP"},
                                 {"containerPort": DEFAULT_GATEWAY_PORT, "name": "gateway", "protocol": "TCP"},
                             ],
-                            "args": ["-c", "/etc/nats/nats.conf"],
+                            # NATS requires a unique `server_name` per node when
+                            # JetStream runs in cluster mode. Pull the pod name
+                            # via the downward API and pass it as --name so each
+                            # StatefulSet replica registers under its own ID.
+                            "env": [
+                                {
+                                    "name": "POD_NAME",
+                                    "valueFrom": {
+                                        "fieldRef": {"fieldPath": "metadata.name"}
+                                    },
+                                }
+                            ],
+                            "args": [
+                                "-c",
+                                "/etc/nats/nats.conf",
+                                "--name",
+                                "$(POD_NAME)",
+                            ],
                             "volumeMounts": [
                                 {"name": "nats-config", "mountPath": "/etc/nats"},
                                 {"name": "nats-storage", "mountPath": "/data"},
                             ],
+                            # NATS publishes three healthz variants. For
+                            # a clustered JetStream deployment we use:
+                            #   liveness:  ?js-server-only=true  — base NATS
+                            #              process up. Most forgiving — only
+                            #              fails when the server has crashed.
+                            #   readiness: ?js-enabled-only=true — JetStream
+                            #              enabled and reachable. Pod becomes
+                            #              Ready once JS is up; doesn't wait
+                            #              for full meta-layer recovery.
+                            #   startup:   ?js-server-only=true with a long
+                            #              failureThreshold — gives the
+                            #              cluster time to form gateway
+                            #              connections before liveness kicks in.
+                            "startupProbe": {
+                                "httpGet": {
+                                    "path": "/healthz?js-server-only=true",
+                                    "port": DEFAULT_MONITORING_PORT,
+                                },
+                                "periodSeconds": 5,
+                                "failureThreshold": 60,
+                            },
                             "livenessProbe": {
-                                "httpGet": {"path": "/healthz", "port": DEFAULT_MONITORING_PORT},
+                                "httpGet": {
+                                    "path": "/healthz?js-server-only=true",
+                                    "port": DEFAULT_MONITORING_PORT,
+                                },
                                 "initialDelaySeconds": 30,
                                 "periodSeconds": 10,
+                                "failureThreshold": 5,
                             },
                             "readinessProbe": {
-                                "httpGet": {"path": "/healthz", "port": DEFAULT_MONITORING_PORT},
+                                "httpGet": {
+                                    "path": "/healthz?js-enabled-only=true",
+                                    "port": DEFAULT_MONITORING_PORT,
+                                },
                                 "initialDelaySeconds": 10,
                                 "periodSeconds": 5,
                             },
@@ -415,6 +460,13 @@ def _build_service(
             # Headless Service — pods get stable per-replica DNS
             # names for the route URLs we emit in nats.conf.
             "clusterIP": "None",
+            # Critical for supercluster: gateway URLs resolve
+            # through the Service DNS, and supercluster startup
+            # is a chicken-and-egg (each cluster waits for its
+            # peers' Service to publish addresses). Setting this
+            # to True lets the headless DNS resolve to pods
+            # before they reach Ready state, breaking the cycle.
+            "publishNotReadyAddresses": True,
             "selector": labels,
             "ports": [
                 {"name": "client", "port": DEFAULT_CLIENT_PORT, "targetPort": DEFAULT_CLIENT_PORT, "protocol": "TCP"},

--- a/tests/core/runtime/test_nats_topology.py
+++ b/tests/core/runtime/test_nats_topology.py
@@ -218,6 +218,65 @@ def test_build_cluster_manifests_service_is_headless():
     assert port_names == {"client", "monitoring", "cluster", "gateway"}
 
 
+def test_build_cluster_manifests_service_publishes_not_ready_addresses():
+    """Live-validation guard: gateway URLs resolve through the
+    Service DNS, and supercluster startup is a chicken-and-egg
+    (each cluster waits for its peers' Service to publish
+    addresses). publishNotReadyAddresses=True breaks the cycle.
+    """
+    a, _, topo = _two_cluster_topo()
+    _, _, svc = build_cluster_manifests(a, supercluster=topo)
+    assert svc["spec"]["publishNotReadyAddresses"] is True
+
+
+def test_build_cluster_manifests_statefulset_passes_pod_name_via_args():
+    """Live-validation guard: NATS requires a unique `server_name`
+    per node when JetStream runs in cluster mode. We pull pod name
+    via downward API and pass it as --name so each StatefulSet
+    replica registers under its own ID.
+    """
+    a, _, topo = _two_cluster_topo()
+    _, sts, _ = build_cluster_manifests(a, supercluster=topo)
+    container = sts["spec"]["template"]["spec"]["containers"][0]
+    # POD_NAME env via downward API
+    env = container["env"]
+    assert any(
+        e.get("name") == "POD_NAME"
+        and e.get("valueFrom", {}).get("fieldRef", {}).get("fieldPath") == "metadata.name"
+        for e in env
+    )
+    # --name $(POD_NAME) on the args list
+    assert "--name" in container["args"]
+    name_idx = container["args"].index("--name")
+    assert container["args"][name_idx + 1] == "$(POD_NAME)"
+
+
+def test_build_cluster_manifests_uses_split_healthz_endpoints():
+    """Live-validation guard: the plain /healthz path returns
+    failure during JetStream's meta-layer recovery, which kills
+    the pod via liveness before the cluster forms. Use the
+    js-server-only and js-enabled-only variants instead.
+    """
+    a, _, topo = _two_cluster_topo()
+    _, sts, _ = build_cluster_manifests(a, supercluster=topo)
+    container = sts["spec"]["template"]["spec"]["containers"][0]
+
+    # Liveness probes base NATS only
+    assert (
+        container["livenessProbe"]["httpGet"]["path"]
+        == "/healthz?js-server-only=true"
+    )
+    # Readiness probes JetStream enabled-only (not full recovery)
+    assert (
+        container["readinessProbe"]["httpGet"]["path"]
+        == "/healthz?js-enabled-only=true"
+    )
+    # Startup probe with a long failureThreshold gives cluster
+    # formation time before liveness kicks in.
+    assert container["startupProbe"]["httpGet"]["path"] == "/healthz?js-server-only=true"
+    assert container["startupProbe"]["failureThreshold"] >= 30
+
+
 def test_build_cluster_manifests_statefulset_labels_carry_locality():
     a, _, topo = _two_cluster_topo()
     _, sts, _ = build_cluster_manifests(a, supercluster=topo)


### PR DESCRIPTION
## Summary

Three real bugs in the Phase 4 round 3 NATS supercluster
manifests (PR #595), caught by **end-to-end validation in the
local kind cluster**. All three fixes are required to get the
supercluster to actually form in Kubernetes — without them the
manifests apply cleanly but pods crash-loop.

## Bugs caught + fixed

### 1. `server_name` required for cluster-mode JetStream

NATS refuses to start:

```
nats-server: jetstream cluster requires `server_name` to be set
```

**Fix:** pull pod name via the downward API and pass as
`--name $(POD_NAME)` so each StatefulSet replica registers
under its own server name.

### 2. Healthz endpoint too aggressive

Plain `/healthz` returns failure during normal startup:

```
[WRN] Healthcheck failed: \"JetStream is still recovering meta layer\"
...
[INF] Trapped \"terminated\" signal
```

The liveness probe killed pods before the cluster could form.

**Fix:** split the health endpoints by what they check:
- `livenessProbe`  → `/healthz?js-server-only=true` (base NATS only)
- `readinessProbe` → `/healthz?js-enabled-only=true` (JS up, not full recovery)
- new `startupProbe` with `failureThreshold: 60` gives cluster
  formation up to 5 minutes before liveness kicks in

### 3. Headless Service chicken-and-egg

Gateway URLs resolve through the peer cluster's headless Service
DNS. A headless Service only publishes endpoints for Ready pods
by default. Each cluster's pods couldn't reach Ready because
gateway lookups for the peer cluster failed — and peer pods
weren't Ready either:

```
[ERR] Error getting IP for explicit gateway \"b\"
  (nats-cluster-b.nats-supercluster.svc.cluster.local:7222):
  lookup ...: no such host
```

**Fix:** set `publishNotReadyAddresses: true` on the Service so
DNS resolves to pods before they reach Ready, breaking the cycle.

## Validation in the local kind cluster

After all three fixes applied:

```
$ kubectl get pods -n nats-supercluster
NAME               READY   STATUS    RESTARTS   AGE
nats-cluster-a-0   1/1     Running   0          2m14s
nats-cluster-a-1   1/1     Running   0          2m2s
nats-cluster-a-2   1/1     Running   0          106s
nats-cluster-b-0   1/1     Running   0          2m14s
nats-cluster-b-1   1/1     Running   0          118s
nats-cluster-b-2   1/1     Running   0          101s
```

End-to-end topology verified via /varz, /routez, /gatewayz:

| Endpoint | Result |
|---|---|
| `cluster-a-0 /varz server_name` | `nats-cluster-a-0` ✅ |
| `cluster-a-0 /varz cluster.name` | `a` ✅ |
| `cluster-a-0 /varz cluster.urls` | 3 pod-DNS routes ✅ |
| `cluster-a-0 /routez num_routes` | 8 ✅ |
| `cluster-a-0 /gatewayz outbound` | `['b']` ✅ |
| `cluster-b-0 /varz server_name` | `nats-cluster-b-0` ✅ |
| `cluster-b-0 /gatewayz outbound` | `['a']` ✅ |
| `cluster-b-0 /gatewayz inbound`  | `['a']` ✅ bidirectional |
| `cluster-b-0 /varz jetstream.config.domain` | `tenant_default_org_default_region_us_west_2_cluster_b` ✅ URN-derived |

## Tests

3 new live-validation guards:

- `test_build_cluster_manifests_service_publishes_not_ready_addresses`
- `test_build_cluster_manifests_statefulset_passes_pod_name_via_args`
- `test_build_cluster_manifests_uses_split_healthz_endpoints`

Sample manifests regenerated; drift guards still pass.

```
$ pytest tests/core/runtime/test_nats_topology.py -q
31 passed in 0.57s
```

## Companion: KEDA scaler also validated

While the supercluster was scaled to 0 (to free CPU on the
single kind node for KEDA's pods), I also installed KEDA from
PR #594 and applied the sample ScaledObject:

```
$ kubectl get scaledobject -n noetl
NAME                                SCALETARGETKIND      ...   READY
noetl-worker-scaler-worker-cpu-01   apps/v1.Deployment   ...   True

$ kubectl get hpa -n noetl
NAME                                         REFERENCE                  MINPODS   MAXPODS
keda-hpa-noetl-worker-scaler-worker-cpu-01   Deployment/noetl-worker    1         20

External Metric Names:
  s0-nats-jetstream-NOETL_COMMANDS
```

KEDA registered the URN-derived consumer name (`noetl_worker_pool`)
against the existing `NOETL_COMMANDS` JetStream stream and is
polling for lag — no code changes needed; the round 2 scaler
manifest just works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)