### PR TITLE
fix(security): redact resolved keychain values from HTTP responses

### DIFF
--- a/noetl/core/sanitize.py
+++ b/noetl/core/sanitize.py
@@ -13,7 +13,7 @@ Usage:
 """
 
 import re
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, Iterable, List, Optional, Set, Union
 
 # Keys that indicate sensitive data (case-insensitive matching)
 SENSITIVE_KEYS: Set[str] = {
@@ -102,6 +102,43 @@ SENSITIVE_PATTERNS: List[re.Pattern] = [
     re.compile(r"-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"),
 ]
 
+# Additional response-boundary patterns. These are intentionally more specific
+# than the logging sanitizer's generic "long alphanumeric string" rule so
+# execution ids, provider ids, and document ids remain visible in API responses.
+SECRET_VALUE_PATTERNS: List[re.Pattern] = [
+    re.compile(r"^Bearer\s+\S+", re.IGNORECASE),
+    re.compile(r"^Basic\s+[A-Za-z0-9+/=]+", re.IGNORECASE),
+    re.compile(r"^eyJ[A-Za-z0-9\-_]+\.eyJ[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+$"),
+    re.compile(r"(?:^|[\"':\s])sk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}"),
+    re.compile(r"(?:^|[\"':\s])sk-ant-[A-Za-z0-9][A-Za-z0-9_\-]{12,}"),
+    re.compile(r"(?:^|[\"':\s])AIza[0-9A-Za-z_\-]{20,}"),
+    re.compile(r"(?:^|[\"':\s])ya29\.[0-9A-Za-z_\-]+"),
+    re.compile(r"(?:^|[\"':\s])gh[pousr]_[0-9A-Za-z_]{20,}"),
+    re.compile(r"(?:^|[\"':\s])github_pat_[0-9A-Za-z_]{20,}"),
+    re.compile(r"(?:^|[\"':\s])xox[baprs]-[0-9A-Za-z\-]{20,}"),
+    re.compile(r"-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"),
+    re.compile(
+        r"(?i)([?&](?:key|api[_-]?key|token|access[_-]?token|id[_-]?token|"
+        r"refresh[_-]?token|client[_-]?secret|signature)=)[^&\s]+"
+    ),
+]
+
+RESPONSE_SENSITIVE_KEYS: Set[str] = {
+    "keychain",
+    "api_secret",
+    "api-secret",
+    "apisecret",
+    "auth0_token",
+    "auth0-token",
+    "auth0_id_token",
+    "auth0-id-token",
+    "auth0_refresh_token",
+    "auth0-refresh-token",
+    "idtoken",
+    "oauth",
+    "jwt",
+}
+
 # Default redaction placeholder
 REDACTED = "[REDACTED]"
 
@@ -182,6 +219,135 @@ def sanitize_sensitive_data(
         {"user": "admin", "password": "[REDACTED]", "Authorization": "[REDACTED]"}
     """
     return _sanitize_recursive(data, additional_keys or set(), redaction, max_depth, 0)
