### PR TITLE
fix(security): scrub producer-side credential payloads

### DIFF
--- a/noetl/core/credential_refs.py
+++ b/noetl/core/credential_refs.py
@@ -7,9 +7,21 @@ from typing import Any, Callable, Optional
 
 from jinja2 import BaseLoader, Environment
 
+from noetl.core.sanitize import REDACTED, redact_keychain_values
+
 NOETL_REF_KEY = "$noetl_ref"
 KEYCHAIN_REF_KIND = "keychain"
 KEYCHAIN_MANIFEST_KEY = "_keychain_manifest"
+HEADER_CREDENTIAL_KEYS = {
+    "authorization",
+    "proxy_authorization",
+    "www_authenticate",
+    "x_api_key",
+    "x_auth_token",
+    "x_access_token",
+    "cookie",
+    "set_cookie",
+}
 
 _JINJA_EXPR_RE = re.compile(r"^\s*\{\{\s*(.*?)\s*\}\}\s*$", re.DOTALL)
 _KEYCHAIN_DOT_RE = re.compile(
@@ -159,6 +171,78 @@ def strip_keychain_namespaces(value: Any, manifest: Any = None) -> Any:
     blocked = {"keychain"}
     blocked.update(keychain_names_from_manifest(manifest))
     return _strip_keychain_namespaces(value, blocked)
+
+
+def producer_scrub_payload(
+    value: Any,
+    context: Optional[dict[str, Any]] = None,
+    *,
+    additional_keys: Optional[set[str]] = None,
+    secret_values: Optional[set[str]] = None,
+    redaction: str = REDACTED,
+) -> Any:
+    """Return a storage-safe copy for producer-side result/temp writes."""
+    context = context or {}
+    manifest = context.get(KEYCHAIN_MANIFEST_KEY) if isinstance(context, dict) else None
+    keys = set(HEADER_CREDENTIAL_KEYS)
+    if additional_keys:
+        keys.update(str(key).lower().replace("-", "_") for key in additional_keys)
+
+    if isinstance(manifest, dict):
+        entries = manifest.get("entries")
+        if isinstance(entries, dict):
+            keys.update(str(name).lower().replace("-", "_") for name in entries.keys())
+            for entry in entries.values():
+                if isinstance(entry, dict) and isinstance(entry.get("fields"), list):
+                    keys.update(str(field).lower().replace("-", "_") for field in entry["fields"])
+
+    values = set(secret_values or set())
+    if isinstance(context, dict):
+        values.update(_collect_secret_strings(context.get("keychain")))
+
+    stripped = strip_keychain_namespaces(value, manifest)
+    return redact_keychain_values(
+        stripped,
+        additional_keys=keys,
+        secret_values=values,
+        redaction=redaction,
+    )
+
+
+def scrub_arrow_ipc_bytes(
+    data_bytes: bytes,
+    *,
+    schema_digest: str,
+    row_count: Optional[int] = None,
+    context: Optional[dict[str, Any]] = None,
+) -> tuple[bytes, str, Optional[int], bool]:
+    """Scrub valid Arrow IPC row payloads before durable or IPC-cache writes."""
+    try:
+        from noetl.core.storage.arrow_ipc import arrow_ipc_to_rows, rows_to_arrow_ipc
+
+        rows = arrow_ipc_to_rows(bytes(data_bytes))
+    except Exception:
+        return bytes(data_bytes), schema_digest, row_count, False
+
+    safe_rows = producer_scrub_payload(rows, context)
+    if safe_rows == rows:
+        return bytes(data_bytes), schema_digest, row_count if row_count is not None else len(rows), False
+
+    payload, safe_schema_digest, safe_row_count = rows_to_arrow_ipc(safe_rows)
+    return payload, safe_schema_digest, safe_row_count, True
+
+
+def _collect_secret_strings(value: Any) -> set[str]:
+    values: set[str] = set()
+    if isinstance(value, dict):
+        for item in value.values():
+            values.update(_collect_secret_strings(item))
+    elif isinstance(value, (list, tuple, set)):
+        for item in value:
+            values.update(_collect_secret_strings(item))
+    elif isinstance(value, str) and value:
+        values.add(value)
+    return values
 
 
 def _strip_keychain_namespaces(value: Any, blocked: set[str]) -> Any:

--- a/noetl/core/storage/result_store.py
+++ b/noetl/core/storage/result_store.py
@@ -40,6 +40,7 @@ from noetl.core.storage.models import (
     IpcHint,
 )
 from noetl.core.storage.arrow_ipc import ARROW_STREAM_MEDIA_TYPE, arrow_ipc_to_rows
+from noetl.core.credential_refs import producer_scrub_payload, scrub_arrow_ipc_bytes
 from noetl.core.storage.router import StorageRouter, default_router
 from noetl.core.storage.extractor import create_preview
 from noetl.core.storage.backends import get_backend
@@ -295,7 +296,8 @@ class TempStore:
         source_step: Optional[str] = None,
         parent_execution_id: Optional[str] = None,
         correlation: Optional[Dict[str, Any]] = None,
-        compress: bool = False
+        compress: bool = False,
+        scrub_context: Optional[Dict[str, Any]] = None,
     ) -> TempRef:
         """
         Store data and return a TempRef pointer.
@@ -315,6 +317,10 @@ class TempStore:
         Returns:
             TempRef pointer to the stored data
         """
