### PR TITLE
fix(sanitize): preserve $noetl_ref keychain placeholders in producer scrub

### DIFF
--- a/noetl/core/sanitize.py
+++ b/noetl/core/sanitize.py
@@ -289,6 +289,32 @@ def _is_response_sensitive_key(key: str) -> bool:
     return False
 
 
+def _is_noetl_keychain_placeholder(value: Any) -> bool:
+    """Return ``True`` when ``value`` is a ``$noetl_ref`` keychain reference
+    dict produced by ``render_preserving_keychain_refs``.
+
+    The placeholder shape is:
+
+        {"$noetl_ref": {"kind": "keychain", "name": "<name>", "field": "<field>"}}
+
+    These placeholders are storage-safe by design — they carry the
+    credential's *name* (which is metadata, already in the keychain manifest
+    anyway), not the resolved value.  The worker dereferences them against
+    ``noetl.keychain`` at tool-execution time.  Scrubbers MUST pass them
+    through; redacting them to ``[REDACTED]`` destroys the only signal the
+    worker has that this field needs late-resolution.
+
+    Implemented inline (no import of ``credential_refs``) to avoid a
+    circular dependency between ``sanitize`` and ``credential_refs``.
+    """
+    if not isinstance(value, dict):
+        return False
+    ref = value.get("$noetl_ref")
+    if not isinstance(ref, dict):
+        return False
+    return ref.get("kind") == "keychain"
+
+
 def _redact_response_recursive(
     data: Any,
     additional_keys: Set[str],
@@ -315,7 +341,22 @@ def _redact_response_recursive(
                 # Blind-redact the value regardless of shape — this is
                 # the producer-scrub contract and the response sanitizer
                 # honors it verbatim.
-                result[key] = redaction
+                #
+                # **Exception**: ``$noetl_ref`` keychain placeholder dicts
+                # produced by ``render_preserving_keychain_refs`` are
+                # storage-safe references, not resolved values.  Replacing
+                # them with ``[REDACTED]`` destroys the worker's only
+                # signal that the field needs late-resolution and the
+                # downstream tool ends up with ``Authorization: Bearer
+                # [REDACTED]`` against the upstream API (concrete failure
+                # in noetl/ai-meta#24 — Duffel returned
+                # ``access_token_not_found`` 401 on every dispatch
+                # despite the keychain cache being correctly populated).
+                # Pass the placeholder through so the worker resolves it.
+                if _is_noetl_keychain_placeholder(value):
+                    result[key] = value
+                else:
+                    result[key] = redaction
             elif partial_match_sensitive:
                 # The key name *partial-matches* an entry in
                 # ``SENSITIVE_KEYS`` / ``RESPONSE_SENSITIVE_KEYS`` but
@@ -367,6 +408,11 @@ def _redact_response_recursive(
                         result[key] = redaction
                     else:
                         result[key] = value
+                elif _is_noetl_keychain_placeholder(value):
+                    # Storage-safe $noetl_ref placeholder; preserve so
+                    # the worker can resolve.  See the blind-redact
+                    # branch above for the failure case this prevents.
+                    result[key] = value
                 elif isinstance(value, (dict, list, tuple)):
                     result[key] = redaction
                 else:

--- a/tests/core/test_redact_keychain_values.py
+++ b/tests/core/test_redact_keychain_values.py
@@ -183,3 +183,102 @@ def test_render_context_workload_with_aliases_and_real_secret():
     assert redacted["workload"]["nats_credential"] == "nats_user"
     assert redacted["workload"]["auth0_token"] == REDACTED
     assert redacted["workload"]["request_id"] == "abc-123"
+
+
+def test_preserves_noetl_ref_placeholder_under_blind_redact_key():
+    """``$noetl_ref`` keychain placeholders must survive blind-redact branch.
+
+    Regression test for noetl/ai-meta#24 — the producer scrub previously
+    replaced ``{"duffel_token": {"$noetl_ref": ...}}`` with
+    ``{"duffel_token": "[REDACTED]"}`` because the key ``duffel_token``
+    was in ``additional_keys`` (derived from the keychain manifest).
+    The worker then received a string sentinel where the placeholder
+    dict should have been, sent ``Authorization: Bearer [REDACTED]``
+    to Duffel, and got ``access_token_not_found`` 401 on every dispatch.
+    """
+    payload = {
+        "duffel_token": {
+            "$noetl_ref": {
+                "kind": "keychain",
+                "name": "duffel_token",
+                "field": "token",
+            }
+        }
+    }
+
+    redacted = redact_keychain_values(payload, additional_keys={"duffel_token"})
+
+    assert redacted["duffel_token"] == payload["duffel_token"]
+
+
+def test_preserves_noetl_ref_placeholder_under_partial_match_key():
+    """Same preservation contract for the partial-match-sensitive branch.
+
+    ``access_token`` is partial-match-sensitive via the ``token``
+    substring rule.  When the value is a ``$noetl_ref`` placeholder
+    (e.g. amadeus's ``{{ keychain.amadeus_token.access_token }}``
+    encoded via ``render_preserving_keychain_refs``) the redactor
+    used to replace it with ``[REDACTED]``.  Now it passes through.
+    """
+    payload = {
+        "access_token": {
+            "$noetl_ref": {
+                "kind": "keychain",
+                "name": "amadeus_token",
+                "field": "access_token",
+            }
+        }
+    }
+
+    # No additional_keys — the partial-match branch handles ``access_token``
+    # via the substring rule.
+    redacted = redact_keychain_values(payload)
+
+    assert redacted["access_token"] == payload["access_token"]
+
+
+def test_still_redacts_resolved_token_string_under_blind_redact_key():
+    """Real credential values must still be redacted — the preservation
+    only applies to ``$noetl_ref`` placeholder dicts.
+    """
+    payload = {
+        "duffel_token": "duffel_test_resolvedSecretValue",
+    }
+
+    redacted = redact_keychain_values(payload, additional_keys={"duffel_token"})
+
+    assert redacted["duffel_token"] == REDACTED
+
+
+def test_redacts_noetl_ref_with_non_keychain_kind():
+    """Only ``kind: keychain`` placeholders survive.  Other ``$noetl_ref``
+    shapes (if any are introduced later) must be redacted by default
+    until they're explicitly opted into the preservation list.
+    """
+    payload = {
+        "duffel_token": {
+            "$noetl_ref": {
+                "kind": "something_else",
+                "name": "foo",
+            }
+        }
+    }
+
+    redacted = redact_keychain_values(payload, additional_keys={"duffel_token"})
+
+    assert redacted["duffel_token"] == REDACTED
+
+
+def test_redacts_dict_without_noetl_ref_under_blind_redact_key():
+    """Any other dict shape under a blind-redact key is still redacted
+    — the preservation is narrow to the placeholder contract.
+    """
+    payload = {
+        "duffel_token": {
+            "nested": "leaked-token-value",
+        }
+    }
+
+    redacted = redact_keychain_values(payload, additional_keys={"duffel_token"})
+
+    assert redacted["duffel_token"] == REDACTED


### PR DESCRIPTION
## Summary

Follow-up to #624 — that PR's worker-side resolver fix was necessary but not sufficient. After #624 shipped to GKE and the noetl image was rebuilt + Helm-rolled out (catalog v13, image `keychain-resolver-20260528145825`), Duffel dispatches still returned `access_token_not_found` 401. Investigation found the producer scrub destroys the `$noetl_ref` placeholder before it reaches the worker.

## Diagnostic

Fetched the offloaded `tool_config` blob via `default_store.resolve(noetl://execution/<id>/result/duffel_dispatch_tool_config/<hash>)` from inside a running worker pod:

```json
{
  "input": {
    "duffel_token": "[REDACTED]",
    ...
  }
}
```

→ It's the literal string `"[REDACTED]"`, not the `{"$noetl_ref": {"kind": "keychain", ...}}` dict that `render_preserving_keychain_refs` produces. `populate_keychain_context`'s scanner sees a string with no `keychain.` substring and no `$noetl_ref` dict → exits early → worker sends `Authorization: Bearer [REDACTED]` to Duffel.

## Root cause

`producer_scrub_payload` (in `core/credential_refs.py`) feeds the keychain manifest's names into `redact_keychain_values` as `additional_keys`. `_redact_response_recursive` then hits the `caller_blind_redact` branch and replaces the **value** (the `$noetl_ref` dict) with the redaction sentinel **regardless of shape**. The branch's docstring says it honors the additional_keys list verbatim — correct when the value is an actual credential string, but destructive when the value is the storage-safe placeholder that exists precisely to avoid storing the credential.

## Fix

`noetl/core/sanitize.py`:

1. New `_is_noetl_keychain_placeholder(value)` helper (inline shape check, no import of `credential_refs` to avoid a circular dep).
2. Both the `caller_blind_redact` branch and the partial-match branch of `_redact_response_recursive` check the value against `_is_noetl_keychain_placeholder` BEFORE replacing. Pass placeholders through unchanged.
3. Only `kind: "keychain"` placeholders survive. Any other `$noetl_ref` kind (if introduced later) still redacts by default.

10 lines of logic + one new helper. No refactoring of adjacent code.

## Tests

Five new regression tests in `tests/core/test_redact_keychain_values.py`:

- `test_preserves_noetl_ref_placeholder_under_blind_redact_key` — the primary regression test for the Duffel failure.
- `test_preserves_noetl_ref_placeholder_under_partial_match_key` — amadeus-style.
- `test_still_redacts_resolved_token_string_under_blind_redact_key` — actual credential strings still redact (no security regression).
- `test_redacts_noetl_ref_with_non_keychain_kind` — only `kind: "keychain"` preserved; future `$noetl_ref` shapes still redact by default.
- `test_redacts_dict_without_noetl_ref_under_blind_redact_key` — generic dicts under sensitive keys still redact.

All 25 tests in the file pass (20 pre-existing + 5 new).

## Test plan

- [x] `pytest tests/core/test_redact_keychain_values.py -v` — 25/25 ✓
- [ ] After merge: rebuild noetl image, Helm rollout, smoke `noetl exec catalog://automation/agents/mcp/duffel ... get_airlines` — should return airline rows, `noetl.keychain.access_count` should increment for the duffel_token cache row, worker logs should show `KEYCHAIN: Resolved 'duffel_token' successfully`.
- [ ] Same smoke against amadeus to confirm no regression.
- [ ] Check `noetl/ai-meta#20` (REDACTED NameError in google-places dispatch) — likely the same root cause, may auto-resolve.

## Related

- Follow-up to #624 (worker-side resolver fix).
- Refs noetl/ai-meta#24 (umbrella).
- Refs noetl/ai-meta#21 (Duffel rotation — auto-unblocks).
- Refs noetl/ai-meta#20 (google-places NameError — suspected same root cause).
- noetl/ops#125 (playbook-side `kind: credential_ref` fix — already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)