+
+
+def redact_keychain_values(
+    data: Any,
+    additional_keys: Optional[Set[str]] = None,
+    secret_values: Optional[Iterable[str]] = None,
+    redaction: str = REDACTED,
+    max_depth: int = 20,
+) -> Any:
+    """
+    Redact secret-bearing values from API response payloads.
+
+    This is a serialization-boundary sanitizer. It returns a redacted copy of
+    ``data`` and does not mutate the stored workflow state or event log.
+
+    Detection combines:
+    - key-based matching for fields such as token, secret, api_key, auth, and
+      keychain-derived names;
+    - value-shape matching for bearer headers, JWTs, common provider key
+      prefixes, private keys, and URLs carrying secret query parameters;
+    - optional exact or embedded matches for caller-provided secret values.
+    """
+    normalized_keys = {str(key).lower().replace("-", "_") for key in (additional_keys or set())}
+    normalized_values = {
+        str(value)
+        for value in (secret_values or set())
+        if isinstance(value, str) and value
+    }
+    return _redact_response_recursive(
+        data,
+        normalized_keys,
+        normalized_values,
+        redaction,
+        max_depth,
+        0,
+    )
+
+
+def _is_response_secret_value(value: str, secret_values: Set[str]) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+
+    if value in secret_values:
+        return True
+    for secret in secret_values:
+        if len(secret) >= 8 and secret in value:
+            return True
+
+    if redact_url_credentials(value) != value:
+        return True
+
+    for pattern in SECRET_VALUE_PATTERNS:
+        if pattern.search(value):
+            return True
+
+    return False
+
+
+def _is_response_sensitive_key(key: str) -> bool:
+    if _is_sensitive_key(key):
+        return True
+    key_lower = key.lower().replace("-", "_")
+    if key_lower in RESPONSE_SENSITIVE_KEYS:
+        return True
+    for sensitive in RESPONSE_SENSITIVE_KEYS:
+        if sensitive.replace("-", "_") in key_lower:
+            return True
+    return False
+
+
+def _redact_response_recursive(
+    data: Any,
+    additional_keys: Set[str],
+    secret_values: Set[str],
+    redaction: str,
+    max_depth: int,
+    current_depth: int,
+) -> Any:
+    if current_depth >= max_depth:
+        return data
+
+    if isinstance(data, dict):
+        result = {}
+        for key, value in data.items():
+            key_text = str(key)
+            key_normalized = key_text.lower().replace("-", "_")
+            if _is_response_sensitive_key(key_text) or key_normalized in additional_keys:
+                result[key] = redaction
+            else:
+                result[key] = _redact_response_recursive(
+                    value,
+                    additional_keys,
+                    secret_values,
+                    redaction,
+                    max_depth,
+                    current_depth + 1,
+                )
+        return result
+
+    if isinstance(data, list):
+        return [
+            _redact_response_recursive(
+                item,
+                additional_keys,
+                secret_values,
+                redaction,
+                max_depth,
+                current_depth + 1,
+            )
+            for item in data
+        ]
+
+    if isinstance(data, tuple):
+        return tuple(
+            _redact_response_recursive(
+                item,
+                additional_keys,
+                secret_values,
+                redaction,
+                max_depth,
+                current_depth + 1,
+            )
+            for item in data
+        )
+
+    if isinstance(data, str) and _is_response_secret_value(data, secret_values):
+        return redaction
+
+    return data
 
 
 def _sanitize_recursive(

--- a/noetl/server/api/aggregate/endpoint.py
+++ b/noetl/server/api/aggregate/endpoint.py
@@ -10,6 +10,7 @@ from typing import Any, Dict
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
 from noetl.core.logger import setup_logger
+from noetl.core.sanitize import redact_keychain_values
 from .service import AggregateService
 
 logger = setup_logger(__name__, include_location=True)
@@ -61,7 +62,7 @@ async def get_loop_iteration_results(execution_id: str, step_name: str) -> Dict[
             step_name=step_name
         )
         # Convert Pydantic model to dict for JSONResponse
-        return result.model_dump(exclude_none=True)
+        return redact_keychain_values(result.model_dump(exclude_none=True))
     except Exception as e:
         logger.exception(f"AGGREGATE.API: Failed to fetch loop results: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/noetl/server/api/broker/service.py
+++ b/noetl/server/api/broker/service.py
@@ -20,7 +20,7 @@ from noetl.core.db.pool import get_pool_connection, get_snowflake_id
 from noetl.core.logger import setup_logger
 from noetl.core.messaging import NATSEventPublisher
 from noetl.core.outbox import enqueue_outbox, publish_outbox_batch
-from noetl.core.sanitize import sanitize_sensitive_data
+from noetl.core.sanitize import redact_keychain_values, sanitize_sensitive_data
 from .schema import EventEmitRequest, EventEmitResponse, EventQuery, EventResponse, EventListResponse, WorkloadData
 
 
@@ -304,8 +304,8 @@ class EventService:
                     node_name=row['node_name'],
                     node_type=row['node_type'],
                     status=row['status'],
-                    context=row['context'],
-                    meta=row['meta'],
+                    context=redact_keychain_values(row['context']),
+                    meta=redact_keychain_values(row['meta']),
                     created_at=row['created_at'].isoformat() if row['created_at'] else None
                 )
     
@@ -411,8 +411,8 @@ class EventService:
                         node_name=row['node_name'],
                         node_type=row['node_type'],
                         status=row['status'],
-                        context=row['context'],
-                        meta=row['meta'],
+                        context=redact_keychain_values(row['context']),
+                        meta=redact_keychain_values(row['meta']),
                         created_at=row['created_at'].isoformat() if row['created_at'] else None
                     )
                     for row in rows

--- a/noetl/server/api/context/endpoints.py
+++ b/noetl/server/api/context/endpoints.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from noetl.core.logger import setup_logger
+from noetl.core.sanitize import redact_keychain_values
 from .service import render_context
 
 logger = setup_logger(__name__, include_location=True)
