### PR TITLE
perf(worker): collapse case-action handler emits into single batch

### DIFF
--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -2187,36 +2187,45 @@ class Worker:
                 # If case action resulted in routing (next/retry), report and handle
                 if case_action and case_action.get('type') in ['next', 'retry']:
                     logger.info(f"[CASE-ACTION] Case evaluation triggered {case_action['type']} action for {step}")
-                    
+
                     # ARCHITECTURE PRINCIPLE #3:
                     # Report case action to server via ACTIONABLE event
                     # Server will issue new command with rendered input from case_action.config
-                    # This follows server-worker-server control loop pattern
-                    await self._emit_event(
-                        server_url,
-                        execution_id,
-                        step,
-                        "case.evaluated",
-                        {
-                            "action": case_action,
-                            "result": response_for_events,
-                            "triggered_by": eval_event_name
-                        },
-                        actionable=True,  # Server should process this for routing
-                        informative=True
-                    )
-                    
-                    # Emit appropriate event based on success or error
-                    # IMPORTANT: Use response_for_events for errors too so large failed
-                    # payloads are externalized and do not bloat event storage.
+                    # This follows server-worker-server control loop pattern.
+                    #
+                    # Performance: emit case.evaluated + call.done|call.error +
+                    # step.exit + command.completed in a single /api/events/batch
+                    # request. Previously each fired as an individual HTTP
+                    # round-trip (~50-100ms each) for a per-step cost of
+                    # 200-400ms even after a fast tool. The batch endpoint
+                    # persists all events in one Postgres transaction via
+                    # cursor.executemany() (server/api/core/batch.py); the
+                    # ordering within the batch is preserved by insertion
+                    # order so case.evaluated stays first.
+                    #
+                    # IMPORTANT: Use response_for_events for errors too so large
+                    # failed payloads are externalized and do not bloat event
+                    # storage.
                     error_event_response = response_for_events if tool_error else error_response
+
+                    case_action_events = [
+                        {
+                            "step": step,
+                            "name": "case.evaluated",
+                            "payload": {
+                                "action": case_action,
+                                "result": response_for_events,
+                                "triggered_by": eval_event_name,
+                            },
+                            "actionable": True,  # Server should process this for routing
+                            "informative": True,
+                        },
+                    ]
                     if tool_error:
-                        await self._emit_event(
-                            server_url,
-                            execution_id,
-                            step,
-                            "call.error",
-                            {
+                        case_action_events.append({
+                            "step": step,
+                            "name": "call.error",
+                            "payload": {
                                 "error": tool_error,
                                 "response": error_event_response,
                                 "case_handled": True,
@@ -2224,60 +2233,57 @@ class Worker:
                                 "loop_event_id": loop_event_id,
                                 "loop_iteration_index": loop_iteration_index,
                             },
-                            actionable=True,  # Case evaluated - server may route/retry
-                            informative=True,
-                            meta=loop_event_meta or None,
-                        )
+                            "actionable": True,  # Case evaluated - server may route/retry
+                            "informative": True,
+                            "meta": loop_event_meta or None,
+                        })
                     else:
-                        await self._emit_event(
-                            server_url,
-                            execution_id,
-                            step,
-                            "call.done",
-                            {
+                        case_action_events.append({
+                            "step": step,
+                            "name": "call.done",
+                            "payload": {
                                 "response": response_for_events,
                                 "case_handled": True,
                                 "command_id": command_id,
                                 "loop_event_id": loop_event_id,
                                 "loop_iteration_index": loop_iteration_index,
                             },
-                            actionable=True,
-                            informative=True,
-                            meta=loop_event_meta or None,
-                        )
-                    
-                    await self._emit_event(
-                        server_url,
-                        execution_id,
-                        step,
-                        "step.exit",
-                        {
+                            "actionable": True,
+                            "informative": True,
+                            "meta": loop_event_meta or None,
+                        })
+                    case_action_events.append({
+                        "step": step,
+                        "name": "step.exit",
+                        "payload": {
                             "status": "COMPLETED" if not tool_error else "CASE_HANDLED",
                             "result": response_for_events,
                             "case_action": case_action,
                             "command_id": command_id,
                         },
-                        actionable=True,  # Server should handle routing
-                        informative=True
-                    )
-                    
-                    # Emit command.completed
+                        "actionable": True,  # Server should handle routing
+                        "informative": True,
+                    })
                     if command_id:
-                        await self._emit_event(
-                            server_url,
-                            execution_id,
-                            step,
-                            "command.completed",
-                            {
+                        case_action_events.append({
+                            "step": step,
+                            "name": "command.completed",
+                            "payload": {
                                 "command_id": command_id,
                                 "worker_id": self.worker_id,
                                 "result": response_for_events,
-                                "case_action": case_action
+                                "case_action": case_action,
                             },
-                            actionable=False,  # Informational - case.evaluated has action
-                            informative=True
-                        )
-                    
+                            "actionable": False,  # Informational - case.evaluated has action
+                            "informative": True,
+                        })
+
+                    await self._emit_batch_events(
+                        server_url,
+                        execution_id,
+                        case_action_events,
+                    )
+
                     logger.info(f"[EVENT] Completed {step} with case action for execution {execution_id}")
                     return  # Exit - server will handle routing based on case_action
             

--- a/tests/worker/test_worker_batch_emit.py
+++ b/tests/worker/test_worker_batch_emit.py
@@ -328,3 +328,78 @@ async def test_execute_command_continues_when_hot_path_initial_events_timeout(mo
         "step.exit",
         "command.completed",
     ]
+
+
+def test_case_action_handler_uses_a_single_batched_emit():
+    """Regression: the case-action routing path (case rules in next.arcs
+    that resolve to a `next` or `retry` action) used to fire four
+    sequential `_emit_event` HTTP roundtrips for
+    `case.evaluated` + `call.done|call.error` + `step.exit` +
+    `command.completed`. At ~50-100 ms per roundtrip that added
+    200-400 ms per case-evaluated step.
+
+    They now fan out as a single `_emit_batch_events` call so the four
+    events land in one HTTP request and one Postgres transaction via
+    the existing /api/events/batch endpoint.
+
+    This test is a code-shape assertion (not a behavior simulation
+    against a fake worker) because the case-action path is buried
+    inside `_execute_command` and requires significant context setup to
+    reach via behavior tests. The existing initial / terminal batch
+    paths are covered by the behavior tests above; this one pins the
+    refactor's structural invariant: the case-action handler must NOT
+    contain four `_emit_event` calls inside its branch.
+    """
+    import inspect
+    import re
+
+    source = inspect.getsource(worker_module)
+
+    # Find the case-action handler. Look for the marker comment that
+    # opens the branch.
+    branch_start = source.find(
+        "if case_action and case_action.get('type') in ['next', 'retry']"
+    )
+    assert branch_start != -1, "case-action branch marker not found"
+
+    # The branch ends at the next `return` statement at the same
+    # indentation level (which is the # Exit - server will handle
+    # routing line). Grab everything between for inspection.
+    branch_end = source.find(
+        "return  # Exit - server will handle routing based on case_action",
+        branch_start,
+    )
+    assert branch_end != -1, "case-action branch close marker not found"
+    branch_body = source[branch_start:branch_end]
+
+    # The collapsed batch path: exactly one _emit_batch_events call.
+    batch_calls = re.findall(r"await\s+self\._emit_batch_events\(", branch_body)
+    assert len(batch_calls) == 1, (
+        f"case-action branch should issue exactly one batched emit; "
+        f"found {len(batch_calls)}"
+    )
+
+    # No individual _emit_event calls inside the branch body. Allow
+    # whitespace differences; the assertion is "no `await self._emit_event(`".
+    individual_calls = re.findall(r"await\s+self\._emit_event\(", branch_body)
+    assert individual_calls == [], (
+        f"case-action branch must not issue individual _emit_event calls "
+        f"(would cause 4 sequential HTTP roundtrips); "
+        f"found {len(individual_calls)}"
+    )
+
+    # The batch must contain at least the four event names. Order is
+    # preserved by the batch endpoint's executemany insert.
+    for required_name in (
+        '"case.evaluated"',
+        '"step.exit"',
+        '"command.completed"',
+    ):
+        assert required_name in branch_body, (
+            f"case-action batch must include {required_name}"
+        )
+    # call.done OR call.error must be present (one is selected at
+    # runtime by tool_error).
+    assert ('"call.done"' in branch_body) and (
+        '"call.error"' in branch_body
+    ), "case-action batch must include both call.done and call.error event templates"


### PR DESCRIPTION
## Summary

The case-action routing path (case rules in `next.arcs` that resolve to a `next` or `retry` action) used to fire four sequential `_emit_event` HTTP roundtrips:

1. `case.evaluated`
2. `call.done` (or `call.error` on tool error)
3. `step.exit`
4. `command.completed`

At ~50–100 ms per roundtrip, that added 200–400 ms per case-evaluated step on top of the already-batched initial and terminal event emits. The non-case-action path already collapsed its terminal events via `_emit_terminal_event_batch`; only the case-action branch was left behind.

## Fix

Collapse the four into a single `_emit_batch_events` call. All four events land in one HTTP request and one Postgres transaction (the server's batch endpoint uses `cursor.executemany` on `noetl.event` inserts in `server/api/core/batch.py`). Ordering within the batch is preserved by insertion order so `case.evaluated` stays first.

## What did not change

- Event names, payloads, actionable / informative flags, meta passthrough.
- Public event-log shape — no implications for replay or observability.
- The non-case-action terminal path (already batched via `_emit_terminal_event_batch`).
- The error-recovery fallback `_emit_event` (only fires when event emission itself fails; not on the hot path).

## Test

New `test_case_action_handler_uses_a_single_batched_emit` is a code-shape assertion pinning the structural invariant:
- exactly one `_emit_batch_events` call in the case-action branch
- zero individual `_emit_event` calls in the same branch
- the batch contains `case.evaluated`, `step.exit`, `command.completed`, plus both `call.done` and `call.error` templates (one selected at runtime by `tool_error`)

A behavior-level test would require setting up the deep `_execute_command` context that triggers case-action routing; the existing initial/terminal batch behavior tests cover the surrounding paths and still pass (8 tests in the file).

## Performance expectation

Per case-evaluated step: ~150–300 ms saved on the four-emit cost (one roundtrip vs four). For a playbook with several case-routing steps this compounds; the typical itinerary-planner doesn't use case routing, but pipelines with retry/route logic see the win directly.

## Larger latency follow-up — for design review

The original "<2s playbook turn" target needs more than this fix. Two architectural moves are still on the table; this PR is the smallest-blast-radius win. The bigger items:

1. **Inline trivial nested playbook execution.** Today every `tool: agent` with `framework: noetl` HTTPs into `/api/execute`, allocates a new `execution_id`, persists `playbook.initialized`, dispatches via NATS. For a child playbook with 1–3 simple steps that overhead is 500–1500 ms. Detecting "trivial" needs design — either heuristic (step count, no callback subjects, no `tool: agent` recursion) or explicit (`spec.inline: true` in the child).
2. **Combine `command.completed` + `step.exit` + `call.done` into a single boundary event.** Currently three separate events per step. The read side and replay would need to handle the combined shape. Touches event-log consumers across the codebase.

Both are scoped for a follow-up handoff; not in this PR.