### PR TITLE
fix(inline-execution): InlineResult.data mirrors dispatched-path terminal-result filter

### DIFF
--- a/noetl/core/workflow/playbook/inline_runner.py
+++ b/noetl/core/workflow/playbook/inline_runner.py
@@ -58,6 +58,15 @@ _META_INLINE_DEPTH = "inline_depth"
 _META_INLINE_MODE = "inline_mode"
 _INLINE_MODE_WORKER = "worker"
 
+# Boundary step names that the dispatched agent path's
+# ``_fetch_sub_execution_terminal_result`` filters out when scanning for the
+# playbook's externally-visible terminal result.  Keep this in sync with
+# ``_BOUNDARY_NODE_NAMES`` in ``noetl/tools/agent/executor.py``.  A playbook
+# whose last step is ``end: {tool: {kind: noop}}`` (the common shape for
+# explicit terminators) must not have its noop ``{"status": "ok"}`` mask the
+# preceding real step's payload at the agent envelope boundary.
+_BOUNDARY_STEP_NAMES = frozenset({"start", "end", ""})
+
 
 @dataclass
 class InlineResult:
@@ -281,6 +290,20 @@ async def run_inline(
     }
 
     last_result: Any = None
+    # ``last_meaningful_result`` tracks the result of the last non-boundary
+    # step.  The dispatched agent path's ``_fetch_sub_execution_terminal_result``
+    # filters terminal events by ``node_name not in {"start", "end", "", None}``
+    # — playbooks routinely end with a ``kind: noop`` ``end`` step whose
+    # ``{"status": "ok"}`` result is a sentinel, not the payload callers
+    # expect.  Mirror that filter so the inline runner's ``InlineResult.data``
+    # carries the same shape the dispatched path returns for the same
+    # playbook.  Phase D on GKE observed the diverged-from-dispatch
+    # symptom: ``automation/agents/mcp/vertex-ai-stub`` ran the
+    # ``canned_chat_completion`` Python step correctly (1799-byte
+    # diagnosis dict) but the runner returned the 15-byte
+    # ``{"status": "ok"}`` from the subsequent ``end`` noop, masking the
+    # real payload at the parent's ``call.done.result.context.data``.
+    last_meaningful_result: Any = None
     failed = False
     fail_error: Optional[Dict[str, Any]] = None
     cancelled = False
@@ -380,6 +403,18 @@ async def run_inline(
         )
         last_result = processed_result
 
+        # The agent envelope's terminal result must mirror the dispatched
+        # path's ``_fetch_sub_execution_terminal_result`` filter: ignore
+        # boundary node names (``start`` / ``end`` / "" / None).  The
+        # dispatched path scans events back-to-front for the highest
+        # event_id whose ``node_name`` is NOT in that boundary set; we
+        # walk the steps forward so we just keep the latest non-boundary
+        # result and surface it as ``InlineResult.data``.  See the
+        # boundary-set comment in
+        # ``noetl/tools/agent/executor.py:_fetch_sub_execution_terminal_result``.
+        if step_name and step_name not in _BOUNDARY_STEP_NAMES:
+            last_meaningful_result = processed_result
+
         # Update child_context with this step's result so later steps can
         # reference it via Jinja templates.
         child_context[step_name] = processed_result
@@ -454,9 +489,20 @@ async def run_inline(
         "INLINE.RUNNER complete child=%s status=ok",
         child_execution_id,
     )
