### PR TITLE
fix(worker): preserve widget envelope payload in control-context projection

### DIFF
--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -726,6 +726,37 @@ class Worker:
                     decision = self._preserve_recursive_control_value(child["inline_decision"])
                     if decision is not None:
                         nested["inline_decision"] = decision
+                # Widget envelope contract — the `payload` field of a
+                # widget envelope is the control-plane render config
+                # (date-picker bounds, party-picker maxes, place-
+                # autocomplete suggestions, button labels, …) that the
+                # SPA's WidgetRenderer dispatches on, NOT a data-plane
+                # payload like rows or response bodies.  Without this
+                # carve-out the universal `payload` blocklist strips
+                # the render config and the SPA's `isWidgetEnvelope`
+                # check fails (it requires `isRecord(value.payload)`),
+                # so the chat renders the bot_message as plain
+                # `Typography` and the widget never appears.  Surfaced
+                # in production via the muno itinerary-planner
+                # ``date_range_picker`` regression: the playbook emits
+                # ``first_widget.payload`` with min_date/max_date/…, the
+                # worker dropped it here, the chat thread fell back to
+                # text-only output.  See ai-meta
+                # ``handoffs/archive/2026-05-27-itinerary-planner-empty-widget/``
+                # for the broader empty-widget arc.
+                #
+                # Detect a widget envelope by structural fingerprint
+                # (`schema_version == 1`, str `widget_type`, dict
+                # `payload`) so unrelated `payload` keys carrying data-
+                # plane content remain blocked.
+                if (
+                    child.get("schema_version") == 1
+                    and isinstance(child.get("widget_type"), str)
+                    and isinstance(child.get("payload"), dict)
+                ):
+                    widget_payload = self._preserve_recursive_control_value(child["payload"])
+                    if isinstance(widget_payload, dict):
+                        nested["payload"] = widget_payload
                 if nested:
                     context[key_str] = nested
 

--- a/tests/worker/test_control_context_projection.py
+++ b/tests/worker/test_control_context_projection.py
@@ -421,3 +421,101 @@ def test_meta_without_inline_decision_does_not_synthesize_meta_key():
 
     assert projected["status"] == "ok"
     assert "meta" not in projected
+
+
+def test_widget_envelope_payload_survives_projection():
+    """The travel itinerary-planner playbook emits widget envelopes shaped
+    as ``{schema_version: 1, widget_type: <str>, variant: <str>, payload:
+    <dict>}`` and the SPA's WidgetRenderer requires the nested ``payload``
+    dict (it dispatches on ``isWidgetEnvelope`` which checks
+    ``isRecord(value.payload)``).  Without the widget-envelope carve-out,
+    the universal ``payload`` entry in ``blocked_keys`` and the
+    nested-scalars-only filter together strip the render config and the
+    chat falls back to plain-text output.  Regression for the muno
+    ``date_range_picker`` symptom — see ai-meta
+    ``handoffs/archive/2026-05-27-itinerary-planner-empty-widget/``.
+    """
+    worker = _worker()
+    projected = worker._extract_control_context(
+        {
+            "bot_message": "Pick the travel dates.",
+            "first_widget": {
+                "schema_version": 1,
+                "widget_type": "date_range_picker",
+                "variant": "compact",
+                "payload": {
+                    "min_date": "2026-05-27",
+                    "max_date": "2027-05-27",
+                    "default_from": "2026-06-17",
+                    "default_to": "2026-06-21",
+                    "locale": "en",
+                    "submit": "submit",
+                },
+            },
+        }
+    )
+
+    first = projected["first_widget"]
+    assert first["schema_version"] == 1
+    assert first["widget_type"] == "date_range_picker"
+    assert first["variant"] == "compact"
+    payload = first["payload"]
+    assert payload["min_date"] == "2026-05-27"
+    assert payload["max_date"] == "2027-05-27"
+    assert payload["default_from"] == "2026-06-17"
+    assert payload["default_to"] == "2026-06-21"
+    assert payload["locale"] == "en"
+    assert payload["submit"] == "submit"
+
+
+def test_widget_envelope_carve_out_only_fires_for_envelope_shape():
+    """The carve-out is structurally targeted — only triggers when the
+    child carries ``schema_version == 1`` AND a str ``widget_type`` AND a
+    dict ``payload``.  Unrelated dicts that happen to have a ``payload``
+    key keep being stripped (the universal data-plane block stands).
+    """
+    worker = _worker()
+    projected = worker._extract_control_context(
+        {
+            "looks_like_widget_but_isnt": {
+                # No schema_version + no widget_type → not a widget envelope.
+                "payload": {"nested": "value"},
+                "label": "scalar-keeps",
+            },
+        }
+    )
+
+    assert projected["looks_like_widget_but_isnt"] == {"label": "scalar-keeps"}
+
+
+def test_widget_envelope_carve_out_preserves_nested_lists_in_payload():
+    """``payload`` dicts can carry nested lists (e.g. flight_list items,
+    place autocomplete suggestions).  The recursive preserve helper must
+    round-trip them.
+    """
+    worker = _worker()
+    projected = worker._extract_control_context(
+        {
+            "first_widget": {
+                "schema_version": 1,
+                "widget_type": "place_autocomplete_input",
+                "variant": "default",
+                "payload": {
+                    "placeholder": "Where do you want to go?",
+                    "suggestions": [
+                        {"label": "Miami", "id": "MIA", "kind": "city"},
+                        {"label": "Paris", "id": "PAR", "kind": "city"},
+                    ],
+                    "submit_on_select": True,
+                },
+            },
+        }
+    )
+
+    payload = projected["first_widget"]["payload"]
+    assert payload["placeholder"] == "Where do you want to go?"
+    assert payload["suggestions"] == [
+        {"label": "Miami", "id": "MIA", "kind": "city"},
+        {"label": "Paris", "id": "PAR", "kind": "city"},
+    ]
+    assert payload["submit_on_select"] is True