@@ -81,7 +82,7 @@ async def render_context_endpoint(request: Request) -> Dict[str, Any]:
         
         return {
             "status": "ok",
-            "rendered": rendered,
+            "rendered": redact_keychain_values(rendered),
             "context_keys": context_keys
         }
         

--- a/noetl/server/api/core/batch.py
+++ b/noetl/server/api/core/batch.py
@@ -14,6 +14,7 @@ from noetl.core.db.pool import get_pool_connection
 from noetl.core.dsl.engine.models import Event
 from noetl.core.messaging import NATSEventPublisher
 from noetl.core.outbox import enqueue_outbox, publish_outbox_batch
+from noetl.core.sanitize import redact_keychain_values
 from .core import (
     logger, get_engine,
     _BATCH_ACCEPT_QUEUE_MAXSIZE, _BATCH_ACCEPT_WORKERS,
@@ -576,7 +577,7 @@ async def _get_batch_request_state(request_id: str) -> dict[str, Any]:
     res = row.get("result") or {}
     ctx = res.get("context") if isinstance(res, dict) else {}
     meta = row.get("meta") or {}
-    return {"request_id": request_id, "execution_id": str(row["execution_id"]), "state": state, "status": row["status"], "error_code": ctx.get("error_code"), "message": ctx.get("message") or row.get("error"), "commands_generated": ctx.get("commands_generated"), "idempotency_key": meta.get("idempotency_key"), "updated_at": _iso_timestamp(row.get("created_at"))}
+    return redact_keychain_values({"request_id": request_id, "execution_id": str(row["execution_id"]), "state": state, "status": row["status"], "error_code": ctx.get("error_code"), "message": ctx.get("message") or row.get("error"), "commands_generated": ctx.get("commands_generated"), "idempotency_key": meta.get("idempotency_key"), "updated_at": _iso_timestamp(row.get("created_at"))})
 
 @router.get("/events/batch/{request_id}/status")
 async def get_batch_event_status(request_id: str):

--- a/noetl/server/api/core/commands.py
+++ b/noetl/server/api/core/commands.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, HTTPException
 from psycopg.rows import dict_row
 from psycopg_pool import PoolTimeout
 from noetl.core.db.pool import get_pool_connection
+from noetl.core.sanitize import redact_keychain_values
 from noetl.core.runtime.topology import placement_evaluation, worker_locator
 from noetl.core.storage import Scope, default_store, estimate_size
 from noetl.claim_policy import decide_reclaim_for_existing_claim
@@ -333,7 +334,9 @@ async def get_command(event_id: int):
                 if not row: raise HTTPException(404, f"command not found: {event_id}")
                 return {
                     "execution_id": row['execution_id'], "node_id": row['step_name'], "node_name": row['step_name'],
-                    "action": row['tool_kind'], "context": row['context'] or {}, "meta": row['meta']
+                    "action": row['tool_kind'],
+                    "context": redact_keychain_values(row['context'] or {}),
+                    "meta": redact_keychain_values(row['meta']),
                 }
     except HTTPException: raise
     except Exception as e:

--- a/noetl/server/api/core/execution.py
+++ b/noetl/server/api/core/execution.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, HTTPException
 from psycopg.rows import dict_row
 from psycopg.types.json import Json
+from noetl.core.sanitize import redact_keychain_values
 from noetl.core.db.pool import get_pool_connection
 from noetl.core.messaging import NATSEventPublisher
 from noetl.core.outbox import enqueue_outbox, publish_outbox_batch
@@ -266,7 +267,7 @@ async def get_execution_status(execution_id: str, full: bool = False):
                 terminal_time,
                 completed or failed,
             )
-            return {"execution_id": execution_id, "current_step": latest.get("node_name"), "completed_steps": completed_steps, "failed": failed, "completed": completed, "completion_inferred": inferred, "variables": _compact_status_variables({}), "source": "event_log_fallback", **duration}
+            return {"execution_id": execution_id, "current_step": latest.get("node_name"), "completed_steps": completed_steps, "failed": failed, "completed": completed, "completion_inferred": inferred, "variables": redact_keychain_values(_compact_status_variables({})), "source": "event_log_fallback", **duration}
 
         completed, failed, inferred = state.completed, state.failed, False
         async with get_pool_connection() as conn:
@@ -309,6 +310,7 @@ async def get_execution_status(execution_id: str, full: bool = False):
             (terminal or latest).get("created_at") if (terminal or latest) else None,
             completed or failed,
         )
-        return {"execution_id": execution_id, "current_step": state.current_step, "completed_steps": list(state.completed_steps), "failed": failed, "completed": completed, "completion_inferred": inferred, "variables": state.variables if full else _compact_status_variables(state.variables), **duration}
+        variables = state.variables if full else _compact_status_variables(state.variables)
+        return {"execution_id": execution_id, "current_step": state.current_step, "completed_steps": list(state.completed_steps), "failed": failed, "completed": completed, "completion_inferred": inferred, "variables": redact_keychain_values(variables), **duration}
     except HTTPException: raise
     except Exception as e: logger.error(f"get_execution_status failed: {e}", exc_info=True); raise HTTPException(500, str(e))

--- a/noetl/server/api/execution/endpoint.py
+++ b/noetl/server/api/execution/endpoint.py
@@ -12,6 +12,7 @@ from psycopg.rows import dict_row
 from psycopg.types.json import Json
 from noetl.core.db.pool import get_pool_connection, get_snowflake_id
 from noetl.core.logger import setup_logger
+from noetl.core.sanitize import redact_keychain_values
 from noetl.core.common import convert_snowflake_ids_for_api, normalize_execution_id_for_db
 from noetl.core.messaging import NATSEventPublisher
 from noetl.core.outbox import enqueue_outbox, publish_outbox_batch
@@ -161,6 +162,9 @@ def _deserialize_event_row(row: dict[str, Any], execution_id: str) -> dict[str, 
             event_data["result"] = json.loads(row["result"])
         except json.JSONDecodeError:
             pass
+    event_data["context"] = redact_keychain_values(event_data.get("context"))
+    event_data["result"] = redact_keychain_values(event_data.get("result"))
+    event_data["error"] = redact_keychain_values(event_data.get("error"))
     return event_data
 
 
@@ -571,8 +575,8 @@ def _execution_entry_from_row(row_dict: dict[str, Any], pending_count: int) -> E
         duration_seconds=round(duration_seconds, 3) if duration_seconds is not None else None,
         duration_human=_format_duration_human(duration_seconds),
         progress=100 if derived_status in {"COMPLETED", "FAILED", "CANCELLED"} else 0,
-        result=row_dict.get("result"),
-        error=row_dict.get("error"),
+        result=redact_keychain_values(row_dict.get("result")),
+        error=redact_keychain_values(row_dict.get("error")),
         parent_execution_id=str(row_dict["parent_execution_id"]) if row_dict.get("parent_execution_id") is not None else None,
     )
 
@@ -624,7 +628,7 @@ async def _load_db_rows_for_ai(
                     (execution_id, event_rows_limit),
                 )
                 rows = await cursor.fetchall()