+        # Producer boundary per agents/rules/execution-model.md secrets rule.
+        data = producer_scrub_payload(data, scrub_context)
+        correlation = producer_scrub_payload(correlation, scrub_context)
+
         data_bytes, meta, preview, original_size = await asyncio.to_thread(
             self._prepare_data_for_storage,
             data,
@@ -384,6 +390,7 @@ class TempStore:
         ipc_cache: Any = None,
         ipc_lease_seconds: Optional[float] = None,
         media_type: str = "application/vnd.apache.arrow.stream",
+        scrub_context: Optional[Dict[str, Any]] = None,
     ) -> TempRef:
         """Store serialized Arrow IPC bytes with optional same-node IPC hint.
 
@@ -392,7 +399,15 @@ class TempStore:
         """
         if not isinstance(data_bytes, (bytes, bytearray, memoryview)):
             raise TypeError("data_bytes must be bytes-like")
-        payload = bytes(data_bytes)
+        # Producer boundary per agents/rules/execution-model.md secrets rule.
+        payload, schema_digest, row_count, scrubbed = scrub_arrow_ipc_bytes(
+            bytes(data_bytes),
+            schema_digest=schema_digest,
+            row_count=row_count,
+            context=scrub_context,
+        )
+        if scrubbed:
+            logger.debug("TEMP: Scrubbed Arrow IPC rows before storing %s", name)
         if not schema_digest:
             raise ValueError("schema_digest is required")
 

--- a/noetl/server/api/result/endpoint.py
+++ b/noetl/server/api/result/endpoint.py
@@ -25,6 +25,7 @@ from noetl.core.storage import (
     default_tracker,
 )
 from noetl.core.logger import setup_logger
+from noetl.core.credential_refs import producer_scrub_payload
 from noetl.core.sanitize import redact_keychain_values
 
 logger = setup_logger(__name__, include_location=True)
