### PR TITLE
fix(logging): redact userinfo from NATS / Postgres / HTTP URLs in logs

### DIFF
--- a/noetl/core/messaging/nats_client.py
+++ b/noetl/core/messaging/nats_client.py
@@ -25,6 +25,7 @@ from nats.js.api import StreamConfig, ConsumerConfig
 from nats.aio.client import Client as NATSClient
 
 from noetl.core.logger import setup_logger
+from noetl.core.sanitize import redact_url_credentials
 
 logger = setup_logger(__name__, include_location=True)
 _MAX_CALLBACK_NAK_DELAY_SECONDS = 3600.0
@@ -113,7 +114,11 @@ class NATSCommandPublisher:
                     max_age=3600,  # 1 hour retention
                     storage="memory"  # Memory for low latency
                 )
-                logger.info(f"Created stream {self.stream_name} | connected to NATS at {self.nats_url}")
+                logger.info(
+                    "Created stream %s | connected to NATS at %s",
+                    self.stream_name,
+                    redact_url_credentials(self.nats_url),
+                )
 
         except Exception as e:
             logger.error(f"Failed to connect to NATS: {e}")
@@ -621,7 +626,7 @@ class NATSCommandSubscriber:
             self._nc = await nats.connect(self.nats_url)
             self._js = self._nc.jetstream()
 
-            logger.debug(f"Connected to NATS at {self.nats_url}")
+            logger.debug("Connected to NATS at %s", redact_url_credentials(self.nats_url))
 
         except Exception as e:
             logger.error(f"Failed to connect to NATS: {e}")

--- a/noetl/core/sanitize.py
+++ b/noetl/core/sanitize.py
@@ -305,3 +305,41 @@ def mask_value(value: str, visible_start: int = 4, visible_end: int = 4) -> str:
         return REDACTED
 
     return f"{value[:visible_start]}...{value[-visible_end:]}"
+
+
+# Matches the userinfo portion of a URL: ``scheme://[user[:pass]@]host...``.
+# Captures the scheme + ``://`` (group 1) and the host-and-rest (group 2);
+# the ``[^/@:]+(?::[^/@]*)?@`` middle is the userinfo segment we strip.
+_URL_CREDENTIALS_RE = re.compile(
+    r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.\-]*://)"  # e.g. nats://, postgres://, https://
+    r"(?:[^/@:\s]+(?::[^/@\s]*)?@)"             # userinfo segment to redact
+    r"(?P<rest>[^\s]+)"                          # host + path + query + fragment
+)
+
+
+def redact_url_credentials(value: str, placeholder: str = REDACTED) -> str:
+    """Replace the userinfo segment of any URL found in ``value`` with a placeholder.
+
+    Use this before logging or writing connection strings (NATS, Postgres,
+    HTTP basic-auth, etc.) so that ``user:password@host`` does not leak into
+    logs or debug files.
+
+    Examples::
+
+        >>> redact_url_credentials("nats://noetl:noetl@nats:4222")
+        'nats://[REDACTED]@nats:4222'
+        >>> redact_url_credentials("connect to postgres://u:p@db/noetl now")
+        'connect to postgres://[REDACTED]@db/noetl now'
+        >>> redact_url_credentials("nats://nats:4222")  # no userinfo
+        'nats://nats:4222'
+
+    Non-string inputs are returned unchanged so callers can pass through
+    arbitrary types without a TypeError.
+    """
+    if not isinstance(value, str):
+        return value
+
+    def _replace(match: "re.Match[str]") -> str:
+        return f"{match.group('scheme')}{placeholder}@{match.group('rest')}"
+
+    return _URL_CREDENTIALS_RE.sub(_replace, value)

--- a/noetl/core/session/nats_session_store.py
+++ b/noetl/core/session/nats_session_store.py
@@ -30,6 +30,8 @@ from nats.js.api import KeyValueConfig
 from nats.js.errors import KeyNotFoundError, BucketNotFoundError
 from nats.js.kv import KeyValue
 
+from noetl.core.sanitize import redact_url_credentials
+
 logger = logging.getLogger(__name__)
 
 # Default TTL in seconds (24 hours)
@@ -183,7 +185,10 @@ class NatsSessionStore:
                 logger.info(f"Created K/V bucket: {self.BUCKET_NAME} with TTL={self.default_ttl}s")
 
             self._connected = True
-            logger.info(f"Connected to NATS K/V session store at {self.nats_url}")
+            logger.info(
+                "Connected to NATS K/V session store at %s",
+                redact_url_credentials(self.nats_url),
+            )
 
         except Exception as e:
             logger.error(f"Failed to connect to NATS K/V: {e}")

--- a/noetl/server/api/core/core.py
+++ b/noetl/server/api/core/core.py
@@ -4,6 +4,7 @@ from typing import Optional
 from noetl.core.dsl.engine.executor import ControlFlowEngine, PlaybookRepo, StateStore
 from noetl.core.messaging import NATSCommandPublisher
 from noetl.core.logger import setup_logger
