### PR TITLE
fix(inline-execution): emit events that comply with strict payload schema + wire parent catalog_id

### DIFF
--- a/noetl/core/workflow/playbook/inline_runner.py
+++ b/noetl/core/workflow/playbook/inline_runner.py
@@ -193,6 +193,7 @@ async def run_inline(
     cancellation_probe: Callable[[str], Any],
     batch_event_emitter: Callable[[str, List[Dict[str, Any]]], Any],
     depth: int,
+    parent_catalog_id: Optional[int] = None,
 ) -> InlineResult:
     """Run a detector-approved child playbook inline inside the current worker.
 
@@ -222,13 +223,27 @@ async def run_inline(
         posts the event list to ``/api/events/batch``.
     depth:
         Current inline depth (0-based, bounded by DEFAULT_MAX_DEPTH = 3).
-
-    Returns
-    -------
-    InlineResult
-        Agent-envelope-compatible result.  Caller attaches ``inline_decision``
-        and ``inlined_*`` keys from ``result.meta`` to the terminal parent event.
+    parent_catalog_id:
+        Optional ``catalog_id`` of the parent's playbook.  Forwarded to the
+        batch emitter so the server can write child events with the right
+        ``noetl.event.catalog_id`` (the column is NOT NULL and the server
+        cannot discover it from an empty event row set for a brand-new
+        inline child).  When the emitter is a closure created by
+        ``executor._make_batch_event_emitter`` it captures this directly;
+        legacy emitters that pre-date the parent-catalog-id seam can pass
+        ``None`` and the server falls back to the per-execution lookup.
     """
+    # Stash on the closure-style emitter for the legacy 2-arg shape; the
+    # caller-supplied emitter signature is preserved for backward
+    # compatibility (existing tests construct 2-arg lambdas).  When the
+    # emitter exposes a ``set_catalog_id`` method (as
+    # ``_make_batch_event_emitter`` does in executor.py) we wire it now.
+    if parent_catalog_id is not None and hasattr(batch_event_emitter, "set_catalog_id"):
+        try:
+            batch_event_emitter.set_catalog_id(parent_catalog_id)
+        except Exception:
+            # Best-effort: a faulty emitter shouldn't abort the runner.
+            pass
     if depth > DEFAULT_MAX_DEPTH:
         # Depth guard: should not be reached because the detector blocks depth
         # > DEFAULT_MAX_DEPTH before this function is ever called.  Guard here
@@ -568,16 +583,27 @@ async def _emit_init_events(
     inline_meta: Dict[str, Any],
     batch_event_emitter: Callable,
 ) -> None:
