### PR TITLE
fix(worker): preserve meta.inline_decision through control-context projection

### DIFF
--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -715,6 +715,17 @@ class Worker:
                     rendered_args = self._preserve_recursive_control_value(child["args"])
                     if rendered_args is not None:
                         nested["args"] = rendered_args
+                # Inline-execution Round A observability — the NoETL agent
+                # bridge attaches `meta.inline_decision` (a dict carrying
+                # `inline`, `reasons`, `depth`, `mode`) so the dry-run path
+                # can be observed end-to-end. Without an explicit carve-out
+                # the dict-of-dict gets stripped by the nested-scalars-only
+                # rule above and the decision never reaches the event log.
+                # Same pattern as error.diagnosis and render.args.
+                if key_str == "meta" and isinstance(child.get("inline_decision"), dict):
+                    decision = self._preserve_recursive_control_value(child["inline_decision"])
+                    if decision is not None:
+                        nested["inline_decision"] = decision
                 if nested:
                     context[key_str] = nested
 

--- a/tests/worker/test_control_context_projection.py
+++ b/tests/worker/test_control_context_projection.py
@@ -341,3 +341,83 @@ def test_non_agent_data_stays_out_of_projection():
     )
 
     assert projected == {"status": "ok"}
+
+
+def test_meta_inline_decision_survives_projection():
+    """The NoETL agent bridge attaches `meta.inline_decision` (a dict
+    carrying inline / reasons / depth / mode) to the agent envelope when
+    NOETL_INLINE_TRIVIAL_CHILDREN=dry_run. Without an explicit carve-out
+    in `_extract_control_context` the dict-of-dict gets stripped by the
+    nested-scalars-only rule and the decision never reaches the event
+    log's result.context.meta. Same pattern as the error.diagnosis and
+    render.args carve-outs above.
+
+    Regression for the visibility gap observed when first enabling the
+    dry-run flag on the live GKE cluster: the detector was firing (per
+    worker logs) but `meta.inline_decision` was missing from every
+    /api/executions/{id}/events row.
+    """
+    worker = _worker()
+    decision = {
+        "inline": False,
+        "reasons": [
+            "framework:ok:noetl",
+            "metadata:skip:inline_when_safe_not_true",
+            "allow_list:ok:path_matched",
+            "steps:ok:1<=3",
+            "callback:ok:none",
+        ],
+        "depth": 0,
+        "mode": "allow_list",
+    }
+    projected = worker._extract_control_context(
+        {
+            "status": "ok",
+            "framework": "noetl",
+            "entrypoint": "automation/agents/mcp/firestore",
+            "data": {"ok": True, "value": 1},
+            "execution_id": "63504...",
+            "duration": 0.21,
+            "meta": {"inline_decision": decision},
+        }
+    )
+
+    # Sanity: the scalar fields still survive (existing behavior).
+    assert projected["status"] == "ok"
+    assert projected["framework"] == "noetl"
+    assert projected["entrypoint"] == "automation/agents/mcp/firestore"
+    assert projected["execution_id"] == "63504..."
+    assert projected["duration"] == 0.21
+    # The agent's data carve-out still kicks in (framework: noetl).
+    assert projected["data"]["ok"] is True
+
+    # The new behavior — meta.inline_decision is preserved.
+    assert "meta" in projected, "meta key should be preserved for inline_decision"
+    assert "inline_decision" in projected["meta"]
+    persisted = projected["meta"]["inline_decision"]
+    assert persisted["inline"] is False
+    assert persisted["depth"] == 0
+    assert persisted["mode"] == "allow_list"
+    # Reasons list (scalar strings) round-trips through
+    # _preserve_recursive_control_value.
+    assert "framework:ok:noetl" in persisted["reasons"]
+
+
+def test_meta_without_inline_decision_does_not_synthesize_meta_key():
+    """The carve-out only fires when meta.inline_decision is present.
+    A generic meta dict with only-non-scalar children still gets the
+    nested-scalars-only treatment and contributes nothing — proving the
+    fix is targeted, not a wholesale relaxation of the projection rule.
+    """
+    worker = _worker()
+    projected = worker._extract_control_context(
+        {
+            "status": "ok",
+            # meta carries no inline_decision and no scalar children:
+            # the existing rule should produce nothing for the meta key.
+            "meta": {"unrelated_dict": {"nested": "value"}},
+        }
+    )
+
+    assert projected["status"] == "ok"
+    assert "meta" not in projected