@@ -157,16 +158,20 @@ async def put_result(
         # Parse TTL
         ttl_seconds = parse_ttl(request.ttl)
 
+        # Producer boundary per agents/rules/execution-model.md secrets rule.
+        safe_data = producer_scrub_payload(request.data)
+        safe_correlation = producer_scrub_payload(request.correlation)
+
         # Store the data
         result_ref = await default_store.put(
             execution_id=execution_id,
             name=request.name,
-            data=request.data,
+            data=safe_data,
             scope=scope,
             store=store,
             ttl_seconds=ttl_seconds,
             source_step=request.source_step,
-            correlation=request.correlation,
+            correlation=safe_correlation,
             compress=request.compress
         )
 

--- a/noetl/server/api/temp/endpoint.py
+++ b/noetl/server/api/temp/endpoint.py
@@ -23,6 +23,7 @@ from noetl.core.storage import (
     default_tracker,
 )
 from noetl.core.logger import setup_logger
+from noetl.core.credential_refs import producer_scrub_payload
 from noetl.core.sanitize import redact_keychain_values
 
 logger = setup_logger(__name__, include_location=True)
@@ -106,16 +107,20 @@ async def put_temp(
             except ValueError:
                 raise HTTPException(400, f"Invalid store tier: {request.store}")
 
+        # Producer boundary per agents/rules/execution-model.md secrets rule.
+        safe_data = producer_scrub_payload(request.data)
+        safe_correlation = producer_scrub_payload(request.correlation)
+
         # Store the data
         temp_ref = await default_store.put(
             execution_id=execution_id,
             name=request.name,
-            data=request.data,
+            data=safe_data,
             scope=scope,
             store=store,
             ttl_seconds=request.ttl_seconds,
             source_step=request.source_step,
-            correlation=request.correlation,
+            correlation=safe_correlation,
             compress=request.compress
         )
 

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -2060,6 +2060,7 @@ class Worker:
                     step_name=step,
                     result=safe_response,
                     output_config=event_output_config,
+                    scrub_context=render_context,
                 )
                 logger.info(f"[DEBUG-PAYLOAD] Step {step} processed_response: {json.dumps(processed_response, default=str)[:1000]}")
                 if is_result_ref(processed_response):

--- a/noetl/worker/result_handler.py
+++ b/noetl/worker/result_handler.py
@@ -34,6 +34,7 @@ from noetl.core.storage import (
     should_externalize,
     create_preview,
 )
+from noetl.core.credential_refs import producer_scrub_payload
 from noetl.core.logger import setup_logger
 
 logger = setup_logger(__name__, include_location=True)
@@ -143,6 +144,7 @@ class ResultHandler:
         step_name: str,
         result: Any,
         output_config: Optional[Dict[str, Any]] = None,
+        scrub_context: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Process step result for storage and template access.
@@ -170,6 +172,8 @@ class ResultHandler:
             return {"_value": None}
 
         output_config = output_config or {}
+        # Producer boundary per agents/rules/execution-model.md secrets rule.
+        result = producer_scrub_payload(result, scrub_context)
 
         # Check size
         size_bytes = estimate_size(result)

--- a/noetl/worker/transient.py
+++ b/noetl/worker/transient.py
@@ -20,6 +20,7 @@ from psycopg.rows import dict_row
 from psycopg.types.json import Json
 
 from noetl.core.db.pool import get_pool_connection, get_pool
+from noetl.core.credential_refs import producer_scrub_payload
 from noetl.core.logger import setup_logger
 
 logger = setup_logger(__name__, include_location=True)
@@ -158,6 +159,8 @@ class TransientVars:
             var_type: Variable classification (user_defined, step_result, computed, iterator_state)
             source_step: Step name that set/updated the variable
         """
+        # Producer boundary per agents/rules/execution-model.md secrets rule.
+        safe_var_value = producer_scrub_payload(var_value)
         # Check if running in worker context (use API) or server context (use DB)
         if TransientVars._is_worker_context():
             # Worker context - use server API
@@ -167,7 +170,7 @@ class TransientVars:
                     response = await client.post(
                         f"{server_url}/api/vars/{execution_id}",
                         json={
-                            "variables": {var_name: var_value},
+                            "variables": {var_name: safe_var_value},
                             "var_type": var_type,
                             "source_step": source_step
                         }
@@ -215,7 +218,7 @@ class TransientVars:
                                 "execution_id": execution_id,
                                 "var_name": var_name,
                                 "var_type": var_type,
-                                "var_value": Json(var_value),
+                                "var_value": Json(safe_var_value),
                                 "source_step": source_step
                             }
                         )
@@ -414,12 +417,17 @@ class TransientVars:
         """
         if not variables:
             return 0
+        # Producer boundary per agents/rules/execution-model.md secrets rule.
+        safe_variables = {
+            var_name: producer_scrub_payload(var_value)
+            for var_name, var_value in variables.items()
+        }
             
         try:
             async with get_pool_connection() as conn:
                 async with conn.cursor() as cur:
                     count = 0
-                    for var_name, var_value in variables.items():
+                    for var_name, var_value in safe_variables.items():
                         await cur.execute(
                             """
                             INSERT INTO noetl.transient (

--- a/tests/core/test_credential_refs.py
+++ b/tests/core/test_credential_refs.py
@@ -7,8 +7,10 @@ from noetl.core.credential_refs import (
     encode_keychain_templates,
     is_mixed_keychain_expression,
     parse_pure_keychain_expression,
+    producer_scrub_payload,
     render_preserving_keychain_refs,
     resolve_credential_references,
+    scrub_arrow_ipc_bytes,
     strip_keychain_namespaces,
 )
 from noetl.core.dsl.render import render_template
@@ -106,3 +108,51 @@ def test_keychain_manifest_and_strip_remove_values_but_keep_hints():
     assert "openai_token" not in stripped
     assert stripped["_keychain_manifest"]["entries"]["openai_token"]["fields"] == ["api_key"]
     assert stripped["region"] == "us-central1"
+
+
+def test_producer_scrub_payload_redacts_headers_and_keychain_namespaces():
+    payload = {
+        "headers": {
+            "Authorization": "Bearer placeholder-token",
+            "X-API-Key": "placeholder-token",
+            "Cookie": "session=placeholder-token",
+        },
+        "body": {"ok": True},
+        "keychain": {"openai_token": {"api_key": "placeholder-secret"}},
+    }
+
+    scrubbed = producer_scrub_payload(payload)
+
+    assert scrubbed["headers"]["Authorization"] == "[REDACTED]"
+    assert scrubbed["headers"]["X-API-Key"] == "[REDACTED]"
+    assert scrubbed["headers"]["Cookie"] == "[REDACTED]"
+    assert scrubbed["body"] == {"ok": True}
+    assert "keychain" not in scrubbed
+
+
+def test_producer_scrub_payload_uses_context_secret_values():
+    payload = {"value": "prefix placeholder-secret suffix"}
+    context = {"keychain": {"openai_token": {"api_key": "placeholder-secret"}}}
+
+    scrubbed = producer_scrub_payload(payload, context)
+
+    assert scrubbed["value"] == "[REDACTED]"
+
+
+def test_scrub_arrow_ipc_bytes_redacts_valid_rows():
+    from noetl.core.storage.arrow_ipc import arrow_ipc_to_rows, rows_to_arrow_ipc
+
+    payload, schema_digest, row_count = rows_to_arrow_ipc(
+        [{"id": 1, "Authorization": "Bearer placeholder-token"}]
+    )
+
+    safe_payload, safe_schema_digest, safe_row_count, scrubbed = scrub_arrow_ipc_bytes(
+        payload,
+        schema_digest=schema_digest,
+        row_count=row_count,
+    )
+
+    assert scrubbed is True
+    assert safe_schema_digest
+    assert safe_row_count == 1
+    assert arrow_ipc_to_rows(safe_payload) == [{"id": 1, "Authorization": "[REDACTED]"}]

--- a/tests/core/test_storage_ipc_cache.py
+++ b/tests/core/test_storage_ipc_cache.py
@@ -109,6 +109,50 @@ async def test_tempstore_put_ipc_bytes_uses_ipc_hint_and_durable_fallback():
 
 
 @pytest.mark.asyncio
+async def test_tempstore_put_scrubs_json_payload_before_storage():
+    from noetl.core.storage import Scope, StoreTier, TempStore
+
+    store = TempStore()
+    ref = await store.put(
+        execution_id="exec-1",
+        name="result-1",
+        data={"headers": {"Authorization": "Bearer placeholder-token"}},
+        scope=Scope.EXECUTION,
+        store=StoreTier.MEMORY,
+    )
+    try:
+        assert await store.get(ref) == {"headers": {"Authorization": "[REDACTED]"}}
+        assert "placeholder-token" not in str(ref.preview)
+    finally:
+        await store.delete(ref)
+
+
+@pytest.mark.asyncio
+async def test_tempstore_put_ipc_bytes_scrubs_rows_before_storage():
+    from noetl.core.storage import Scope, StoreTier, TempStore, arrow_ipc_to_rows, rows_to_arrow_ipc
+
+    rows = [{"id": 1, "Authorization": "Bearer placeholder-token"}]
+    payload, schema_digest, row_count = rows_to_arrow_ipc(rows)
+    store = TempStore()
+    ref = await store.put_ipc_bytes(
+        execution_id="exec-1",
+        name="frame-1",
+        data_bytes=payload,
+        schema_digest=schema_digest,
+        row_count=row_count,
+        scope=Scope.EXECUTION,
+        store=StoreTier.MEMORY,
+    )
+    try:
+        stored_payload = await store.get_ipc_bytes(ref)
+        assert arrow_ipc_to_rows(stored_payload) == [
+            {"id": 1, "Authorization": "[REDACTED]"}
+        ]
+    finally:
+        await store.delete(ref)
+
+
+@pytest.mark.asyncio
 async def test_tempstore_ipc_stats_track_admission_failure():
     from noetl.core.storage import ArrowIpcSharedMemoryCache, Scope, StoreTier, TempStore
 

--- a/tests/server/test_producer_side_scrub_endpoints.py
+++ b/tests/server/test_producer_side_scrub_endpoints.py
@@ -1,0 +1,64 @@
+import pytest
+
+from noetl.core.storage import ResultRef, Scope, StoreTier
+from noetl.server.api.result import endpoint as result_endpoint
+from noetl.server.api.result.endpoint import ResultPutRequest
+from noetl.server.api.temp import endpoint as temp_endpoint
+from noetl.server.api.temp.endpoint import TempPutRequest
+
+
+class _CaptureStore:
+    def __init__(self):
+        self.puts = []
+
+    async def put(self, **kwargs):
+        self.puts.append(kwargs)
+        return ResultRef.create(
+            execution_id=kwargs["execution_id"],
+            name=kwargs["name"],
+            store=StoreTier.MEMORY,
+            scope=Scope.EXECUTION,
+        )
+
+
+class _Tracker:
+    def register_ref(self, *_args, **_kwargs):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_result_put_scrubs_payload_before_store(monkeypatch):
+    store = _CaptureStore()
+    monkeypatch.setattr(result_endpoint, "default_store", store)
+    monkeypatch.setattr(result_endpoint, "default_tracker", _Tracker())
+
+    await result_endpoint.put_result(
+        "123",
+        ResultPutRequest(
+            name="api_result",
+            data={"headers": {"Authorization": "Bearer placeholder-token"}},
+            correlation={"Cookie": "session=placeholder-token"},
+        ),
+    )
+
+    assert store.puts[0]["data"]["headers"]["Authorization"] == "[REDACTED]"
+    assert store.puts[0]["correlation"]["Cookie"] == "[REDACTED]"
+
+
+@pytest.mark.asyncio
+async def test_temp_put_scrubs_payload_before_store(monkeypatch):
+    store = _CaptureStore()
+    monkeypatch.setattr(temp_endpoint, "default_store", store)
+    monkeypatch.setattr(temp_endpoint, "default_tracker", _Tracker())
+
+    await temp_endpoint.put_temp(
+        "123",
+        TempPutRequest(
+            name="api_temp",
+            data={"headers": {"X-API-Key": "placeholder-token"}},
+            correlation={"Set-Cookie": "session=placeholder-token"},
+        ),
+    )
+
+    assert store.puts[0]["data"]["headers"]["X-API-Key"] == "[REDACTED]"
+    assert store.puts[0]["correlation"]["Set-Cookie"] == "[REDACTED]"

--- a/tests/worker/test_result_handler.py
+++ b/tests/worker/test_result_handler.py
@@ -9,6 +9,22 @@ class _FailStore:
         raise RuntimeError("kv unavailable")
 
 
+class _CaptureStore:
+    def __init__(self):
+        self.puts = []
+
+    async def put(self, **kwargs):
+        from noetl.core.storage import ResultRef, Scope, StoreTier
+
+        self.puts.append(kwargs)
+        return ResultRef.create(
+            execution_id=kwargs["execution_id"],
+            name=kwargs["name"],
+            store=StoreTier.MEMORY,
+            scope=Scope.EXECUTION,
+        )
+
+
 @pytest.mark.asyncio
 async def test_result_handler_store_failure_returns_bounded_payload(monkeypatch):
     monkeypatch.setattr(result_handler_module, "PREVIEW_MAX_BYTES", 64)
@@ -26,3 +42,25 @@ async def test_result_handler_store_failure_returns_bounded_payload(monkeypatch)
     assert processed["_size_bytes"] > 64
     assert "rows" in processed
     assert processed["rows"] != large_result["rows"]
+
+
+@pytest.mark.asyncio
+async def test_result_handler_scrubs_preview_extracted_and_stored_data(monkeypatch):
+    monkeypatch.setattr(result_handler_module, "PREVIEW_MAX_BYTES", 1024)
+    store = _CaptureStore()
+    handler = ResultHandler(execution_id="123", store=store, inline_max_bytes=8)
+    result = {
+        "status": "ok",
+        "headers": {"Authorization": "Bearer placeholder-token"},
+        "body": "x" * 40,
+    }
+
+    processed = await handler.process_result(
+        step_name="fetch_rows",
+        result=result,
+        output_config={"output_select": ["headers.Authorization"]},
+    )
+
+    assert store.puts[0]["data"]["headers"]["Authorization"] == "[REDACTED]"
+    assert processed["Authorization"] == "[REDACTED]"
+    assert "placeholder-token" not in str(processed["_preview"])

--- a/tests/worker/test_transient_producer_scrub.py
+++ b/tests/worker/test_transient_producer_scrub.py
@@ -1,0 +1,86 @@
+import pytest
+
+import noetl.worker.transient as transient_module
+from noetl.worker.transient import TransientVars
+
+
+class _Response:
+    status_code = 200
+
+
+class _AsyncClient:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def post(self, url, json):
+        _AsyncClient.calls.append({"url": url, "json": json})
+        return _Response()
+
+
+_AsyncClient.calls = []
+
+
+@pytest.mark.asyncio
+async def test_transient_set_cached_scrubs_worker_api_payload(monkeypatch):
+    _AsyncClient.calls = []
+    monkeypatch.setenv("NOETL_WORKER_MODE", "true")
+    monkeypatch.setattr(transient_module.httpx, "AsyncClient", _AsyncClient)
+
+    await TransientVars.set_cached(
+        "headers",
+        {"Authorization": "Bearer placeholder-token"},
+        execution_id=123,
+    )
+
+    variables = _AsyncClient.calls[0]["json"]["variables"]
+    assert variables["headers"]["Authorization"] == "[REDACTED]"
+
+
+class _Cursor:
+    def __init__(self):
+        self.params = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def execute(self, _query, params):
+        self.params.append(params)
+
+
+class _Connection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    def cursor(self, *args, **kwargs):
+        return self._cursor
+
+
+@pytest.mark.asyncio
+async def test_transient_set_multiple_scrubs_db_payload(monkeypatch):
+    cursor = _Cursor()
+    monkeypatch.delenv("NOETL_WORKER_MODE", raising=False)
+    monkeypatch.setattr(transient_module, "get_pool_connection", lambda: _Connection(cursor))
+
+    count = await TransientVars.set_multiple(
+        {"headers": {"Cookie": "session=placeholder-token"}},
+        execution_id=123,
+    )
+
+    assert count == 1
+    assert cursor.params[0]["var_value"].obj["Cookie"] == "[REDACTED]"

--- a/tests/worker/test_worker_playbook_tool.py
+++ b/tests/worker/test_worker_playbook_tool.py
@@ -68,7 +68,7 @@ async def test_execute_command_scrubs_keychain_namespace_before_result_persisten
         def __init__(self, execution_id):
             self.execution_id = execution_id
 
-        async def process_result(self, step_name, result, output_config):
+        async def process_result(self, step_name, result, output_config, scrub_context=None):
             seen_results.append(result)
             return result
 


### PR DESCRIPTION
## Summary
- add producer_scrub_payload for result/temp/transient storage boundaries, composed with existing read-side redaction patterns
- scrub worker result previews, output-selected fields, and stored result payloads before persistence
- scrub transient var_value writes and result/temp write endpoint payloads before storage
- scrub valid Arrow IPC row payloads by decoding rows, redacting, and reserializing before durable or IPC-cache writes
- update the secrets-and-redaction wiki page for Round B

## Predecessors
- #603 closed read-side HTTP response redaction
- #604 closed Round A command/state and worker-dispatch reference storage
- Wiki: https://github.com/noetl/noetl/wiki/secrets-and-redaction

## Producer Surfaces Patched
- worker result handler previews, output-selected fields, and stored payloads
- shared result/temp store JSON writes through TempStore.put
- transient variables through TransientVars.set_cached and set_multiple
- PUT /api/result/{execution_id} write boundary
- PUT /api/temp/{execution_id} write boundary
- Arrow IPC writes through TempStore.put_ipc_bytes

## Arrow IPC Strategy
Chose producer-side scrub before serialization for valid Arrow stream payloads. The storage layer decodes valid Arrow rows, applies the same producer scrub, and reserializes before durable storage or IPC-cache admission. Existing invalid-byte compatibility is preserved for callers that were not sending decodable Arrow bytes.

## Validation
- uv run pytest tests/core/test_credential_refs.py tests/core/test_redact_keychain_values.py tests/unit/dsl/engine/test_keychain_command_storage.py tests/server/test_keychain_processor_manifest.py tests/worker/test_worker_playbook_tool.py::test_execute_tool_resolves_keychain_refs_at_dispatch tests/worker/test_worker_playbook_tool.py::test_execute_command_scrubs_keychain_namespace_before_result_persistence tests/worker/test_result_handler.py tests/server/test_producer_side_scrub_endpoints.py tests/worker/test_transient_producer_scrub.py tests/core/test_storage_ipc_cache.py::test_tempstore_put_scrubs_json_payload_before_storage tests/core/test_storage_ipc_cache.py::test_tempstore_put_ipc_bytes_scrubs_rows_before_storage -q
- uv run python -m py_compile noetl/core/credential_refs.py noetl/worker/result_handler.py noetl/worker/transient.py noetl/server/api/result/endpoint.py noetl/server/api/temp/endpoint.py noetl/core/storage/result_store.py noetl/worker/nats_worker.py
- Full uv run pytest currently stops during collection on existing missing modules/fixtures: noetl.tools.tools, tests/fixtures/playbook_test_config.yaml, noetl.tools.shared, noetl.server.stuck_execution_reaper, noetl.tools.auth
- Live GKE validation with image credential-refs-round-b-20260526020112, Cloud Build 9009277c-f818-480d-8c0a-e5646c60b964, Helm revision 161
- Temporary execution 634970636074353484 completed; result/temp/vars write statuses were 200; DB pattern counts were 0 across event, execution state, and transient rows for the placeholder credential shape; result/temp resolve responses had 0 placeholder hits and redacted placeholders present

## Notes
The live app currently exposes the result/temp routers through the app-level /api prefix, so the validation used the deployed /api/api/result and /api/api/temp routes. The code patch remains in the endpoint modules requested by the handoff.