### PR TITLE
fix(security): redact_keychain_values must not destroy credential aliases (continuation of #617)

### DIFF
--- a/noetl/core/sanitize.py
+++ b/noetl/core/sanitize.py
@@ -305,8 +305,72 @@ def _redact_response_recursive(
         for key, value in data.items():
             key_text = str(key)
             key_normalized = key_text.lower().replace("-", "_")
-            if _is_response_sensitive_key(key_text) or key_normalized in additional_keys:
+            caller_blind_redact = key_normalized in additional_keys
+            partial_match_sensitive = _is_response_sensitive_key(key_text)
+            if caller_blind_redact:
+                # The caller explicitly named this key as one that always
+                # carries a credential value (HTTP header keys like
+                # ``authorization`` / ``cookie`` / ``x_api_key``, or
+                # keychain manifest namespaces like ``openai_token``).
+                # Blind-redact the value regardless of shape — this is
+                # the producer-scrub contract and the response sanitizer
+                # honors it verbatim.
                 result[key] = redaction
+            elif partial_match_sensitive:
+                # The key name *partial-matches* an entry in
+                # ``SENSITIVE_KEYS`` / ``RESPONSE_SENSITIVE_KEYS`` but
+                # the caller did NOT explicitly list it.  This is the
+                # path that historically destroyed credential alias
+                # references: a key like ``db_credential`` partial-matches
+                # ``credential``; a postgres task ``auth`` field exact-
+                # matches ``auth``.  Their values are alias names
+                # (``pg_auth``, ``openai_session``, ...) used by the
+                # NoETL keychain to look up actual secrets at tool-
+                # execution time.  Blindly redacting them breaks every
+                # downstream credential lookup.
+                #
+                # Concrete failure on the noetl-demo GKE cluster (the
+                # auth0_login_optimized playbook):
+                #   - command.issued event stores ``auth: "{{ db_credential }}"``
+                #     (raw Jinja template, untouched).
+                #   - Worker claims the command and fetches the
+                #     externalized ``render_context`` via
+                #     ``/api/temp/{execution_id}/{name}`` or
+                #     ``/api/result/...`` — both response endpoints run
+                #     ``redact_keychain_values`` over the payload.
+                #   - Pre-fix, ``redact_keychain_values`` saw
+                #     ``db_credential: "pg_auth"`` in render_context,
+                #     partial-matched ``credential``, and replaced the
+                #     value with ``"[REDACTED]"`` regardless of shape.
+                #   - Jinja then rendered ``{{ db_credential }}`` →
+                #     ``"[REDACTED]"`` and the worker's auth resolver
+                #     called ``GET /api/credentials/[REDACTED]`` which
+                #     404'd.  See ``worker/auth_resolver.py:434``
+                #     traceback: ``Auth resolution failed for 'auth':
+                #     Credential '[REDACTED]' not found``.
+                #
+                # Strategy for the partial-match case:
+                #   - String values: only redact when
+                #     ``_is_response_secret_value`` matches (caller-supplied
+                #     secrets set, URL credentials, SECRET_VALUE_PATTERNS:
+                #     Bearer / Basic / JWT / sk-/sk-ant-/AIza/ya29/
+                #     gh{p,o,u,s,r}_/github_pat_/xox{baprs}-/PEM headers /
+                #     long random query-string secrets).  Short
+                #     identifier-shaped strings pass through.
+                #   - Nested dict / list / tuple values: preserve the
+                #     prior broad redaction — key-only inspection cannot
+                #     reach individual leaves without re-encountering
+                #     the same key trap.
+                #   - Other scalars (int, bool, None): pass through.
+                if isinstance(value, str):
+                    if _is_response_secret_value(value, secret_values):
+                        result[key] = redaction
+                    else:
+                        result[key] = value
+                elif isinstance(value, (dict, list, tuple)):
+                    result[key] = redaction
+                else:
+                    result[key] = value
             else:
                 result[key] = _redact_response_recursive(
                     value,
@@ -366,36 +430,46 @@ def _sanitize_recursive(
     if isinstance(data, dict):
         result = {}
         for key, value in data.items():
-            # Check if key indicates sensitive data
-            key_is_sensitive = (
-                _is_sensitive_key(key)
-                or (isinstance(key, str) and key.lower() in additional_keys)
-            )
-            if key_is_sensitive:
-                # The sensitive-key check uses partial substring matches
-                # (``db_credential`` matches ``credential``, ``oauth_token``
-                # matches ``token``, etc.) so we cannot blindly redact every
-                # value under a matching key — that pattern destroys
-                # credential alias references which the NoETL keychain uses
-                # to look up actual secrets at tool execution time.
-                # Example failure: a postgres task with
-                # ``auth: "{{ db_credential }}"`` and workload
-                # ``db_credential: pg_auth`` gets rendered to
-                # ``auth: "pg_auth"`` (the alias name).  Pre-fix, this
-                # function rewrote that to ``auth: "[REDACTED]"``, the
-                # worker tried to GET ``/api/credentials/[REDACTED]`` and
-                # the lookup 404'd — silently breaking every playbook that
-                # routes a credential by alias.
+            caller_blind_redact = isinstance(key, str) and key.lower() in additional_keys
+            partial_match_sensitive = _is_sensitive_key(key)
+            if caller_blind_redact:
+                # Caller named this key explicitly — blind-redact regardless
+                # of value shape.  This is how producer-scrub passes HTTP
+                # header conventions (Authorization / Cookie / X-API-Key /
+                # ...) through additional_keys; those values are
+                # credentials by HTTP convention even when they're short.
+                result[key] = redaction
+            elif partial_match_sensitive:
+                # The key name partial-matches ``SENSITIVE_KEYS`` but the
+                # caller did NOT explicitly list it.  This is the path
+                # that historically destroyed credential alias references:
+                # ``db_credential`` matches ``credential``, postgres task
+                # ``auth`` exact-matches ``auth`` — but the values are
+                # alias names (``pg_auth``, ``openai_session``, ...) that
+                # the NoETL keychain uses to look up actual secrets at
+                # tool-execution time.  Blindly redacting them breaks
+                # every downstream credential lookup.
                 #
-                # Strategy:
+                # Concrete failure on the noetl-demo GKE cluster (the
+                # auth0_login_optimized playbook):
+                #   - workload ``db_credential: pg_auth`` (alias)
+                #   - step ``auth: "{{ db_credential }}"`` renders to
+                #     ``auth: "pg_auth"``
+                #   - Pre-fix the broker sanitizer rewrote that to
+                #     ``auth: "[REDACTED]"`` and the worker's auth resolver
+                #     looked up ``GET /api/credentials/[REDACTED]`` →
+                #     404.  See ``worker/auth_resolver.py:434`` trace:
+                #     ``Auth resolution failed for 'auth': Credential
+                #     '[REDACTED]' not found``.
+                #
+                # Strategy for the partial-match case:
                 #   - String values: only redact when ``_is_sensitive_value``
-                #     matches (Bearer tokens, JWTs, long random secrets,
-                #     PEM headers, etc.).  Short identifier-shaped strings
-                #     pass through — they're alias references, not secrets.
+                #     matches (Bearer / JWT / long random / PEM / API key
+                #     shapes).  Short identifier-shaped strings pass
+                #     through — they're alias references, not secrets.
                 #   - Nested dict / list values: preserve the prior broad
-                #     redaction since key-only inspection cannot reach
-                #     individual leaves; recursion would re-encounter the
-                #     same sensitive-key trap.
+                #     redaction; recursion cannot value-check leaves
+                #     without re-encountering the same key trap.
                 #   - Other scalars (int, bool, None): pass through.
                 #
                 # Resolved secret values still get redacted on the

--- a/tests/core/test_redact_keychain_values.py
+++ b/tests/core/test_redact_keychain_values.py
@@ -84,3 +84,102 @@ def test_redaction_is_idempotent():
 @pytest.mark.parametrize("value", [None, 42, True, "plain text", {"region": "Miami"}])
 def test_non_secret_values_passthrough(value):
     assert redact_keychain_values(value) == value
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the credential-alias preservation fix.  See the long
+# header comment in ``_redact_response_recursive`` (noetl/core/sanitize.py)
+# for the failure mode this guards against.  Mirror tests live in
+# tests/core/test_sanitize_sensitive_data.py for the write-side sanitizer
+# under the same partial-key-match trap.
+# ---------------------------------------------------------------------------
+
+
+def test_preserves_postgres_auth_alias():
+    """Render-context fetches surfaced ``auth: 'pg_auth'`` to the worker.
+    Pre-fix the response redactor saw the ``auth`` key, blindly redacted
+    the value, and the worker's auth resolver looked up
+    ``GET /api/credentials/[REDACTED]`` which 404'd."""
+    payload = {"auth": "pg_auth", "kind": "postgres", "command": "SELECT 1"}
+    assert redact_keychain_values(payload) == payload
+
+
+def test_preserves_db_credential_workload_alias():
+    """``db_credential`` partial-matches ``credential`` in
+    ``SENSITIVE_KEYS``.  The value ``pg_auth`` is a short alias name."""
+    assert redact_keychain_values({"db_credential": "pg_auth"}) == {
+        "db_credential": "pg_auth"
+    }
+
+
+def test_preserves_nats_credential_alias():
+    """Same pattern for any downstream-resolved credential reference."""
+    payload = {
+        "nats_credential": "nats_user",
+        "auth0_credential": "auth0_client",
+        "oauth_token": "session_alias",
+    }
+    assert redact_keychain_values(payload) == payload
+
+
+def test_redacts_bearer_token_under_auth_key():
+    """Real Bearer tokens still get redacted regardless of key name."""
+    payload = {"auth": "Bearer " + ("D" * 32)}
+    assert redact_keychain_values(payload) == {"auth": REDACTED}
+
+
+def test_redacts_jwt_under_token_key():
+    payload = {"token": _jwt()}
+    assert redact_keychain_values(payload) == {"token": REDACTED}
+
+
+def test_caller_supplied_secret_still_redacts_short_alias_shaped_value():
+    """When the caller passes ``secret_values={'pg_auth'}``, an exact match
+    on the alias-shaped string is treated as a known secret and redacted.
+    This is the legitimate value-based escape hatch."""
+    redacted = redact_keychain_values(
+        {"auth": "pg_auth"}, secret_values={"pg_auth"}
+    )
+    assert redacted == {"auth": REDACTED}
+
+
+def test_nested_dict_under_sensitive_key_blanket_redacted():
+    """Nested structures under a sensitive key still get blanket-redacted —
+    we cannot value-check individual leaves without re-encountering the
+    same key trap on the way down."""
+    payload = {"credentials": {"username": "admin", "password": "real_secret"}}
+    assert redact_keychain_values(payload) == {"credentials": REDACTED}
+
+
+def test_nested_list_under_sensitive_key_blanket_redacted():
+    payload = {"tokens": ["t1", "t2", "t3"]}
+    assert redact_keychain_values(payload) == {"tokens": REDACTED}
+
+
+def test_non_string_scalars_under_sensitive_keys_pass_through():
+    """ints, bools, None under sensitive keys cannot be credentials."""
+    payload = {
+        "token_expiry": 3600,
+        "is_credential_present": True,
+        "refresh_token": None,
+    }
+    assert redact_keychain_values(payload) == payload
+
+
+def test_render_context_workload_with_aliases_and_real_secret():
+    """End-to-end shape: the workload dict the worker fetches via
+    ``/api/temp/{execution_id}/{name}`` for Jinja rendering.  Aliases
+    must survive; a real Bearer token in a leaf still redacts."""
+    render_context = {
+        "workload": {
+            "db_credential": "pg_auth",
+            "nats_credential": "nats_user",
+            "auth0_token": "Bearer " + ("E" * 32),
+            "request_id": "abc-123",
+        },
+    }
+    redacted = redact_keychain_values(render_context)
+    assert redacted["workload"]["db_credential"] == "pg_auth"
+    assert redacted["workload"]["nats_credential"] == "nats_user"
+    assert redacted["workload"]["auth0_token"] == REDACTED
+    assert redacted["workload"]["request_id"] == "abc-123"


### PR DESCRIPTION
## 🔴 Production hotfix continuation

PR #617 patched `_sanitize_recursive` (write-side) but the production flow still reproduced `Gateway login failed (401): Failed to create session: Database error` because the same key-blind-redact bug exists in the **second** recursive function — `_redact_response_recursive`, used by `redact_keychain_values` on read-side endpoints.

The auth0_login flow hits this path: the worker fetches its externalized `render_context` via `/api/temp/{execution_id}/{name}` (response endpoint runs `redact_keychain_values` over the payload). Pre-fix, that redactor mangled `db_credential: pg_auth` → `db_credential: [REDACTED]` in the rendered context. Jinja then resolved `{{ db_credential }}` to `[REDACTED]` and the worker's auth resolver 404'd against `/api/credentials/[REDACTED]`.

## How it surfaced (after #617 + redeploy)

Execution `635639679932432976` on the demo cluster:

- `command.issued` event in `noetl.event` shows `auth: "{{ db_credential }}"` — raw Jinja template, untouched. ✓ (#617 working)
- Worker claim returns this directly (no redaction at claim).
- Worker fetches externalized `render_context` via temp API.
- Worker traceback (`/usr/local/lib/python3.12/site-packages/noetl/worker/auth_resolver.py:434`):
  ```
  ValueError: Authentication resolution failed: Auth resolution failed for 'auth':
  Credential '[REDACTED]' fetch failed: Credential '[REDACTED]' not found
  ```
- `rendered_auth` was `[REDACTED]` — proving Jinja resolved `{{ db_credential }}` to the redacted value, which means the render_context fetched from `/api/temp/` had `db_credential: [REDACTED]`.
- Server log:
  ```
  INFO: GET /api/credentials/%5BREDACTED%5D?include_data=true HTTP/1.1" 404 Not Found
  ```

## The fix

Both `_sanitize_recursive` and `_redact_response_recursive` now use a **two-tier** key check:

| Match type | Behavior |
|---|---|
| Key in caller-supplied `additional_keys` (e.g. `HEADER_CREDENTIAL_KEYS = {authorization, cookie, x_api_key, ...}` from producer-scrub) | **Blind redact** — HTTP header conventions where the value IS the credential by convention |
| Key partial-matches `SENSITIVE_KEYS` / `RESPONSE_SENSITIVE_KEYS` (e.g. `db_credential` matches `credential`, postgres `auth` exact-matches `auth`) | **Combined key+value check** — only redact if the value also looks like a secret |

### Value-side rules under partial-match keys

- String matches `_is_response_secret_value` / `_is_sensitive_value` (Bearer / Basic / JWT / `sk-` / `sk-ant-` / `AIza` / `ya29` / `gh{p,o,u,s,r}_` / `github_pat_` / `xox{baprs}-` / PEM / URL credentials) → redact.
- Short identifier-shaped string → pass through (alias reference).
- Nested dict / list / tuple → blind-redact (cannot value-check leaves without re-encountering the same key trap).
- Other scalar (int / bool / None) → pass through.

`producer_scrub_payload` (keychain-manifest-aware) remains the primary defence for resolved secret leaves. This relaxation only un-redacts short identifier strings under partial-match keys — i.e. the alias names the keychain pattern needs to function.

## What does NOT change

- `producer_scrub_payload` HTTP header redaction: `Authorization`, `Cookie`, `X-API-Key`, etc. still blind-redact via `additional_keys` (now caller-blind-redact tier).
- Keychain manifest namespaces passed via `additional_keys`: still blind-redact.
- Wire-shape secrets (Bearer / JWT / sk-... / AIza... / etc.): still redact regardless of key.
- Nested dicts under sensitive keys: still blanket-redact.

## Risk

Low. The leak surface for resolved secret values is unchanged — `_is_response_secret_value` patterns + caller-supplied `secret_values` + keychain-manifest exact-match all still catch them. The producer-scrub layer runs upstream of this read-side redactor and is keychain-manifest-aware. The fix only restores credential-alias passthrough that the keychain pattern depends on.

## Test plan

- [x] `uv run pytest tests/core/test_sanitize_sensitive_data.py tests/core/test_redact_keychain_values.py tests/core/test_credential_refs.py tests/core/test_sanitize_url_credentials.py -q` → 59 passed.
- [ ] After merge: rebuild image (v2.102.6), redeploy GKE, retry `travel.mestumre.dev/callback`. Expect Jinja to render `{{ db_credential }}` → `pg_auth`, worker to fetch `/api/credentials/pg_auth` → success, postgres step to run with the resolved DSN.

## New tests in `tests/core/test_redact_keychain_values.py`

- `test_preserves_postgres_auth_alias`
- `test_preserves_db_credential_workload_alias`
- `test_preserves_nats_credential_alias`
- `test_redacts_bearer_token_under_auth_key`
- `test_redacts_jwt_under_token_key`
- `test_caller_supplied_secret_still_redacts_short_alias_shaped_value`
- `test_nested_dict_under_sensitive_key_blanket_redacted`
- `test_nested_list_under_sensitive_key_blanket_redacted`
- `test_non_string_scalars_under_sensitive_keys_pass_through`
- `test_render_context_workload_with_aliases_and_real_secret`

## Related

- Predecessor: #617 (same bug class in `_sanitize_recursive`; was incomplete because `_redact_response_recursive` has the same logic in a different module path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)