### PR TITLE
fix(security): persist keychain references for worker dispatch

### DIFF
--- a/noetl/core/credential_refs.py
+++ b/noetl/core/credential_refs.py
@@ -1,0 +1,233 @@
+"""Credential reference helpers for storage-safe keychain handling."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Optional
+
+from jinja2 import BaseLoader, Environment
+
+NOETL_REF_KEY = "$noetl_ref"
+KEYCHAIN_REF_KIND = "keychain"
+KEYCHAIN_MANIFEST_KEY = "_keychain_manifest"
+
+_JINJA_EXPR_RE = re.compile(r"^\s*\{\{\s*(.*?)\s*\}\}\s*$", re.DOTALL)
+_KEYCHAIN_DOT_RE = re.compile(
+    r"^keychain\.([A-Za-z_][A-Za-z0-9_-]*)(?:\.([A-Za-z_][A-Za-z0-9_-]*))?\s*$"
+)
+_KEYCHAIN_BRACKET_RE = re.compile(
+    r"^keychain\[['\"]([^'\"]+)['\"]\](?:\[['\"]([^'\"]+)['\"]\])?\s*$"
+)
+_KEYCHAIN_SEARCH_RE = re.compile(
+    r"keychain(?:\.([A-Za-z_][A-Za-z0-9_-]*)|\[['\"]([^'\"]+)['\"]\])"
+)
+
+
+def keychain_ref(name: str, field: Optional[str] = None) -> dict[str, Any]:
+    return {
+        NOETL_REF_KEY: {
+            "kind": KEYCHAIN_REF_KIND,
+            "name": name,
+            "field": field,
+        }
+    }
+
+
+def is_keychain_ref(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    ref = value.get(NOETL_REF_KEY)
+    return isinstance(ref, dict) and ref.get("kind") == KEYCHAIN_REF_KIND and bool(ref.get("name"))
+
+
+def build_keychain_manifest(keychain_section: Any, resolved_fields: Optional[dict[str, set[str]]] = None) -> dict[str, Any]:
+    entries: dict[str, dict[str, Any]] = {}
+    if not isinstance(keychain_section, list):
+        return {"entries": entries}
+
+    for entry in keychain_section:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not name:
+            continue
+        fields: set[str] = set()
+        map_config = entry.get("map")
+        if isinstance(map_config, dict):
+            fields.update(str(k) for k in map_config.keys())
+        if isinstance(resolved_fields, dict):
+            fields.update(str(k) for k in resolved_fields.get(str(name), set()))
+        entries[str(name)] = {
+            "kind": entry.get("kind") or entry.get("type") or "unknown",
+            "fields": sorted(fields),
+        }
+    return {"entries": entries}
+
+
+def keychain_names_from_manifest(manifest: Any) -> set[str]:
+    if not isinstance(manifest, dict):
+        return set()
+    entries = manifest.get("entries")
+    if not isinstance(entries, dict):
+        return set()
+    return {str(name) for name in entries.keys()}
+
+
+def parse_pure_keychain_expression(template: str) -> Optional[dict[str, Any]]:
+    if not isinstance(template, str):
+        return None
+
+    match = _JINJA_EXPR_RE.match(template)
+    if not match:
+        return None
+
+    inner = match.group(1).strip()
+    base = inner.split("|", 1)[0].strip()
+    dot_match = _KEYCHAIN_DOT_RE.match(base)
+    if dot_match:
+        return keychain_ref(dot_match.group(1), dot_match.group(2))
+
+    bracket_match = _KEYCHAIN_BRACKET_RE.match(base)
+    if bracket_match:
+        return keychain_ref(bracket_match.group(1), bracket_match.group(2))
+
+    return None
+
+
+def contains_keychain_template(value: Any) -> bool:
+    return isinstance(value, str) and "{{" in value and "}}" in value and "keychain" in value and bool(_KEYCHAIN_SEARCH_RE.search(value))
+
+
+def is_mixed_keychain_expression(value: Any) -> bool:
+    if not contains_keychain_template(value):
+        return False
+    return parse_pure_keychain_expression(value) is None
+
+
+def encode_keychain_templates(value: Any) -> Any:
+    if isinstance(value, str):
+        parsed = parse_pure_keychain_expression(value)
+        return parsed if parsed is not None else value
+    if isinstance(value, dict):
+        return {k: encode_keychain_templates(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [encode_keychain_templates(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(encode_keychain_templates(item) for item in value)
+    return value
+
+
+def render_preserving_keychain_refs(
+    env: Environment,
+    value: Any,
+    context: dict[str, Any],
+    render_fn: Callable[[Environment, Any, dict[str, Any]], Any],
+) -> Any:
+    if isinstance(value, str):
+        parsed = parse_pure_keychain_expression(value)
+        if parsed is not None:
+            return parsed
+        if is_mixed_keychain_expression(value):
+            return value
+        return render_fn(env, value, context)
+    if isinstance(value, dict):
+        return {k: render_preserving_keychain_refs(env, v, context, render_fn) for k, v in value.items()}
+    if isinstance(value, list):
+        return [render_preserving_keychain_refs(env, item, context, render_fn) for item in value]
+    if isinstance(value, tuple):
+        return tuple(render_preserving_keychain_refs(env, item, context, render_fn) for item in value)
+    return value
+
+
+def extract_keychain_ref_names(value: Any) -> set[str]:
+    refs: set[str] = set()
+    if is_keychain_ref(value):
+        refs.add(str(value[NOETL_REF_KEY]["name"]))
+        return refs
+    if isinstance(value, dict):
+        for item in value.values():
+            refs.update(extract_keychain_ref_names(item))
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            refs.update(extract_keychain_ref_names(item))
+    elif isinstance(value, str) and contains_keychain_template(value):
+        refs.update(match.group(1) or match.group(2) for match in _KEYCHAIN_SEARCH_RE.finditer(value))
+    return {ref for ref in refs if ref}
+
+
+def strip_keychain_namespaces(value: Any, manifest: Any = None) -> Any:
+    blocked = {"keychain"}
+    blocked.update(keychain_names_from_manifest(manifest))
+    return _strip_keychain_namespaces(value, blocked)
+
+
+def _strip_keychain_namespaces(value: Any, blocked: set[str]) -> Any:
+    if isinstance(value, dict):
+        result = {}
+        for k, v in value.items():
+            if str(k) == KEYCHAIN_MANIFEST_KEY:
+                result[k] = v
+                continue
+            if str(k) in blocked:
+                continue
+            result[k] = _strip_keychain_namespaces(v, blocked)
+        return result
+    if isinstance(value, list):
+        return [_strip_keychain_namespaces(item, blocked) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_strip_keychain_namespaces(item, blocked) for item in value)
+    return value
+
+
+async def resolve_credential_references(
+    value: Any,
+    context: dict[str, Any],
+    *,
+    catalog_id: int | str,
+    execution_id: Optional[int | str] = None,
+    api_base_url: str = "http://noetl.noetl.svc.cluster.local:8082",
+    refresh_threshold_seconds: int = 300,
+) -> tuple[Any, dict[str, Any]]:
+    names = extract_keychain_ref_names(value)
+    resolved_keychain: dict[str, Any] = {}
+    if names:
+        from noetl.worker.keychain_resolver import resolve_keychain_entries
+
+        resolved_keychain = await resolve_keychain_entries(
+            keychain_refs=names,
+            catalog_id=int(catalog_id),
+            execution_id=int(execution_id) if execution_id is not None else None,
+            api_base_url=api_base_url,
+            refresh_threshold_seconds=refresh_threshold_seconds,
+        )
+
+    resolved_context = dict(context or {})
+    if resolved_keychain:
+        resolved_context["keychain"] = resolved_keychain
+
+    env = Environment(loader=BaseLoader())
+    from noetl.core.dsl.render import add_b64encode_filter, render_template
+
+    env = add_b64encode_filter(env)
+    return _resolve_value(value, resolved_context, env, render_template), resolved_context
+
+
+def _resolve_value(value: Any, context: dict[str, Any], env: Environment, render_fn: Callable[..., Any]) -> Any:
+    if is_keychain_ref(value):
+        ref = value[NOETL_REF_KEY]
+        data = context.get("keychain", {}).get(ref.get("name"), {})
+        field = ref.get("field")
+        if field is None:
+            return data
+        if isinstance(data, dict):
+            return data.get(field)
+        return None
+    if isinstance(value, str) and contains_keychain_template(value):
+        return render_fn(env, value, context)
+    if isinstance(value, dict):
+        return {k: _resolve_value(v, context, env, render_fn) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_resolve_value(item, context, env, render_fn) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_resolve_value(item, context, env, render_fn) for item in value)
+    return value

--- a/noetl/core/dsl/engine/executor/commands.py
+++ b/noetl/core/dsl/engine/executor/commands.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from .common import *
 from .state import ExecutionState
 from .store import PlaybookRepo, StateStore
+from noetl.core.credential_refs import (
+    KEYCHAIN_MANIFEST_KEY,
+    render_preserving_keychain_refs,
+    strip_keychain_namespaces,
+)
 
 class CommandCreationMixin:
     async def _create_inline_command(
@@ -45,7 +50,8 @@ class CommandCreationMixin:
 
         # Render Jinja2 templates in tool config
         from noetl.core.dsl.render import render_template as recursive_render
-        rendered_tool_config = recursive_render(self.jinja_env, tool_config, context)
+        rendered_tool_config = render_preserving_keychain_refs(self.jinja_env, tool_config, context, recursive_render)
+        safe_context = strip_keychain_namespaces(context, context.get(KEYCHAIN_MANIFEST_KEY))
 
         # Create command for inline task
         # Use step_name as the step, task_name in metadata for tracking
@@ -57,7 +63,7 @@ class CommandCreationMixin:
                 config=rendered_tool_config
             ),
             input={},
-            render_context=context,
+            render_context=safe_context,
             attempt=1,
             priority=0,
             metadata={"inline_task": True, "task_name": task_name, "parent_step": step_name}
@@ -120,7 +126,7 @@ class CommandCreationMixin:
                 }
             ),
             input={},
-            render_context=context,
+            render_context=strip_keychain_namespaces(context, context.get(KEYCHAIN_MANIFEST_KEY)),
             attempt=1,
             priority=0,
             metadata={
@@ -900,7 +906,7 @@ class CommandCreationMixin:
                 context["iter"] = dict(context["iter"])
             
             iterator_value = state.variables.get(step.loop.iterator)
-            # Update both top-level and 'iter' namespace for canonical v10 compatibility
+            # Update both top-level and 'iter' namespace for v10 compatibility.
             context[step.loop.iterator] = iterator_value
             context["loop_index"] = claimed_index
             if "iter" in context and isinstance(context["iter"], dict):
@@ -970,7 +976,7 @@ class CommandCreationMixin:
         step_args.update(filtered_args)
 
         # Render Jinja2 templates in merged input.
-        rendered_input = recursive_render(self.jinja_env, step_args, context)
+        rendered_input = render_preserving_keychain_refs(self.jinja_env, step_args, context, recursive_render)
 
         if step.tool is None:
             logger.info(
@@ -1008,7 +1014,7 @@ class CommandCreationMixin:
 
             if policy_rules:
                 # Convert single tool to task sequence format so policy rules work
-                # Use canonical format: { name: "task_label", kind: "...", ... }
+                # Use v10 task format: { name: "task_label", kind: "...", ... }.
                 task_label = f"{step.step}_task"
                 pipeline = [{"name": task_label, **tool_dict}]
                 tool_kind = "task_sequence"
@@ -1018,9 +1024,9 @@ class CommandCreationMixin:
                 # NOTE: step.result removed in v10 - output config is now in tool.output or tool.spec.policy
 
                 # Render Jinja2 templates in tool config
-                tool_config = recursive_render(self.jinja_env, tool_config, context)
+                tool_config = render_preserving_keychain_refs(self.jinja_env, tool_config, context, recursive_render)
 
-        # Extract next targets for conditional routing (canonical v10 format)
+        # Extract next targets for conditional routing (v10 format)
         next_targets = None
         if step.next:
             next_targets = [arc.model_dump(exclude_none=True) for arc in _get_next_arcs(step)]
@@ -1055,6 +1061,8 @@ class CommandCreationMixin:
                 key: value for key, value in command_metadata.items() if value is not None
             }
 
+        safe_render_context = strip_keychain_namespaces(context, context.get(KEYCHAIN_MANIFEST_KEY))
+
         command = Command(
             execution_id=state.execution_id,
             step=command_step,
@@ -1063,7 +1071,7 @@ class CommandCreationMixin:
                 config=tool_config
             ),
             input=rendered_input,
-            render_context=context,
+            render_context=safe_render_context,
             pipeline=pipeline,
             next_targets=next_targets,
             spec=command_spec,

--- a/noetl/core/dsl/engine/executor/lifecycle.py
+++ b/noetl/core/dsl/engine/executor/lifecycle.py
@@ -7,6 +7,7 @@ from .outbox import drain_executor_outbox, enqueue_executor_outbox
 from .state import ExecutionState
 from .store import PlaybookRepo, StateStore
 from noetl.core.dsl.engine.models import Event, Command
+from noetl.core.credential_refs import KEYCHAIN_MANIFEST_KEY, strip_keychain_namespaces
 
 class LifecycleMixin:
     async def _persist_event(self, event: Event, state: ExecutionState, conn=None):
@@ -164,15 +165,14 @@ class LifecycleMixin:
         if playbook.keychain and catalog_id:
             from noetl.server.keychain_processor import process_keychain_section
             try:
-                keychain_data = await process_keychain_section(
+                keychain_manifest = await process_keychain_section(
                     keychain_section=playbook.keychain,
                     catalog_id=catalog_id,
                     execution_id=int(execution_id),
                     workload_vars=state.variables
                 )
-                if keychain_data:
-                    state.variables.update(keychain_data)
-                    state.variables.setdefault("keychain", {}).update(keychain_data)
+                if keychain_manifest:
+                    state.variables[KEYCHAIN_MANIFEST_KEY] = keychain_manifest
             except Exception as e:
                 logger.error(f"ENGINE: Failed to process keychain section: {e}")
 
@@ -181,7 +181,12 @@ class LifecycleMixin:
         if not start_step:
             raise ValueError(f"Entry step '{entry_step_name}' not found.")
         
-        workload_snapshot = {k: v for k, v in state.variables.items() if not (isinstance(v, dict) and 'status' in v)}
+        keychain_manifest = state.variables.get(KEYCHAIN_MANIFEST_KEY)
+        workload_snapshot = {
+            k: v if k == KEYCHAIN_MANIFEST_KEY else strip_keychain_namespaces(v, keychain_manifest)
+            for k, v in state.variables.items()
+            if not (isinstance(v, dict) and 'status' in v)
+        }
 
         from noetl.core.dsl.engine.models import LifecycleEventPayload
         playbook_init_event = Event(

--- a/noetl/core/dsl/engine/executor/state.py
+++ b/noetl/core/dsl/engine/executor/state.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .common import *
 
 from noetl.core.dsl.engine.planner import FanoutReducePlan, build_fanout_reduce_plan
+from noetl.core.credential_refs import KEYCHAIN_MANIFEST_KEY, keychain_names_from_manifest, strip_keychain_namespaces
 
 
 class ExecutionState:
@@ -53,7 +54,7 @@ class ExecutionState:
         # NOTE: 'vars' key is REMOVED in strict v10 - use 'ctx' instead
         for k, v in payload.items():
             if k == "ctx" and isinstance(v, dict):
-                # Merge execution request ctx into variables (canonical v10)
+                # Merge execution request ctx into variables for v10 compatibility.
                 self.variables.update(v)
                 logger.debug(f"[STATE-INIT] Merged execution ctx into variables: {list(v.keys())}")
             else:
@@ -107,19 +108,23 @@ class ExecutionState:
 
         # Compact variables: strip step result mirrors (they're in step_results)
         compact_vars = {}
+        keychain_manifest = self.variables.get(KEYCHAIN_MANIFEST_KEY)
+        keychain_names = keychain_names_from_manifest(keychain_manifest)
         for k, v in self.variables.items():
             # Keep only playbook workload vars and set mutations (scalars/small dicts)
             # Skip step result mirrors (dicts with 'reference' or 'status' + 'context')
             if isinstance(v, dict) and ("reference" in v or ("status" in v and "context" in v)):
                 continue  # step result mirror — skip
-            compact_vars[k] = v
+            if k == "keychain" or k in keychain_names:
+                continue
+            compact_vars[k] = v if k == KEYCHAIN_MANIFEST_KEY else strip_keychain_namespaces(v, keychain_manifest)
 
         return {
             "execution_id": self.execution_id,
             "catalog_id": self.catalog_id,
             "playbook_path": playbook_metadata.get("path") or playbook_metadata.get("name"),
             "parent_execution_id": self.parent_execution_id,
-            "payload": self.payload,
+            "payload": strip_keychain_namespaces(self.payload, keychain_manifest),
             "current_step": self.current_step,
             "variables": compact_vars,
             "last_event_id": self.last_event_id,
@@ -496,6 +501,9 @@ class ExecutionState:
             collection_size = len(loop_state["collection"]) if "collection" in loop_state else int(loop_state.get("collection_size", 0))
             iter_vars["_last"] = loop_state["index"] >= (collection_size - 1)
 
+        keychain_manifest = self.variables.get(KEYCHAIN_MANIFEST_KEY)
+        context_vars = strip_keychain_namespaces(self.variables, keychain_manifest)
+
         context = {
             "event": {
                 "name": event.name,
@@ -503,11 +511,11 @@ class ExecutionState:
                 "step": event.step,
                 "timestamp": event.timestamp.isoformat() if event.timestamp else None,
             },
-            # Canonical v10: ctx = execution-scoped, iter = iteration-scoped
-            "ctx": self.variables,  # Execution-scoped variables (canonical v10)
-            "iter": iter_vars,      # Iteration-scoped variables (canonical v10)
+            # ctx = execution-scoped, iter = iteration-scoped
+            "ctx": context_vars,
+            "iter": iter_vars,
             # Backward compatibility: workload namespace for {{ workload.xxx }}
-            "workload": self.variables,  # Legacy alias for Core playbooks
+            "workload": context_vars,
         }
 
         # Step results are accessed via {{ step_name.field }} through TaskResultProxy.
@@ -519,7 +527,10 @@ class ExecutionState:
                 context[step_name] = step_result
 
         # Add variables to context only if they don't collide with reserved keys
+        keychain_names = keychain_names_from_manifest(keychain_manifest)
         for k, v in self.variables.items():
+            if k == "keychain" or k in keychain_names:
+                continue
             if k not in context and k not in protected_fields:
                 context[k] = v
         

--- a/noetl/core/dsl/engine/executor/transitions.py
+++ b/noetl/core/dsl/engine/executor/transitions.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 from .common import *
+from noetl.core.credential_refs import (
+    KEYCHAIN_MANIFEST_KEY,
+    render_preserving_keychain_refs,
+    strip_keychain_namespaces,
+)
 from .outbox import drain_executor_outbox, enqueue_executor_outbox
 from .state import ExecutionState
 from .store import PlaybookRepo, StateStore
@@ -238,7 +243,8 @@ class TransitionMixin:
             if not k.startswith("__")
         }
         step_args.update(filtered_input)
-        rendered_input = recursive_render(self.jinja_env, step_args, base_context)
+        rendered_input = render_preserving_keychain_refs(self.jinja_env, step_args, base_context, recursive_render)
+        safe_base_context = strip_keychain_namespaces(base_context, base_context.get(KEYCHAIN_MANIFEST_KEY))
 
         # Next router passes through unchanged — evaluated when
         # loop.done fires (i.e. all workers exited).
@@ -293,7 +299,7 @@ class TransitionMixin:
                 step=f"{step_def.step}:task_sequence",
                 tool=ToolCall(kind="cursor_worker", config=tool_config),
                 input=rendered_input,
-                render_context=base_context,
+                render_context=safe_base_context,
                 pipeline=tasks,
                 next_targets=next_targets,
                 spec=command_spec,
@@ -1093,7 +1099,7 @@ class TransitionMixin:
                         target_step = next_item
                         arc_set = {}
                     elif isinstance(next_item, dict):
-                        # {step: name, set: {...}} (canonical)
+                        # v10 form: {step: name, set: {...}}
                         target_step = next_item.get("step")
                         arc_set = next_item.get("set") or {}
 

--- a/noetl/server/keychain_processor.py
+++ b/noetl/server/keychain_processor.py
@@ -13,6 +13,7 @@ import httpx
 from typing import Dict, Any, List, Optional
 from datetime import datetime, timezone, timedelta
 from noetl.core.logger import setup_logger
+from noetl.core.credential_refs import build_keychain_manifest
 from jinja2 import Template, Environment, StrictUndefined
 
 logger = setup_logger(__name__, include_location=True)
@@ -57,7 +58,8 @@ async def process_keychain_section(
         api_base_url: Base URL of NoETL API
         
     Returns:
-        Dict mapping keychain names to their data (for immediate use if needed)
+        Keychain manifest with names and field hints. Resolved values stay in
+        noetl.keychain and are not returned to workflow state.
     """
     if not keychain_section:
         logger.debug("KEYCHAIN_PROCESSOR: No keychain section to process")