+    # ``InlineResult.data`` carries the dispatched-path equivalent:
+    # the last non-boundary step's processed result.  Fall back to
+    # ``last_result`` only when no meaningful step ran (e.g. a degenerate
+    # workflow that is just a boundary step) — this preserves the previous
+    # shape for that one corner case while fixing the common case where
+    # the workflow ends with an ``end: noop`` terminator.
+    envelope_data = (
+        last_meaningful_result
+        if last_meaningful_result is not None
+        else last_result
+    )
     return InlineResult(
         status="ok",
-        data=last_result,
+        data=envelope_data,
         execution_id=child_execution_id,
         meta={
             "inline_decision": inline_decision.to_dict(),

--- a/tests/core/workflow/test_inline_runner.py
+++ b/tests/core/workflow/test_inline_runner.py
@@ -419,3 +419,145 @@ async def test_inline_runner_inline_result_envelope_shape():
     assert "execution_id" in envelope
     assert "meta" in envelope
     assert envelope["meta"]["inline_mode"] == "worker"
+
+
+@pytest.mark.asyncio
+async def test_inline_runner_data_skips_noop_end_boundary_step():
+    """Regression test for Bug B from Round B Phase D: when a playbook ends
+    with an ``end: {tool: {kind: noop}}`` terminator, the runner's
+    ``InlineResult.data`` must surface the last MEANINGFUL step's result,
+    not the noop's ``{"status": "ok"}``.  This mirrors the dispatched
+    agent path's ``_fetch_sub_execution_terminal_result`` which filters
+    out boundary node names (``start`` / ``end`` / "" / None) when
+    walking events for the playbook's externally-visible terminal
+    result.
+
+    Phase D evidence on GKE
+    (``automation/agents/mcp/vertex-ai-stub``, child execution id
+    ``465179147430762901``): worker log
+    ``[RESULT] Step canned_chat_completion: inline result (1799b)``
+    followed by ``[RESULT] Step end: inline result (15b)``.  Pre-fix the
+    runner returned the 15-byte ``{"status": "ok"}`` and masked the
+    1799-byte diagnosis payload.
+    """
+    _events, emitter = _make_emitter()
+
+    playbook = {
+        "metadata": {"name": "test/python_then_end_noop"},
+        "workflow": [
+            {
+                "step": "produce_payload",
+                "tool": {
+                    "kind": "python",
+                    "code": "result = {'category': 'unknown', 'confidence': 0.63}",
+                },
+            },
+            {"step": "end", "tool": {"kind": "noop"}},
+        ],
+    }
+
+    result = await run_inline(
+        parent_execution_id="parent-bugb",
+        parent_command_id="cmd-bugb",
+        parent_step="agent_step",
+        child_playbook=playbook,
+        child_input={},
+        inline_decision=_make_decision(),
+        jinja_env=Environment(),
+        cancellation_probe=_cancellation_probe_returning(False),
+        batch_event_emitter=emitter,
+        depth=0,
+    )
+
+    assert result.status == "ok"
+    # The data must be ``produce_payload``'s result, NOT ``end``'s
+    # ``{"status": "ok"}``.  The exact wrapper shape comes from
+    # ResultHandler scrub; we only assert the meaningful payload is
+    # reachable.
+    data_str = repr(result.data)
+    assert "category" in data_str or "confidence" in data_str, (
+        f"InlineResult.data lost the meaningful step's payload. "
+        f"Got: {result.data!r}"
+    )
+    # Sanity: the noop end's degenerate sentinel must NOT be the whole
+    # data envelope.
+    assert result.data != {"status": "ok"}, (
+        "InlineResult.data is the noop terminator's sentinel; the "
+        "boundary-step filter regressed."
+    )
+
+
+@pytest.mark.asyncio
+async def test_inline_runner_data_falls_back_when_only_boundary_steps():
+    """Degenerate corner case: a workflow that contains only an ``end``
+    step has no meaningful results.  Fall back to ``last_result``
+    (the noop's payload) rather than ``None`` so callers don't have to
+    special-case ``data is None``."""
+    _events, emitter = _make_emitter()
+
+    playbook = {
+        "metadata": {"name": "test/only_end_step"},
+        "workflow": [
+            {"step": "end", "tool": {"kind": "noop"}},
+        ],
+    }
+
+    result = await run_inline(
+        parent_execution_id="parent-only-end",
+        parent_command_id="cmd-only-end",
+        parent_step="agent_step",
+        child_playbook=playbook,
+        child_input={},
+        inline_decision=_make_decision(),
+        jinja_env=Environment(),
+        cancellation_probe=_cancellation_probe_returning(False),
+        batch_event_emitter=emitter,
+        depth=0,
+    )
+
+    assert result.status == "ok"
+    # No meaningful steps ran; the runner falls back to the noop's
+    # result rather than emitting ``data=None``.
+    assert result.data is not None
+
+
+@pytest.mark.asyncio
+async def test_inline_runner_data_skips_start_boundary_step():
+    """``start`` is also a boundary node name in the dispatched path's
+    filter.  A workflow that opens with a ``start`` step (rare but
+    declarable) must not mask a real intermediate result either."""
+    _events, emitter = _make_emitter()
+
+    playbook = {
+        "metadata": {"name": "test/start_then_python"},
+        "workflow": [
+            {"step": "start", "tool": {"kind": "noop"}},
+            {
+                "step": "do_work",
+                "tool": {
+                    "kind": "python",
+                    "code": "result = {'value': 42}",
+                },
+            },
+            {"step": "end", "tool": {"kind": "noop"}},
+        ],
+    }
+
+    result = await run_inline(
+        parent_execution_id="parent-start",
+        parent_command_id="cmd-start",
+        parent_step="agent_step",
+        child_playbook=playbook,
+        child_input={},
+        inline_decision=_make_decision(),
+        jinja_env=Environment(),
+        cancellation_probe=_cancellation_probe_returning(False),
+        batch_event_emitter=emitter,
+        depth=0,
+    )
+
+    assert result.status == "ok"
+    data_str = repr(result.data)
+    assert "value" in data_str or "42" in data_str, (
+        f"InlineResult.data lost do_work's payload. Got: {result.data!r}"
+    )


### PR DESCRIPTION
## Summary

The Round B inline runner was returning `last_result` from the **literal last** workflow step. Playbooks routinely end with an `end: {tool: {kind: noop}}` terminator whose result is a 15-byte `{"status": "ok"}` sentinel. That sentinel was masking the preceding meaningful step's payload at the parent's agent envelope boundary.

The dispatched agent path's `_fetch_sub_execution_terminal_result` in `noetl/tools/agent/executor.py` already filters out events whose `node_name` is in `{"start", "end", "", None}`. This PR makes the runner mirror that filter.

## How this surfaced

Phase D live validation of Round B on GKE (helm rev 168, image `inline-runner-v3-20260526074734` built from `noetl@a0a6f605` = v2.102.2, `NOETL_INLINE_TRIVIAL_CHILDREN=enforce`), after #613 fixed the catalog-fallback 404 and #614 fixed the bigint overflow.

Smoke playbook `tests/inline_runner_phase_d_smoke` → `automation/agents/mcp/vertex-ai-stub`, execution `635359538601788321`:

- ✅ Detector returns `inline_decision.inline = true`, all tool kinds identified.
- ✅ Inline runner fires. Parent's call.done carries `meta.inline_mode = "worker"` + `meta.inlined_in_parent`.
- ✅ Child execution_id is 18 digits (`465179147430762901`) — fits bigint, no overflow.
- ✅ Python step **does** execute correctly. Worker log:
  ```
  PYTHON.EXECUTE_PYTHON_TASK: Captured 'result' variable, type=dict
  [RESULT] Step canned_chat_completion: inline result (1799b)
  [RESULT] Step end: inline result (15b)
  ```
- ❌ But parent's `call.done.result.context.data` was `{"status": "ok"}` — the 15-byte end-step sentinel masked the 1799-byte canned diagnosis payload.

## What changes

`noetl/core/workflow/playbook/inline_runner.py`:

- New module-level constant `_BOUNDARY_STEP_NAMES = frozenset({"start", "end", ""})`. Header comment cross-references the matching `_BOUNDARY_NODE_NAMES` in `executor.py`.
- New local `last_meaningful_result` variable tracked alongside `last_result` in the step-execution loop. Updated only when `step_name and step_name not in _BOUNDARY_STEP_NAMES`.
- The success-path `InlineResult` return now uses `envelope_data = last_meaningful_result if last_meaningful_result is not None else last_result`. The fall-back preserves the previous shape for degenerate all-boundary workflows so callers don't have to special-case `data is None`.

`tests/core/workflow/test_inline_runner.py` — three regression tests:

- `test_inline_runner_data_skips_noop_end_boundary_step`: 2-step `[python, end-noop]` playbook. Asserts data carries the python payload, not the noop sentinel.
- `test_inline_runner_data_falls_back_when_only_boundary_steps`: degenerate `[end-noop]` only — asserts `data is not None`.
- `test_inline_runner_data_skips_start_boundary_step`: 3-step `[start-noop, python, end-noop]` — asserts data carries the python payload.

## What does NOT change

- Cancellation, failure, recursion-depth, dispatched-vs-inline event-sequence parity — all existing 53 tests pass unchanged.
- Event emission order, scrub via `ResultHandler`, inline metadata keys — unchanged.
- `_BOUNDARY_STEP_NAMES` is `{"start", "end", ""}` — a frozenset that does NOT include `None`. The runner's `step_name` comes from `_step_name(raw_step)` and is always a string; the `None` case in the dispatched path is for events where the field was unset by an older emitter. Both filters reject equivalently.

## Risk

Low. The change narrows what counts as the "playbook's result" to match the dispatched path's existing rule. Any playbook whose last step is NOT a boundary node (e.g. all the test fixtures whose workflows end with a single meaningful step) is unaffected — `last_meaningful_result == last_result` for those.

The fall-back to `last_result` for all-boundary workflows preserves the prior degenerate-case behavior.

## Test plan

- [x] `uv run pytest tests/core/workflow/test_inline_runner.py tests/core/workflow/test_inline_runner_parity.py tests/tools/test_agent_executor.py -q` → 56 passed.
- [ ] After merge: rebuild image off `noetl` main, redeploy GKE, flip worker env back to `enforce`, re-run smoke playbook.
- [ ] Verify parent's `call.done.result.context.data` now carries the `vertex-ai-stub` canned diagnosis (`category`, `confidence`, `root_cause`, etc.).
- [ ] Then spot-check parent-cancel cascade with an inline child in flight.

## Related

- Phase D handoff: `handoffs/active/2026-05-26-noetl-inline-trivial-children/round-03-prompt.md` + `round-03-result.md`.
- Predecessor fixes: #614 (bigint) → #613 (catalog 404) → #612 (Round B runner feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)