### PR TITLE
fix(outbox): publish JSON over NATS, not arrow-feather bytes

### DIFF
--- a/noetl/core/outbox.py
+++ b/noetl/core/outbox.py
@@ -160,7 +160,27 @@ async def publish_outbox_batch(
     limit: int = 100,
     publisher: NATSEventPublisher | None = None,
 ) -> int:
-    """Publish one claimed outbox batch to the configured event distribution stream."""
+    """Publish one claimed outbox batch to the configured event distribution stream.
+
+    All NATS payloads are published as JSON via ``publish_event``, regardless of
+    whether ``payload_bytes`` (arrow-feather) is present in the outbox row.
+
+    Background: ``enqueue_outbox`` always writes an arrow-feather encoded copy of
+    the event into ``payload_bytes`` for projector fan-out consumers that read the
+    outbox table directly.  The previous code sent those raw bytes over NATS as
+    well, which caused the gateway (``src/playbook_state.rs``, ``serde_json::from_slice``)
+    to log 438 "Failed to parse lifecycle NATS payload as JSON" warnings and never
+    deliver a ``playbook/state`` SSE frame to the SPA.
+
+    The projector's NATS consumer (``noetl/core/projector/nats_worker.py``,
+    ``decode_projector_notification``) already handles both JSON and arrow-feather
+    (JSON first, feather fallback), so switching to JSON here does not break it.
+    The arrow-feather bytes remain available in the ``payload_bytes`` DB column for
+    any reader that queries the outbox table directly.
+
+    Fix introduced: kadyapam/outbox-nats-publish-json (2026-05-27).
+    Root-cause chain: round-02 of handoff 2026-05-27-itinerary-planner-spa-hang.
+    """
 
     rows = await claim_outbox_batch(limit=limit)
     if not rows:
@@ -170,13 +190,10 @@ async def publish_outbox_batch(
     for row in rows:
         try:
             payload = row.get("payload") or {}
-            subject = row.get("subject")
-            payload_bytes = row.get("payload_bytes")
-            if subject and payload_bytes:
-                await event_publisher.ensure_connected()
-                await event_publisher._publish_event_payload(subject, bytes(payload_bytes))
-            else:
-                await event_publisher.publish_event(payload)
+            # Always publish JSON over NATS. The JSONB ``payload`` column is the
+            # source of truth for the event envelope; ``payload_bytes`` stays in
+            # the DB for direct-table readers (projector fan-out) only.
+            await event_publisher.publish_event(payload)
             await mark_outbox_published(int(row["outbox_id"]))
             published += 1
         except Exception as exc:

--- a/tests/core/test_outbox.py
+++ b/tests/core/test_outbox.py
@@ -126,32 +126,47 @@ async def test_publish_outbox_batch_publishes_and_marks(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_publish_outbox_batch_uses_preencoded_bytes_when_subject_exists(monkeypatch):
+async def test_publish_outbox_batch_publishes_json_even_when_payload_bytes_present(monkeypatch):
+    """Regression test: outbox rows that carry both ``payload`` (JSONB) and
+    ``payload_bytes`` (arrow-feather) must be published over NATS as JSON, not
+    as raw arrow-feather bytes.
+
+    The gateway (``src/playbook_state.rs``) uses ``serde_json::from_slice`` to
+    parse NATS payloads.  Publishing arrow-feather bytes caused 438 parse failures
+    in production and zero ``playbook/state`` SSE frames reaching the SPA.
+
+    Fix: ``publish_outbox_batch`` always calls ``publish_event(payload)`` which
+    JSON-encodes the JSONB column.  The arrow-feather bytes remain in the DB for
+    direct-table readers; they are never sent over NATS.
+    """
+    import json
+
     import noetl.core.outbox as outbox
 
+    event_payload = {"event_id": 101, "execution_id": 7, "event_type": "playbook.completed"}
     claim_rows = [
         {
             "outbox_id": 1,
             "event_id": 101,
             "execution_id": 7,
             "subject": "noetl.events.default.default.7.0",
-            "payload": {"event_id": 101},
-            "payload_bytes": b"ARROW1...",
+            "payload": event_payload,
+            "payload_bytes": b"ARROW1...",  # arrow-feather bytes must NOT go to NATS
             "attempts": 1,
         }
     ]
-    sent = []
+    published = []
     marked = []
 
     class Publisher:
-        async def ensure_connected(self):
-            sent.append(("connected", None))
+        async def _publish_event_payload(self, subject, payload):  # pragma: no cover
+            raise AssertionError(
+                "arrow-feather path must not be used for NATS publish; "
+                f"received subject={subject!r} payload_prefix={payload[:8]!r}"
+            )
 
-        async def _publish_event_payload(self, subject, payload):
-            sent.append((subject, payload))
-
-        async def publish_event(self, event):  # pragma: no cover - fallback must not run
-            raise AssertionError(f"unexpected fallback publish: {event}")
+        async def publish_event(self, event):
+            published.append(event)
 
     async def fake_claim(*, limit):
         return claim_rows
@@ -165,11 +180,12 @@ async def test_publish_outbox_batch_uses_preencoded_bytes_when_subject_exists(mo
     count = await outbox.publish_outbox_batch(limit=10, publisher=Publisher())
 
     assert count == 1
-    assert sent == [
-        ("connected", None),
-        ("noetl.events.default.default.7.0", b"ARROW1..."),
-    ]
     assert marked == [1]
+
+    # Verify the published payload round-trips through JSON (it is JSON-serialisable).
+    assert len(published) == 1
+    assert json.dumps(published[0])  # must not raise
+    assert published[0].get("event_type") == "playbook.completed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 🔴 Final piece of the SPA hang fix chain

This PR is round-02 of the SPA-hang investigation. After PRs #12 + #120 fixed the gateway's NATS subject + parser, events now reach the gateway on the correct subject — but the gateway logs 438 `Failed to parse lifecycle NATS payload as JSON` warnings on every chat turn and zero `playbook/state` SSE frames reach the SPA.

## Root cause

`publish_outbox_batch` at [`noetl/core/outbox.py:170-181`](https://github.com/noetl/noetl/blob/main/noetl/core/outbox.py) sent `payload_bytes` (arrow-feather encoded) directly over NATS whenever the outbox row had it set. `enqueue_outbox` always populates that column, so every outbox-driven NATS message was binary.

The gateway's playbook_state listener at [`repos/gateway/src/playbook_state.rs:29`](https://github.com/noetl/gateway/blob/main/src/playbook_state.rs) parses NATS payloads with `serde_json::from_slice` — JSON only. Captured live on the `noetl-demo-19700101` GKE cluster:

```
noetl.outbox: 442 rows, 438 PUBLISHED to NATS as arrow-feather
gateway: 438 "Failed to parse lifecycle NATS payload as JSON" warnings, 0 successful state messages
```

The Muno "planning…" hang traces back to this single line in `publish_outbox_batch`.

## Fix

Always call `publish_event(payload)` instead of `_publish_event_payload(subject, payload_bytes)`. `publish_event` JSON-encodes the JSONB `payload` column.

## Consumer audit

The fix is safe — verified across the monorepo:

| Consumer | Format expected | Behavior change |
|---|---|---|
| **Gateway** `playbook_state.rs` | JSON only | ✓ Was broken on arrow-feather; now works |
| **Projector** `core/projector/nats_worker.py::decode_projector_notification` | JSON + arrow-feather (JSON first, feather fallback) | ✓ Still works |
| Any other `noetl.events.*` subscriber | — | None found |

The arrow-feather bytes remain written to the `noetl.outbox.payload_bytes` column for any consumer that reads the outbox table directly. Only the NATS wire format changes.

## Tests

```
uv run pytest tests/core/test_outbox.py -q
→ 5 passed
```

The existing `test_publish_outbox_batch_uses_preencoded_bytes_when_subject_exists` is **renamed** to `test_publish_outbox_batch_publishes_json_even_when_payload_bytes_present` and rewritten as a tripwire: the mock's `_publish_event_payload` raises `AssertionError` if invoked. A future regression to the arrow-feather wire format would fail loudly instead of silently breaking SSE.

## Rollout plan

This PR alone does not fix production. After merging:

1. CI publishes v2.102.8 to PyPI.
2. Rebuild noetl image off `main`.
3. `helm upgrade noetl` on GKE with the new image tag.
4. Verify gateway logs show `playbook/state` messages flowing instead of `Failed to parse` warnings.
5. Retry the SPA chat at `travel.mestumre.dev` — expecting the date_range_picker widget to appear.

User has signalled they need this in production by morning. This PR's merge → rebuild → redeploy is the unblock path.

## Related

- Round-02 handoff prompt: [`handoffs/active/2026-05-27-itinerary-planner-spa-hang/round-02-prompt.md`](https://github.com/noetl/ai-meta/blob/main/handoffs/active/2026-05-27-itinerary-planner-spa-hang/round-02-prompt.md)
- Predecessor chain in this same session:
  - noetl#617 / #618 — sanitize alias passthrough (login)
  - noetl#619 — runner event-emit schema + catalog_id + silent-drop guard
  - noetl/gateway#12 — NATS subject parser shape
  - noetl/ops#120 — `NATS_UPDATES_SUBJECT_PREFIX="noetl.events."`
- Also outstanding from the session:
  - noetl/ops#121 — chart-backed `NOETL_EVENT_MIRROR_ENABLED=true` (HOLD until full DB schema bump prereq is solved on Cloud SQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)