-                event_rows = [_json_ready(dict(r)) for r in rows]
+                event_rows = [redact_keychain_values(_json_ready(dict(r))) for r in rows]
 
             if include_event_log_rows:
                 await cursor.execute(
@@ -653,7 +657,7 @@ async def _load_db_rows_for_ai(
                         (execution_id, event_log_rows_limit),
                     )
                     rows = await cursor.fetchall()
-                    event_log_rows = [_json_ready(dict(r)) for r in rows]
+                    event_log_rows = [redact_keychain_values(_json_ready(dict(r))) for r in rows]
 
     try:
         async with get_pool_connection() as conn:
@@ -691,7 +695,7 @@ async def _load_db_rows_for_ai(
                         )
                         await cursor.execute(sql, tuple(params))
                         rows = await cursor.fetchall()
-                        metric_rows = [_json_ready(dict(r)) for r in rows]
+                        metric_rows = [redact_keychain_values(_json_ready(dict(r))) for r in rows]
     except Exception as metric_exc:
         logger.warning("Skipping metric rows for execution %s due to query error: %s", execution_id, metric_exc)
 
@@ -814,7 +818,7 @@ async def _load_ai_execution_output(
         }
 
     status = _derive_execution_terminal_status(dict(latest_row) if latest_row else None)
-    return ai_report, ai_raw_output, status
+    return redact_keychain_values(ai_report), redact_keychain_values(ai_raw_output), status
 
 
 @router.post("/executions/{execution_id}/finalize", response_model=FinalizeExecutionResponse)
@@ -1308,7 +1312,7 @@ async def get_execution(
                         result=None,
                         error=None,
                         parent_execution_id=str(state.parent_execution_id) if state.parent_execution_id is not None else None,
-                        events=[ExecutionEventResponse(**event) for event in events] if include_events else [],
+                        events=[ExecutionEventResponse(**redact_keychain_values(event)) for event in events] if include_events else [],
                         events_included=include_events,
                         events_endpoint=f"/api/executions/{execution_id}/events",
                         pagination=ExecutionEventsPagination(**pagination) if include_events else None,
@@ -1362,7 +1366,7 @@ async def get_execution(
             else latest_event.get("error") if latest_event else None
         ),
         parent_execution_id=str(first_event["parent_execution_id"]) if first_event.get("parent_execution_id") is not None else None,
-        events=[ExecutionEventResponse(**event) for event in events] if include_events else [],
+        events=[ExecutionEventResponse(**redact_keychain_values(event)) for event in events] if include_events else [],
         events_included=include_events,
         events_endpoint=f"/api/executions/{execution_id}/events",
         pagination=ExecutionEventsPagination(**pagination) if include_events else None,
@@ -1399,7 +1403,7 @@ async def get_execution_events(
         "execution_id": detail.execution_id,
         "path": detail.path,
         "status": detail.status,
-        "events": events,
+        "events": redact_keychain_values(events),
         "pagination": pagination,
     }
 
@@ -1872,12 +1876,12 @@ async def analyze_execution_with_ai(
         path=bundle.path,
         status=bundle.status,
         generated_at=datetime.now(timezone.utc),
-        bundle=bundle,
+        bundle=AnalyzeExecutionResponse.model_validate(redact_keychain_values(bundle.model_dump())),
         ai_playbook_path=request.analysis_playbook_path,
         ai_execution_id=str(ai_execution_id),
         ai_execution_status=ai_execution_status,
-        ai_report=_json_ready(ai_report),
-        ai_raw_output=_json_ready(ai_raw_output),
+        ai_report=redact_keychain_values(_json_ready(ai_report)),
+        ai_raw_output=redact_keychain_values(_json_ready(ai_raw_output)),
         approval_required=request.approval_required,
         approved=request.approved,
         auto_fix_mode=auto_fix_mode,

--- a/noetl/server/api/replay/endpoint.py
+++ b/noetl/server/api/replay/endpoint.py
@@ -8,6 +8,7 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Query
 
 from noetl.core.logger import setup_logger
+from noetl.core.sanitize import redact_keychain_values
 
 from .service import ReplayCutoff, ReplayService
 
@@ -40,7 +41,7 @@ async def replay_state(
             detail="Use only one replay cutoff: as_of_event_id, as_of_position, or as_of_time",
         )
     try:
-        return await ReplayService.replay_state(
+        return redact_keychain_values(await ReplayService.replay_state(
             tenant_id=tenant_id,
             organization_id=organization_id,
             execution_id=execution_id,
@@ -52,7 +53,7 @@ async def replay_state(
             projection=projection,
             limit=limit,
             resolve_payloads=resolve_payloads,
-        )
+        ))
     except HTTPException:
         raise
     except Exception as exc:

--- a/noetl/server/api/result/endpoint.py
+++ b/noetl/server/api/result/endpoint.py
@@ -25,6 +25,7 @@ from noetl.core.storage import (
     default_tracker,
 )
 from noetl.core.logger import setup_logger
+from noetl.core.sanitize import redact_keychain_values
 
 logger = setup_logger(__name__, include_location=True)
 
@@ -216,7 +217,7 @@ async def get_result_by_step(
         ref = matching[-1]
 
         if resolve:
-            return await default_store.get(ref)
+            return redact_keychain_values(await default_store.get(ref))
         else:
             return ResultRefResponse(
                 ref=ref.ref,
@@ -226,9 +227,9 @@ async def get_result_by_step(
                 expires_at=ref.expires_at.isoformat() if ref.expires_at else None,
                 bytes=ref.meta.bytes,
                 sha256=ref.meta.sha256,
-                preview=ref.preview,
-                extracted=getattr(ref, 'extracted', None),
-                correlation=ref.correlation
+                preview=redact_keychain_values(ref.preview),
+                extracted=redact_keychain_values(getattr(ref, 'extracted', None)),
+                correlation=redact_keychain_values(ref.correlation)
             )
 
     except HTTPException:
@@ -253,7 +254,7 @@ async def resolve_ref(
     - Inline data
     """
     try:
-        return await default_store.resolve(ref)
+        return redact_keychain_values(await default_store.resolve(ref))
     except KeyError as e:
         raise HTTPException(404, str(e))
     except Exception as e:
@@ -299,9 +300,9 @@ async def list_results(
                     expires_at=r.expires_at.isoformat() if r.expires_at else None,
                     bytes=r.meta.bytes,
                     sha256=r.meta.sha256,
-                    preview=r.preview,
-                    extracted=getattr(r, 'extracted', None),
-                    correlation=r.correlation
+                    preview=redact_keychain_values(r.preview),
+                    extracted=redact_keychain_values(getattr(r, 'extracted', None)),
+                    correlation=redact_keychain_values(r.correlation)
                 )
                 for r in refs
             ]

--- a/noetl/server/api/temp/endpoint.py
+++ b/noetl/server/api/temp/endpoint.py
@@ -23,6 +23,7 @@ from noetl.core.storage import (
     default_tracker,
 )
 from noetl.core.logger import setup_logger
+from noetl.core.sanitize import redact_keychain_values
 
 logger = setup_logger(__name__, include_location=True)
 
@@ -163,7 +164,7 @@ async def get_temp_by_name(
         ref = matching[-1]
 
         if resolve:
-            return await default_store.get(ref)
+            return redact_keychain_values(await default_store.get(ref))
         else:
             return TempRefResponse(
                 ref=ref.ref,
@@ -173,8 +174,8 @@ async def get_temp_by_name(
                 expires_at=ref.expires_at.isoformat() if ref.expires_at else None,
                 bytes=ref.meta.bytes,
                 sha256=ref.meta.sha256,
-                preview=ref.preview,
-                correlation=ref.correlation
+                preview=redact_keychain_values(ref.preview),
+                correlation=redact_keychain_values(ref.correlation)
             )
 
     except HTTPException:
@@ -199,7 +200,7 @@ async def resolve_ref(
     - Inline data
     """
     try:
-        return await default_store.resolve(ref)
+        return redact_keychain_values(await default_store.resolve(ref))
     except KeyError as e:
         raise HTTPException(404, str(e))
     except Exception as e:
@@ -245,8 +246,8 @@ async def list_temps(
                     expires_at=r.expires_at.isoformat() if r.expires_at else None,
                     bytes=r.meta.bytes,
                     sha256=r.meta.sha256,
-                    preview=r.preview,
-                    correlation=r.correlation
+                    preview=redact_keychain_values(r.preview),
+                    correlation=redact_keychain_values(r.correlation)
                 )
                 for r in refs
             ]

--- a/noetl/server/api/vars/endpoint.py
+++ b/noetl/server/api/vars/endpoint.py
@@ -17,6 +17,7 @@ from fastapi.responses import JSONResponse
 
 from noetl.worker.transient import TransientVars
 from noetl.core.logger import setup_logger
+from noetl.core.sanitize import redact_keychain_values
 from .schema import (
     VariableListResponse,
     VariableValueResponse,
@@ -50,7 +51,7 @@ async def list_variables(
         variables = {}
         for var_name, metadata in vars_with_metadata.items():
             variables[var_name] = VariableMetadata(
-                value=metadata['value'],
+                value=redact_keychain_values(metadata['value']),
                 type=metadata['type'],
                 source_step=metadata.get('source_step'),
                 created_at=metadata['created_at'],
@@ -107,7 +108,7 @@ async def get_variable(
         return VariableValueResponse(
             execution_id=execution_id,
             var_name=var_name,
-            value=cached_var['value'],
+            value=redact_keychain_values(cached_var['value']),
             type=cached_var['type'],
             source_step=cached_var.get('source_step'),
             created_at=cached_var['created_at'],

--- a/tests/api/execution/test_status_endpoint_parity.py
+++ b/tests/api/execution/test_status_endpoint_parity.py
@@ -154,3 +154,53 @@ async def test_status_endpoint_fallback_marks_missing_state_execution_failed_on_
     assert result["completed"] is False
     assert result["end_time"] == latest.isoformat()
     assert result["duration_human"] == "25m"
+
+
+@pytest.mark.asyncio
+async def test_status_endpoint_redacts_secret_bearing_variables(monkeypatch):
+    start = datetime(2026, 4, 18, 18, 0, 0, tzinfo=timezone.utc)
+    latest = datetime(2026, 4, 18, 18, 1, 0, tzinfo=timezone.utc)
+    terminal = {
+        "event_type": "playbook.completed",
+        "node_name": "end",
+        "status": "COMPLETED",
+        "created_at": latest,
+    }
+    state = _FakeState()
+    state.completed = True
+    state.current_step = "end"
+    state.completed_steps = {"start", "end"}
+    state.variables = {
+        "keychain": {
+            "openai_token": {
+                "api_key": "sk-" + "test_" + ("A" * 32),
+            }
+        },
+        "auth0_token": ".".join(["eyJhbGciOiJIUzI1NiJ9", "eyJzdWIiOiIxMjMifQ", "signature"]),
+        "provider_payload": {
+            "image_url": "https://example.invalid/static?key=" + ("B" * 32),
+            "label": "Miami",
+        },
+    }
+
+    monkeypatch.setattr(core_execution, "get_engine", lambda: _FakeEngine(state))
+    monkeypatch.setattr(
+        core_execution,
+        "get_pool_connection",
+        lambda: _ConnCtx(
+            _FakeConn(
+                _FakeCursor(
+                    first_event={"created_at": start},
+                    latest_event=terminal,
+                    terminal_event=terminal,
+                )
+            )
+        ),
+    )
+
+    result = await core_execution.get_execution_status("607458339856843442", full=True)
+
+    assert result["variables"]["keychain"] == "[REDACTED]"
+    assert result["variables"]["auth0_token"] == "[REDACTED]"
+    assert result["variables"]["provider_payload"]["image_url"] == "[REDACTED]"
+    assert result["variables"]["provider_payload"]["label"] == "Miami"

--- a/tests/api/test_vars_response_redaction.py
+++ b/tests/api/test_vars_response_redaction.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from noetl.server.api.vars import endpoint as vars_endpoint
+
+
+def _now():
+    return datetime(2026, 5, 24, 20, 0, 0, tzinfo=timezone.utc)
+
+
+def _jwt() -> str:
+    return ".".join(["eyJhbGciOiJIUzI1NiJ9", "eyJzdWIiOiIxMjMifQ", "signature"])
+
+
+@pytest.mark.asyncio
+async def test_list_variables_redacts_secret_values(monkeypatch):
+    async def fake_get_all_vars_with_metadata(_execution_id):
+        return {
+            "auth0_token": {
+                "value": _jwt(),
+                "type": "user_defined",
+                "source_step": "login",
+                "created_at": _now(),
+                "accessed_at": _now(),
+                "access_count": 0,
+            },
+            "safe_region": {
+                "value": "us-central1",
+                "type": "user_defined",
+                "source_step": None,
+                "created_at": _now(),
+                "accessed_at": _now(),
+                "access_count": 0,
+            },
+        }
+
+    monkeypatch.setattr(
+        vars_endpoint.TransientVars,
+        "get_all_vars_with_metadata",
+        fake_get_all_vars_with_metadata,
+    )
+
+    response = await vars_endpoint.list_variables(123)
+
+    assert response.variables["auth0_token"].value == "[REDACTED]"
+    assert response.variables["safe_region"].value == "us-central1"
+
+
+@pytest.mark.asyncio
+async def test_get_variable_redacts_secret_value(monkeypatch):
+    async def fake_get_cached(_var_name, _execution_id):
+        return {
+            "value": {"api_key": "sk-" + "test_" + ("A" * 32)},
+            "type": "computed",
+            "source_step": "resolve",
+            "created_at": _now(),
+            "accessed_at": _now(),
+            "access_count": 1,
+        }
+
+    monkeypatch.setattr(vars_endpoint.TransientVars, "get_cached", fake_get_cached)
+
+    response = await vars_endpoint.get_variable(123, "provider_config")
+
+    assert response.value == {"api_key": "[REDACTED]"}

--- a/tests/core/test_redact_keychain_values.py
+++ b/tests/core/test_redact_keychain_values.py
@@ -1,0 +1,86 @@
+"""Tests for API response redaction at serialization boundaries."""
+
+from __future__ import annotations
+
+import pytest
+
+from noetl.core.sanitize import REDACTED, redact_keychain_values
+
+
+def _jwt() -> str:
+    return ".".join(["eyJhbGciOiJIUzI1NiJ9", "eyJzdWIiOiIxMjMifQ", "signature"])
+
+
+def _provider_key() -> str:
+    return "sk-" + "test_" + ("A" * 32)
+
+
+def _url_with_key() -> str:
+    return "https://example.invalid/static?key=" + ("B" * 32)
+
+
+def test_redacts_keychain_nested_values_by_key():
+    payload = {
+        "variables": {
+            "keychain": {
+                "openai_token": {
+                    "api_key": _provider_key(),
+                }
+            },
+            "safe_region": "us-central1",
+        }
+    }
+
+    redacted = redact_keychain_values(payload)
+
+    assert redacted["variables"]["keychain"] == REDACTED
+    assert redacted["variables"]["safe_region"] == "us-central1"
+
+
+def test_redacts_user_bearer_and_jwt_values():
+    payload = {
+        "auth0_token": _jwt(),
+        "headers": {"Authorization": "Bearer " + ("C" * 48)},
+    }
+
+    redacted = redact_keychain_values(payload)
+
+    assert redacted["auth0_token"] == REDACTED
+    assert redacted["headers"]["Authorization"] == REDACTED
+
+
+def test_redacts_secret_shaped_intermediate_values_without_secret_key():
+    payload = {
+        "provider_response": {
+            "image_url": _url_with_key(),
+            "notes": "public",
+        }
+    }
+
+    redacted = redact_keychain_values(payload)
+
+    assert redacted["provider_response"]["image_url"] == REDACTED
+    assert redacted["provider_response"]["notes"] == "public"
+
+
+def test_redacts_known_secret_values_embedded_in_text():
+    secret = "opaque-secret-value"
+    payload = {"message": f"provider returned {secret}"}
+
+    redacted = redact_keychain_values(payload, secret_values={secret})
+
+    assert redacted["message"] == REDACTED
+
+
+def test_redaction_is_idempotent():
+    payload = {"token": _jwt(), "nested": [{"api_key": _provider_key()}]}
+
+    once = redact_keychain_values(payload)
+    twice = redact_keychain_values(once)
+
+    assert once == twice
+
+
+@pytest.mark.parametrize("value", [None, 42, True, "plain text", {"region": "Miami"}])
+def test_non_secret_values_passthrough(value):
+    assert redact_keychain_values(value) == value


### PR DESCRIPTION
## Summary

This PR masks resolved keychain values and other secret-bearing values before NoETL HTTP responses leave the server. The live issue was that `noetl status --json` could expose resolved credentials in the `variables` response body. This change keeps stored workflow state untouched and applies redaction only at read serialization boundaries.

## Detection strategy

`redact_keychain_values()` combines:

- key-based matching for names such as token, secret, api_key, password, authorization, keychain, credential, and private-key fields;
- value-shape matching for bearer/basic auth headers, JWT-shaped strings, common provider-key prefixes, private-key headers, and URLs with credential-bearing query parameters;
- optional exact-value matching for callers that already know a value must be masked.

The helper returns a copy, is idempotent, and uses `[REDACTED]` consistently.

## Endpoints patched

- `GET /api/executions/{id}/status`
- `GET /api/executions/{id}`
- `GET /api/executions/{id}/events`
- `GET /api/vars/{id}` and `GET /api/vars/{id}/{var_name}`
- `GET /api/result/*`
- `GET /api/temp/*`
- `GET /api/replay/state`
- `GET /api/aggregate/loop/results`
- `POST /api/context/render`
- `GET /api/event*`
- `GET /api/commands/{event_id}` read-only debug response
- `GET /api/events/batch/{request_id}/status` and stream payloads
- execution analyze / analyze-with-AI bundles and raw outputs

Worker claim/execution paths are left unredacted so workers keep the runtime data they need.

## Validation

- `python -m py_compile` on touched modules: pass
- Focused pytest suite: `15 passed`
- API-focused pytest suite: `126 passed`, `3 failed` in existing unrelated tests around replay fixture stage IDs and worker locator expectations
- Full `pytest tests/`: collection stops on existing missing modules/fixture (`noetl.tools.tools`, `noetl.tools.shared`, `noetl.server.stuck_execution_reaper`, `noetl.tools.auth`, missing playbook test config)
- Live GKE validation: built `us-central1-docker.pkg.dev/noetl-demo-19700101/noetl/noetl:keychain-redaction-69d55d40-20260524125244`, upgraded Helm release `noetl` revision 158, rollout succeeded, and the same execution that previously returned secret-bearing paths now returns zero scanner findings with placeholder values at representative keychain/token fields.

## Wiki

Updated the noetl wiki: https://github.com/noetl/noetl/wiki/secrets-and-redaction

## Follow-up

Storage-side hygiene remains out of scope here. A later change should stop persisting resolved credential values in workflow state and event payloads where the runtime can safely re-resolve or reference them instead.
