### PR TITLE
feat(inline-execution): Round A detector + dry-run observability

### DIFF
--- a/noetl/core/workflow/playbook/inline_execution.py
+++ b/noetl/core/workflow/playbook/inline_execution.py
@@ -1,0 +1,341 @@
+"""Round A inline-child eligibility detector.
+
+This module is intentionally pure: no database reads, no HTTP calls, and no
+dispatch decisions. Round A only explains whether a child playbook would be a
+safe candidate for a later inline runner.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import fnmatch
+import os
+from typing import Any, Iterable, Mapping, Optional
+
+
+DEFAULT_MAX_STEPS = 3
+DEFAULT_MAX_DEPTH = 3
+DEFAULT_ALLOWED_TOOL_KINDS = frozenset({"python", "mcp", "noop"})
+DEFAULT_ALLOW_LIST = ("automation/agents/mcp/*",)
+ALLOW_LIST_ENV = "NOETL_INLINE_TRIVIAL_CHILDREN_ALLOW_LIST"
+
+
+@dataclass(frozen=True)
+class InlineDecision:
+    inline: bool
+    reasons: list[str]
+    depth: int
+    mode: Optional[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "inline": self.inline,
+            "reasons": list(self.reasons),
+            "depth": self.depth,
+            "mode": self.mode,
+        }
+
+
+def detect_inline_child(
+    child_playbook: Any,
+    parent_context: Optional[Mapping[str, Any]] = None,
+    *,
+    child_path: Optional[str] = None,
+    framework: str = "noetl",
+    depth: Optional[int] = None,
+    max_steps: int = DEFAULT_MAX_STEPS,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    allowed_tool_kinds: Iterable[str] = DEFAULT_ALLOWED_TOOL_KINDS,
+    allow_list: Optional[Iterable[str]] = None,
+) -> InlineDecision:
+    """Return the Round A inline eligibility decision for a child playbook."""
+
+    playbook = _as_mapping(child_playbook)
+    parent_context = parent_context or {}
+    current_depth = _resolve_depth(parent_context, depth)
+    allowed_kinds = {str(kind).strip().lower() for kind in allowed_tool_kinds}
+    patterns = tuple(allow_list) if allow_list is not None else load_allow_list_from_env()
+    reasons: list[str] = []
+    blocked = False
+
+    if str(framework or "").strip().lower() == "noetl":
+        reasons.append("framework:ok:noetl")
+    else:
+        reasons.append(f"framework:block:{framework}")
+        blocked = True
+
+    if current_depth <= max_depth:
+        reasons.append(f"depth:ok:{current_depth}<={max_depth}")
+    else:
+        reasons.append(f"depth:block:{current_depth}>{max_depth}")
+        blocked = True
+
+    metadata = _as_mapping(playbook.get("metadata"))
+    metadata_flag = metadata.get("inline_when_safe")
+    metadata_mode = False
+    metadata_invalid = False
+    if metadata_flag is True:
+        metadata_mode = True
+        reasons.append("metadata:ok:inline_when_safe=true")
+    elif metadata_flag is None or metadata_flag is False:
+        reasons.append("metadata:skip:inline_when_safe_not_true")
+    else:
+        metadata_invalid = True
+        reasons.append("metadata:block:inline_when_safe_must_be_boolean_true")
+        blocked = True
+
+    allow_mode = _path_matches_allow_list(child_path, patterns)
+    if allow_mode:
+        reasons.append("allow_list:ok:path_matched")
+    else:
+        reasons.append("allow_list:skip:path_not_matched")
+
+    mode: Optional[str]
+    if metadata_mode:
+        mode = "metadata_opt_in"
+    elif allow_mode:
+        mode = "allow_list"
+    else:
+        mode = None
+        if not metadata_invalid:
+            reasons.append("mode:block:not_opted_in_or_allow_listed")
+            blocked = True
+
+    workflow = _as_list(playbook.get("workflow"))
+    step_count = len(workflow)
+    if 0 < step_count <= max_steps:
+        reasons.append(f"steps:ok:{step_count}<={max_steps}")
+    else:
+        reasons.append(f"steps:block:{step_count}>{max_steps}" if step_count else "steps:block:missing_workflow")
+        blocked = True
+
+    executor = _as_mapping(playbook.get("executor"))
+    executor_spec = _as_mapping(executor.get("spec"))
+    if executor_spec.get("final_step"):
+        reasons.append("finalizer:block:executor_spec_final_step")
+        blocked = True
+    else:
+        reasons.append("finalizer:ok:none")
+
+    if _contains_key_with_truthy_value(playbook, "callback_subject"):
+        reasons.append("callback:block:callback_subject_present")
+        blocked = True
+    else:
+        reasons.append("callback:ok:none")
+
+    if _contains_async_true(playbook):
+        reasons.append("async:block:spec_async_true")
+        blocked = True
+    else:
+        reasons.append("async:ok:none")
+
+    if _contains_output_ref(playbook):
+        reasons.append("output_ref:block:present")
+        blocked = True
+    else:
+        reasons.append("output_ref:ok:none")
+
+    loop_blocked = _append_loop_reasons(workflow, reasons)
+    blocked = blocked or loop_blocked
+
+    tool_blocked = _append_tool_reasons(workflow, reasons, allowed_kinds)
+    blocked = blocked or tool_blocked
+
+    tenant_blocked = _append_tenant_reasons(metadata, parent_context, reasons)
+    blocked = blocked or tenant_blocked
+
+    return InlineDecision(
+        inline=not blocked,
+        reasons=reasons,
+        depth=current_depth,
+        mode=mode,
+    )
+
+
+def load_allow_list_from_env(env: Mapping[str, str] | None = None) -> tuple[str, ...]:
+    env = env if env is not None else os.environ
+    raw = str(env.get(ALLOW_LIST_ENV, "") or "").strip()
+    if not raw:
+        return DEFAULT_ALLOW_LIST
+    return tuple(item.strip() for item in raw.split(",") if item.strip())
+
+
+def _resolve_depth(parent_context: Mapping[str, Any], explicit_depth: Optional[int]) -> int:
+    if explicit_depth is not None:
+        return max(0, int(explicit_depth))
+    for key in ("inline_depth", "_inline_depth"):
+        if key in parent_context:
+            try:
+                return max(0, int(parent_context[key]))
+            except (TypeError, ValueError):
+                return 0
+    meta = _as_mapping(parent_context.get("meta"))
+    if "inline_depth" in meta:
+        try:
+            return max(0, int(meta["inline_depth"]))
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
+def _path_matches_allow_list(path: Optional[str], patterns: Iterable[str]) -> bool:
+    if not path:
+        return False
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def _append_loop_reasons(workflow: list[Any], reasons: list[str]) -> bool:
+    blocked = False
+    loop_seen = False
+    for idx, raw_step in enumerate(workflow):
+        step = _as_mapping(raw_step)
+        loop = _as_mapping(step.get("loop"))
+        if not loop:
+            continue
+        loop_seen = True
+        loop_spec = _as_mapping(loop.get("spec"))
+        loop_policy = _as_mapping(loop_spec.get("policy"))
+        mode = str(loop_spec.get("mode") or loop.get("mode") or "sequential").lower()
+        if mode in {"parallel", "cursor"}:
+            reasons.append(f"loop:block:step[{idx}].mode={mode}")
+            blocked = True
+        elif loop.get("cursor") is not None:
+            reasons.append(f"loop:block:step[{idx}].cursor_present")
+            blocked = True
+        elif str(loop_policy.get("exec") or "").lower() == "distributed":
+            reasons.append(f"loop:block:step[{idx}].policy_exec=distributed")
+            blocked = True
+        else:
+            reasons.append(f"loop:ok:step[{idx}].mode={mode or 'sequential'}")
+    if not loop_seen:
+        reasons.append("loop:ok:none")
+    return blocked
+
+
+def _append_tool_reasons(
+    workflow: list[Any],
+    reasons: list[str],
+    allowed_kinds: set[str],
+) -> bool:
+    blocked = False
+    for idx, raw_step in enumerate(workflow):
+        kinds = _tool_kinds(_as_mapping(raw_step).get("tool"))
+        if not kinds:
+            reasons.append(f"tool:block:step[{idx}].missing_tool_kind")
+            blocked = True
+            continue
+        for kind in kinds:
+            if kind == "agent":
+                reasons.append(f"tool:block:step[{idx}].kind=agent")
+                blocked = True
+            elif kind in {"playbook", "playbooks"}:
+                reasons.append(f"tool:block:step[{idx}].kind={kind}")
+                blocked = True
+            elif kind not in allowed_kinds:
+                reasons.append(f"tool:block:step[{idx}].kind={kind}")
+                blocked = True
+            else:
+                reasons.append(f"tool:ok:step[{idx}].kind={kind}")
+    return blocked
+
+
+def _append_tenant_reasons(
+    metadata: Mapping[str, Any],
+    parent_context: Mapping[str, Any],
+    reasons: list[str],
+) -> bool:
+    blocked = False
+    for key in ("tenant_id", "organization_id"):
+        child_value = metadata.get(key)
+        parent_value = _context_value(parent_context, key)
+        if child_value is None:
+            reasons.append(f"{key}:ok:no_child_constraint")
+            continue
+        if parent_value is None:
+            reasons.append(f"{key}:block:parent_missing")
+            blocked = True
+            continue
+        if str(child_value) == str(parent_value):
+            reasons.append(f"{key}:ok:match")
+        else:
+            reasons.append(f"{key}:block:mismatch")
+            blocked = True
+    return blocked
+
+
+def _context_value(context: Mapping[str, Any], key: str) -> Any:
+    if key in context:
+        return context.get(key)
+    for container_key in ("workload", "ctx", "meta"):
+        container = _as_mapping(context.get(container_key))
+        if key in container:
+            return container.get(key)
+    return None
+
+
+def _tool_kinds(tool: Any) -> list[str]:
+    if tool is None:
+        return []
+    if isinstance(tool, list):
+        kinds: list[str] = []
+        for item in tool:
+            item_map = _as_mapping(item)
+            kind = item_map.get("kind")
+            if kind is not None:
+                kinds.append(str(kind).strip().lower())
+        return kinds
+    tool_map = _as_mapping(tool)
+    kind = tool_map.get("kind")
+    return [str(kind).strip().lower()] if kind is not None else []
+
+
+def _contains_async_true(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if str(key) == "async" and bool(item):
+                return True
+            if _contains_async_true(item):
+                return True
+    elif isinstance(value, list):
+        return any(_contains_async_true(item) for item in value)
+    return False
+
+
+def _contains_output_ref(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if str(key) == "output_ref" and item not in (None, "", {}):
+                return True
+            if _contains_output_ref(item):
+                return True
+    elif isinstance(value, list):
+        return any(_contains_output_ref(item) for item in value)
+    return False
+
+
+def _contains_key_with_truthy_value(value: Any, needle: str) -> bool:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if str(key) == needle and bool(item):
+                return True
+            if _contains_key_with_truthy_value(item, needle):
+                return True
+    elif isinstance(value, list):
+        return any(_contains_key_with_truthy_value(item, needle) for item in value)
+    return False
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    if hasattr(value, "model_dump"):
+        dumped = value.model_dump()
+        return dumped if isinstance(dumped, Mapping) else {}
+    if hasattr(value, "dict"):
+        dumped = value.dict()
+        return dumped if isinstance(dumped, Mapping) else {}
+    return {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []

--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -26,6 +26,7 @@ import time
 from typing import Any, Callable, Dict, Optional, Tuple
 
 from jinja2 import Environment
+import yaml
 
 from noetl.core.dsl.render import render_template
 from noetl.core.logger import setup_logger
@@ -308,7 +309,7 @@ def _compact_mcp_result_for_agent_context(result: Any) -> Any:
                     compact_data[key] = value[:max_items]
                 else:
                     # Travel renderers and most MCP consumers expect the
-                    # canonical collection field to be `items`; Amadeus uses
+                    # shared collection field to be `items`; Amadeus uses
                     # domain-specific names for hotels/activities.
                     compact_data["items"] = value[:max_items]
                 compact_data.setdefault(f"{key}_total", len(value))
@@ -545,6 +546,8 @@ _REQUIRED_DIAGNOSIS_KEYS = (
     "suggested_action",
     "source",
 )
+_INLINE_TRIVIAL_CHILDREN_ENV = "NOETL_INLINE_TRIVIAL_CHILDREN"
+_INLINE_TRIVIAL_CHILDREN_MODES = {"off", "dry_run", "enforce"}
 _TROUBLESHOOT_ON_FAILURE_KEYS = {
     "confidence_threshold",
     "escalate_to",
@@ -704,6 +707,128 @@ def _fetch_persisted_diagnosis_with_backoff(
         remaining = max(0.0, deadline_at - now)
         time.sleep(min(sleep_seconds, remaining))
         sleep_seconds = min(sleep_seconds * multiplier, max_sleep_seconds)
+
+
+def _inline_trivial_children_mode() -> str:
+    raw = os.environ.get(_INLINE_TRIVIAL_CHILDREN_ENV, "off")
+    mode = str(raw or "off").strip().lower()
+    if not mode:
+        return "off"
+    return mode if mode in _INLINE_TRIVIAL_CHILDREN_MODES else "invalid"
+
+
+def _load_inline_child_playbook_for_dry_run(
+    *,
+    entrypoint: str,
+    task_config: Dict[str, Any],
+    context: Dict[str, Any],
+    jinja_env: Any,
+) -> Dict[str, Any]:
+    for key in ("inline_child_playbook", "child_playbook", "playbook"):
+        candidate = task_config.get(key)
+        if isinstance(candidate, dict):
+            return dict(candidate)
+
+    for key in (
+        "inline_child_playbook_content",
+        "child_playbook_content",
+        "playbook_content",
+        "content",
+    ):
+        content = task_config.get(key)
+        if isinstance(content, str) and content.strip():
+            try:
+                parsed = yaml.safe_load(content) or {}
+                return parsed if isinstance(parsed, dict) else {}
+            except Exception as exc:
+                logger.debug(
+                    "AGENT.INLINE dry-run failed to parse inline content for %s: %s",
+                    entrypoint,
+                    exc,
+                )
+                return {}
+
+    try:
+        from noetl.core.workflow.playbook.loader import (
+            load_playbook_content,
+            render_playbook_content,
+        )
+
+        _path, content, error = load_playbook_content({"path": entrypoint}, "inline-dry-run")
+        if error or not content:
+            if error:
+                logger.debug(
+                    "AGENT.INLINE dry-run could not load %s: %s",
+                    entrypoint,
+                    error,
+                )
+            return {}
+        rendered, render_error = render_playbook_content(
+            content,
+            context,
+            jinja_env,
+            "inline-dry-run",
+        )
+        if render_error or not rendered:
+            if render_error:
+                logger.debug(
+                    "AGENT.INLINE dry-run could not render %s: %s",
+                    entrypoint,
+                    render_error,
+                )
+            return {}
+        parsed = yaml.safe_load(rendered) or {}
+        return parsed if isinstance(parsed, dict) else {}
+    except Exception as exc:
+        logger.debug(
+            "AGENT.INLINE dry-run could not inspect %s: %s",
+            entrypoint,
+            exc,
+        )
+        return {}
+
+
+def _inline_decision_for_noetl_child(
+    *,
+    entrypoint: str,
+    task_config: Dict[str, Any],
+    context: Dict[str, Any],
+    jinja_env: Any,
+) -> Optional[Dict[str, Any]]:
+    mode = _inline_trivial_children_mode()
+    if mode == "off":
+        return None
+    if mode == "enforce":
+        raise RuntimeError(
+            f"{_INLINE_TRIVIAL_CHILDREN_ENV}=enforce is reserved; Round B not yet implemented"
+        )
+    if mode == "invalid":
+        raise RuntimeError(
+            f"{_INLINE_TRIVIAL_CHILDREN_ENV} must be one of: dry_run, enforce, off"
+        )
+
+    from noetl.core.workflow.playbook.inline_execution import detect_inline_child
+
+    child_playbook = _load_inline_child_playbook_for_dry_run(
+        entrypoint=entrypoint,
+        task_config=task_config,
+        context=context,
+        jinja_env=jinja_env,
+    )
+    decision = detect_inline_child(
+        child_playbook,
+        context,
+        child_path=entrypoint,
+        framework="noetl",
+    ).to_dict()
+    logger.debug(
+        "AGENT.INLINE dry-run decision entrypoint=%s inline=%s mode=%s reasons=%s",
+        entrypoint,
+        decision.get("inline"),
+        decision.get("mode"),
+        decision.get("reasons"),
+    )
+    return decision
 
 
 def _dispatch_troubleshoot_diagnosis(
@@ -965,6 +1090,26 @@ def _invoke_noetl_playbook(
             },
         }
 
+    try:
+        inline_decision = _inline_decision_for_noetl_child(
+            entrypoint=entrypoint,
+            task_config=task_config,
+            context=context,
+            jinja_env=jinja_env,
+        )
+    except RuntimeError as exc:
+        return {
+            "status": "error",
+            "framework": "noetl",
+            "entrypoint": entrypoint,
+            "error": {
+                "kind": "agent.configuration",
+                "code": "INLINE_TRIVIAL_CHILDREN_UNAVAILABLE",
+                "message": str(exc),
+                "retryable": False,
+            },
+        }
+
     # The plugin's task_config contract expects `path` (catalog
     # playbook path) plus an optional `input` dict. Build that out
     # of `entrypoint` + the agent's payload + invoke_kwargs.
@@ -1074,6 +1219,8 @@ def _invoke_noetl_playbook(
             "execution_id": sub_execution_id or sub_result.get("execution_id"),
             "duration": sub_result.get("duration"),
         }
+        if inline_decision is not None:
+            envelope["meta"] = {"inline_decision": inline_decision}
         if normalised_status != "ok":
             error_message = (
                 (sub_terminal.get("error") if sub_terminal else None)
@@ -1117,7 +1264,7 @@ def _invoke_noetl_playbook(
         return envelope
 
     # Defensive: plugin returned something unexpected.
-    return {
+    envelope = {
         "status": "error",
         "framework": "noetl",
         "entrypoint": entrypoint,
@@ -1128,6 +1275,9 @@ def _invoke_noetl_playbook(
             "retryable": False,
         },
     }
+    if inline_decision is not None:
+        envelope["meta"] = {"inline_decision": inline_decision}
+    return envelope
 
 
 def _call_plan(

--- a/tests/core/workflow/test_inline_execution.py
+++ b/tests/core/workflow/test_inline_execution.py
@@ -1,0 +1,309 @@
+from noetl.core.workflow.playbook.inline_execution import (
+    DEFAULT_ALLOW_LIST,
+    InlineDecision,
+    detect_inline_child,
+    load_allow_list_from_env,
+)
+
+
+def _playbook(**overrides):
+    doc = {
+        "metadata": {"name": "child", "path": "automation/agents/mcp/firestore"},
+        "workflow": [
+            {
+                "step": "call",
+                "tool": {"kind": "python"},
+            }
+        ],
+    }
+    doc.update(overrides)
+    return doc
+
+
+def _reason(decision, prefix):
+    return any(reason.startswith(prefix) for reason in decision.reasons)
+
+
+def test_allow_list_hit_is_inline_candidate():
+    decision = detect_inline_child(
+        _playbook(),
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is True
+    assert decision.mode == "allow_list"
+    assert _reason(decision, "allow_list:ok")
+    assert _reason(decision, "tool:ok")
+
+
+def test_metadata_opt_in_boolean_true_is_inline_candidate():
+    decision = detect_inline_child(
+        _playbook(metadata={"name": "child", "inline_when_safe": True}),
+        child_path="custom/child",
+    )
+
+    assert decision.inline is True
+    assert decision.mode == "metadata_opt_in"
+    assert _reason(decision, "metadata:ok")
+
+
+def test_metadata_truthy_non_bool_is_rejected():
+    decision = detect_inline_child(
+        _playbook(metadata={"name": "child", "inline_when_safe": "true"}),
+        child_path="custom/child",
+    )
+
+    assert decision.inline is False
+    assert decision.mode is None
+    assert "metadata:block:inline_when_safe_must_be_boolean_true" in decision.reasons
+
+
+def test_not_opted_in_or_allow_listed_blocks_inline():
+    decision = detect_inline_child(_playbook(), child_path="custom/child")
+
+    assert decision.inline is False
+    assert decision.mode is None
+    assert "mode:block:not_opted_in_or_allow_listed" in decision.reasons
+
+
+def test_depth_limit_enforced():
+    decision = detect_inline_child(
+        _playbook(),
+        child_path="automation/agents/mcp/firestore",
+        depth=4,
+    )
+
+    assert decision.inline is False
+    assert "depth:block:4>3" in decision.reasons
+
+
+def test_depth_can_be_read_from_parent_context():
+    decision = detect_inline_child(
+        _playbook(),
+        {"meta": {"inline_depth": 2}},
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is True
+    assert decision.depth == 2
+    assert "depth:ok:2<=3" in decision.reasons
+
+
+def test_step_count_limit_enforced():
+    workflow = [
+        {"step": "one", "tool": {"kind": "python"}},
+        {"step": "two", "tool": {"kind": "mcp"}},
+        {"step": "three", "tool": {"kind": "noop"}},
+        {"step": "four", "tool": {"kind": "python"}},
+    ]
+    decision = detect_inline_child(
+        _playbook(workflow=workflow),
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is False
+    assert "steps:block:4>3" in decision.reasons
+
+
+def test_missing_workflow_blocks_inline():
+    decision = detect_inline_child(
+        _playbook(workflow=[]),
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is False
+    assert "steps:block:missing_workflow" in decision.reasons
+
+
+def test_disallowed_agent_tool_kind_blocks_inline():
+    decision = detect_inline_child(
+        _playbook(workflow=[{"step": "child", "tool": {"kind": "agent"}}]),
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is False
+    assert "tool:block:step[0].kind=agent" in decision.reasons
+
+
+def test_disallowed_playbook_tool_kind_blocks_inline():
+    decision = detect_inline_child(
+        _playbook(workflow=[{"step": "child", "tool": {"kind": "playbook"}}]),
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is False
+    assert "tool:block:step[0].kind=playbook" in decision.reasons
+
+
+def test_disallowed_http_tool_kind_blocks_inline():
+    decision = detect_inline_child(
+        _playbook(workflow=[{"step": "call", "tool": {"kind": "http"}}]),
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is False
+    assert "tool:block:step[0].kind=http" in decision.reasons
+
+
+def test_pipeline_tool_kinds_must_all_be_allowed():
+    decision = detect_inline_child(
+        _playbook(
+            workflow=[
+                {
+                    "step": "pipeline",
+                    "tool": [
+                        {"name": "safe", "kind": "python"},
+                        {"name": "unsafe", "kind": "http"},
+                    ],
+                }
+            ]
+        ),
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is False
+    assert "tool:ok:step[0].kind=python" in decision.reasons
+    assert "tool:block:step[0].kind=http" in decision.reasons
+
+
+def test_parallel_loop_blocks_inline():
+    decision = detect_inline_child(
+        _playbook(
+            workflow=[
+                {
+                    "step": "loop",
+                    "loop": {"in": "{{ items }}", "iterator": "item", "spec": {"mode": "parallel"}},
+                    "tool": {"kind": "python"},
+                }
+            ]
+        ),
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is False
+    assert "loop:block:step[0].mode=parallel" in decision.reasons
+
+
+def test_cursor_loop_blocks_inline():
+    decision = detect_inline_child(
+        _playbook(
+            workflow=[
+                {
+                    "step": "loop",
+                    "loop": {"cursor": {"kind": "postgres"}, "iterator": "row", "spec": {"mode": "cursor"}},
+                    "tool": {"kind": "python"},
+                }
+            ]
+        ),
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is False
+    assert "loop:block:step[0].mode=cursor" in decision.reasons
+
+
+def test_distributed_loop_blocks_inline():
+    decision = detect_inline_child(
+        _playbook(
+            workflow=[
+                {
+                    "step": "loop",
+                    "loop": {
+                        "in": "{{ items }}",
+                        "iterator": "item",
+                        "spec": {"mode": "sequential", "policy": {"exec": "distributed"}},
+                    },
+                    "tool": {"kind": "python"},
+                }
+            ]
+        ),
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is False
+    assert "loop:block:step[0].policy_exec=distributed" in decision.reasons
+
+
+def test_finalizer_blocks_inline():
+    decision = detect_inline_child(
+        _playbook(executor={"spec": {"final_step": "cleanup"}}),
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is False
+    assert "finalizer:block:executor_spec_final_step" in decision.reasons
+
+
+def test_callback_subject_blocks_inline():
+    decision = detect_inline_child(
+        _playbook(workflow=[{"step": "call", "spec": {"callback_subject": "reply"}, "tool": {"kind": "python"}}]),
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is False
+    assert "callback:block:callback_subject_present" in decision.reasons
+
+
+def test_async_spec_blocks_inline():
+    decision = detect_inline_child(
+        _playbook(workflow=[{"step": "call", "spec": {"async": True}, "tool": {"kind": "python"}}]),
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is False
+    assert "async:block:spec_async_true" in decision.reasons
+
+
+def test_output_ref_blocks_inline():
+    decision = detect_inline_child(
+        _playbook(workflow=[{"step": "call", "tool": {"kind": "python", "output_ref": "nats://ref"}}]),
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is False
+    assert "output_ref:block:present" in decision.reasons
+
+
+def test_same_tenant_mismatch_blocks_inline():
+    decision = detect_inline_child(
+        _playbook(metadata={"name": "child", "tenant_id": "tenant-b"}),
+        {"tenant_id": "tenant-a"},
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is False
+    assert "tenant_id:block:mismatch" in decision.reasons
+
+
+def test_same_tenant_match_allows_inline():
+    decision = detect_inline_child(
+        _playbook(metadata={"name": "child", "tenant_id": "tenant-a", "organization_id": "org-a"}),
+        {"workload": {"tenant_id": "tenant-a", "organization_id": "org-a"}},
+        child_path="automation/agents/mcp/firestore",
+    )
+
+    assert decision.inline is True
+    assert "tenant_id:ok:match" in decision.reasons
+    assert "organization_id:ok:match" in decision.reasons
+
+
+def test_custom_allow_list_env_csv():
+    assert load_allow_list_from_env({"NOETL_INLINE_TRIVIAL_CHILDREN_ALLOW_LIST": "x/*, y/z"}) == (
+        "x/*",
+        "y/z",
+    )
+
+
+def test_allow_list_default_when_env_empty():
+    assert load_allow_list_from_env({}) == DEFAULT_ALLOW_LIST
+
+
+def test_decision_serializes_to_dict():
+    decision = InlineDecision(inline=True, reasons=["ok"], depth=1, mode="allow_list")
+
+    assert decision.to_dict() == {
+        "inline": True,
+        "reasons": ["ok"],
+        "depth": 1,
+        "mode": "allow_list",
+    }

--- a/tests/tools/test_agent_executor.py
+++ b/tests/tools/test_agent_executor.py
@@ -132,6 +132,131 @@ async def test_agent_executor_returns_structured_error_for_bad_entrypoint():
     assert result["error"]["kind"] == "agent.execution"
 
 
+def _install_successful_noetl_child(monkeypatch, calls):
+    def fake_execute_playbook_task(task_config, context, jinja_env, task_with):
+        calls.append(
+            {
+                "task_config": dict(task_config),
+                "task_with": dict(task_with or {}),
+            }
+        )
+        return {
+            "status": "success",
+            "execution_id": "child-exec-1",
+            "duration": 0.01,
+        }
+
+    monkeypatch.setattr(
+        "noetl.core.workflow.playbook.execute_playbook_task",
+        fake_execute_playbook_task,
+    )
+    monkeypatch.setattr(
+        agent_executor,
+        "_wait_for_sub_execution_terminal",
+        lambda *args, **kwargs: {
+            "status": "COMPLETED",
+            "execution_id": "child-exec-1",
+            "completed": True,
+            "failed": False,
+        },
+    )
+    monkeypatch.setattr(
+        agent_executor,
+        "_fetch_sub_execution_terminal_result",
+        lambda execution_id: {"ok": True, "items": ["result"]},
+    )
+
+
+@pytest.mark.asyncio
+async def test_noetl_inline_dry_run_off_does_not_inspect_child(monkeypatch):
+    calls = []
+    monkeypatch.delenv(agent_executor._INLINE_TRIVIAL_CHILDREN_ENV, raising=False)
+    monkeypatch.setattr(
+        agent_executor,
+        "_load_inline_child_playbook_for_dry_run",
+        lambda **kwargs: pytest.fail("dry-run loader should not run when flag is off"),
+    )
+    _install_successful_noetl_child(monkeypatch, calls)
+
+    result = await execute_agent_task(
+        task_config={
+            "framework": "noetl",
+            "entrypoint": "automation/agents/mcp/weather",
+            "payload": {"city": "SFO"},
+        },
+        context={},
+        jinja_env=Environment(),
+        task_with={},
+    )
+
+    assert result["status"] == "ok"
+    assert result["data"] == {"ok": True, "items": ["result"]}
+    assert "meta" not in result
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_noetl_inline_dry_run_attaches_decision_without_changing_dispatch(monkeypatch):
+    calls = []
+    monkeypatch.setenv(agent_executor._INLINE_TRIVIAL_CHILDREN_ENV, "dry_run")
+    monkeypatch.setattr(
+        agent_executor,
+        "_load_inline_child_playbook_for_dry_run",
+        lambda **kwargs: {
+            "metadata": {"inline_when_safe": True},
+            "workflow": [
+                {
+                    "step": "shape",
+                    "tool": {"kind": "python"},
+                }
+            ],
+        },
+    )
+    _install_successful_noetl_child(monkeypatch, calls)
+
+    result = await execute_agent_task(
+        task_config={
+            "framework": "noetl",
+            "entrypoint": "automation/agents/mcp/weather",
+            "payload": {"city": "SFO"},
+        },
+        context={},
+        jinja_env=Environment(),
+        task_with={},
+    )
+
+    assert result["status"] == "ok"
+    assert len(calls) == 1
+    assert calls[0]["task_config"]["path"] == "automation/agents/mcp/weather"
+    decision = result["meta"]["inline_decision"]
+    assert decision["inline"] is True
+    assert decision["mode"] == "metadata_opt_in"
+
+
+@pytest.mark.asyncio
+async def test_noetl_inline_enforce_errors_before_dispatch(monkeypatch):
+    monkeypatch.setenv(agent_executor._INLINE_TRIVIAL_CHILDREN_ENV, "enforce")
+    monkeypatch.setattr(
+        "noetl.core.workflow.playbook.execute_playbook_task",
+        lambda *args, **kwargs: pytest.fail("enforce must not dispatch in Round A"),
+    )
+
+    result = await execute_agent_task(
+        task_config={
+            "framework": "noetl",
+            "entrypoint": "automation/agents/mcp/weather",
+        },
+        context={},
+        jinja_env=Environment(),
+        task_with={},
+    )
+
+    assert result["status"] == "error"
+    assert result["error"]["kind"] == "agent.configuration"
+    assert result["error"]["code"] == "INLINE_TRIVIAL_CHILDREN_UNAVAILABLE"
+    assert "Round B not yet implemented" in result["error"]["message"]
+
+
 @pytest.mark.asyncio
 async def test_agent_executor_adk_keyword_payload_and_async_generator():
     module_name = "test_agent_exec_adk_mod"


### PR DESCRIPTION
## Summary

Round A for inline trivial children:
- adds a pure eligibility detector at `noetl/core/workflow/playbook/inline_execution.py`
- wires dry-run observability into `framework: noetl` agent calls behind `NOETL_INLINE_TRIVIAL_CHILDREN=dry_run`
- attaches decisions to the parent agent envelope at `meta.inline_decision`
- reserves `NOETL_INLINE_TRIVIAL_CHILDREN=enforce` as an explicit configuration error until Round B

## Eligibility Surface

The detector returns `inline`, `reasons`, `depth`, and `mode`. It requires `framework: noetl`, depth <= 3, workflow length 1..3, metadata opt-in or path allow-list, same tenant/org constraints, allowed tool kinds only, and no callbacks, async markers, output refs, finalizers, cursor/parallel/distributed loops, nested agents, or nested playbooks.

Default allow-list: `automation/agents/mcp/*`.
Override: `NOETL_INLINE_TRIVIAL_CHILDREN_ALLOW_LIST` as comma-separated `fnmatch` patterns.

## Runtime Behavior

`NOETL_INLINE_TRIVIAL_CHILDREN` values:
- `off` or unset: no detector call
- `dry_run`: compute decision, log at DEBUG, attach `meta.inline_decision`, then dispatch exactly as before
- `enforce`: fail with an `agent.configuration` error because Round B is not implemented

## Explicit Non-Changes

This PR does not change child execution behavior. Every child playbook still goes through `/api/execute` and NATS. It does not change event-log shape, replay, cancellation, worker dispatch, command projection rows, or result storage/redaction behavior.

No files under `noetl/core/dsl/engine/executor/`, `noetl/server/api/core/`, or worker dispatch code were changed.

## Wiki

Wiki page pushed to `noetl/noetl.wiki`:
https://github.com/noetl/noetl/wiki/inline_execution

## Tests

```bash
uv run pytest tests/core/workflow/test_inline_execution.py tests/tools/test_agent_executor.py -q
```

Result: 45 passed, 1 existing Pydantic deprecation warning.