### PR DESCRIPTION
## Summary

`Worker._extract_control_context` filters step results down to a control-plane subset before they reach the event log:
- Only scalar children of nested dicts survive
- `blocked_keys` (including `payload`) are stripped at every depth — they're for data-plane content like rows / response bodies that belong in TempStore, not the event row

Widget envelopes share the key name but carry **control-plane** render config (date-picker bounds, party-picker maxes, place-autocomplete suggestions, button labels). The SPA's `WidgetRenderer` requires `isRecord(value.payload)`; without the payload the chat falls back to plain text and the widget never appears.

This was the root cause of the muno itinerary-planner empty-widget regression where the right-pane date picker showed up but wasn't openable — the playbook emitted a complete envelope, the worker stripped `payload` here, the stored event had only `{schema_version, widget_type, variant}`, and `isWidgetEnvelope` returned false.

## Fix

Add a fourth carve-out alongside the existing ones (`error.diagnosis`, `render.args`, `meta.inline_decision`). Detect a widget envelope by its structural fingerprint:

- `schema_version == 1`
- `widget_type` is a str
- `payload` is a dict

When all three match, preserve `payload` via `_preserve_recursive_control_value` so nested config (and nested lists like `place_autocomplete_input.suggestions[]`) round-trip cleanly.

Detection is targeted — random dicts with a `payload` key are still stripped (the universal data-plane block stands).

## Evidence

Production reproduction at `2026-05-27T21:44Z`, execution `636284665740919133`:

```
Playbook _env('date_range_picker', 'compact', {
    min_date, max_date, default_from, default_to, locale, submit
})
   ↓
Stored event row's context.first_widget:
   {variant: "compact", widget_type: "date_range_picker", schema_version: 1}
   ← payload field missing
```

SPA's `isWidgetEnvelope` returns false → chat falls back to plain `Typography` → date picker never appears in the message envelope.

## Test plan

- [x] `pytest tests/worker/test_control_context_projection.py -v` — 18 pass (15 existing + 3 new for the widget carve-out).
- [x] `pytest tests/worker/ -q` — 73 pass. The 2 failures in `test_worker_playbook_tool.py` (`FakeResultHandler.process_result()` signature mismatch) reproduce on `main` identically and are unrelated to this change.
- [ ] After merge + noetl image rebuild + helm upgrade, exercise a muno chat turn on `travel.mestumre.dev`. The `date_range_picker` widget should render inline in the assistant message under "Pick the travel dates." — clickable, with the date range submission flowing through to the next turn.

Cross-link: ai-meta `handoffs/archive/2026-05-27-itinerary-planner-empty-widget/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)