### PR TITLE
fix(inline-execution): cancellation probe hits cancellation-check endpoint, not /status

### DIFF
--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -1263,13 +1263,37 @@ def _dispatch_troubleshoot_diagnosis(
 def _make_cancellation_probe() -> Callable:
     """Return a lightweight cancellation probe for the inline runner.
 
-    The probe hits ``/api/executions/{id}/status`` and returns True when the
-    execution's status is ``cancelled``.  It is best-effort: network errors
-    return False so the runner continues rather than aborting on a transient
-    probe failure.
+    The probe hits ``/api/executions/{id}/cancellation-check`` — the same
+    purpose-built endpoint the dispatched worker path uses (see
+    ``noetl/worker/nats_worker.py:1108``).  Round A's design (round-01
+    result) named this exact endpoint as the cancellation seam; an earlier
+    runner shape hit ``/status`` by mistake, but that endpoint does not
+    surface cancellation state — its response carries only
+    ``completed``/``failed`` flags and the probe returned False on every
+    call, silently breaking the cancel cascade.
 
-    The probe is a plain sync callable; ``run_inline`` wraps the call in an
-    awaitable context so async callers work too.
+    Response shape (from ``get_execution_cancellation_status`` in
+    ``noetl/server/api/execution/endpoint.py``):
+    ```json
+    {
+        "execution_id": "123456789",
+        "status": "RUNNING" | "CANCELLED" | "COMPLETED" | "FAILED",
+        "cancelled": true | false,
+        "completed": true | false,
+        "failed": true | false
+    }
+    ```
+
+    We trust the explicit ``cancelled`` flag rather than parsing
+    ``status`` so a future status-vocabulary tweak does not silently
+    regress the probe.
+
+    Best-effort: network errors, 404, and parse failures all return
+    False so a transient blip lets the runner continue rather than
+    aborting the child mid-flight on a probe miss.
+
+    The probe is a plain sync callable; ``run_inline`` wraps the call in
+    an awaitable context so async callers work too.
     """
     def probe(execution_id: str) -> bool:
         if not execution_id:
@@ -1280,12 +1304,12 @@ def _make_cancellation_probe() -> Callable:
             server_url = os.environ.get("NOETL_SERVER_URL", "http://localhost:8083").rstrip("/")
             if not server_url.endswith("/api"):
                 server_url = server_url + "/api"
-            url = f"{server_url}/executions/{execution_id}/status"
+            url = f"{server_url}/executions/{execution_id}/cancellation-check"
             resp = _requests.get(url, timeout=3.0)
             if resp.status_code != 200:
                 return False
             doc = resp.json() or {}
-            return str(doc.get("status") or "").lower() == "cancelled"
+            return bool(doc.get("cancelled"))
         except Exception:
             return False
 

--- a/tests/tools/test_agent_executor.py
+++ b/tests/tools/test_agent_executor.py
@@ -1521,3 +1521,139 @@ async def test_noetl_inline_enforce_depth_limit_falls_back_to_dispatch(monkeypat
     # Detector blocked inline (depth too deep) → dispatch ran.
     assert result["status"] == "ok"
     assert len(dispatch_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cancellation probe — regression tests for Bug C from Round B Phase D
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_requests_for_probe(monkeypatch, response_status: int, response_body):
+    """Monkeypatch the ``requests`` module with a fake that captures
+    the URL hit by ``_make_cancellation_probe``.  Returns the captured
+    state dict so callers can assert on the URL."""
+    captured: Dict[str, Any] = {}
+
+    class _Resp:
+        status_code = response_status
+
+        def __init__(self, body):
+            self._body = body
+
+        def json(self):
+            return self._body
+
+    class _FakeRequestsModule:
+        @staticmethod
+        def get(url, timeout=None):
+            captured["url"] = url
+            captured["timeout"] = timeout
+            return _Resp(response_body)
+
+    monkeypatch.setitem(sys.modules, "requests", _FakeRequestsModule)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+    return captured
+
+
+def test_cancellation_probe_hits_cancellation_check_endpoint(monkeypatch):
+    """Regression test for Bug C from Round B Phase D: the probe URL must
+    end with ``/cancellation-check``, not ``/status``.  Round A's design
+    (round-01 result) named the cancellation-check endpoint as the
+    cancellation seam; the dispatched worker path uses the same endpoint
+    at noetl/worker/nats_worker.py:1108.  An earlier shape hit ``/status``
+    which returned ``completed``/``failed`` flags but never surfaced
+    cancellation state, so the probe returned False on every call and the
+    cancel cascade silently broke on the live cluster."""
+    captured = _install_fake_requests_for_probe(
+        monkeypatch,
+        response_status=200,
+        response_body={"cancelled": False, "status": "RUNNING"},
+    )
+    probe = agent_executor._make_cancellation_probe()
+    probe("123456789012345678")
+
+    assert captured["url"].endswith("/cancellation-check"), (
+        f"probe must hit /cancellation-check; got {captured['url']!r}. "
+        f"The /status endpoint does not surface cancellation state."
+    )
+    assert "/api/executions/123456789012345678/cancellation-check" in captured["url"]
+
+
+def test_cancellation_probe_returns_true_on_cancelled_response(monkeypatch):
+    """When the cancellation-check endpoint reports ``cancelled: true``
+    the probe must return True so the runner aborts the child between
+    steps."""
+    _install_fake_requests_for_probe(
+        monkeypatch,
+        response_status=200,
+        response_body={"cancelled": True, "status": "CANCELLED"},
+    )
+    probe = agent_executor._make_cancellation_probe()
+    assert probe("123456789012345678") is True
+
+
+def test_cancellation_probe_returns_false_on_running_response(monkeypatch):
+    """When the endpoint reports ``cancelled: false`` the probe must
+    return False so the runner continues normally."""
+    _install_fake_requests_for_probe(
+        monkeypatch,
+        response_status=200,
+        response_body={"cancelled": False, "status": "RUNNING"},
+    )
+    probe = agent_executor._make_cancellation_probe()
+    assert probe("123456789012345678") is False
+
+
+def test_cancellation_probe_returns_false_on_missing_cancelled_field(monkeypatch):
+    """Best-effort: if a future endpoint shape omits ``cancelled``, fall
+    back to False rather than crashing the runner.  The dispatched path
+    will see the cancellation through its own seam; the inline runner
+    just doesn't proactively abort in that case."""
+    _install_fake_requests_for_probe(
+        monkeypatch,
+        response_status=200,
+        response_body={"status": "RUNNING"},  # no `cancelled` key
+    )
+    probe = agent_executor._make_cancellation_probe()
+    assert probe("123456789012345678") is False
+
+
+def test_cancellation_probe_returns_false_on_404(monkeypatch):
+    """A 404 (e.g. execution_id not yet visible to the server) must not
+    abort the child — return False and let the next probe see the
+    cancellation."""
+    _install_fake_requests_for_probe(
+        monkeypatch,
+        response_status=404,
+        response_body={"detail": "not found"},
+    )
+    probe = agent_executor._make_cancellation_probe()
+    assert probe("123456789012345678") is False
+
+
+def test_cancellation_probe_returns_false_on_empty_id(monkeypatch):
+    """Guard: an empty or None execution_id must not produce a request
+    against the server."""
+    captured = _install_fake_requests_for_probe(
+        monkeypatch,
+        response_status=200,
+        response_body={"cancelled": True},
+    )
+    probe = agent_executor._make_cancellation_probe()
+    assert probe("") is False
+    assert "url" not in captured, "empty execution_id must not trigger an HTTP call"
+
+
+def test_cancellation_probe_returns_false_on_network_error(monkeypatch):
+    """Transient network errors must not abort the child; the probe
+    returns False on any exception from ``requests.get``."""
+    class _RaisingFakeRequests:
+        @staticmethod
+        def get(url, timeout=None):
+            raise RuntimeError("simulated network outage")
+
+    monkeypatch.setitem(sys.modules, "requests", _RaisingFakeRequests)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+
+    probe = agent_executor._make_cancellation_probe()
+    assert probe("123456789012345678") is False


### PR DESCRIPTION
## Summary

The inline runner's cancellation probe was hitting the wrong endpoint. Round A's design called for `/api/executions/{id}/cancellation-check` (the purpose-built worker-side cancellation seam that the dispatched path already uses); codex's implementation hit `/api/executions/{id}/status` instead. The `/status` endpoint does not surface cancellation state — its response carries only `completed`, `failed`, `completed_steps`, `current_step`, etc. The probe was reading a `status` field that does not exist, so it returned False on every call and the cancel cascade silently broke.

## How this surfaced

Phase D parent-cancel cascade spot-check on GKE (helm rev 169, image `inline-runner-v4-20260526084305` built from `noetl@5b41e323` = v2.102.3, `NOETL_INLINE_TRIVIAL_CHILDREN=enforce`):

- Smoke parent `tests/inline_cancel_smoke_parent` invokes `automation/agents/mcp/inline-cancel-smoke` (3-step `[sleep 3s, sleep 3s, end-noop]` child playbook) under the inline runner.
- Started parent execution `635384123825062053`, issued `noetl cancel` at t=1.5s.
- `noetl cancel` succeeded; `execution.cancelled` event landed in the parent's event log.
- `/api/executions/.../cancellation-check` returns `{"cancelled": true, "status": "CANCELLED"}` — the server sees the cancel clearly.
- **But the inline runner ran ALL THREE child steps to completion** — the parent's `call.done.result.context.data` contains `{"phase": "second", "slept": 2}`, i.e. step 2's payload. That step is a 3-second `time.sleep(3)`. After a 1.5s cancel, 6 seconds of sleeps still completed.
- Root cause: probe URL is `/status`. Status endpoint shape (pre-fix):
  ```json
  {"completed": true, "failed": false, "current_step": "call_slow_child", ...}
  ```
  No `status` field. `doc.get("status")` returns `None`. `None.lower() == "cancelled"` is False. Probe always returned False; runner never aborted.

## What changes

`noetl/tools/agent/executor.py` `_make_cancellation_probe`:

- URL changes from `/executions/{id}/status` to `/executions/{id}/cancellation-check`.
- Result parsing changes from `doc.get("status") == "cancelled"` to `bool(doc.get("cancelled"))`. Trusting the explicit boolean flag instead of parsing the status vocabulary keeps the probe forward-compatible.
- Expanded docstring documents the cross-reference to `nats_worker.py:1108` (the dispatched-path's matching call) and the response shape from `endpoint.py:1163`.

`tests/tools/test_agent_executor.py` — 7 new regression tests:

- `test_cancellation_probe_hits_cancellation_check_endpoint` — asserts the URL ends with `/cancellation-check`.
- `test_cancellation_probe_returns_true_on_cancelled_response`.
- `test_cancellation_probe_returns_false_on_running_response`.
- `test_cancellation_probe_returns_false_on_missing_cancelled_field` — best-effort fallback for future shape drift.
- `test_cancellation_probe_returns_false_on_404`.
- `test_cancellation_probe_returns_false_on_empty_id` — guard against accidental HTTP calls.
- `test_cancellation_probe_returns_false_on_network_error`.

## What does NOT change

- `_make_batch_event_emitter` — unchanged. Event-emission seam is independent.
- Inline runner internals (`run_inline`, step loop, `_BOUNDARY_STEP_NAMES`, id allocation) — unchanged.
- Existing 56 tests across `tests/core/workflow/test_inline_runner.py` + `tests/core/workflow/test_inline_runner_parity.py` + `tests/tools/test_agent_executor.py` — pass unchanged.

## Risk

Low. The fix routes the probe to the correct endpoint that the rest of the worker code already trusts for the same purpose. The exception-handling envelope around the request is unchanged — network errors still degrade gracefully to "no cancel" (False), so a transient blip doesn't abort a child mid-flight.

## Test plan

- [x] `uv run pytest tests/core/workflow/test_inline_runner.py tests/core/workflow/test_inline_runner_parity.py tests/tools/test_agent_executor.py -q` → 63 passed.
- [ ] After merge: rebuild image off `noetl` main, redeploy GKE, flip worker env back to `enforce`, re-run cancel-cascade smoke playbook.
- [ ] Verify the parent's terminal envelope carries `error.code: PLAYBOOK_CANCELLED` and the child stops at step 1 / step 2 (not running all three).

## Related

- Round B handoff: `handoffs/active/2026-05-26-noetl-inline-trivial-children/round-03-prompt.md` + `round-03-result.md`.
- Predecessor fixes in the Round B Phase D cascade:
  - #613 (catalog version="latest" 404 → detector saw real playbook content)
  - #614 (uuid4 modulus → bigint-safe child execution_id)
  - #615 (result envelope mirrors dispatched-path boundary-step filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)