### PR TITLE
fix(api): listings endpoint joins noetl.event for terminal-state correctness

### DIFF
--- a/noetl/server/api/execution/endpoint.py
+++ b/noetl/server/api/execution/endpoint.py
@@ -878,11 +878,27 @@ async def get_executions(
             try:
                 # Keep this endpoint lightweight for UI polling. Avoid scanning giant payload columns.
                 await cursor.execute("SET LOCAL statement_timeout = '8s'")
+                # The noetl.execution projection columns (status, last_event_type,
+                # end_time) can lag behind the immutable event log when a
+                # playbook.completed / workflow.failed / etc. event fires but the
+                # projection write that follows it is delayed or missed (nested
+                # playbook completions, transient projector races). The status
+                # endpoint at /api/executions/{id}/status reads the event log
+                # directly and stays correct; the listings endpoint historically
+                # used only the projection and reported stale RUNNING rows.
+                #
+                # Fix: LATERAL-join the event log for each row in the page and
+                # prefer the event-log-derived terminal columns. The index
+                # idx_event_exec_type ON noetl.event (execution_id, event_type,
+                # event_id DESC) makes the per-row lookup O(log n). For
+                # in-progress executions the projection columns remain the
+                # fallback.
                 await cursor.execute("""
                     SELECT
                         e.execution_id,
                         e.catalog_id,
                         COALESCE(
+                            term_evt.event_type,
                             e.last_event_type,
                             CASE
                                 WHEN e.status IN ('COMPLETED', 'FAILED', 'CANCELLED')
@@ -891,58 +907,82 @@ async def get_executions(
                             END
                         ) AS event_type,
                         e.last_node_name AS node_name,
-                        e.status,
-                        e.status AS event_status,
+                        COALESCE(term_evt.status, e.status) AS status,
+                        COALESCE(term_evt.status, e.status) AS event_status,
                         COALESCE(e.last_event_type, 'execution.projected') AS derived_event_type,
                         COALESCE(e.start_time, e.created_at) AS start_time,
-                        e.end_time,
+                        COALESCE(term_evt.created_at, e.end_time) AS end_time,
                         NULL::jsonb AS result,
                         e.error,
                         e.parent_execution_id,
-                        CASE
-                            WHEN e.last_event_type IN (
-                                'execution.cancelled',
-                                'playbook.failed',
-                                'workflow.failed',
-                                'command.failed',
-                                'playbook.completed',
-                                'workflow.completed'
-                            )
-                            THEN e.last_event_type
-                            WHEN e.status IN ('COMPLETED', 'FAILED', 'CANCELLED')
-                            THEN 'execution.' || lower(e.status)
-                            ELSE NULL
-                        END AS terminal_event_type,
-                        CASE
-                            WHEN e.last_event_type IN (
-                                'execution.cancelled',
-                                'playbook.failed',
-                                'workflow.failed',
-                                'command.failed',
-                                'playbook.completed',
-                                'workflow.completed'
-                            )
-                             OR e.status IN ('COMPLETED', 'FAILED', 'CANCELLED')
-                            THEN e.status
-                            ELSE NULL
-                        END AS terminal_status,
-                        CASE
-                            WHEN e.last_event_type IN (
-                                'execution.cancelled',
-                                'playbook.failed',
-                                'workflow.failed',
-                                'command.failed',
-                                'playbook.completed',
-                                'workflow.completed'
-                            )
-                             OR e.status IN ('COMPLETED', 'FAILED', 'CANCELLED')
-                            THEN COALESCE(e.end_time, e.updated_at)
-                            ELSE NULL
-                        END AS terminal_end_time,
+                        COALESCE(
+                            term_evt.event_type,
+                            CASE
+                                WHEN e.last_event_type IN (
+                                    'execution.cancelled',
+                                    'playbook.failed',
+                                    'workflow.failed',
+                                    'command.failed',
+                                    'playbook.completed',
+                                    'workflow.completed'
+                                )
+                                THEN e.last_event_type
+                                WHEN e.status IN ('COMPLETED', 'FAILED', 'CANCELLED')
+                                THEN 'execution.' || lower(e.status)
+                                ELSE NULL
+                            END
+                        ) AS terminal_event_type,
+                        COALESCE(
+                            term_evt.status,
+                            CASE
+                                WHEN e.last_event_type IN (
+                                    'execution.cancelled',
+                                    'playbook.failed',
+                                    'workflow.failed',
+                                    'command.failed',
+                                    'playbook.completed',
+                                    'workflow.completed'
+                                )
+                                 OR e.status IN ('COMPLETED', 'FAILED', 'CANCELLED')
+                                THEN e.status
+                                ELSE NULL
+                            END
+                        ) AS terminal_status,
+                        COALESCE(
+                            term_evt.created_at,
+                            CASE
+                                WHEN e.last_event_type IN (
+                                    'execution.cancelled',
+                                    'playbook.failed',
+                                    'workflow.failed',
+                                    'command.failed',
+                                    'playbook.completed',
+                                    'workflow.completed'
+                                )
+                                 OR e.status IN ('COMPLETED', 'FAILED', 'CANCELLED')
+                                THEN COALESCE(e.end_time, e.updated_at)
+                                ELSE NULL
+                            END
+                        ) AS terminal_end_time,
                         COALESCE(c.path, 'unknown') AS path,
                         COALESCE(c.version, 0) AS version
                     FROM noetl.execution e
                     LEFT JOIN noetl.catalog c ON c.catalog_id = e.catalog_id
+                    LEFT JOIN LATERAL (
+                        SELECT event_type, status, created_at
+                        FROM noetl.event
+                        WHERE execution_id = e.execution_id
+                          AND event_type IN (
+                            'execution.cancelled',
+                            'playbook.failed',
+                            'workflow.failed',
+                            'command.failed',
+                            'playbook.completed',
+                            'workflow.completed'
+                          )
+                        ORDER BY event_id DESC
+                        LIMIT 1
+                    ) term_evt ON true
                     ORDER BY COALESCE(e.start_time, e.created_at) DESC NULLS LAST, e.execution_id DESC
                     LIMIT %(limit)s
                     OFFSET %(offset)s

--- a/tests/api/execution/test_executions_status_consistency.py
+++ b/tests/api/execution/test_executions_status_consistency.py
@@ -359,8 +359,80 @@ async def test_get_executions_applies_page_size_and_offset(monkeypatch):
     assert len(result) == 1
     assert cursor._params == {"limit": 25, "offset": 25}
     assert "FROM noetl.execution e" in cursor._query
-    assert "FROM noetl.event" not in cursor._query
+    # The listings endpoint joins LATERAL noetl.event for terminal-event
+    # detection so a stale projection cannot mask a completed execution.
+    # See test_get_executions_uses_event_log_lateral_for_terminal_state.
+    assert "LEFT JOIN LATERAL" in cursor._query
+    assert "FROM noetl.event" in cursor._query
     assert "WHEN e.last_event_type IN (" in cursor._query
+
+
+@pytest.mark.asyncio
+async def test_get_executions_uses_event_log_lateral_for_terminal_state(monkeypatch):
+    """The listings endpoint must not rely solely on the noetl.execution
+    projection for terminal status. The projection can lag behind the
+    immutable event log when a playbook.completed event fires but the
+    projection write that follows it is delayed or missed. When the LATERAL
+    join against noetl.event finds a terminal event, the listings must
+    surface that terminal status even if e.status / e.last_event_type are
+    stale.
+
+    Regression for the production observability bug where 82 of 100 listed
+    executions reported status:RUNNING despite playbook.completed events
+    having fired hours earlier. The per-execution /status endpoint was
+    correct because it reads the event log directly; the listings endpoint
+    only read the projection and reported stale RUNNING.
+    """
+    start = datetime(2026, 5, 26, 10, 0, 0, tzinfo=timezone.utc)
+    terminal = datetime(2026, 5, 26, 10, 0, 12, tzinfo=timezone.utc)
+    rows = [
+        {
+            # Projection columns are STALE — execution has actually completed
+            # but the projection row still shows RUNNING.
+            "execution_id": "456",
+            "catalog_id": "789",
+            "status": "RUNNING",
+            "event_status": "RUNNING",
+            "event_type": "playbook.completed",
+            "derived_event_type": "execution.projected",
+            "start_time": start,
+            "end_time": None,
+            "result": None,
+            "error": None,
+            "parent_execution_id": None,
+            # The LATERAL join against noetl.event populated these from
+            # the immutable event log:
+            "terminal_event_type": "playbook.completed",
+            "terminal_status": "COMPLETED",
+            "terminal_end_time": terminal,
+            "path": "tests/listings_stale_projection_regression",
+            "version": 1,
+        }
+    ]
+    cursor = _FakeCursor(rows)
+
+    monkeypatch.setattr(
+        execution_api,
+        "get_pool_connection",
+        lambda: _ConnCtx(_FakeConn(cursor)),
+    )
+
+    result = await execution_api.get_executions()
+
+    assert len(result) == 1
+    # The listings entry must reflect the event-log-derived terminal state
+    # even though the projection columns were stale.
+    assert result[0].status == "COMPLETED"
+    assert result[0].end_time == terminal
+    assert result[0].progress == 100
+
+    # SQL contract: the LATERAL join + the projection fallback must both be
+    # present. The order is `term_evt.event_type` first (event-log wins),
+    # then the projection columns as fallback for in-progress rows.
+    assert "LEFT JOIN LATERAL" in cursor._query
+    assert "term_evt" in cursor._query
+    assert "FROM noetl.event" in cursor._query
+    assert "'playbook.completed'" in cursor._query
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The `/api/executions` listings endpoint historically read terminal state only from the `noetl.execution` projection (`status`, `last_event_type`, `end_time`). That projection can lag the immutable event log when a `playbook.completed` / `playbook.failed` / `workflow.completed` / `workflow.failed` / `execution.cancelled` event fires but the projection write that follows it is delayed or missed (most often on nested-playbook completion). The per-execution endpoint `/api/executions/{id}/status` has always been correct because it reads the event log directly; the listings endpoint reported stale `status:RUNNING` for 82 of 100 recent rows during the 2026-05-24 production triage.

## Fix

Add a `LEFT JOIN LATERAL` against `noetl.event` in the listings SQL to find the latest terminal event per row. Prefer event-log-derived `event_type` / `status` / `created_at` over the projection columns when present.

```sql
LEFT JOIN LATERAL (
    SELECT event_type, status, created_at
    FROM noetl.event
    WHERE execution_id = e.execution_id
      AND event_type IN (
        'execution.cancelled',
        'playbook.failed',
        'workflow.failed',
        'command.failed',
        'playbook.completed',
        'workflow.completed'
      )
    ORDER BY event_id DESC
    LIMIT 1
) term_evt ON true
```

The existing index `idx_event_exec_type ON noetl.event (execution_id, event_type, event_id DESC)` makes the per-row lookup O(log n), so the endpoint stays inside the `SET LOCAL statement_timeout = '8s'` budget for UI polling.

In-progress executions (no terminal event in the log yet) still read `terminal_event_type` / `terminal_status` / `terminal_end_time` from the projection as before.

## What did not change

- The per-execution status endpoint (already correct).
- The projection writers (`noetl/core/dsl/engine/executor/store.py`). A future round can investigate why the projection lags; this PR is the read-side correction so observability stops surfacing stale `RUNNING`.
- Response shape (`ExecutionEntryResponse`).

## Tests

- New regression test `test_get_executions_uses_event_log_lateral_for_terminal_state` simulates the stale-projection scenario: row has `status:RUNNING` and `end_time:NULL` but the LATERAL join surfaces `playbook.completed`. Asserts response is `COMPLETED`.
- Updated `test_get_executions_applies_page_size_and_offset` to assert the LATERAL join is now present in the listings query (was previously asserted absent).
- All 15 tests in `tests/api/execution/test_executions_status_consistency.py` pass.

## Wiki

[noetl/noetl/wiki/noetl/server/api/execution](https://github.com/noetl/noetl/wiki/noetl/server/api/execution) — "List — GET /executions" section gained a "Terminal-state derivation" paragraph documenting the new LATERAL join and why it's necessary.

## Background

This addresses [the executions-listing-stale-status follow-up](https://github.com/noetl/ai-meta/blob/main/handoffs/archive/2026-05-24-noetl-storage-side-credential-hygiene/round-01-result.md) flagged in two earlier rounds of the credential-hygiene arc.