### PR TITLE
fix(worker): recover missing NATS durable consumer

### DIFF
--- a/noetl/core/messaging/nats_client.py
+++ b/noetl/core/messaging/nats_client.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import math
 import re
+import time
 from contextlib import suppress
 from typing import Any, Optional, Callable, Awaitable
 import nats
@@ -320,6 +321,7 @@ class NATSCommandSubscriber:
         self._background_tasks: set = set()
         self._inflight_semaphore = asyncio.Semaphore(self.max_inflight)
         self._throttle_hits = 0
+        self._fetch_recovery_last_attempt = 0.0
 
     def _record_message_action(self, action: str, delay_seconds: Optional[float] = None) -> None:
         if self._message_action_observer is None:
@@ -328,6 +330,32 @@ class NATSCommandSubscriber:
             self._message_action_observer(action, delay_seconds)
         except Exception:
             logger.debug("Ignoring NATS message action observer failure", exc_info=True)
+
+    async def _recover_fetch_subscription(self) -> None:
+        """Recreate the durable pull subscription after runtime drift."""
+        if not self._js:
+            raise RuntimeError("Not connected to NATS")
+
+        now = time.monotonic()
+        if now - self._fetch_recovery_last_attempt < 30.0:
+            return
+        self._fetch_recovery_last_attempt = now
+
+        logger.warning(
+            "Attempting to recover NATS pull subscription for stream=%s consumer=%s",
+            self.stream_name,
+            self.consumer_name,
+        )
+        await self._ensure_consumer()
+        self._subscription = await self._js.pull_subscribe(
+            self.subject,
+            durable=self.consumer_name,
+        )
+        logger.info(
+            "Recovered NATS pull subscription for stream=%s consumer=%s",
+            self.stream_name,
+            self.consumer_name,
+        )
 
     @staticmethod
     def _decode_json_message(payload: bytes) -> dict[str, Any]:
@@ -726,6 +754,14 @@ class NATSCommandSubscriber:
                 except Exception as e:
                     self._inflight_semaphore.release()
                     logger.error(f"Error fetching messages: {e}")
+                    try:
+                        await self._recover_fetch_subscription()
+                    except Exception as recover_error:
+                        logger.warning(
+                            "NATS fetch recovery failed for consumer %s: %s",
+                            self.consumer_name,
+                            recover_error,
+                        )
                     await asyncio.sleep(0.1)
 
         except Exception as e:

--- a/tests/core/test_nats_command_subscriber.py
+++ b/tests/core/test_nats_command_subscriber.py
@@ -17,6 +17,7 @@ class _FakeJetStream:
         self._add_consumer_error = add_consumer_error
         self.add_consumer_calls = []
         self.delete_consumer_calls = []
+        self.pull_subscribe_calls = []
 
     async def consumer_info(self, stream, consumer):
         if self._consumer_info_results:
@@ -35,6 +36,10 @@ class _FakeJetStream:
 
     async def delete_consumer(self, stream, consumer):
         self.delete_consumer_calls.append((stream, consumer))
+
+    async def pull_subscribe(self, subject, durable):
+        self.pull_subscribe_calls.append((subject, durable))
+        return SimpleNamespace(subject=subject, durable=durable)
 
 
 @pytest.mark.asyncio
@@ -98,6 +103,43 @@ async def test_add_consumer_tolerates_race_when_existing_consumer_matches_config
     _, config = fake_js.add_consumer_calls[0]
     assert config.max_ack_pending == 64
     assert fake_js.delete_consumer_calls == []
+
+
+@pytest.mark.asyncio
+async def test_recover_fetch_subscription_recreates_missing_consumer():
+    subscriber = NATSCommandSubscriber(
+        subject="noetl.commands",
+        consumer_name="test-consumer",
+        stream_name="NOETL_COMMANDS",
+        max_ack_pending=64,
+        max_inflight=1,
+    )
+    fake_js = _FakeJetStream(consumer_info_results=[RuntimeError("consumer not found")])
+    subscriber._js = fake_js
+
+    await subscriber._recover_fetch_subscription()
+
+    assert len(fake_js.add_consumer_calls) == 1
+    assert fake_js.pull_subscribe_calls == [("noetl.commands", "test-consumer")]
+
+
+@pytest.mark.asyncio
+async def test_recover_fetch_subscription_is_rate_limited():
+    subscriber = NATSCommandSubscriber(
+        subject="noetl.commands",
+        consumer_name="test-consumer",
+        stream_name="NOETL_COMMANDS",
+        max_ack_pending=64,
+        max_inflight=1,
+    )
+    fake_js = _FakeJetStream(consumer_info_results=[RuntimeError("consumer not found")])
+    subscriber._js = fake_js
+
+    await subscriber._recover_fetch_subscription()
+    await subscriber._recover_fetch_subscription()
+
+    assert len(fake_js.add_consumer_calls) == 1
+    assert fake_js.pull_subscribe_calls == [("noetl.commands", "test-consumer")]
 
 
 def test_consumer_config_enforces_ack_wait_budget(monkeypatch):


### PR DESCRIPTION
## Summary
- recover the worker pull subscription when JetStream fetches fail after durable consumer drift
- re-run consumer validation and rebuild the pull subscription on a rate-limited path
- add focused tests for recovery and rate limiting

## Validation
- uv run pytest tests/core/test_nats_command_subscriber.py

## Context
GKE diagnostic handoff showed worker pods can remain Running after NOETL_COMMANDS/noetl_worker_pool disappears because fetch errors are logged and suppressed inside the long-running fetch loop. Restarting the worker recreates the consumer, so the missing durable is runtime drift rather than command/env/NATS endpoint mismatch.