@@ -76,6 +78,7 @@ async def process_keychain_section(
     logger.debug(f"KEYCHAIN_PROCESSOR: Processing {len(keychain_section)} keychain entries for execution {execution_id} (api_base_url={api_base_url})")
     
     keychain_data = {}
+    resolved_fields: Dict[str, set[str]] = {}
     
     async with httpx.AsyncClient(timeout=30.0) as client:
         for entry in keychain_section:
@@ -119,12 +122,14 @@ async def process_keychain_section(
                 
                 if success:
                     keychain_data[entry_name] = data
+                    if isinstance(data, dict):
+                        resolved_fields[str(entry_name)] = {str(k) for k in data.keys()}
                     logger.debug(f"KEYCHAIN_PROCESSOR: Successfully stored entry '{entry_name}'")
                 else:
                     raise RuntimeError(f"KEYCHAIN_PROCESSOR: Failed to store entry '{entry_name}' in database")
     
     logger.debug(f"KEYCHAIN_PROCESSOR: Completed processing {len(keychain_data)}/{len(keychain_section)} entries")
-    return keychain_data
+    return build_keychain_manifest(keychain_section, resolved_fields)
 
 
 async def _process_secret_manager(

--- a/noetl/worker/keychain_resolver.py
+++ b/noetl/worker/keychain_resolver.py
@@ -426,7 +426,7 @@ async def populate_keychain_context(
         refresh_threshold_seconds=refresh_threshold_seconds
     )
     
-    logger.debug(f"[KEYCHAIN-WORKER] Resolved keychain_data | keys={list(keychain_data.keys())} | data={keychain_data}")
+    logger.debug("[KEYCHAIN-WORKER] Resolved keychain entries | keys=%s", list(keychain_data.keys()))
     
     # Add to context
     context['keychain'] = keychain_data

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -30,6 +30,10 @@ from noetl.worker.adaptive_concurrency import AdaptiveConcurrencyController
 from noetl.core.logging_context import LoggingContext
 from noetl.core.logger import setup_logger
 from noetl.core.sanitize import redact_url_credentials
+from noetl.core.credential_refs import (
+    resolve_credential_references,
+    strip_keychain_namespaces,
+)
 from noetl.core.urls import (
     build_api_url as _api_url,
     normalize_server_base_url as _normalize_server_base_url,
@@ -747,7 +751,7 @@ class Worker:
 
     @staticmethod
     def _normalize_output_config(tool_config: dict[str, Any]) -> dict[str, Any]:
-        """Bridge canonical `tool.output` config to the legacy ResultHandler shape."""
+        """Bridge `tool.output` config to the legacy ResultHandler shape."""
         if not isinstance(tool_config, dict):
             return {}
 
@@ -2045,6 +2049,7 @@ class Worker:
             # Contract: worker owns payload persistence; events carry refs/metadata only.
             t_result_start = time.perf_counter()
             try:
+                safe_response = strip_keychain_namespaces(response)
                 result_handler = ResultHandler(execution_id=execution_id)
                 output_config = self._normalize_output_config(tool_config)
                 event_output_config = dict(output_config)
@@ -2053,7 +2058,7 @@ class Worker:
                 event_output_config["inline_max_bytes"] = int(os.getenv("NOETL_INLINE_MAX_BYTES", "10485760"))
                 processed_response = await result_handler.process_result(
                     step_name=step,
-                    result=response,
+                    result=safe_response,
                     output_config=event_output_config,
                 )
                 logger.info(f"[DEBUG-PAYLOAD] Step {step} processed_response: {json.dumps(processed_response, default=str)[:1000]}")
@@ -2112,20 +2117,21 @@ class Worker:
             error_response = None
             is_agent_envelope = (str(tool_kind or "").strip().lower() == "agent")
             if isinstance(response, dict) and not is_agent_envelope:
-                if response.get('status') in ('error', 'failed'):
+                safe_response_for_error = strip_keychain_namespaces(response)
+                if safe_response_for_error.get('status') in ('error', 'failed'):
                     # Extract error from either 'error' dict (task_sequence) or 'error' string (other tools)
-                    error_val = response.get('error')
+                    error_val = safe_response_for_error.get('error')
                     if isinstance(error_val, dict):
                         tool_error = error_val.get('message', str(error_val))
                     else:
                         tool_error = error_val or 'Tool returned error status'
-                    error_response = response
+                    error_response = safe_response_for_error
                 # Also check nested data errors (for tools that return {data: {...}})
-                elif isinstance(response.get('data'), dict):
-                    for key, value in response['data'].items():
+                elif isinstance(safe_response_for_error.get('data'), dict):
+                    for key, value in safe_response_for_error['data'].items():
                         if isinstance(value, dict) and value.get('status') == 'error':
                             tool_error = f"{key}: {value.get('message', 'Unknown error')}"
-                            error_response = response
+                            error_response = safe_response_for_error
                             break
             
             # HYBRID CASE EVALUATION: Worker-side evaluation with both event and data context
@@ -2468,8 +2474,19 @@ class Worker:
                 api_base_url=server_url,
                 refresh_threshold_seconds=refresh_threshold
             )
+            resolved_payload, context = await resolve_credential_references(
+                {"config": config, "args": args},
+                context,
+                catalog_id=catalog_id,
+                execution_id=execution_id,
+                api_base_url=server_url,
+                refresh_threshold_seconds=refresh_threshold,
+            )
+            if isinstance(resolved_payload, dict):
+                config = resolved_payload.get("config", config)
+                args = resolved_payload.get("args", args)
             k_end = time.perf_counter()
-            logger.debug(f"[PERF] populate_keychain_context took {k_end - k_start:.4f}s")
+            logger.debug(f"[PERF] keychain dispatch resolution took {k_end - k_start:.4f}s")
         
         import time
         t_jinja_start = time.perf_counter()
@@ -2488,7 +2505,7 @@ class Worker:
         # For workbook tool, preserve 'name' field from config (it's the workbook action name)
         # For other tools, add 'name' as step name for logging
         task_config = {**config}
-        # Merge canonical tool args/input with command input overrides.
+        # Merge tool args/input with command input overrides.
         # `args` is still used by Python playbooks, while newer tools prefer
         # `input`; keep both forms flowing through the worker adapter.
         config_args = config.get("args") if isinstance(config.get("args"), dict) else {}

--- a/tests/core/test_credential_refs.py
+++ b/tests/core/test_credential_refs.py
@@ -1,0 +1,108 @@
+import pytest
+from jinja2 import Environment
+
+from noetl.core.credential_refs import (
+    NOETL_REF_KEY,
+    build_keychain_manifest,
+    encode_keychain_templates,
+    is_mixed_keychain_expression,
+    parse_pure_keychain_expression,
+    render_preserving_keychain_refs,
+    resolve_credential_references,
+    strip_keychain_namespaces,
+)
+from noetl.core.dsl.render import render_template
+
+
+def test_pure_keychain_expression_encodes_as_ref():
+    encoded = parse_pure_keychain_expression("{{ keychain.openai_token.api_key | default('') }}")
+
+    assert encoded == {
+        NOETL_REF_KEY: {
+            "kind": "keychain",
+            "name": "openai_token",
+            "field": "api_key",
+        }
+    }
+
+
+def test_mixed_keychain_expression_is_deferred():
+    template = "Bearer {{ keychain.openai_token.api_key }}"
+
+    assert is_mixed_keychain_expression(template) is True
+    assert encode_keychain_templates(template) == template
+
+
+def test_render_preserving_keychain_refs_renders_non_secret_templates_only():
+    payload = {
+        "region": "{{ workload.region }}",
+        "api_key": "{{ keychain.openai_token.api_key | default('') }}",
+        "header": "Bearer {{ keychain.openai_token.api_key }}",
+    }
+
+    rendered = render_preserving_keychain_refs(
+        Environment(),
+        payload,
+        {"workload": {"region": "us-central1"}},
+        render_template,
+    )
+
+    assert rendered["region"] == "us-central1"
+    assert rendered["api_key"][NOETL_REF_KEY]["name"] == "openai_token"
+    assert rendered["api_key"][NOETL_REF_KEY]["field"] == "api_key"
+    assert rendered["header"] == "Bearer {{ keychain.openai_token.api_key }}"
+
+
+@pytest.mark.asyncio
+async def test_resolve_credential_references_resolves_refs_and_templates(monkeypatch):
+    async def fake_resolve_keychain_entries(**kwargs):
+        assert kwargs["keychain_refs"] == {"openai_token"}
+        return {"openai_token": {"api_key": "placeholder-secret"}}
+
+    import noetl.worker.keychain_resolver as keychain_resolver
+
+    monkeypatch.setattr(keychain_resolver, "resolve_keychain_entries", fake_resolve_keychain_entries)
+
+    payload = {
+        "api_key": {
+            NOETL_REF_KEY: {
+                "kind": "keychain",
+                "name": "openai_token",
+                "field": "api_key",
+            }
+        },
+        "header": "Bearer {{ keychain.openai_token.api_key }}",
+    }
+
+    resolved, context = await resolve_credential_references(
+        payload,
+        {"execution_id": "2"},
+        catalog_id="1",
+        execution_id="2",
+    )
+
+    assert resolved == {
+        "api_key": "placeholder-secret",
+        "header": "Bearer placeholder-secret",
+    }
+    assert context["keychain"]["openai_token"]["api_key"] == "placeholder-secret"
+
+
+def test_keychain_manifest_and_strip_remove_values_but_keep_hints():
+    manifest = build_keychain_manifest(
+        [{"name": "openai_token", "kind": "secret_manager", "map": {"api_key": "{{ path }}"}}],
+        {"openai_token": {"api_key"}},
+    )
+    payload = {
+        "keychain": {"openai_token": {"api_key": "placeholder-secret"}},
+        "openai_token": {"api_key": "placeholder-secret"},
+        "_keychain_manifest": manifest,
+        "region": "us-central1",
+    }
+
+    stripped = strip_keychain_namespaces(payload, manifest)
+
+    assert "keychain" not in stripped
+    assert "openai_token" not in stripped
+    assert stripped["_keychain_manifest"]["entries"]["openai_token"]["fields"] == ["api_key"]
+    assert stripped["region"] == "us-central1"

--- a/tests/server/test_keychain_processor_manifest.py
+++ b/tests/server/test_keychain_processor_manifest.py
@@ -1,0 +1,57 @@
+import pytest
+
+from noetl.server.keychain_processor import process_keychain_section
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def json(self):
+        return {"status": "success"}
+
+
+class _FakeAsyncClient:
+    def __init__(self, *args, **kwargs):
+        self.posts = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def post(self, url, json=None):
+        self.posts.append((url, json))
+        return _FakeResponse()
+
+
+@pytest.mark.asyncio
+async def test_process_keychain_section_returns_manifest_not_resolved_values(monkeypatch):
+    import noetl.server.keychain_processor as processor
+
+    monkeypatch.setattr(processor.httpx, "AsyncClient", _FakeAsyncClient)
+
+    result = await process_keychain_section(
+        keychain_section=[
+            {
+                "name": "openai_token",
+                "kind": "static",
+                "scope": "global",
+                "map": {"api_key": "placeholder-secret"},
+            }
+        ],
+        catalog_id=42,
+        execution_id=123,
+        workload_vars={},
+        api_base_url="http://noetl.test",
+    )
+
+    assert result == {
+        "entries": {
+            "openai_token": {
+                "kind": "static",
+                "fields": ["api_key"],
+            }
+        }
+    }
+    assert "placeholder-secret" not in str(result)

--- a/tests/unit/dsl/engine/test_keychain_command_storage.py
+++ b/tests/unit/dsl/engine/test_keychain_command_storage.py
@@ -1,0 +1,105 @@
+import pytest
+from jinja2 import Environment
+
+from noetl.core.credential_refs import KEYCHAIN_MANIFEST_KEY, NOETL_REF_KEY
+from noetl.core.dsl.engine.executor.commands import CommandCreationMixin
+from noetl.core.dsl.engine.executor.state import ExecutionState
+from noetl.core.dsl.engine.models import Playbook
+
+
+class _CommandCreator(CommandCreationMixin):
+    def __init__(self):
+        self.jinja_env = Environment()
+
+
+def _playbook() -> Playbook:
+    return Playbook.model_validate(
+        {
+            "apiVersion": "noetl.io/v10",
+            "kind": "Playbook",
+            "metadata": {"name": "keychain-storage-test"},
+            "workload": {"region": "us-central1"},
+            "keychain": [
+                {
+                    "name": "openai_token",
+                    "kind": "secret_manager",
+                    "map": {"api_key": "{{ openai_secret_path }}"},
+                }
+            ],
+            "workflow": [
+                {
+                    "step": "extract_turn",
+                    "input": {
+                        "region": "{{ workload.region }}",
+                        "api_key": "{{ keychain.openai_token.api_key | default('') }}",
+                        "header": "Bearer {{ keychain.openai_token.api_key }}",
+                    },
+                    "tool": {
+                        "kind": "python",
+                        "input": {
+                            "api_key": "{{ keychain.openai_token.api_key | default('') }}",
+                            "header": "Bearer {{ keychain.openai_token.api_key }}",
+                        },
+                        "code": "result = {'ok': True}",
+                    },
+                }
+            ],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_command_context_stores_refs_and_deferred_templates():
+    playbook = _playbook()
+    state = ExecutionState("123", playbook, {}, catalog_id=42)
+    state.variables[KEYCHAIN_MANIFEST_KEY] = {
+        "entries": {
+            "openai_token": {
+                "kind": "secret_manager",
+                "fields": ["api_key"],
+            }
+        }
+    }
+    state.variables["keychain"] = {"openai_token": {"api_key": "placeholder-secret"}}
+    creator = _CommandCreator()
+
+    command = await creator._create_command_for_step(state, playbook.workflow[0], {})
+
+    assert command.input["region"] == "us-central1"
+    assert command.input["api_key"][NOETL_REF_KEY] == {
+        "kind": "keychain",
+        "name": "openai_token",
+        "field": "api_key",
+    }
+    assert command.input["header"] == "Bearer {{ keychain.openai_token.api_key }}"
+    assert command.tool.config["input"]["api_key"][NOETL_REF_KEY]["name"] == "openai_token"
+    assert command.tool.config["input"]["header"] == "Bearer {{ keychain.openai_token.api_key }}"
+    assert "keychain" not in command.render_context
+    assert "openai_token" not in command.render_context
+
+
+def test_execution_state_serialization_does_not_persist_resolved_keychain_values():
+    playbook = _playbook()
+    state = ExecutionState(
+        "123",
+        playbook,
+        {"keychain": {"openai_token": {"api_key": "placeholder-secret"}}},
+        catalog_id=42,
+    )
+    state.variables[KEYCHAIN_MANIFEST_KEY] = {
+        "entries": {
+            "openai_token": {
+                "kind": "secret_manager",
+                "fields": ["api_key"],
+            }
+        }
+    }
+    state.variables["openai_token"] = {"api_key": "placeholder-secret"}
+
+    state_dict = state.to_dict()
+
+    assert "keychain" not in state_dict["variables"]
+    assert "openai_token" not in state_dict["variables"].keys()
+    assert "keychain" not in state_dict["payload"]
+    assert "placeholder-secret" not in str(state_dict)
+    assert state_dict["variables"][KEYCHAIN_MANIFEST_KEY]["entries"]["openai_token"]["fields"] == ["api_key"]

--- a/tests/worker/test_worker_playbook_tool.py
+++ b/tests/worker/test_worker_playbook_tool.py
@@ -3,6 +3,106 @@ import httpx
 
 import noetl.worker.nats_worker as worker_module
 from noetl.worker.nats_worker import Worker
+from noetl.core.credential_refs import NOETL_REF_KEY
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_resolves_keychain_refs_at_dispatch(monkeypatch):
+    worker = Worker(worker_id="test-worker")
+    seen = {}
+
+    async def fake_resolve_keychain_entries(**_kwargs):
+        return {"openai_token": {"api_key": "placeholder-secret"}}
+
+    async def fake_execute_python_task_async(task_config, context, _jinja_env, args):
+        seen["task_config"] = task_config
+        seen["context"] = context
+        seen["args"] = args
+        return {"data": {"status": "ok"}}
+
+    import noetl.worker.keychain_resolver as keychain_resolver
+
+    monkeypatch.setattr(keychain_resolver, "resolve_keychain_entries", fake_resolve_keychain_entries)
+    monkeypatch.setattr(worker_module, "execute_python_task_async", fake_execute_python_task_async)
+
+    result = await worker._execute_tool(
+        "python",
+        {
+            "input": {
+                "api_key": {
+                    NOETL_REF_KEY: {
+                        "kind": "keychain",
+                        "name": "openai_token",
+                        "field": "api_key",
+                    }
+                },
+                "header": "Bearer {{ keychain.openai_token.api_key }}",
+            },
+            "code": "result = {'status': 'ok'}",
+        },
+        {},
+        "extract_turn",
+        {"catalog_id": "42", "execution_id": "123"},
+    )
+
+    assert result == {"status": "ok"}
+    assert seen["task_config"]["input"]["api_key"] == "placeholder-secret"
+    assert seen["task_config"]["input"]["header"] == "Bearer placeholder-secret"
+    assert seen["context"]["keychain"]["openai_token"]["api_key"] == "placeholder-secret"
+
+
+@pytest.mark.asyncio
+async def test_execute_command_scrubs_keychain_namespace_before_result_persistence(monkeypatch):
+    worker = Worker(worker_id="test-worker")
+    batch_payloads = []
+    seen_results = []
+
+    async def fake_execute_tool(*_args, **_kwargs):
+        return {
+            "status": "ok",
+            "keychain": {"openai_token": {"api_key": "placeholder-secret"}},
+            "data": {"value": 1, "keychain": {"openai_token": {"api_key": "placeholder-secret"}}},
+        }
+
+    class FakeResultHandler:
+        def __init__(self, execution_id):
+            self.execution_id = execution_id
+
+        async def process_result(self, step_name, result, output_config):
+            seen_results.append(result)
+            return result
+
+    async def fake_emit_event(_server_url, _execution_id, _step, _event_name, _payload, **_kwargs):
+        return None
+
+    async def fake_emit_batch_events(_server_url, _execution_id, events, **_kwargs):
+        batch_payloads.extend(events)
+        return True
+
+    monkeypatch.setattr(worker, "_execute_tool", fake_execute_tool)
+    monkeypatch.setattr(worker, "_emit_event", fake_emit_event)
+    monkeypatch.setattr(worker, "_emit_batch_events", fake_emit_batch_events)
+    monkeypatch.setattr(worker_module, "ResultHandler", FakeResultHandler)
+
+    command = {
+        "execution_id": "123",
+        "step": "extract_turn",
+        "tool_kind": "python",
+        "meta": {"catalog_id": "42"},
+        "context": {
+            "tool_config": {},
+            "input": {},
+            "render_context": {},
+        },
+    }
+
+    await worker._execute_command(command, server_url="http://noetl.test", command_id="cmd-1")
+
+    assert seen_results == [{"status": "ok", "data": {"value": 1}}]
+    call_done = next(item["payload"] for item in batch_payloads if item["name"] == "call.done")
+    step_exit = next(item["payload"] for item in batch_payloads if item["name"] == "step.exit")
+    assert "keychain" not in str(call_done)
+    assert "keychain" not in str(step_exit)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- store keychain manifests and reference objects in execution state/command context instead of resolved keychain values
- resolve keychain references and deferred keychain templates in memory at worker dispatch
- strip keychain namespaces from worker result payloads before result handling/event emission
- update the wiki page for the new storage-side command/state behavior

## Scope
This is Round A only: command/state persistence plus worker dispatch. Result previews, extracted fields, transient variables, result/temp API producer writes, and Arrow IPC producer-side hardening stay in the next round.

## Validation
- uv run pytest tests/core/test_credential_refs.py tests/core/test_redact_keychain_values.py tests/unit/dsl/engine/test_keychain_command_storage.py tests/server/test_keychain_processor_manifest.py tests/worker/test_worker_playbook_tool.py::test_execute_tool_resolves_keychain_refs_at_dispatch tests/worker/test_worker_playbook_tool.py::test_execute_command_scrubs_keychain_namespace_before_result_persistence -q
- uv run python -m py_compile noetl/core/credential_refs.py noetl/server/keychain_processor.py noetl/core/dsl/engine/executor/lifecycle.py noetl/core/dsl/engine/executor/state.py noetl/core/dsl/engine/executor/commands.py noetl/core/dsl/engine/executor/transitions.py noetl/worker/nats_worker.py noetl/worker/keychain_resolver.py
- Live GKE validation with patched image storage-refs-round-a-20260526005308, Cloud Build a4cc2405-46ae-4f23-86b2-86567a5d7aef, Helm revision 160
- Three temporary distributed executions completed successfully: 634932706026980051, 634932719557804767, 634932733440951033
- DB-side verification across those executions: event provider-key hits 0, command provider-key hits 0, state provider-key hits 0; command reference rows 3; deferred-template rows 3; provider success rows 9; persisted keychain namespace rows 0

## Wiki
Updated noetl/noetl wiki: noetl/core/secrets-and-redaction.md (commit aad9b64).