+    # ``payload.result`` is gated by the server-side
+    # ``_validate_reference_only_payload`` filter
+    # (``noetl/server/api/core/events.py``) — only the keys in
+    # ``_STRICT_RESULT_ALLOWED_KEYS = {"status", "reference", "context",
+    # "command_id"}`` are accepted.  ``workload`` and ``playbook_path``
+    # used to live directly in ``result`` here, which caused every batch
+    # to be rejected with ``payload.result includes unsupported keys:
+    # playbook_path, workload`` and the runner's ``_safe_emit`` silently
+    # swallowed the 500.  Moving them into ``inline_meta`` keeps the
+    # information attached to the event without violating the schema.
+    init_meta = dict(inline_meta)
+    init_meta.setdefault("playbook_path", playbook_path)
+    if isinstance(workload, dict):
+        init_meta.setdefault("inline_workload", workload)
     events = [
         {
             "step": playbook_path,
             "name": "playbook.initialized",
             "payload": _with_inline_meta(
-                {
-                    "status": "initialized",
-                    "result": {"workload": workload, "playbook_path": playbook_path},
-                },
-                inline_meta,
+                {"status": "initialized", "result": {"status": "INITIALIZED"}},
+                init_meta,
             ),
             "actionable": False,
             "informative": True,
@@ -586,11 +612,8 @@ async def _emit_init_events(
             "step": "workflow",
             "name": "workflow.initialized",
             "payload": _with_inline_meta(
-                {
-                    "status": "initialized",
-                    "result": {"playbook_path": playbook_path, "workload": workload},
-                },
-                inline_meta,
+                {"status": "initialized", "result": {"status": "INITIALIZED"}},
+                init_meta,
             ),
             "actionable": False,
             "informative": True,
@@ -750,12 +773,34 @@ async def _emit_workflow_completed(
     inline_meta: Dict[str, Any],
     batch_event_emitter: Callable,
 ) -> None:
+    # ``payload.result`` is gated by ``_STRICT_RESULT_ALLOWED_KEYS =
+    # {"status", "reference", "context", "command_id"}``.  The
+    # processed_result coming in here is the last meaningful step's
+    # result envelope (often ``{"id": "...", "data": {...}, "status":
+    # "ok"}`` from a tool like postgres or python).  Pre-fix this was
+    # spread directly into ``payload.result`` and the server rejected
+    # the batch with ``payload.result includes unsupported keys: data,
+    # id``.  Wrap the tool result in ``context`` (which IS allowed) so
+    # downstream readers can still reach the payload at
+    # ``result.context.*`` — the same shape the dispatched path
+    # surfaces via ``LifecycleEventPayload`` plus the ``call.done``
+    # event chain.
+    result_envelope: Dict[str, Any] = {"status": "ok"}
+    if isinstance(result, dict):
+        # Reuse the tool's status when present so the lifecycle event
+        # reflects the actual terminal outcome.
+        tool_status = result.get("status")
+        if isinstance(tool_status, str) and tool_status.strip():
+            result_envelope["status"] = tool_status
+        result_envelope["context"] = result
+    elif result is not None:
+        result_envelope["context"] = {"value": result}
     events = [
         {
             "step": "workflow",
             "name": "workflow.completed",
             "payload": _with_inline_meta(
-                {"status": "completed", "result": result},
+                {"status": "completed", "result": result_envelope},
                 inline_meta,
             ),
             "actionable": False,
@@ -765,7 +810,7 @@ async def _emit_workflow_completed(
             "step": playbook_path,
             "name": "playbook.completed",
             "payload": _with_inline_meta(
-                {"status": "completed"},
+                {"status": "completed", "result": {"status": "ok"}},
                 inline_meta,
             ),
             "actionable": False,

--- a/noetl/server/api/core/batch.py
+++ b/noetl/server/api/core/batch.py
@@ -186,6 +186,17 @@ async def _persist_batch_acceptance(req: BatchEventRequest, idempotency_key: Opt
         async with conn.cursor(row_factory=dict_row) as cur:
             await cur.execute("SELECT catalog_id FROM noetl.event WHERE execution_id = %s LIMIT 1", (exec_id,))
             catalog_id = (await cur.fetchone() or {}).get("catalog_id")
+            # Fall back to the request's caller-supplied catalog_id when no
+            # prior event row exists for this execution.  This is the
+            # inline-runner path: a worker creates a child execution_id
+            # in-process and emits its first events via this endpoint —
+            # there is no ``POST /api/execute`` ingress for that execution,
+            # so the DB lookup above returns ``None`` and the
+            # ``noetl.event.catalog_id`` NOT NULL constraint would block
+            # the insert.  The DB-discovered value still wins when present
+            # so cross-batch rows stay consistent.
+            if catalog_id is None and req.catalog_id is not None:
+                catalog_id = req.catalog_id
             if idempotency_key:
                 await cur.execute("SELECT meta, result FROM noetl.event WHERE execution_id = %s AND event_type = 'batch.accepted' AND meta->>'idempotency_key' = %s ORDER BY event_id DESC LIMIT 1", (exec_id, idempotency_key))
                 if row := await cur.fetchone():

--- a/noetl/server/api/core/models.py
+++ b/noetl/server/api/core/models.py
@@ -64,6 +64,19 @@ class BatchEventRequest(BaseModel):
     execution_id: str
     events: list[BatchEventItem]
     worker_id: Optional[str] = None
+    catalog_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "Fallback catalog_id for executions that have no prior event "
+            "rows (e.g. inline-runner children created in-worker without a "
+            "``POST /api/execute`` ingress). The persistence path normally "
+            "discovers ``catalog_id`` by querying the first existing event "
+            "row for the execution; for inline children there is no such "
+            "row yet, so the caller must supply it. Ignored when the "
+            "execution already has events written — the DB-discovered value "
+            "wins to keep cross-batch event rows consistent."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_batch_limits(self):

--- a/noetl/tools/agent/executor.py
+++ b/noetl/tools/agent/executor.py
@@ -1316,17 +1316,42 @@ def _make_cancellation_probe() -> Callable:
     return probe
 
 
-def _make_batch_event_emitter() -> Callable:
-    """Return a batch event emitter for the inline runner.
+class _BatchEventEmitter:
+    """Callable batch event emitter for the inline runner.
 
-    Posts a list of event dicts to ``/api/events/batch``.  Best-effort: HTTP
-    errors are logged at DEBUG and swallowed so the runner continues rather
-    than aborting on an emission failure.
+    Posts a list of event dicts to ``/api/events/batch``.  Exposes a
+    ``set_catalog_id`` mutator that ``run_inline`` calls to wire the
+    parent's ``catalog_id`` through — the server's persistence path
+    discovers ``catalog_id`` by querying any prior event row for the
+    execution, but inline children have no prior rows, so the caller
+    must supply it explicitly in the request body
+    (``BatchEventRequest.catalog_id``).
 
-    The emitter is a plain sync callable; ``run_inline`` wraps it in an
-    awaitable context.
+    A persistently-failing emission upgrades to a WARNING log so the
+    silent-drop class of bug stops being invisible.  Round B Phase D
+    on GKE captured the original symptom: an itinerary-planner-class
+    child playbook triggered ``payload.result includes unsupported
+    keys`` and ``null value in column catalog_id`` server errors that
+    the runner's ``_safe_emit`` swallowed at DEBUG, leaving the SPA
+    hung on ``Muno is planning...`` with no visible diagnostic.
+
+    The emitter is a plain sync callable; ``run_inline`` wraps the
+    call in an awaitable context so async callers work too.
     """
-    def emitter(execution_id: str, events: list) -> bool:
+
+    __slots__ = ("_catalog_id", "_consecutive_failures")
+
+    def __init__(self) -> None:
+        self._catalog_id: Optional[int] = None
+        self._consecutive_failures = 0
+
+    def set_catalog_id(self, catalog_id: Optional[int]) -> None:
+        try:
+            self._catalog_id = int(catalog_id) if catalog_id is not None else None
+        except (TypeError, ValueError):
+            self._catalog_id = None
+
+    def __call__(self, execution_id: str, events: list) -> bool:
         if not execution_id or not events:
             return True
         try:
@@ -1336,18 +1361,61 @@ def _make_batch_event_emitter() -> Callable:
             if not server_url.endswith("/api"):
                 server_url = server_url + "/api"
             url = f"{server_url}/events/batch"
-            payload_body = {"execution_id": execution_id, "events": events}
+            payload_body: Dict[str, Any] = {
+                "execution_id": execution_id,
+                "events": events,
+            }
+            if self._catalog_id is not None:
+                payload_body["catalog_id"] = self._catalog_id
             resp = _requests.post(url, json=payload_body, timeout=5.0)
-            return resp.status_code in (200, 201, 202, 204)
-        except Exception as exc:
-            logger.debug(
-                "AGENT.INLINE batch emitter failed execution_id=%s: %s",
+            ok = resp.status_code in (200, 201, 202, 204)
+            if ok:
+                self._consecutive_failures = 0
+                return True
+            self._consecutive_failures += 1
+            # First failure logs at DEBUG (typical transient HTTP blip);
+            # repeated failures upgrade to WARNING so the silent-drop
+            # behaviour stops hiding real defects.  Phase D on GKE was
+            # masked precisely because every emission failed silently.
+            log_method = (
+                logger.warning if self._consecutive_failures >= 3 else logger.debug
+            )
+            try:
+                body_preview = resp.text[:500] if resp.text else ""
+            except Exception:
+                body_preview = ""
+            log_method(
+                "AGENT.INLINE batch emitter HTTP %s for execution_id=%s "
+                "(consecutive_failures=%d) body=%s",
+                resp.status_code,
                 execution_id,
+                self._consecutive_failures,
+                body_preview,
+            )
+            return False
+        except Exception as exc:
+            self._consecutive_failures += 1
+            log_method = (
+                logger.warning if self._consecutive_failures >= 3 else logger.debug
+            )
+            log_method(
+                "AGENT.INLINE batch emitter exception execution_id=%s "
+                "(consecutive_failures=%d): %s",
+                execution_id,
+                self._consecutive_failures,
                 exc,
             )
             return False
 
-    return emitter
+
+def _make_batch_event_emitter() -> _BatchEventEmitter:
+    """Return a batch event emitter for the inline runner.
+
+    See ``_BatchEventEmitter`` for the contract.  Returned as the class
+    instance rather than a closure so ``run_inline`` can wire the
+    parent's ``catalog_id`` through ``set_catalog_id``.
+    """
+    return _BatchEventEmitter()
 
 
 def _invoke_noetl_playbook(
@@ -1942,6 +2010,29 @@ async def execute_agent_task(
                     mode=inline_decision.get("mode"),
                 )
 
+                # Parent ``catalog_id`` flows into the batch emitter so
+                # the server can populate ``noetl.event.catalog_id`` for
+                # child events.  The worker drops the parent's catalog_id
+                # into the rendered context at ``nats_worker.py:1926``;
+                # fall back to ``meta.catalog_id`` on the agent envelope
+                # for completeness.
+                parent_catalog_id_raw: Any = (
+                    (context or {}).get("catalog_id")
+                    or ((context or {}).get("meta") or {}).get("catalog_id")
+                )
+                try:
+                    parent_catalog_id: Optional[int] = (
+                        int(parent_catalog_id_raw)
+                        if parent_catalog_id_raw is not None
+                        else None
+                    )
+                except (TypeError, ValueError):
+                    parent_catalog_id = None
+
+                batch_emitter = _make_batch_event_emitter()
+                if parent_catalog_id is not None:
+                    batch_emitter.set_catalog_id(parent_catalog_id)
+
                 inline_result = await run_inline(
                     parent_execution_id=parent_execution_id_str,
                     parent_command_id=parent_command_id_str,
@@ -1951,8 +2042,9 @@ async def execute_agent_task(
                     inline_decision=decision_obj,
                     jinja_env=jinja_env,
                     cancellation_probe=_make_cancellation_probe(),
-                    batch_event_emitter=_make_batch_event_emitter(),
+                    batch_event_emitter=batch_emitter,
                     depth=int(inline_decision.get("depth") or 0),
+                    parent_catalog_id=parent_catalog_id,
                 )
                 return inline_result.to_envelope(entrypoint=entrypoint)
 

--- a/tests/core/workflow/test_inline_runner.py
+++ b/tests/core/workflow/test_inline_runner.py
@@ -561,3 +561,288 @@ async def test_inline_runner_data_skips_start_boundary_step():
     assert "value" in data_str or "42" in data_str, (
         f"InlineResult.data lost do_work's payload. Got: {result.data!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Event payload schema regression tests
+#
+# Round B Phase D on the noetl-demo GKE cluster failed because the runner's
+# emitted events did not comply with ``_STRICT_RESULT_ALLOWED_KEYS = {"status",
+# "reference", "context", "command_id"}``.  The server's
+# ``_validate_reference_only_payload`` rejected every batch with
+# ``payload.result includes unsupported keys: ...`` and the runner's
+# ``_safe_emit`` swallowed the 500.  Symptom: SPA hung on "Muno is planning..."
+# with no visible diagnostic.  These tests guard the event payload shapes.
+# ---------------------------------------------------------------------------
+
+
+_STRICT_RESULT_ALLOWED_KEYS = {"status", "reference", "context", "command_id"}
+
+
+def _assert_payload_result_keys_allowed(payload, *, event_name: str) -> None:
+    """Helper mirroring the server's ``_validate_reference_only_payload``
+    rule for the ``payload.result`` key set."""
+    if not isinstance(payload, dict):
+        return
+    result_obj = payload.get("result")
+    if result_obj is None:
+        return
+    assert isinstance(result_obj, dict), (
+        f"{event_name}: payload.result must be a dict; got {type(result_obj).__name__}"
+    )
+    unknown = {k for k in result_obj.keys() if k not in _STRICT_RESULT_ALLOWED_KEYS}
+    assert not unknown, (
+        f"{event_name}: payload.result includes unsupported keys: "
+        f"{sorted(unknown)} (allowed: {sorted(_STRICT_RESULT_ALLOWED_KEYS)})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_inline_runner_emitted_events_comply_with_strict_payload_schema():
+    """Every event the inline runner emits must keep ``payload.result``
+    within ``_STRICT_RESULT_ALLOWED_KEYS``.  Pre-fix ``playbook.initialized``
+    and ``workflow.initialized`` smuggled ``workload``/``playbook_path``
+    into ``result``, and ``workflow.completed`` spread the tool result
+    dict (``{"id": "...", "data": {...}, "status": "ok"}``) directly into
+    ``result``, both of which the server's
+    ``_validate_reference_only_payload`` rejected with HTTP 500."""
+    events, emitter = _make_emitter()
+
+    playbook = {
+        "metadata": {"name": "test/firestore_dispatch_style"},
+        "workflow": [
+            {
+                "step": "firestore_dispatch",
+                "tool": {
+                    "kind": "python",
+                    # Mirror the real firestore mcp playbook's terminal
+                    # result envelope: ``{"id": "...", "data": {...},
+                    # "status": "ok"}``.  Pre-fix this was the exact shape
+                    # that broke workflow.completed.
+                    "code": (
+                        "result = {"
+                        "    'id': '8d3da932-dcde-4274-8a47-firestore',"
+                        "    'data': {'rows': [{'value': 'ok'}]},"
+                        "    'status': 'ok',"
+                        "}"
+                    ),
+                },
+            },
+            {"step": "end", "tool": {"kind": "noop"}},
+        ],
+    }
+
+    result = await run_inline(
+        parent_execution_id="parent-schema",
+        parent_command_id="cmd-schema",
+        parent_step="agent_step",
+        child_playbook=playbook,
+        child_input={"firestore_database": "(default)"},
+        inline_decision=_make_decision(),
+        jinja_env=Environment(),
+        cancellation_probe=_cancellation_probe_returning(False),
+        batch_event_emitter=emitter,
+        depth=0,
+    )
+
+    assert result.status == "ok"
+    # The runner must have emitted at least the playbook.initialized +
+    # workflow.completed events.
+    event_names = {ev.get("name") for ev in events}
+    assert "playbook.initialized" in event_names
+    assert "workflow.initialized" in event_names
+    assert "workflow.completed" in event_names
+    assert "playbook.completed" in event_names
+
+    for ev in events:
+        _assert_payload_result_keys_allowed(
+            ev.get("payload"), event_name=ev.get("name", "<unknown>")
+        )
+
+
+@pytest.mark.asyncio
+async def test_inline_runner_workflow_completed_wraps_tool_result_in_context():
+    """``workflow.completed`` historically dropped the last step's result
+    dict directly into ``payload.result``, which violated the
+    strict-allowed-keys rule (``id``, ``data`` are not allowed at that
+    layer).  The fix wraps the tool result inside ``payload.result.context``
+    so downstream readers can still reach it at ``result.context.*`` and
+    the strict-keys check passes.
+
+    Note: the runner emits ``workflow.completed`` with ``last_result``
+    (the literal last step's result), not ``last_meaningful_result`` —
+    mirroring the dispatched path's ``LifecycleEventPayload(result=
+    event.payload.get('result'))`` shape where ``event`` is the
+    terminating step.exit event.  Data preservation for the agent
+    envelope (which uses ``last_meaningful_result``) is covered by
+    ``test_inline_runner_data_skips_noop_end_boundary_step``."""
+    events, emitter = _make_emitter()
+
+    # Single-step playbook so ``last_result`` is the tool's dict
+    # directly (the very shape that pre-fix violated the schema).
+    playbook = {
+        "metadata": {"name": "test/python_with_id_data_status"},
+        "workflow": [
+            {
+                "step": "produce",
+                "tool": {
+                    "kind": "python",
+                    "code": "result = {'id': 'x', 'data': {'category': 'unknown'}, 'status': 'ok'}",
+                },
+            },
+        ],
+    }
+
+    await run_inline(
+        parent_execution_id="parent-ctx",
+        parent_command_id="cmd-ctx",
+        parent_step="agent_step",
+        child_playbook=playbook,
+        child_input={},
+        inline_decision=_make_decision(),
+        jinja_env=Environment(),
+        cancellation_probe=_cancellation_probe_returning(False),
+        batch_event_emitter=emitter,
+        depth=0,
+    )
+
+    completed = [e for e in events if e.get("name") == "workflow.completed"]
+    assert completed, "workflow.completed must be emitted"
+    payload = completed[0].get("payload") or {}
+    result_obj = payload.get("result") or {}
+    # Strict-keys rule
+    assert set(result_obj.keys()).issubset(_STRICT_RESULT_ALLOWED_KEYS), (
+        f"workflow.completed payload.result has forbidden keys: "
+        f"{sorted(result_obj.keys())}"
+    )
+    # The actual tool payload is reachable through context
+    ctx = result_obj.get("context") or {}
+    assert isinstance(ctx, dict), f"result.context must be a dict; got {ctx!r}"
+    assert "id" in ctx or "data" in ctx or "category" in repr(ctx), (
+        f"workflow.completed lost the tool result payload. "
+        f"Got result.context={ctx!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_inline_runner_init_events_move_workload_into_meta():
+    """``playbook.initialized`` and ``workflow.initialized`` historically
+    placed ``workload`` and ``playbook_path`` directly inside
+    ``payload.result``, which the server rejected.  The fix moves both
+    into ``payload.meta`` so the information is preserved without
+    violating the strict-allowed-keys rule."""
+    events, emitter = _make_emitter()
+
+    playbook = {
+        "metadata": {"name": "test/init_event_meta"},
+        "workflow": [
+            {"step": "noop", "tool": {"kind": "noop"}},
+        ],
+    }
+
+    await run_inline(
+        parent_execution_id="parent-init",
+        parent_command_id="cmd-init",
+        parent_step="agent_step",
+        child_playbook=playbook,
+        child_input={"db_credential": "pg_auth", "tenant": "demo"},
+        inline_decision=_make_decision(),
+        jinja_env=Environment(),
+        cancellation_probe=_cancellation_probe_returning(False),
+        batch_event_emitter=emitter,
+        depth=0,
+    )
+
+    for evt_name in ("playbook.initialized", "workflow.initialized"):
+        matching = [e for e in events if e.get("name") == evt_name]
+        assert matching, f"expected {evt_name!r} event in emitted stream"
+        payload = matching[0].get("payload") or {}
+        # Strict keys must hold
+        _assert_payload_result_keys_allowed(payload, event_name=evt_name)
+        # ``workload`` and ``playbook_path`` must NOT appear under result
+        result_obj = payload.get("result") or {}
+        assert "workload" not in result_obj
+        assert "playbook_path" not in result_obj
+        # ...but should be reachable via payload.meta
+        meta = payload.get("meta") or {}
+        assert meta.get("playbook_path") == "test/init_event_meta"
+        # ``inline_workload`` carries the child_input dict (renamed to
+        # avoid colliding with the generic ``workload`` field downstream
+        # readers may project from event meta).
+        assert isinstance(meta.get("inline_workload"), dict)
+        assert meta["inline_workload"].get("db_credential") == "pg_auth"
+
+
+# ---------------------------------------------------------------------------
+# parent_catalog_id wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inline_runner_passes_parent_catalog_id_to_emitter():
+    """The runner must forward ``parent_catalog_id`` to the batch emitter
+    via the emitter's ``set_catalog_id`` mutator.  Without it the server
+    cannot populate ``noetl.event.catalog_id`` for child events (the
+    column is NOT NULL and the per-execution DB lookup returns None for
+    inline children with no prior event rows)."""
+
+    set_catalog_id_calls: list = []
+
+    class _ProbeEmitter:
+        def __init__(self) -> None:
+            self.emit_calls: list = []
+
+        def set_catalog_id(self, catalog_id):
+            set_catalog_id_calls.append(catalog_id)
+
+        def __call__(self, execution_id, events):
+            self.emit_calls.append((execution_id, events))
+            return True
+
+    emitter = _ProbeEmitter()
+
+    await run_inline(
+        parent_execution_id="parent-cat",
+        parent_command_id="cmd-cat",
+        parent_step="agent_step",
+        child_playbook={"workflow": [{"step": "noop", "tool": {"kind": "noop"}}]},
+        child_input={},
+        inline_decision=_make_decision(),
+        jinja_env=Environment(),
+        cancellation_probe=_cancellation_probe_returning(False),
+        batch_event_emitter=emitter,
+        depth=0,
+        parent_catalog_id=635123456789012345,
+    )
+
+    assert set_catalog_id_calls == [635123456789012345], (
+        f"runner did not wire parent_catalog_id through; got calls: "
+        f"{set_catalog_id_calls!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_inline_runner_legacy_emitter_without_set_catalog_id_still_works():
+    """Tests in the suite construct simple 2-arg lambdas as emitters.
+    Those must keep working — the runner only calls ``set_catalog_id``
+    if the emitter exposes it, and a missing method must not abort
+    the run."""
+    events, emitter = _make_emitter()
+
+    result = await run_inline(
+        parent_execution_id="parent-legacy",
+        parent_command_id="cmd-legacy",
+        parent_step="agent_step",
+        child_playbook={"workflow": [{"step": "noop", "tool": {"kind": "noop"}}]},
+        child_input={},
+        inline_decision=_make_decision(),
+        jinja_env=Environment(),
+        cancellation_probe=_cancellation_probe_returning(False),
+        batch_event_emitter=emitter,
+        depth=0,
+        parent_catalog_id=635999999999999999,
+    )
+
+    assert result.status == "ok"
+    # The legacy callable still received emissions.
+    assert events, "legacy emitter must still receive events"

--- a/tests/tools/test_agent_executor.py
+++ b/tests/tools/test_agent_executor.py
@@ -1657,3 +1657,123 @@ def test_cancellation_probe_returns_false_on_network_error(monkeypatch):
 
     probe = agent_executor._make_cancellation_probe()
     assert probe("123456789012345678") is False
+
+
+# ---------------------------------------------------------------------------
+# Batch event emitter (_BatchEventEmitter) — Round B Phase D regression
+# ---------------------------------------------------------------------------
+
+
+def test_batch_event_emitter_sends_catalog_id_in_request_body(monkeypatch):
+    """The inline runner's batch emitter must include ``catalog_id`` in
+    the POST body to ``/api/events/batch`` after ``set_catalog_id``
+    has been called.  Without this the server's persistence path
+    cannot populate ``noetl.event.catalog_id`` for inline-child events
+    (no prior event rows exist for the DB-lookup fallback)."""
+    captured: Dict[str, Any] = {}
+
+    class _Resp:
+        status_code = 202
+
+        @property
+        def text(self):
+            return ""
+
+    class _FakeRequests:
+        @staticmethod
+        def post(url, json=None, timeout=None):
+            captured["url"] = url
+            captured["json"] = json
+            return _Resp()
+
+    monkeypatch.setitem(sys.modules, "requests", _FakeRequests)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+
+    emitter = agent_executor._make_batch_event_emitter()
+    emitter.set_catalog_id(635123456789012345)
+    ok = emitter(
+        "999999999999999999",
+        [{"step": "x", "name": "playbook.initialized", "payload": {}}],
+    )
+
+    assert ok is True
+    assert captured["url"].endswith("/events/batch")
+    body = captured["json"]
+    assert body["execution_id"] == "999999999999999999"
+    assert body["catalog_id"] == 635123456789012345
+
+
+def test_batch_event_emitter_omits_catalog_id_when_unset(monkeypatch):
+    """Backwards compat: a fresh emitter with no ``set_catalog_id`` call
+    omits the field entirely so the server's DB-lookup path keeps its
+    pre-Round-B behaviour."""
+    captured: Dict[str, Any] = {}
+
+    class _Resp:
+        status_code = 202
+
+        @property
+        def text(self):
+            return ""
+
+    class _FakeRequests:
+        @staticmethod
+        def post(url, json=None, timeout=None):
+            captured["json"] = json
+            return _Resp()
+
+    monkeypatch.setitem(sys.modules, "requests", _FakeRequests)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+
+    emitter = agent_executor._make_batch_event_emitter()
+    emitter("777", [{"step": "x", "name": "noop", "payload": {}}])
+
+    assert "catalog_id" not in captured["json"]
+
+
+def test_batch_event_emitter_warns_after_repeated_failures(monkeypatch):
+    """Round B Phase D was masked because every emission failed silently
+    at DEBUG.  The emitter must upgrade to WARNING after three
+    consecutive failures so the silent-drop class of bug becomes
+    visible in logs.
+
+    Uses a direct ``logging.Handler`` rather than ``caplog`` because the
+    executor's custom ``setup_logger`` configures handlers that don't
+    propagate to the root logger that ``caplog`` attaches to."""
+    import logging
+
+    class _FailingRequests:
+        @staticmethod
+        def post(url, json=None, timeout=None):
+            raise RuntimeError("simulated network blip")
+
+    monkeypatch.setitem(sys.modules, "requests", _FailingRequests)
+    monkeypatch.setenv("NOETL_SERVER_URL", "http://noetl.test:8082")
+
+    captured_records: list = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured_records.append(record)
+
+    handler = _Capture(level=logging.WARNING)
+    target_logger = agent_executor.logger
+    prior_level = target_logger.level
+    target_logger.addHandler(handler)
+    target_logger.setLevel(logging.DEBUG)
+    try:
+        emitter = agent_executor._make_batch_event_emitter()
+        for _ in range(4):
+            emitter("111", [{"step": "x", "name": "noop", "payload": {}}])
+    finally:
+        target_logger.removeHandler(handler)
+        target_logger.setLevel(prior_level)
+
+    warning_records = [r for r in captured_records if r.levelno >= logging.WARNING]
+    assert warning_records, (
+        "expected at least one WARNING-level log from the batch emitter "
+        f"after 4 consecutive failures; got: "
+        f"{[r.levelname for r in captured_records]!r}"
+    )
+    # The message should reference the consecutive-failures counter.
+    assert any("consecutive_failures" in r.getMessage() for r in warning_records)


### PR DESCRIPTION
## Production bug — Round B inline runner could never write events on GKE

The Round B runner was emitting events the server rejects. ``_safe_emit`` swallowed every 500 at DEBUG, so nothing surfaced in operator-visible logs. Phase D vertex-ai-stub smoke didn't catch this because that playbook's tool result was *also* shaped wrong, but the wrapper-level smoke (parent's call.done envelope-data) was driven by ``run_inline``'s return value rather than the event log — so it appeared to succeed.

When the itinerary-planner SPA exercised the full agent chain, the silent event drops caused the orchestrator to hang on ``Muno is planning...`` with no diagnostic.

## Three compounding defects

| # | Symptom | Cause |
|---|---|---|
| 1 | `payload.result includes unsupported keys: playbook_path, workload` | `_emit_init_events` spread these into `result` |
| 2 | `payload.result includes unsupported keys: data, id` | `_emit_workflow_completed` spread tool result dict into `result` |
| 3 | `null value in column "catalog_id" of relation "event_*"` | Runner never propagated parent's catalog_id; server's DB lookup returns None for inline children (no prior event rows) |

All three are gated by `_STRICT_RESULT_ALLOWED_KEYS = {"status", "reference", "context", "command_id"}` in `noetl/server/api/core/events.py:_validate_reference_only_payload` + the NOT NULL `catalog_id` column constraint.

## Server-side change

`BatchEventRequest` accepts an optional `catalog_id`. `_persist_batch_acceptance` uses it as a fallback when the per-execution DB lookup returns `None`. The DB-discovered value wins when present (cross-batch rows stay consistent).

## Worker-side changes

### `_BatchEventEmitter` class

Replaces the closure-style emitter in `executor.py`. Exposes `set_catalog_id` so `run_inline` can wire the parent's catalog_id through. Sends `catalog_id` in the POST body when set.

**Silent-drop guard**: persistent emission failures upgrade from DEBUG to WARNING at `consecutive_failures >= 3`. The Phase D lesson is encoded so future regressions surface in operator logs.

### `execute_agent_task` wiring

Extracts the parent's `catalog_id` from `context.catalog_id` (the worker drops it there at `nats_worker.py:1926`), wires it through both the emitter and `run_inline`.

### `run_inline` signature

Adds `parent_catalog_id: Optional[int] = None`. Calls `set_catalog_id` on emitters that expose the mutator. Falls back gracefully for legacy 2-arg callable emitters (existing tests build those).

### Event payload schema fixes

- `_emit_init_events`: `workload` and `playbook_path` move from `payload.result` → `payload.meta`. `payload.result` becomes `{"status": "INITIALIZED"}` (schema-compliant).
- `_emit_workflow_completed`: wraps the tool result inside `payload.result.context`. Downstream readers reach the payload at `result.context.*` — the same shape the dispatched path's `call.done` chain produces. Status reuses the tool's own status when present.
- Other emit functions (`_emit_step_enter`, `_emit_step_exit`, `_emit_step_error`, `_emit_cancelled_events`, `_emit_workflow_failed`) were already schema-compliant — no `payload.result` key on those.

## Tests

130 tests pass across inline-runner, agent-executor, and sanitize suites.

**New tests in `tests/core/workflow/test_inline_runner.py`** (5 cases):
- `test_inline_runner_emitted_events_comply_with_strict_payload_schema` — asserts every emitted event obeys `_STRICT_RESULT_ALLOWED_KEYS`.
- `test_inline_runner_workflow_completed_wraps_tool_result_in_context`.
- `test_inline_runner_init_events_move_workload_into_meta`.
- `test_inline_runner_passes_parent_catalog_id_to_emitter`.
- `test_inline_runner_legacy_emitter_without_set_catalog_id_still_works`.

**New tests in `tests/tools/test_agent_executor.py`** (3 cases):
- `test_batch_event_emitter_sends_catalog_id_in_request_body`.
- `test_batch_event_emitter_omits_catalog_id_when_unset` (backwards compat).
- `test_batch_event_emitter_warns_after_repeated_failures` (the silent-drop guard).

## Cluster status

GKE `noetl-demo-19700101` is currently on `NOETL_INLINE_TRIVIAL_CHILDREN=off` via `kubectl set env` on the worker deployment (emergency revert). Login + itinerary-planner flow work.

## What needs to happen after merge

- [ ] Pointer bump in ai-meta.
- [ ] Rebuild image off the new `main`, redeploy GKE.
- [ ] Re-flip worker to `NOETL_INLINE_TRIVIAL_CHILDREN=enforce`.
- [ ] Run the itinerary-planner flow end-to-end. Check server logs for any 500s on `/api/events/batch` — there should be **none**.
- [ ] If that passes, the cluster stays on `enforce` durably via the existing ConfigMap-backed value from `noetl/ops#119`.

## Related

- Round B runner feature: noetl#612.
- Phase D fixes already merged: #613 (catalog version=latest), #614 (uuid4 bigint), #615 (terminal result envelope), #616 (cancellation probe).
- Sanitize alias passthrough: #617, #618.
- Ops chart-backed enforce mode: noetl/ops#119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)