### PR DESCRIPTION
## Summary

The Round A inline-execution dry-run path (PR #608) attaches `meta.inline_decision` to the agent envelope so operators can observe which trivial children the detector would inline. After enabling `NOETL_INLINE_TRIVIAL_CHILDREN=dry_run` on the live GKE cluster I discovered the decision **never reaches the event log**.

The detector was firing — visible in worker INFO-level `[DEBUG-PAYLOAD]` logs as `meta.inline_decision: {inline: false, reasons: ["framework:ok:noetl", ...]}` on `processed_response`. But every `/api/executions/{id}/events` response had `result.context.meta = None`.

## Root cause

`Worker._extract_control_context` in `noetl/worker/nats_worker.py:630` projects the agent envelope into the event row's `result.context`. It iterates the envelope's keys and for dict-typed children it retains only nested **scalars**:

```python
if isinstance(child, dict):
    nested = {
        str(nk): nv
        for nk, nv in child.items()
        if self._is_scalar(nv)
        ...
    }
```

The agent envelope's `meta = {"inline_decision": {<dict>}}` is a dict-of-dict — `nv` is not scalar — so `nested` ends up empty and the whole `meta` key gets discarded. The existing `error.diagnosis` and `render.args` carve-outs have the same shape (dict-of-dict values that need recursive preservation); `meta.inline_decision` didn't have one.

## Fix

Add a targeted carve-out using the existing `_preserve_recursive_control_value` helper, mirroring the `error.diagnosis` / `render.args` pattern:

```python
if key_str == "meta" and isinstance(child.get("inline_decision"), dict):
    decision = self._preserve_recursive_control_value(child["inline_decision"])
    if decision is not None:
        nested["inline_decision"] = decision
```

Narrow scope: only `meta.inline_decision` is rescued. A `meta` dict without `inline_decision` still gets the nested-scalars-only treatment (covered by `test_meta_without_inline_decision_does_not_synthesize_meta_key`).

## Tests

- New `test_meta_inline_decision_survives_projection` — asserts the decision dict round-trips through the projection with `inline`, `reasons`, `depth`, `mode` preserved alongside the existing envelope fields.
- New `test_meta_without_inline_decision_does_not_synthesize_meta_key` — pins the targeted scope.
- All 15 tests in `tests/worker/test_control_context_projection.py` pass (13 pre-existing + 2 new).

## What did not change

- The agent envelope shape — `meta.inline_decision` was already attached upstream by PR #608.
- The Round A detector logic in `noetl/core/workflow/playbook/inline_execution.py`.
- The dispatch path; this remains a Round A dry-run observability change.
- Other carve-outs (`error.diagnosis`, `render.args`, `data` for `framework: noetl`).

## Wiki

[noetl/noetl/wiki/inline_execution](https://github.com/noetl/noetl/wiki/inline_execution) — added an "Event-log persistence" subsection under Logging documenting that the decision lands at `result.context.meta.inline_decision` and citing the carve-out.

## Live verification

After this PR merges and a new image deploys, the existing live cluster (Helm rev 162 with `NOETL_INLINE_TRIVIAL_CHILDREN=dry_run` on noetl-worker) will start surfacing decisions in the event log. The dry-run experiment that prompted this PR (execution `635041599201739615`) showed the detector firing but no event-log persistence; a re-run after this lands will show `meta.inline_decision` on every agent `call.done` row.