### PR TITLE
fix(catalog): distinguish empty vs missing terminal scopes; skip None entries

### DIFF
--- a/noetl/server/api/catalog/service.py
+++ b/noetl/server/api/catalog/service.py
@@ -303,11 +303,18 @@ class CatalogService:
 
         terminal = metadata.get("terminal")
         terminal = terminal if isinstance(terminal, dict) else {}
-        terminal_scopes = terminal.get("scopes") or terminal.get("scope") or []
+        if "scopes" in terminal:
+            terminal_scopes = terminal.get("scopes")
+        elif "scope" in terminal:
+            terminal_scopes = terminal.get("scope")
+        else:
+            terminal_scopes = []
         if isinstance(terminal_scopes, str):
             normalized_terminal_scopes = [scope.strip() for scope in terminal_scopes.split(",") if scope.strip()]
         elif isinstance(terminal_scopes, list):
-            normalized_terminal_scopes = [str(scope).strip() for scope in terminal_scopes if str(scope).strip()]
+            normalized_terminal_scopes = [
+                str(scope).strip() for scope in terminal_scopes if scope is not None and str(scope).strip()
+            ]
         else:
             normalized_terminal_scopes = []
 

--- a/tests/api/test_catalog_agent_filters.py
+++ b/tests/api/test_catalog_agent_filters.py
@@ -79,3 +79,79 @@ def test_extract_agent_metadata_preserves_terminal_scopes():
     assert metadata["terminal_visible"] is True
     assert metadata["terminal"]["workspace"] == "kubernetes"
     assert metadata["terminal_scopes"] == ["/mcp/kubernetes"]
+
+
+def test_extract_agent_metadata_prefers_explicit_empty_scopes():
+    metadata = CatalogService._extract_agent_metadata(
+        {
+            "metadata": {
+                "agent": True,
+                "terminal": {
+                    "scopes": [],
+                    "scope": "/mcp/kubernetes",
+                },
+            }
+        }
+    )
+
+    assert metadata["terminal_scopes"] == []
+
+
+def test_extract_agent_metadata_normalizes_singular_scope():
+    metadata = CatalogService._extract_agent_metadata(
+        {
+            "metadata": {
+                "agent": True,
+                "terminal": {
+                    "scope": "/mcp/kubernetes",
+                },
+            }
+        }
+    )
+
+    assert metadata["terminal_scopes"] == ["/mcp/kubernetes"]
+
+
+def test_extract_agent_metadata_skips_none_terminal_scope_entries():
+    metadata = CatalogService._extract_agent_metadata(
+        {
+            "metadata": {
+                "agent": True,
+                "terminal": {
+                    "scopes": ["/mcp/kubernetes", None, "  "],
+                },
+            }
+        }
+    )
+
+    assert metadata["terminal_scopes"] == ["/mcp/kubernetes"]
+
+
+def test_extract_agent_metadata_normalizes_comma_separated_scopes_string():
+    metadata = CatalogService._extract_agent_metadata(
+        {
+            "metadata": {
+                "agent": True,
+                "terminal": {
+                    "scopes": "/mcp/kubernetes, /mcp/noetl",
+                },
+            }
+        }
+    )
+
+    assert metadata["terminal_scopes"] == ["/mcp/kubernetes", "/mcp/noetl"]
+
+
+def test_extract_agent_metadata_normalizes_comma_separated_scope_string():
+    metadata = CatalogService._extract_agent_metadata(
+        {
+            "metadata": {
+                "agent": True,
+                "terminal": {
+                    "scope": "/mcp/kubernetes, /mcp/noetl",
+                },
+            }
+        }
+    )
+
+    assert metadata["terminal_scopes"] == ["/mcp/kubernetes", "/mcp/noetl"]


### PR DESCRIPTION
## Summary

Two small fixes to `CatalogService._extract_agent_metadata`:

1. Distinguish an **explicit empty `terminal[\"scopes\"]`** from
   a missing key. The previous short-circuit boolean coercion
   `terminal.get(\"scopes\") or terminal.get(\"scope\") or []`
   collapsed empty-list and missing into the same fallback, so
   an agent that deliberately declared \"no terminal scopes\"
   was indistinguishable from one with the field unset.

2. **Filter `None` entries** out of the scope list before
   normalization. Previously `str(None).strip()` returned the
   literal string `\"None\"` (which is truthy), so a stray
   `None` in the scope list leaked through as the visible
   string `\"None\"`.

## The diff

```python
# Before
terminal_scopes = terminal.get(\"scopes\") or terminal.get(\"scope\") or []
# ...
normalized_terminal_scopes = [str(scope).strip() for scope in terminal_scopes if str(scope).strip()]

# After
if \"scopes\" in terminal:
    terminal_scopes = terminal.get(\"scopes\")
elif \"scope\" in terminal:
    terminal_scopes = terminal.get(\"scope\")
else:
    terminal_scopes = []
# ...
normalized_terminal_scopes = [
    str(scope).strip() for scope in terminal_scopes if scope is not None and str(scope).strip()
]
```

Singular `scope` form still supported for back-compat. Empty
strings + whitespace-only entries continue to be filtered.

## Tests

`tests/api/test_catalog_agent_filters.py` — **5 new cases**:

- `test_extract_agent_metadata_prefers_explicit_empty_scopes` —
  confirms `scopes: []` survives even when `scope` is also set.
- `test_extract_agent_metadata_normalizes_singular_scope` —
  back-compat for the legacy singular form.
- `test_extract_agent_metadata_skips_none_terminal_scope_entries` —
  `None` entries dropped, not coerced to `\"None\"`.
- `test_extract_agent_metadata_normalizes_comma_separated_scopes_string`
- `test_extract_agent_metadata_normalizes_comma_separated_scope_string`
  — both keys accept comma-separated string input.

```
$ pytest tests/api/test_catalog_agent_filters.py -q
12 passed in 3.59s
```

## Origin

This fix sat in a Codex stash from an earlier round
(`kadyapam/catalog-agent-discovery-kind`) and never landed.
Picked up during housekeeping after PRs #600 / #601 closed out
the GKE diagnostic work and the credential redaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)