### PR TITLE
fix(inline-execution): detector falls back to catalog when child is placeholder

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -717,6 +717,121 @@ def _inline_trivial_children_mode() -> str:
     return mode if mode in _INLINE_TRIVIAL_CHILDREN_MODES else "invalid"
 
 
+def _looks_like_placeholder_playbook(parsed: Dict[str, Any]) -> bool:
+    """Detect the broker-resolution placeholder stub emitted by
+    ``loader.create_placeholder_playbook`` when the child playbook is
+    not present on the worker's local filesystem (the normal case for
+    cross-repo entrypoints like ``automation/agents/mcp/firestore``,
+    which lives in noetl/ops, not in the noetl image).
+
+    The stub has exactly two steps named ``start`` and ``end``,
+    neither with a ``tool`` definition. Treating it as the real child
+    would make the inline detector mark every cross-repo MCP child as
+    `inline:false` for ``missing_tool_kind`` reasons, defeating the
+    dry-run observability path. When this returns True we fall through
+    to the catalog HTTP lookup so the detector sees the actual
+    workflow.
+    """
+    if not isinstance(parsed, dict):
+        return False
+    workflow = parsed.get("workflow")
+    if not isinstance(workflow, list) or len(workflow) != 2:
+        return False
+    expected = ("start", "end")
+    for idx, step in enumerate(workflow):
+        if not isinstance(step, dict):
+            return False
+        if step.get("step") != expected[idx]:
+            return False
+        if step.get("tool") is not None:
+            return False
+    return True
+
+
+def _load_inline_child_playbook_from_catalog(entrypoint: str) -> Optional[Dict[str, Any]]:
+    """Fetch the child playbook content from the noetl-server catalog
+    via the HTTP API. Used when the local filesystem lookup returns a
+    placeholder stub.
+
+    Synchronous (uses ``requests`` like the existing
+    ``_fetch_persisted_diagnosis_from_doc`` helper) so the dry-run
+    detector path can stay sync. The async catalog helper at
+    ``noetl.core.workflow.workbook.catalog.fetch_playbook_from_catalog``
+    has the same contract but is not callable from sync code without
+    setting up an event loop.
+
+    Returns the parsed playbook dict on success or None on any
+    failure. Best-effort: a failed catalog lookup falls back to
+    "no inspection" and the detector returns ``inline:false`` with a
+    clear reason, matching the existing behavior for un-inspectable
+    children.
+    """
+    try:
+        import requests
+    except ImportError:
+        logger.debug(
+            "AGENT.INLINE dry-run: requests module unavailable; cannot "
+            "fetch child playbook %s from catalog",
+            entrypoint,
+        )
+        return None
+
+    server_url = os.environ.get("NOETL_SERVER_URL", "http://localhost:8083").rstrip("/")
+    if not server_url.endswith("/api"):
+        server_url = server_url + "/api"
+    resource_url = f"{server_url}/catalog/resource"
+
+    try:
+        resp = requests.post(
+            resource_url,
+            json={"path": entrypoint, "version": "latest"},
+            timeout=5.0,
+        )
+        if resp.status_code == 404:
+            logger.debug(
+                "AGENT.INLINE dry-run: child playbook %s not in catalog",
+                entrypoint,
+            )
+            return None
+        resp.raise_for_status()
+        entry = resp.json() or {}
+    except Exception as exc:
+        logger.debug(
+            "AGENT.INLINE dry-run: catalog fetch failed for %s: %s",
+            entrypoint,
+            exc,
+        )
+        return None
+
+    # The catalog entry carries the rendered playbook content either as
+    # a parsed dict under ``payload``/``content``/``parsed`` or as a
+    # YAML string. Tolerate both shapes.
+    for candidate_key in ("payload", "parsed", "content"):
+        candidate = entry.get(candidate_key)
+        if isinstance(candidate, dict) and candidate:
+            return candidate
+        if isinstance(candidate, str) and candidate.strip():
+            try:
+                parsed = yaml.safe_load(candidate)
+                if isinstance(parsed, dict) and parsed:
+                    return parsed
+            except Exception as exc:
+                logger.debug(
+                    "AGENT.INLINE dry-run: failed to parse catalog %s "
+                    "for %s: %s",
+                    candidate_key, entrypoint, exc,
+                )
+                continue
+
+    logger.debug(
+        "AGENT.INLINE dry-run: catalog entry for %s had no parseable "
+        "playbook content; keys=%s",
+        entrypoint,
+        list(entry.keys()) if isinstance(entry, dict) else "(non-dict)",
+    )
+    return None
+
+
 def _load_inline_child_playbook_for_dry_run(
     *,
     entrypoint: str,
@@ -778,7 +893,27 @@ def _load_inline_child_playbook_for_dry_run(
                 )
             return {}
         parsed = yaml.safe_load(rendered) or {}
-        return parsed if isinstance(parsed, dict) else {}
+        if not isinstance(parsed, dict):
+            return {}
+        # If the on-disk lookup fell back to the broker-resolution
+        # placeholder (the workflow only has `start` + `end`, no tools),
+        # the detector cannot meaningfully inspect the child. Fall
+        # through to the catalog so the detector sees the real workflow
+        # the noetl-server would dispatch for this path.
+        if _looks_like_placeholder_playbook(parsed):
+            catalog_view = _load_inline_child_playbook_from_catalog(entrypoint)
+            if isinstance(catalog_view, dict) and catalog_view:
+                logger.debug(
+                    "AGENT.INLINE dry-run: replaced placeholder with "
+                    "catalog view for %s",
+                    entrypoint,
+                )
+                return catalog_view
+            # No catalog content either — leave the parsed placeholder
+            # in place. The detector will emit `missing_tool_kind`
+            # reasons, which is the correct outcome for a child the
+            # runtime genuinely cannot inspect.
+        return parsed
     except Exception as exc:
         logger.debug(
             "AGENT.INLINE dry-run could not inspect %s: %s",

--- a/tests/tools/test_agent_executor.py
+++ b/tests/tools/test_agent_executor.py
@@ -875,3 +875,225 @@ def test_fetch_sub_execution_terminal_result_swallows_request_failure(monkeypatc
 
     result = agent_executor._fetch_sub_execution_terminal_result("12345")
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Catalog-fallback for the dry-run loader. When the on-disk lookup falls back
+# to the placeholder stub (real-world case for cross-repo entrypoints like
+# automation/agents/mcp/firestore where the file lives in noetl/ops, not in
+# the noetl image), the loader must fetch the actual playbook from the
+# noetl-server catalog so the detector can inspect the real workflow.
+#
+# Without this, the live GKE dry-run experiment with PR #608 + PR #609 saw
+# every mcp/firestore decision come back inline=false with
+# "tool:block:step[0].missing_tool_kind" + "step[1].missing_tool_kind" — even
+# though the real firestore playbook has exactly one step with tool.kind=python.
+# The detector was inspecting the broker-resolution placeholder, not the real
+# child.
+# ---------------------------------------------------------------------------
+
+
+def test_placeholder_detector_matches_broker_resolution_stub():
+    """The placeholder shape comes from loader.create_placeholder_playbook —
+    exactly start + end with no tool. Pin the detector against that exact
+    shape so a future change to the placeholder catches a test failure
+    here before silently breaking the catalog-fallback trigger."""
+    placeholder = {
+        "apiVersion": "noetl.io/v1",
+        "kind": "Playbook",
+        "name": "firestore",
+        "path": "automation/agents/mcp/firestore",
+        "workload": {},
+        "workflow": [
+            {
+                "step": "start",
+                "desc": "Placeholder for path-referenced playbook",
+                "next": [{"step": "end"}],
+            },
+            {"step": "end", "desc": "End"},
+        ],
+    }
+    assert agent_executor._looks_like_placeholder_playbook(placeholder) is True
+
+
+def test_placeholder_detector_does_not_match_real_one_step_playbook():
+    real_playbook = {
+        "apiVersion": "noetl.io/v2",
+        "kind": "Playbook",
+        "workload": {},
+        "workflow": [
+            {
+                "step": "firestore_dispatch",
+                "tool": {"kind": "python", "code": "..."},
+            }
+        ],
+    }
+    assert agent_executor._looks_like_placeholder_playbook(real_playbook) is False
+
+
+def test_placeholder_detector_does_not_match_three_step_playbook():
+    """Multi-step playbooks (start + real + end, or longer) are not stubs."""
+    multi_step = {
+        "workflow": [
+            {"step": "start", "next": [{"step": "fetch"}]},
+            {"step": "fetch", "tool": {"kind": "python"}},
+            {"step": "end"},
+        ]
+    }
+    assert agent_executor._looks_like_placeholder_playbook(multi_step) is False
+
+
+def test_placeholder_detector_rejects_two_steps_with_tool_definition():
+    """A two-step playbook with tool defined is not the placeholder. The
+    placeholder is defined by both having exactly the (start, end) names
+    AND lacking tool definitions."""
+    two_step_with_tools = {
+        "workflow": [
+            {"step": "start", "tool": {"kind": "python"}},
+            {"step": "end"},
+        ]
+    }
+    assert agent_executor._looks_like_placeholder_playbook(two_step_with_tools) is False
+
+
+def test_placeholder_detector_handles_non_dict_input():
+    """Defensive: callers may pass empty dicts, None, or unexpected shapes.
+    The detector should return False (not raise)."""
+    assert agent_executor._looks_like_placeholder_playbook({}) is False
+    assert agent_executor._looks_like_placeholder_playbook({"workflow": []}) is False
+    assert agent_executor._looks_like_placeholder_playbook({"workflow": "not-a-list"}) is False
+
+
+def test_load_inline_child_from_catalog_returns_payload_dict(monkeypatch):
+    """Successful catalog fetch with `payload` dict shape."""
+    captured: Dict[str, Any] = {}
+
+    class _FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "path": "automation/agents/mcp/firestore",
+                "version": 7,
+                "payload": {
+                    "apiVersion": "noetl.io/v2",
+                    "kind": "Playbook",
+                    "workflow": [
+                        {"step": "firestore_dispatch", "tool": {"kind": "python"}}
+                    ],
+                },
+            }
+
+    class _FakeRequestsModule:
+        @staticmethod
+        def post(url, json=None, timeout=None):
+            captured["url"] = url
+            captured["json"] = json
+            captured["timeout"] = timeout
+            return _FakeResponse()
+
+    monkeypatch.setitem(sys.modules, "requests", _FakeRequestsModule)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+
+    result = agent_executor._load_inline_child_playbook_from_catalog(
+        "automation/agents/mcp/firestore"
+    )
+
+    assert result is not None
+    assert result["workflow"][0]["step"] == "firestore_dispatch"
+    assert result["workflow"][0]["tool"]["kind"] == "python"
+    # Correct URL (server_url + /api + /catalog/resource).
+    assert captured["url"] == "http://noetl.test:8082/api/catalog/resource"
+    assert captured["json"] == {
+        "path": "automation/agents/mcp/firestore",
+        "version": "latest",
+    }
+
+
+def test_load_inline_child_from_catalog_parses_yaml_string_content(monkeypatch):
+    """Catalog entry may carry the playbook as a YAML string under
+    `content` instead of a parsed dict. The loader must parse it."""
+    class _FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "content": (
+                    "apiVersion: noetl.io/v2\n"
+                    "kind: Playbook\n"
+                    "workflow:\n"
+                    "  - step: firestore_dispatch\n"
+                    "    tool:\n"
+                    "      kind: python\n"
+                ),
+            }
+
+    class _FakeRequestsModule:
+        @staticmethod
+        def post(url, json=None, timeout=None):
+            return _FakeResponse()
+
+    monkeypatch.setitem(sys.modules, "requests", _FakeRequestsModule)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+
+    result = agent_executor._load_inline_child_playbook_from_catalog(
+        "automation/agents/mcp/firestore"
+    )
+
+    assert result is not None
+    assert result["workflow"][0]["step"] == "firestore_dispatch"
+    assert result["workflow"][0]["tool"]["kind"] == "python"
+
+
+def test_load_inline_child_from_catalog_returns_none_on_404(monkeypatch):
+    """A 404 from the catalog endpoint is a clean "not found" signal,
+    not an error to bubble up. Caller falls back to leaving the
+    placeholder in place."""
+    class _FakeResponse:
+        status_code = 404
+
+        def raise_for_status(self):
+            raise RuntimeError("must not be called on 404 short-circuit")
+
+        def json(self):
+            raise RuntimeError("must not be called on 404 short-circuit")
+
+    class _FakeRequestsModule:
+        @staticmethod
+        def post(url, json=None, timeout=None):
+            return _FakeResponse()
+
+    monkeypatch.setitem(sys.modules, "requests", _FakeRequestsModule)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+
+    result = agent_executor._load_inline_child_playbook_from_catalog(
+        "missing/playbook"
+    )
+
+    assert result is None
+
+
+def test_load_inline_child_from_catalog_returns_none_on_network_failure(monkeypatch):
+    """Network failure / connection error → None, never raises. The
+    detector then keeps the placeholder and emits a clear reason chain
+    rather than crashing the agent path."""
+
+    class _FakeRequestsModule:
+        @staticmethod
+        def post(url, json=None, timeout=None):
+            raise ConnectionError("simulated network failure")
+
+    monkeypatch.setitem(sys.modules, "requests", _FakeRequestsModule)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+
+    result = agent_executor._load_inline_child_playbook_from_catalog(
+        "automation/agents/mcp/firestore"
+    )
+
+    assert result is None


### PR DESCRIPTION
## Summary

The Round A dry-run loader inspects the child playbook to decide eligibility. For cross-repo entrypoints (e.g. `automation/agents/mcp/firestore` lives in `noetl/ops`, not in the noetl image), the local filesystem lookup fails and `loader.create_placeholder_playbook()` returns a stub with exactly two steps (`start` + `end`) and no tools. The detector then sees the stub and blocks every such child with `tool:block:step[0].missing_tool_kind` + `step[1].missing_tool_kind`.

This was discovered during live GKE dry-run verification of PR #608 + PR #609. Synthetic itinerary-planner execution `635063984781000752` (Reykjavik) produced 12 events all with `inline=false` for that reason chain — despite the real `firestore.yaml` having one step with `tool.kind: python` that would otherwise pass every eligibility check.

## Fix

- **`_looks_like_placeholder_playbook()`** — recognizes the broker-resolution stub by exact shape:
  ```python
  workflow == [
      {step: "start", tool: None, ...},
      {step: "end",   tool: None, ...},
  ]
  ```
- **`_load_inline_child_playbook_from_catalog()`** — fetches the real child from the noetl-server catalog via `POST /api/catalog/resource`. Sync `requests` matching the existing `_fetch_persisted_diagnosis_from_doc` helper. Tolerates `payload` dict and `content` YAML-string shapes.
- **`_load_inline_child_playbook_for_dry_run()`** — now checks for the placeholder after the local-filesystem render and falls through to the catalog lookup when matched. Best-effort: a failed catalog lookup leaves the placeholder in place (the detector emits `missing_tool_kind`, which is the correct outcome for genuinely un-inspectable children).

## What did not change

- The Round A detector logic itself (`noetl/core/workflow/playbook/inline_execution.py`).
- PR #608's dry-run wiring or env-flag semantics.
- PR #609's `meta.inline_decision` projection through `_extract_control_context`.
- Dispatch behavior — every child still goes through `/api/execute` and NATS.

## Tests

9 new tests in `tests/tools/test_agent_executor.py`:
- Placeholder detector matches the exact stub shape from `loader.create_placeholder_playbook`.
- Real one-step / multi-step / two-step-with-tools playbooks are not flagged as placeholders.
- Catalog loader returns parsed dict from `payload`.
- Catalog loader parses YAML-string `content`.
- Catalog loader returns None on 404 without raising.
- Catalog loader returns None on network failure without raising.

All 30 tests in the file pass.

## Live verification (post-merge)

After this PR merges and a new image deploys, the next synthetic itinerary-planner turn should produce decisions where the detector inspects the **actual** mcp/firestore workflow. Expected outcomes:
- `tool:ok:step[0].kind=python` instead of `tool:block:step[0].missing_tool_kind`.
- A more meaningful `inline` decision: still likely `inline:false` for now because `mcp/firestore` lacks `metadata.inline_when_safe: true`, but at least for the right reason. After landing `metadata.inline_when_safe: true` on `firestore.yaml` (separate noetl/ops PR), the dry-run should start showing `inline:true` on those calls.

## Background

- PR #608 — Round A detector + dry-run observability
- PR #609 — `meta.inline_decision` event-log persistence
- This PR — make the dry-run signal accurate for the production workload
- Round B (queued, gated on `proceed with inline implementation`) — the actual inline execution path