### PR TITLE
fix(runtime): KEDA scaler default nats_account must be NOETL, not $G

### DIFF
--- a/ci/manifests/keda/scaledobject-worker-cpu-01.yaml
+++ b/ci/manifests/keda/scaledobject-worker-cpu-01.yaml
@@ -42,7 +42,7 @@ spec:
   - type: nats-jetstream
     metadata:
       natsServerMonitoringEndpoint: nats.nats.svc.cluster.local:8222
-      account: $G
+      account: NOETL
       stream: NOETL_COMMANDS
       consumer: noetl_worker_pool
       lagThreshold: '10'

--- a/noetl/core/runtime/keda.py
+++ b/noetl/core/runtime/keda.py
@@ -54,9 +54,14 @@ DEFAULT_NATS_STREAM = "NOETL_COMMANDS"
 #: consumer lag. Matches ``ci/manifests/nats/`` defaults.
 DEFAULT_NATS_MONITORING_ENDPOINT = "nats.nats.svc.cluster.local:8222"
 
-#: NATS default-account marker. ``$G`` is the global account; per-tenant
-#: accounts come in Phase 4 round 3 (supercluster).
-DEFAULT_NATS_ACCOUNT = "$G"
+#: NATS account that the existing NoETL deployment uses (see
+#: ``ci/manifests/nats/nats.yaml`` — the ``noetl`` user lives in
+#: the ``NOETL`` account, not the global ``$G`` account). KEDA's
+#: ``nats-jetstream`` scaler filters monitoring queries by account
+#: name; pointing at the wrong account returns ``num_pending: 0``
+#: silently. Per-tenant accounts in a future round can override
+#: this per-pool.
+DEFAULT_NATS_ACCOUNT = "NOETL"
 
 
 def worker_pool_segment(worker_pool_urn: str) -> str:

--- a/tests/core/runtime/test_keda.py
+++ b/tests/core/runtime/test_keda.py
@@ -95,6 +95,11 @@ def test_build_worker_scaledobject_emits_keda_v1alpha1_schema():
     md = trigger["metadata"]
     assert md["natsServerMonitoringEndpoint"] == DEFAULT_NATS_MONITORING_ENDPOINT
     assert md["account"] == DEFAULT_NATS_ACCOUNT
+    # Live-validation pin: the default must match the NATS account
+    # the noetl user actually lives in. Pointing KEDA at the wrong
+    # account (e.g. the global "$G") returns num_pending: 0
+    # silently and breaks scaling. See ci/manifests/nats/nats.yaml.
+    assert DEFAULT_NATS_ACCOUNT == "NOETL"
     assert md["stream"] == DEFAULT_NATS_STREAM
     # KEDA requires every metadata value to be a string, even for
     # numeric fields. Guard the contract.


### PR DESCRIPTION
## Summary

Live kind-cluster smoke test of PR #594's KEDA scaler caught a real
bug: `DEFAULT_NATS_ACCOUNT = \"\$G\"` silently breaks scaling against
the standard NoETL deployment.

## The smoke that caught it

Drove 200 messages into `NOETL_COMMANDS` with the consumer paused
so they piled up in `num_pending`. JetStream monitoring confirmed
the lag was real:

```
$ wget -qO- 'http://nats:8222/jsz?consumers=true&streams=true&accounts=true&account=NOETL'
account: NOETL
 stream: NOETL_COMMANDS messages: 200
  consumer: noetl_worker_pool num_pending: 200
```

But KEDA's external metric stuck at 0:

```
$ kubectl get --raw \"/apis/external.metrics.k8s.io/v1beta1/namespaces/noetl/s0-nats-jetstream-NOETL_COMMANDS\"
{ \"metricName\": \"s0-nats-jetstream-NOETL_COMMANDS\", \"value\": \"0\" }
```

## Root cause

The existing `ci/manifests/nats/nats.yaml` declares an `accounts {}`
block with `\$SYS` (system) and `NOETL` (where the `noetl` user
actually lives). The global `\$G` account isn't even registered on
the server. KEDA's `nats-jetstream` scaler queries the monitoring
API filtered by `account` — with the wrong account name, the
consumer's `num_pending` simply doesn't appear and KEDA reads 0.

## Smoke after the fix

Patched the live ScaledObject to `account: NOETL`, watched the HPA
react. Full scale-up + scale-down loop validated:

| T | TARGETS | deploy.replicas | KEDA action |
|---|---|---|---|
| baseline | `0/10 (avg)` | 1 | idle |
| publish 200 + pause consumer | | | |
| +5s | `200/10 (avg)` | **4** | first HPA tick — jump to 4 |
| +15s | `50/10 (avg)` | **8** | double again |
| +25s | `25/10 (avg)` | **16** | double again |
| +35s | `12500m/10 (avg)` | **20** | hit `maxReplicas` cap |
| resume consumer → drain | | | |
| +1.5 min | `0/10` | 20 | lag at 0, cooldown timer starts |
| +5 min | `0/10` | **1** | scale-down to `minReplicas` |

## Fix

One-line change to `DEFAULT_NATS_ACCOUNT`:

```python
DEFAULT_NATS_ACCOUNT = \"NOETL\"
```

Plus a pinning assertion in the existing test so future edits to
the default break loudly:

```python
assert DEFAULT_NATS_ACCOUNT == \"NOETL\"
```

Sample manifest regenerated; existing drift guard
(`test_sample_manifest_matches_generator_output`) confirms the
committed YAML matches the new generator output.

## Test plan

- [x] `pytest tests/core/runtime/ -q` — **53 passed**
  (22 KEDA + 31 NATS topology, all existing assertions still
  hold against the new default)
- [x] Live kind validation:
  1. Apply regenerated `scaledobject-worker-cpu-01.yaml`
  2. Confirm `spec.triggers[0].metadata.account == NOETL`
  3. Publish lag burst → KEDA scales `noetl-worker` 1 → 20
  4. Drain → KEDA scales back to 1 via HPA stabilization

## Out of scope

- **No supercluster generator change.** `nats_topology.py`'s
  rendered `nats.conf` already carries the `NOETL` + `\$SYS`
  accounts block verbatim — that piece was correct.
- **Per-tenant accounts remain out-of-phase.** A future round can
  derive the account name from the worker-pool URN's tenant
  segment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)