### PR TITLE
perf(inline-execution): cache catalog lookups in dry-run loader

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -748,6 +748,58 @@ def _looks_like_placeholder_playbook(parsed: Dict[str, Any]) -> bool:
     return True
 
 
+# Process-local cache for the catalog HTTP lookup used by the inline-
+# trivial-children dry-run detector. The fallback was added by PR #610;
+# under PR #608's NOETL_INLINE_TRIVIAL_CHILDREN=dry_run mode the
+# detector fires once per `tool: agent` step on every turn, and an
+# uncached lookup hits the noetl-server `/api/catalog/resource`
+# endpoint per call. A typical itinerary-planner turn fires 8-10 agent
+# calls — measured impact: per-turn duration jumped from 10s
+# (placeholder path) to 39s (uncached catalog path) on the live GKE
+# cluster after PR #610 landed.
+#
+# This cache is dry-run-only by virtue of the env-gated caller chain;
+# the dispatched path does not consult it. The cache value records
+# both successful fetches (parsed playbook dict) and conclusive
+# failures (None) so we don't re-attempt a 404 or network error
+# burst on every step within a turn.
+#
+# Tuning knobs:
+# - NOETL_INLINE_TRIVIAL_CHILDREN_CATALOG_CACHE_TTL_SECONDS overrides
+#   the default TTL. 0 or negative disables the cache (forces every
+#   call to go through HTTP, which is what tests want when they
+#   monkeypatch the requests module).
+# - _clear_inline_child_catalog_cache() is exported below for tests
+#   to reset state cleanly.
+_INLINE_CATALOG_CACHE_TTL_ENV = "NOETL_INLINE_TRIVIAL_CHILDREN_CATALOG_CACHE_TTL_SECONDS"
+_INLINE_CATALOG_CACHE_DEFAULT_TTL = 300.0
+# Sentinel that distinguishes "we've recorded a None result" from
+# "this key has never been looked up". Keying on entrypoint alone is
+# sufficient because the loader always asks for `version: "latest"`.
+_INLINE_CATALOG_CACHE_NONE = object()
+_inline_child_catalog_cache: Dict[str, Tuple[float, Any]] = {}
+
+
+def _clear_inline_child_catalog_cache() -> None:
+    """Reset the dry-run catalog cache. Intended for test use only;
+    production code does not need to clear the cache during a process
+    lifetime. The cache is per-process and resets on worker restart."""
+    _inline_child_catalog_cache.clear()
+
+
+def _inline_catalog_cache_ttl_seconds() -> float:
+    """Read the cache TTL from the env every call so test harnesses
+    can disable the cache by setting the env var to ``0`` without
+    needing to monkeypatch a module global."""
+    raw = os.environ.get(_INLINE_CATALOG_CACHE_TTL_ENV)
+    if raw is None or not raw.strip():
+        return _INLINE_CATALOG_CACHE_DEFAULT_TTL
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return _INLINE_CATALOG_CACHE_DEFAULT_TTL
+
+
 def _load_inline_child_playbook_from_catalog(entrypoint: str) -> Optional[Dict[str, Any]]:
     """Fetch the child playbook content from the noetl-server catalog
     via the HTTP API. Used when the local filesystem lookup returns a
@@ -760,12 +812,37 @@ def _load_inline_child_playbook_from_catalog(entrypoint: str) -> Optional[Dict[s
     has the same contract but is not callable from sync code without
     setting up an event loop.
 
+    Results are cached in a process-local dict (see the cache state
+    above) so that a turn with 10 agent calls causes one HTTP roundtrip
+    instead of ten. Both successful fetches and conclusive failures
+    (404, network error) are cached so a missing/broken catalog entry
+    doesn't generate per-step retry storms inside a turn.
+
     Returns the parsed playbook dict on success or None on any
     failure. Best-effort: a failed catalog lookup falls back to
     "no inspection" and the detector returns ``inline:false`` with a
     clear reason, matching the existing behavior for un-inspectable
     children.
     """
+    ttl = _inline_catalog_cache_ttl_seconds()
+    now = time.time()
+    if ttl > 0:
+        cached = _inline_child_catalog_cache.get(entrypoint)
+        if cached is not None:
+            cached_at, cached_value = cached
+            if (now - cached_at) <= ttl:
+                if cached_value is _INLINE_CATALOG_CACHE_NONE:
+                    return None
+                return cached_value
+
+    def _cache(value: Any) -> Any:
+        if ttl > 0:
+            _inline_child_catalog_cache[entrypoint] = (
+                now,
+                _INLINE_CATALOG_CACHE_NONE if value is None else value,
+            )
+        return value
+
     try:
         import requests
     except ImportError:
@@ -774,7 +851,7 @@ def _load_inline_child_playbook_from_catalog(entrypoint: str) -> Optional[Dict[s
             "fetch child playbook %s from catalog",
             entrypoint,
         )
-        return None
+        return _cache(None)
 
     server_url = os.environ.get("NOETL_SERVER_URL", "http://localhost:8083").rstrip("/")
     if not server_url.endswith("/api"):
@@ -792,7 +869,7 @@ def _load_inline_child_playbook_from_catalog(entrypoint: str) -> Optional[Dict[s
                 "AGENT.INLINE dry-run: child playbook %s not in catalog",
                 entrypoint,
             )
-            return None
+            return _cache(None)
         resp.raise_for_status()
         entry = resp.json() or {}
     except Exception as exc:
@@ -801,7 +878,7 @@ def _load_inline_child_playbook_from_catalog(entrypoint: str) -> Optional[Dict[s
             entrypoint,
             exc,
         )
-        return None
+        return _cache(None)
 
     # The catalog entry carries the rendered playbook content either as
     # a parsed dict under ``payload``/``content``/``parsed`` or as a
@@ -809,12 +886,12 @@ def _load_inline_child_playbook_from_catalog(entrypoint: str) -> Optional[Dict[s
     for candidate_key in ("payload", "parsed", "content"):
         candidate = entry.get(candidate_key)
         if isinstance(candidate, dict) and candidate:
-            return candidate
+            return _cache(candidate)
         if isinstance(candidate, str) and candidate.strip():
             try:
                 parsed = yaml.safe_load(candidate)
                 if isinstance(parsed, dict) and parsed:
-                    return parsed
+                    return _cache(parsed)
             except Exception as exc:
                 logger.debug(
                     "AGENT.INLINE dry-run: failed to parse catalog %s "
@@ -829,7 +906,7 @@ def _load_inline_child_playbook_from_catalog(entrypoint: str) -> Optional[Dict[s
         entrypoint,
         list(entry.keys()) if isinstance(entry, dict) else "(non-dict)",
     )
-    return None
+    return _cache(None)
 
 
 def _load_inline_child_playbook_for_dry_run(

--- a/tests/tools/test_agent_executor.py
+++ b/tests/tools/test_agent_executor.py
@@ -964,6 +964,18 @@ def test_placeholder_detector_handles_non_dict_input():
     assert agent_executor._looks_like_placeholder_playbook({"workflow": "not-a-list"}) is False
 
 
+@pytest.fixture(autouse=True)
+def _reset_inline_catalog_cache():
+    """Per-test isolation for the catalog cache. The cache is process-
+    local and persists across calls during a worker's lifetime, but
+    test-to-test cross-contamination would cause false positives when
+    later tests expect the loader to consult the mocked requests
+    module."""
+    agent_executor._clear_inline_child_catalog_cache()
+    yield
+    agent_executor._clear_inline_child_catalog_cache()
+
+
 def test_load_inline_child_from_catalog_returns_payload_dict(monkeypatch):
     """Successful catalog fetch with `payload` dict shape."""
     captured: Dict[str, Any] = {}
@@ -1097,3 +1109,168 @@ def test_load_inline_child_from_catalog_returns_none_on_network_failure(monkeypa
     )
 
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Catalog lookup cache. PR #610 added the HTTP fallback so the detector sees
+# the real child playbook for cross-repo entrypoints; uncached, that fallback
+# hits noetl-server on every `tool: agent` step. Measured impact on the live
+# GKE cluster: per-turn duration moved from 10s (placeholder-only path) to
+# 39s (uncached catalog path) for an itinerary-planner turn that fires ~8
+# agent calls. This cache keeps the dry-run hot path near zero overhead.
+# ---------------------------------------------------------------------------
+
+
+class _CountingFakeRequests:
+    """Records every POST so tests can assert the cache fired (1 call,
+    not N) or was bypassed (>1 call) without inspecting cache internals."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    def post(self, url, json=None, timeout=None):
+        self.calls += 1
+        if not self._responses:
+            raise RuntimeError("no more fake responses")
+        return self._responses.pop(0)
+
+
+class _FakeOkResponse:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_catalog_cache_hits_on_second_call_for_same_entrypoint(monkeypatch):
+    payload = {
+        "apiVersion": "noetl.io/v2",
+        "kind": "Playbook",
+        "workflow": [{"step": "do_thing", "tool": {"kind": "python"}}],
+    }
+    fake = _CountingFakeRequests([_FakeOkResponse({"payload": payload})])
+    monkeypatch.setitem(sys.modules, "requests", fake)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+    # Default TTL applies; the test doesn't need to wait.
+
+    first = agent_executor._load_inline_child_playbook_from_catalog(
+        "automation/agents/mcp/firestore"
+    )
+    second = agent_executor._load_inline_child_playbook_from_catalog(
+        "automation/agents/mcp/firestore"
+    )
+
+    assert first is not None and second is not None
+    assert first == second
+    # The cache must have served the second call without a second HTTP
+    # roundtrip. The fake only had one response queued.
+    assert fake.calls == 1
+
+
+def test_catalog_cache_caches_none_results_too(monkeypatch):
+    """A 404 / network failure / missing entry must be cached so a
+    catalog miss does not retry on every subsequent agent step in
+    the same turn — the worst case of the uncached path."""
+    class _Fake404Response:
+        status_code = 404
+
+        def raise_for_status(self):
+            raise RuntimeError("must not be called on 404 short-circuit")
+
+        def json(self):
+            raise RuntimeError("must not be called on 404 short-circuit")
+
+    fake = _CountingFakeRequests([_Fake404Response()])
+    monkeypatch.setitem(sys.modules, "requests", fake)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+
+    first = agent_executor._load_inline_child_playbook_from_catalog("missing/playbook")
+    second = agent_executor._load_inline_child_playbook_from_catalog("missing/playbook")
+
+    assert first is None
+    assert second is None
+    assert fake.calls == 1
+
+
+def test_catalog_cache_different_entrypoints_do_not_collide(monkeypatch):
+    payload_a = {"workflow": [{"step": "a", "tool": {"kind": "python"}}]}
+    payload_b = {"workflow": [{"step": "b", "tool": {"kind": "python"}}]}
+    fake = _CountingFakeRequests([
+        _FakeOkResponse({"payload": payload_a}),
+        _FakeOkResponse({"payload": payload_b}),
+    ])
+    monkeypatch.setitem(sys.modules, "requests", fake)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+
+    got_a = agent_executor._load_inline_child_playbook_from_catalog("path/a")
+    got_b = agent_executor._load_inline_child_playbook_from_catalog("path/b")
+    got_a_again = agent_executor._load_inline_child_playbook_from_catalog("path/a")
+
+    assert got_a == payload_a
+    assert got_b == payload_b
+    # Third call to path/a is a cache hit; total HTTP calls = 2.
+    assert got_a_again == payload_a
+    assert fake.calls == 2
+
+
+def test_catalog_cache_zero_ttl_disables_cache(monkeypatch):
+    """Setting TTL <= 0 forces every call through HTTP. This matches
+    the test contract elsewhere in the file that monkeypatches
+    `requests` and expects the loader to actually invoke it."""
+    payload = {"workflow": [{"step": "do_thing", "tool": {"kind": "python"}}]}
+    fake = _CountingFakeRequests([
+        _FakeOkResponse({"payload": payload}),
+        _FakeOkResponse({"payload": payload}),
+    ])
+    monkeypatch.setitem(sys.modules, "requests", fake)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+    monkeypatch.setenv(
+        agent_executor._INLINE_CATALOG_CACHE_TTL_ENV, "0"
+    )
+
+    agent_executor._load_inline_child_playbook_from_catalog("automation/agents/mcp/foo")
+    agent_executor._load_inline_child_playbook_from_catalog("automation/agents/mcp/foo")
+
+    assert fake.calls == 2
+
+
+def test_catalog_cache_expires_after_ttl(monkeypatch):
+    """After the TTL elapses the loader re-fetches. Simulate elapsed
+    time by monkeypatching time.time() rather than actually sleeping."""
+    payload_v1 = {"workflow": [{"step": "v1", "tool": {"kind": "python"}}]}
+    payload_v2 = {"workflow": [{"step": "v2", "tool": {"kind": "python"}}]}
+    fake = _CountingFakeRequests([
+        _FakeOkResponse({"payload": payload_v1}),
+        _FakeOkResponse({"payload": payload_v2}),
+    ])
+    monkeypatch.setitem(sys.modules, "requests", fake)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+    # Short TTL so the test is fast and obvious.
+    monkeypatch.setenv(
+        agent_executor._INLINE_CATALOG_CACHE_TTL_ENV, "10"
+    )
+
+    # Pin the time the loader sees so we control TTL boundary
+    # behavior without sleeping.
+    fake_time = [1000.0]
+
+    def _fake_time_time():
+        return fake_time[0]
+
+    monkeypatch.setattr(agent_executor.time, "time", _fake_time_time)
+
+    first = agent_executor._load_inline_child_playbook_from_catalog("path/cached")
+    # Advance past the TTL.
+    fake_time[0] += 15.0
+    second = agent_executor._load_inline_child_playbook_from_catalog("path/cached")
+
+    assert first == payload_v1
+    assert second == payload_v2
+    assert fake.calls == 2


### PR DESCRIPTION
## Summary

PR #610 added the HTTP catalog fallback so the Round A detector sees the real child playbook for cross-repo entrypoints (e.g. `automation/agents/mcp/firestore` lives in `noetl/ops`). Uncached, that fallback hits `POST /api/catalog/resource` on every `tool: agent` step.

Measured on the live GKE cluster (Helm rev 164):

| Image | Per-turn duration | Note |
|---|---|---|
| pre-#610 (placeholder path) | ~10s | But signal was wrong: every decision blocked with `missing_tool_kind` |
| post-#610 (uncached catalog path) | **~39s** | Signal correct but per-agent-call HTTP overhead |
| This PR (cached catalog path) | **target ~10s** | Signal correct **and** fast |

For a turn that fires 8–10 agent calls, the uncached approach generates 8–10 HTTP roundtrips into noetl-server. Catalog content is essentially static during a turn — caching is the obvious fix.

## Design

- **Cache:** process-local `Dict[str, Tuple[float, value-or-sentinel]]` keyed by entrypoint.
- **TTL:** default 300s. Overridable via env `NOETL_INLINE_TRIVIAL_CHILDREN_CATALOG_CACHE_TTL_SECONDS`. Setting it to `0` disables the cache (used by tests that monkeypatch `requests`).
- **Negative caching:** 404s and network failures are cached too (as a sentinel `None`) so a missing/broken catalog entry doesn't burst-retry on every step.
- **Dry-run-only:** the cache is dry-run-only by virtue of the env-gated caller chain. The dispatched path doesn't consult it.
- **Process-local:** cache resets on worker restart. No cross-pod state.
- **`_clear_inline_child_catalog_cache()`:** exported for tests.

## Tests

5 new cache-behavior tests + 1 autouse fixture for isolation between catalog tests:

| Test | What it pins |
|---|---|
| `_reset_inline_catalog_cache` (autouse) | Per-test isolation; clears cache before + after each test |
| `test_catalog_cache_hits_on_second_call_for_same_entrypoint` | One HTTP call serves two consecutive loads |
| `test_catalog_cache_caches_none_results_too` | A 404 is cached; the second call doesn't retry |
| `test_catalog_cache_different_entrypoints_do_not_collide` | Distinct keys → distinct entries |
| `test_catalog_cache_zero_ttl_disables_cache` | `TTL=0` forces every call through HTTP (test compatibility) |
| `test_catalog_cache_expires_after_ttl` | After TTL elapses (via monkeypatched `time.time`), the loader re-fetches |

All 35 tests pass. The previously-failing `test_load_inline_child_from_catalog_returns_none_on_network_failure` now passes because the autouse fixture clears cross-test cache state.

## What did not change

- The detector logic in `noetl/core/workflow/playbook/inline_execution.py`.
- `_load_inline_child_playbook_for_dry_run()` (placeholder detection + catalog fallback) — only `_load_inline_child_playbook_from_catalog()` gained caching.
- Dispatch behavior — every child still goes through `/api/execute` and NATS as today.
- PR #608 / #609 / #610 surfaces.

## Background

- PR #607 — case-action emit batching
- PR #608 — Round A detector + dry-run observability
- PR #609 — `meta.inline_decision` event-log projection
- PR #610 — catalog fallback for cross-repo children
- **This PR** — cache the catalog fallback so dry-run overhead returns to ~zero per turn
- Round B (queued) — actual inline execution path