+from noetl.core.sanitize import redact_url_credentials
 
 logger = setup_logger(__name__, include_location=True)
 
@@ -193,7 +194,7 @@ async def get_nats_publisher():
             subject=settings.nats_subject
         )
         await _nats_publisher.connect()
-        logger.info(f"NATS publisher initialized: {settings.nats_url}")
+        logger.info("NATS publisher initialized: %s", redact_url_credentials(settings.nats_url))
     
     return _nats_publisher
 

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -29,6 +29,7 @@ from noetl.core.messaging import NATSCommandSubscriber
 from noetl.worker.adaptive_concurrency import AdaptiveConcurrencyController
 from noetl.core.logging_context import LoggingContext
 from noetl.core.logger import setup_logger
+from noetl.core.sanitize import redact_url_credentials
 from noetl.core.urls import (
     build_api_url as _api_url,
     normalize_server_base_url as _normalize_server_base_url,
@@ -937,7 +938,7 @@ class Worker:
         logger.info(
             "Worker %s starting (NATS: %s, inflight=%s, db_inflight=%s, max_ack_pending=%s)",
             self.worker_id,
-            self.nats_url,
+            redact_url_credentials(self.nats_url),
             self._max_inflight_commands,
             self._max_inflight_db_commands,
             worker_settings.nats_max_ack_pending,
@@ -3730,13 +3731,18 @@ def run_worker_sync(
         
         worker_id = f"worker-{uuid.uuid4().hex[:8]}"
         
+        # Redact userinfo (user:password@) from NATS URL before writing /
+        # logging — the debug file lands under /tmp inside the pod, but
+        # logs ship to victorialogs and would otherwise leak the
+        # configured NATS credentials.
+        safe_nats_url = redact_url_credentials(nats_url)
         with open("/tmp/worker_config.txt", "w") as f:
             f.write(f"Worker ID: {worker_id}\n")
-            f.write(f"NATS URL: {nats_url}\n")
+            f.write(f"NATS URL: {safe_nats_url}\n")
             f.write(f"Server URL: {server_url}\n")
             f.flush()
-        
-        logger.info(f"Starting Core worker {worker_id} | NATS={nats_url} | Server={server_url}")
+
+        logger.info(f"Starting Core worker {worker_id} | NATS={safe_nats_url} | Server={server_url}")
         
         with open("/tmp/worker_before_run.txt", "w") as f:
             f.write(f"About to call asyncio.run at {datetime.now()}\n")

--- a/tests/core/test_sanitize_url_credentials.py
+++ b/tests/core/test_sanitize_url_credentials.py
@@ -1,0 +1,111 @@
+"""Unit tests for :func:`noetl.core.sanitize.redact_url_credentials`.
+
+Driven by the GKE diagnostic round
+(handoffs/archive/2026-05-23-gke-worker-consumer-missing): worker
+startup logs were emitting NATS connection strings with embedded
+``user:password@`` credentials, which then shipped to VictoriaLogs.
+The redaction helper closes that leak; these tests pin the contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from noetl.core.sanitize import REDACTED, redact_url_credentials
+
+
+def test_redacts_nats_userinfo():
+    assert (
+        redact_url_credentials("nats://noetl:noetl@nats.nats.svc.cluster.local:4222")
+        == f"nats://{REDACTED}@nats.nats.svc.cluster.local:4222"
+    )
+
+
+def test_redacts_postgres_userinfo():
+    assert (
+        redact_url_credentials("postgres://noetl:secret@postgres.noetl.svc:5432/noetl")
+        == f"postgres://{REDACTED}@postgres.noetl.svc:5432/noetl"
+    )
+
+
+def test_redacts_http_basic_auth_userinfo():
+    assert (
+        redact_url_credentials("https://admin:hunter2@api.example.com/v1")
+        == f"https://{REDACTED}@api.example.com/v1"
+    )
+
+
+def test_redacts_user_only_userinfo():
+    """user@host with no password is still userinfo and should be redacted."""
+    assert (
+        redact_url_credentials("nats://noetl@nats:4222")
+        == f"nats://{REDACTED}@nats:4222"
+    )
+
+
+def test_passthrough_when_no_userinfo():
+    assert (
+        redact_url_credentials("nats://nats.nats.svc.cluster.local:4222")
+        == "nats://nats.nats.svc.cluster.local:4222"
+    )
+    assert (
+        redact_url_credentials("http://noetl.noetl.svc.cluster.local:8082")
+        == "http://noetl.noetl.svc.cluster.local:8082"
+    )
+
+
+def test_redacts_url_embedded_in_log_line():
+    """The worker startup line embeds the URL in prose — patcher should
+    catch URLs found anywhere in the string, not just at the start."""
+    msg = (
+        "Starting Core worker worker-c8384760 | "
+        "NATS=nats://noetl:noetl@nats:4222 | "
+        "Server=http://noetl.noetl.svc:8082"
+    )
+    out = redact_url_credentials(msg)
+    assert "noetl:noetl@" not in out
+    assert f"nats://{REDACTED}@nats:4222" in out
+    # http://noetl... has no userinfo, so it must pass through unchanged
+    assert "http://noetl.noetl.svc:8082" in out
+
+
+def test_redacts_multiple_urls_in_one_string():
+    msg = "primary=postgres://u1:p1@db1/x replica=postgres://u2:p2@db2/x"
+    out = redact_url_credentials(msg)
+    assert "u1:p1@" not in out
+    assert "u2:p2@" not in out
+    assert out.count(f"postgres://{REDACTED}@") == 2
+
+
+def test_idempotent_when_already_redacted():
+    once = redact_url_credentials("nats://noetl:noetl@nats:4222")
+    twice = redact_url_credentials(once)
+    assert once == twice
+
+
+def test_non_string_inputs_passthrough():
+    """Helper is documented as passing non-string inputs through unchanged."""
+    assert redact_url_credentials(None) is None
+    assert redact_url_credentials(42) == 42
+    assert redact_url_credentials(["nats://a:b@c"]) == ["nats://a:b@c"]
+
+
+def test_custom_placeholder():
+    out = redact_url_credentials(
+        "nats://noetl:noetl@nats:4222", placeholder="***"
+    )
+    assert out == "nats://***@nats:4222"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "no urls here",
+        "just-a-host-no-scheme.example.com",
+        "nats://",  # malformed; no host
+        "user:password@host",  # missing scheme
+    ],
+)
+def test_passthrough_for_edge_cases(value: str):
+    assert redact_url_credentials(value) == value


### PR DESCRIPTION
## Summary

The GKE worker diagnostic round
([handoffs/archive/2026-05-23-gke-worker-consumer-missing](https://github.com/noetl/ai-meta/blob/main/handoffs/archive/2026-05-23-gke-worker-consumer-missing/round-01-result.md))
flagged that worker startup logs were leaking the NATS
connection string with embedded `user:password@` credentials.
Those logs ship to VictoriaLogs in their raw form.

This PR adds a generic redaction helper and wires it into five
log sites that emit credentialed URLs.

## What changed

### New helper — `noetl/core/sanitize.py`

```python
def redact_url_credentials(value: str, placeholder: str = REDACTED) -> str:
    \"\"\"Replace the userinfo segment of any URL found in ``value``.\"\"\"
```

Works on full URLs (`nats://u:p@host:port`) and URLs embedded in
prose (`\"Starting worker | NATS=nats://u:p@... | Server=...\"`).
Idempotent. Non-string inputs pass through unchanged.

### Five log-site updates

| File | Site | Before | After |
|---|---|---|---|
| `core/messaging/nats_client.py` | \"Created stream\" log | `f\"...connected to NATS at {self.nats_url}\"` | `redact_url_credentials(self.nats_url)` |
| `core/messaging/nats_client.py` | \"Connected to NATS\" debug | `f\"...at {self.nats_url}\"` | `redact_url_credentials(self.nats_url)` |
| `core/session/nats_session_store.py` | \"Connected to NATS K/V\" | `f\"...at {self.nats_url}\"` | `redact_url_credentials(self.nats_url)` |
| `server/api/core/core.py` | \"NATS publisher initialized\" | `f\"...: {settings.nats_url}\"` | `redact_url_credentials(settings.nats_url)` |
| `worker/nats_worker.py` | `Worker NN starting` log + `/tmp/worker_config.txt` + `Starting Core worker NN` log | raw `nats_url` | `redact_url_credentials(nats_url)` (shared variable) |

## Behavior change scope

**Log-line-only.** No env / connection / runtime semantics
changed. Connection strings continue to be built and consumed
verbatim — only their string representation in logs and the
worker's `/tmp/worker_config.txt` debug dump is redacted.

## Tests

- `tests/core/test_sanitize_url_credentials.py` (NEW) — **15 cases**:
  NATS / Postgres / HTTP basic-auth URLs, user-only userinfo,
  no-userinfo passthrough, multi-URL strings, log-line embedding,
  idempotency, non-string passthrough, custom placeholder, and
  edge cases (empty, malformed, missing scheme).
- `tests/core/test_nats_command_subscriber.py` — **14 existing
  pass** (no regression on PR #600's recovery path).

```
$ pytest tests/core/test_sanitize_url_credentials.py tests/core/test_nats_command_subscriber.py -q
29 passed in 1.02s
```

## Related

- Diagnostic origin:
  [`handoffs/archive/2026-05-23-gke-worker-consumer-missing/round-01-result.md`](https://github.com/noetl/ai-meta/blob/main/handoffs/archive/2026-05-23-gke-worker-consumer-missing/round-01-result.md)
  (\"Issues observed\" section, item 1).
- Follow-up still tracked: broader GKE deploy hardening lives at
  [`handoffs/active/2026-05-23-gke-playbook-hardening/`](https://github.com/noetl/ai-meta/blob/main/handoffs/active/2026-05-23-gke-playbook-hardening/round-01-prompt.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)