### PR TITLE
fix(inline-execution): catalog fallback omits version field; "latest" returned 404

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -858,10 +858,21 @@ def _load_inline_child_playbook_from_catalog(entrypoint: str) -> Optional[Dict[s
         server_url = server_url + "/api"
     resource_url = f"{server_url}/catalog/resource"
 
+    # The catalog resource endpoint treats a missing or ``None`` ``version``
+    # as "give me the highest version row for this path".  An earlier shape
+    # sent ``version: "latest"`` as a literal string, which the endpoint
+    # could not parse and returned 404 for — silently breaking detector
+    # decisions in any deployment where the child playbook lived in the
+    # server-side catalog rather than on the worker's local filesystem.
+    # Confirmed against GKE: ``{"path": ..., "version": "latest"}`` returns
+    # 404 ``Catalog entry not found``; omitting the field returns the
+    # highest-version row.  Omit the field rather than send ``null`` so
+    # we stay forward-compatible with future server-side version
+    # validation that may reject explicit ``None``.
     try:
         resp = requests.post(
             resource_url,
-            json={"path": entrypoint, "version": "latest"},
+            json={"path": entrypoint},
             timeout=5.0,
         )
         if resp.status_code == 404:

--- a/tests/tools/test_agent_executor.py
+++ b/tests/tools/test_agent_executor.py
@@ -1177,10 +1177,57 @@ def test_load_inline_child_from_catalog_returns_payload_dict(monkeypatch):
     assert result["workflow"][0]["tool"]["kind"] == "python"
     # Correct URL (server_url + /api + /catalog/resource).
     assert captured["url"] == "http://noetl.test:8082/api/catalog/resource"
-    assert captured["json"] == {
-        "path": "automation/agents/mcp/firestore",
-        "version": "latest",
-    }
+    # Version is omitted from the request body. The server treats a
+    # missing version as "give me the highest version row". An earlier
+    # shape sent ``{"version": "latest"}`` as a literal string and the
+    # endpoint returned 404 — silently breaking detector decisions on
+    # any deployment whose child playbook lived in the server-side
+    # catalog rather than the worker's local filesystem.
+    assert captured["json"] == {"path": "automation/agents/mcp/firestore"}
+
+
+def test_load_inline_child_from_catalog_omits_version_field(monkeypatch):
+    """Regression test for the version="latest" → 404 bug. The catalog
+    HTTP request body must NOT carry a ``version`` field; the server
+    treats a missing field as "give me the highest version row" for
+    the path. An earlier shape sent the literal string ``"latest"`` and
+    the server returned 404 ``Catalog entry not found``, silently
+    forcing every detector decision on GKE to ``inline=False`` with
+    placeholder-cascade ``missing_tool_kind`` reasons."""
+    captured: Dict[str, Any] = {}
+
+    class _FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "path": "automation/agents/mcp/firestore",
+                "version": 4,
+                "payload": {"workflow": [{"step": "s", "tool": {"kind": "python"}}]},
+            }
+
+    class _FakeRequestsModule:
+        @staticmethod
+        def post(url, json=None, timeout=None):
+            captured["json"] = json
+            return _FakeResponse()
+
+    monkeypatch.setitem(sys.modules, "requests", _FakeRequestsModule)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+
+    agent_executor._load_inline_child_playbook_from_catalog(
+        "automation/agents/mcp/firestore"
+    )
+
+    body = captured["json"]
+    assert "version" not in body, (
+        f"request body must omit `version`; got {body!r}. "
+        "Sending version=\"latest\" returns 404 from /api/catalog/resource."
+    )
+    assert body == {"path": "automation/agents/mcp/firestore"}
 
 
 def test_load_inline_child_from_catalog_parses_yaml_string_content(monkeypatch):


### PR DESCRIPTION
## Summary

The inline-execution detector's catalog HTTP fallback (introduced in #610) was sending `{"path": ..., "version": "latest"}` to `/api/catalog/resource`. The server cannot parse the literal string `"latest"` — it returns 404, and the detector falls through to a filesystem placeholder stub. Every step in the stub trips `missing_tool_kind`, so the decision is always `inline=False`.

This has been silently breaking detector decisions on any deployment whose child playbook lives in the server-side catalog rather than the worker's local filesystem (i.e. every cluster deploy).

## Evidence captured on GKE

```bash
# version="latest" → 404
curl -sX POST $SERVER/api/catalog/resource \
  -H 'Content-Type: application/json' \
  -d '{"path":"automation/agents/mcp/vertex-ai-stub","version":"latest"}'
# → {"detail":"Catalog entry not found"}

# version omitted → returns highest version (4)
curl -sX POST $SERVER/api/catalog/resource \
  -H 'Content-Type: application/json' \
  -d '{"path":"automation/agents/mcp/vertex-ai-stub"}'
# → 200 with full content + version: 4
```

Surfaced during Phase D of the Round B inline-execution arc (smoke run `635314756663902717`):

- Worker pod env confirmed `NOETL_INLINE_TRIVIAL_CHILDREN=enforce`, image `inline-runner-20260526062449` (built from `009a7f72` = v2.102.0).
- `inline_runner.py` module importable in the running container.
- Detector invoked manually inside the worker for `automation/agents/mcp/vertex-ai-stub` returns `inline=False` with `tool:block:step[0].missing_tool_kind`, `tool:block:step[1].missing_tool_kind` reasons — the placeholder cascade signature.
- Smoke parent's child execution `635314763886494217` shows full dispatched lifecycle (`command.claimed`, `command.issued`); zero events carry `meta.inlined_in_parent` or `meta.inline_mode = "worker"`.

## What changes

`noetl/tools/agent/executor.py` `_load_inline_child_playbook_from_catalog`:

- Request body changes from `{"path": entrypoint, "version": "latest"}` to `{"path": entrypoint}`.
- Header comment explains the bug, the GKE reproduction, and why we omit the field rather than send `None` (forward-compat with future server-side validation that may reject explicit nulls).

`tests/tools/test_agent_executor.py`:

- Updated assertion in `test_load_inline_child_from_catalog_returns_payload_dict` — the captured request body now equals `{"path": "..."}` with no `version` key.
- New regression test `test_load_inline_child_from_catalog_omits_version_field` — explicit assertion that `"version" not in body`, with a docstring linking the failure mode back to the 404 cascade.

40/40 tests in `tests/tools/test_agent_executor.py` pass.

## What does NOT change

- Server-side `/api/catalog/resource` endpoint behavior is untouched. The version-omitted semantics it already supports are correct; only the client was wrong.
- No behavior regression from this fix on any deployment where the catalog fallback was previously returning 404 — those deployments were always reaching the dispatched path; they will continue to do so by the Round B `enforce`-mode safety net when the detector says `inline=False`. The fix only enables decisions that should have been positive to actually be positive.
- Worker dispatch path, event log shape, replay semantics, cancellation behavior, and the Round B inline runner all untouched.

## Risk

Low. The change is one-line plus a comment. The only deployment the fix could affect is one where:

1. A child playbook is in the server catalog (the common case).
2. The detector previously returned `inline=False` because of the 404.
3. With the fix, it now correctly evaluates the child and may return `inline=True`.

Under `NOETL_INLINE_TRIVIAL_CHILDREN=dry_run` (current GKE state), this only changes the `meta.inline_decision` content surfaced to operators — no execution change. Under `enforce`, this is the point at which the inline runner will actually start firing for eligible children. Round B's runner has 74 passing tests including dispatched-vs-inline parity.

## Test plan

- [x] `uv run pytest tests/tools/test_agent_executor.py -q` → 40 passed.
- [ ] After merge: rebuild image off `noetl` main, redeploy, re-run smoke playbook under `enforce`, confirm `meta.inlined_in_parent` + `meta.inline_mode = "worker"` keys appear on child events.
- [ ] Then spot-check parent-cancel cascade with an inline child in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)