### PR TITLE
fix(render): TaskResultProxy falls back to context for stripped fields

### DIFF
--- a/noetl/core/dsl/render.py
+++ b/noetl/core/dsl/render.py
@@ -100,6 +100,36 @@ class TaskResultProxy:
         if isinstance(data, dict) and name in data:
             return _wrap(data[name])
 
+        # Fall back to ``data["context"][name]`` for fields that the
+        # producer set at the top level of its result envelope but
+        # ``ExecutionState.to_dict()`` later stripped during state
+        # compaction.  The compaction at ``state.py`` keeps only
+        # ``status`` / ``reference`` / ``context`` / scalars at the
+        # top level — every dict-valued field gets dropped.  The
+        # producer's full output is preserved under ``context`` by
+        # the ``mark_step_completed`` writer (it adds the alias
+        # ``result = {**result, "context": dict(result)}``).  Without
+        # this fallback, ``{{ step.dict_field }}`` resolves correctly
+        # in-process but fails the first time the state is reloaded
+        # from the ``execution.state`` JSONB — which is exactly the
+        # path hit between command issuance and template rendering
+        # for subsequent steps.
+        #
+        # See the 2026-05-27 travel itinerary-planner empty-widget
+        # diagnostic for the failure mode: ``normalize_input``
+        # writes ``input_event: {...}`` at the top level, the state
+        # is persisted, the dict is dropped, ``extract_turn`` renders
+        # ``{{ normalize_input.input_event }}`` against the compacted
+        # shape and gets ``Undefined`` — extraction silently falls
+        # through to the generic ``bot_text`` widget and the SPA's
+        # Searches sidebar stays empty.
+        if (
+            isinstance(data, dict)
+            and isinstance(data.get("context"), dict)
+            and name in data["context"]
+        ):
+            return _wrap(data["context"][name])
+
         # On-demand resolution from shared cache (TempStore):
         # When the dict has a reference but not the requested field,
         # resolve the reference and cache the result for this proxy instance.

--- a/tests/unit/dsl/test_render_reference_only.py
+++ b/tests/unit/dsl/test_render_reference_only.py
@@ -12,7 +12,17 @@ def test_task_result_proxy_exposes_canonical_data_and_rejects_result_alias():
         _ = proxy.result
 
 
-def test_task_result_proxy_does_not_flatten_context_keys_to_top_level():
+def test_task_result_proxy_falls_back_to_context_for_attribute_access():
+    # ``ExecutionState.to_dict()`` compacts persisted step_results by
+    # stripping top-level dict-valued fields and keeping the producer's
+    # full output only under ``context`` (the alias added by
+    # ``mark_step_completed``).  The proxy must therefore resolve
+    # ``step.field`` against ``data["context"][field]`` when the field
+    # is no longer at the top level after a state reload.  Without
+    # this fallback, ``{{ normalize_input.input_event }}`` (and any
+    # other dict-valued producer field) silently renders to
+    # ``Undefined`` on the second and subsequent template renders
+    # within an execution.
     proxy = TaskResultProxy(
         {
             "status": "COMPLETED",
@@ -20,9 +30,64 @@ def test_task_result_proxy_does_not_flatten_context_keys_to_top_level():
         }
     )
 
-    with pytest.raises(AttributeError):
-        _ = proxy.facility_mapping_id
-    with pytest.raises(KeyError):
-        _ = proxy["facility_mapping_id"]
-
+    assert proxy.facility_mapping_id == 46
     assert proxy.context.facility_mapping_id == 46
+
+
+def test_task_result_proxy_context_fallback_prefers_top_level():
+    # Top-level lookup wins over ``context.<name>`` when both exist.
+    # This guards against a producer that intentionally puts a
+    # different value at the top level than under ``context``.
+    proxy = TaskResultProxy(
+        {
+            "status": "COMPLETED",
+            "thread_path": "top-level-path",
+            "context": {"thread_path": "context-path"},
+        }
+    )
+
+    assert proxy.thread_path == "top-level-path"
+
+
+def test_task_result_proxy_compacted_step_result_resolves_dict_field():
+    # Regression: the muno itinerary-planner playbook's ``normalize_input``
+    # step writes ``input_event: {...}`` at the top level.  The
+    # ``mark_step_completed`` writer aliases the full dict under
+    # ``context``; the compaction layer then strips the top-level
+    # ``input_event`` dict on the next state persist.  After the
+    # reload, the proxy still has to make
+    # ``{{ normalize_input.input_event }}`` resolve.
+    compacted_normalize_input = {
+        "status": "COMPLETED",
+        "thread_path": "chat_threads/travel-ui-x-y",
+        "thread_id": "travel-ui-x-y",
+        "event_type": "user_message",
+        "replay": False,
+        "context": {
+            "thread_path": "chat_threads/travel-ui-x-y",
+            "thread_id": "travel-ui-x-y",
+            "event_type": "user_message",
+            "event_payload": {"text": "trip to paris"},
+            "input_event": {
+                "type": "user_message",
+                "payload": {"text": "trip to paris"},
+                "actor": {"kind": "user", "uid": "guest"},
+            },
+            "replay": False,
+        },
+    }
+    proxy = TaskResultProxy(compacted_normalize_input)
+
+    # Scalar fields surviving compaction at top level.
+    assert proxy.thread_path == "chat_threads/travel-ui-x-y"
+    assert proxy.event_type == "user_message"
+
+    # Dict fields stripped by compaction, resolvable via context
+    # fallback.  ``input_event`` is the field that previously rendered
+    # to ``Undefined`` and broke the extract_turn LLM call.
+    input_event = proxy.input_event
+    assert input_event["type"] == "user_message"
+    assert input_event["payload"]["text"] == "trip to paris"
+
+    event_payload = proxy.event_payload
+    assert event_payload["text"] == "trip to paris"


### PR DESCRIPTION
## Summary

`ExecutionState.to_dict()` compacts persisted `step_results` by keeping only `status` / `reference` / `context` / scalars at the top level — every dict-valued top-level field gets dropped to keep the `execution.state` JSONB bounded. The producer's full output is preserved under `context` by `mark_step_completed` (the alias `result = {**result, "context": dict(result)}`).

Without a fallback in `TaskResultProxy.__getattr__`, a template like `{{ step.dict_field }}` resolves in-process while the step result is fresh, then silently renders to `Undefined` once the state is reloaded from JSONB — exactly the path between command issuance and template rendering for every subsequent step.

## Production failure mode

The muno itinerary-planner playbook surfaced this:

1. `normalize_input` writes `input_event: {...}` (a dict) at the top level of its result.
2. `mark_step_completed` aliases the dict under `context`.
3. `ExecutionState.to_dict()` strips top-level `input_event` during the next state persist (it's a dict, not in the keep-list).
4. `extract_turn` runs on the next worker, reloads state, renders `{{ normalize_input.input_event }}` against `{status, context: {input_event: {...}, ...}}`.
5. Proxy raises `AttributeError` → Jinja `Undefined` → `extract_turn` python step runs with empty event → LLM extraction silently no-ops → `render_widget_chat` produces the generic `bot_text` fallback `"I can help plan the trip from here."` → SPA Searches sidebar stays empty.

Full diagnostic trace: ai-meta `handoffs/archive/2026-05-27-itinerary-planner-spa-hang/round-04-result.md` follow-up section.

## Fix

When the top-level lookup misses and `data["context"]` is a dict containing `name`, return `data["context"][name]`. Top-level wins on collision so a producer that intentionally puts a different value at the top level keeps the explicit shape.

This changes the policy from the March 2026 strict refactor (`b2fd0519`) which had the proxy reject `step.foo` when `foo` lived only under `context`. The strict-only test is replaced by three regression tests pinned to the new policy:

- top-level lookup wins over `context.<name>` on collision,
- the muno itinerary compacted shape resolves `input_event` via the fallback,
- `proxy.context.<name>` still works for the explicit path.

## Test plan

- [x] `pytest tests/unit/dsl/test_render_reference_only.py -v` — 4 pass.
- [x] `pytest tests/unit/dsl/ -q` — 89 pass, no regressions.
- [ ] After merge + deploy, exercise a muno chat turn on `travel.mestumre.dev` and confirm the SPA renders a real itinerary widget (not the `bot_text` fallback) and the Searches sidebar populates.
- [ ] Confirm `Template rendering error: 'TaskResultProxy object' has no attribute 'input_event'` no longer fires in noetl-server logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)