### PR TITLE
feat(batch): per-phase timing instrumentation in batch.completed context

### DIFF
--- a/noetl/core/dsl/engine/executor/events.py
+++ b/noetl/core/dsl/engine/executor/events.py
@@ -251,12 +251,63 @@ class EventHandlingMixin:
             )
             return None
 
-    async def handle_event(self, event: Event, conn=None, already_persisted: bool = False) -> list[Command]:
+    async def handle_event(
+        self,
+        event: Event,
+        conn=None,
+        already_persisted: bool = False,
+        timing_capture: Optional[dict] = None,
+    ) -> list[Command]:
+        """Public entry point.  Thin wrapper around ``_handle_event_inner`` that
+        captures per-phase wall-clock when the caller passes in a
+        ``timing_capture`` dict (see noetl/ai-meta#29 for the profiling brief).
+
+        Args:
+            event: The event to process.
+            already_persisted: If True, skip persisting the event (it was already
+                persisted by caller).
+            timing_capture: Optional dict; when supplied, populated with per-phase
+                wall-clock measurements in milliseconds.  Currently emits:
+
+                - ``state_load_ms``: wall-clock for the initial state read
+                  (``load_state_for_update`` for the batch path,
+                  ``load_state`` for the unlocked path, plus any cache-
+                  refresh re-read).
+                - ``engine_total_ms``: wall-clock for this entire
+                  ``handle_event`` invocation, captured at function exit.
+
+                ``engine_walk_ms`` can be inferred as
+                ``engine_total_ms - state_load_ms`` and aggregates the
+                DSL state-machine walk plus all ``save_state`` calls
+                made during this invocation.  A future PR may split
+                ``state_save_ms`` out into its own field.
+        """
+        engine_start_ts = time.perf_counter()
+        try:
+            return await self._handle_event_inner(
+                event,
+                conn=conn,
+                already_persisted=already_persisted,
+                timing_capture=timing_capture,
+            )
+        finally:
+            if timing_capture is not None:
+                timing_capture["engine_total_ms"] = round(
+                    (time.perf_counter() - engine_start_ts) * 1000, 3
+                )
+
+    async def _handle_event_inner(
+        self,
+        event: Event,
+        conn=None,
+        already_persisted: bool = False,
+        timing_capture: Optional[dict] = None,
+    ) -> list[Command]:
         """
         Handle an event and return commands to enqueue.
-        
+
         This is the core engine method called by the API.
-        
+
         Args:
             event: The event to process
             already_persisted: If True, skip persisting the event (it was already persisted by caller)
@@ -274,9 +325,10 @@ class EventHandlingMixin:
         normalized_payload = _unwrap_event_payload(event.payload)
         preserved_loop_snapshots: dict[str, dict[str, Any]] = {}
         cache_refreshed = False
-        
 
 
+
+        state_load_start = time.perf_counter()
         if conn:
             state = await self.state_store.load_state_for_update(event.execution_id, conn)
         else:
@@ -293,6 +345,10 @@ class EventHandlingMixin:
                 )
                 state = await self.state_store.load_state(event.execution_id)
                 cache_refreshed = True
+        if timing_capture is not None:
+            timing_capture["state_load_ms"] = round(
+                (time.perf_counter() - state_load_start) * 1000, 3
+            )
         if not state:
             logger.error(f"Execution state not found: {event.execution_id}")
             return commands

--- a/noetl/server/api/core/batch.py
+++ b/noetl/server/api/core/batch.py
@@ -423,22 +423,86 @@ async def _issue_commands_for_batch(job: _BatchAcceptJob, commands: list) -> Non
     publish_items = [(p["execution_id"], p["evt_id"], p["cmd_id"], p["step"]) for p in prepared_commands]
     await _publish_commands_with_recovery(publish_items, server_url=server_url)
 
-async def _process_accepted_batch(job: _BatchAcceptJob) -> int:
+async def _process_accepted_batch(
+    job: _BatchAcceptJob,
+    timing_capture: Optional[dict] = None,
+) -> int:
+    """Run the batch's engine pass + command issuance.
+
+    When ``timing_capture`` is supplied (the dispatcher passes a dict from
+    ``_process_batch_job``), populate per-phase wall-clock measurements in
+    milliseconds.  See noetl/ai-meta#29 for the profiling brief.  Phases
+    captured at this layer:
+
+      - ``pool_checkout_ms``: wall-clock for ``get_pool_connection`` to
+        return a usable connection.  Reflects pool saturation.
+      - ``lock_acquire_ms``: wall-clock for the
+        ``pg_advisory_xact_lock(execution_id)`` SQL.  Reflects lock
+        contention against other batches for the same execution.
+      - ``engine_total_ms`` + ``state_load_ms``: populated by
+        ``engine.handle_event`` itself via the same ``timing_capture``
+        dict.  See that method's docstring for definitions.
+      - ``issue_commands_ms``: wall-clock for ``_issue_commands_for_batch``.
+      - ``commit_ms``: wall-clock for the transaction commit (measured as
+        the time spent inside the ``engine_conn.transaction()`` __aexit__
+        after ``engine.handle_event`` returns).
+      - ``actionable_event``: ``True`` when ``last_actionable_event`` was
+        non-None and the engine ran; ``False`` for batches that were
+        accepted but had nothing actionable (the fast no-op path).
+    """
     from .events import _invalidate_execution_state_cache
     commands = []
     engine = None
     if job.last_actionable_event:
         engine = get_engine()
+        if timing_capture is not None:
+            timing_capture["actionable_event"] = True
+        pool_start = time.perf_counter()
         async with get_pool_connection() as engine_conn:
+            if timing_capture is not None:
+                timing_capture["pool_checkout_ms"] = round(
+                    (time.perf_counter() - pool_start) * 1000, 3
+                )
+            tx_start = time.perf_counter()
             async with engine_conn.transaction():
                 async with engine_conn.cursor() as cur:
                     await cur.execute(f"SET LOCAL statement_timeout = {int(_BATCH_PROCESSING_STATEMENT_TIMEOUT_MS)}"); await cur.execute(f"SET LOCAL idle_in_transaction_session_timeout = {int(_BATCH_PROCESSING_STATEMENT_TIMEOUT_MS)}")
+                    lock_start = time.perf_counter()
                     await cur.execute("SELECT pg_advisory_xact_lock(%s)", (int(job.last_actionable_event.execution_id),))
-                    commands = await engine.handle_event(job.last_actionable_event, conn=engine_conn, already_persisted=True)
+                    if timing_capture is not None:
+                        timing_capture["lock_acquire_ms"] = round(
+                            (time.perf_counter() - lock_start) * 1000, 3
+                        )
+                    commands = await engine.handle_event(
+                        job.last_actionable_event,
+                        conn=engine_conn,
+                        already_persisted=True,
+                        timing_capture=timing_capture,
+                    )
+                    engine_done_ts = time.perf_counter()
+            if timing_capture is not None:
+                # Time between engine.handle_event returning and transaction
+                # commit completing — captures COMMIT wall-clock (writes any
+                # dirtied state JSONB + advisory-lock release + flush).
+                timing_capture["commit_ms"] = round(
+                    (time.perf_counter() - engine_done_ts) * 1000, 3
+                )
+                # Total time inside the engine_conn.transaction() block.
+                timing_capture["transaction_ms"] = round(
+                    (time.perf_counter() - tx_start) * 1000, 3
+                )
+    elif timing_capture is not None:
+        timing_capture["actionable_event"] = False
+    issue_start = time.perf_counter()
     try: await _issue_commands_for_batch(job, commands)
     except Exception as e:
         if engine and commands: await _invalidate_execution_state_cache(str(job.execution_id), reason=f"batch_command_issue_failed:{type(e).__name__}", engine=engine)
         raise
+    finally:
+        if timing_capture is not None:
+            timing_capture["issue_commands_ms"] = round(
+                (time.perf_counter() - issue_start) * 1000, 3
+            )
     return len(commands)
 
 def _drain_contiguous_jobs_for_execution(execution_id: int) -> list[_BatchAcceptJob]:
@@ -474,14 +538,20 @@ async def _process_batch_job(job: _BatchAcceptJob) -> None:
         },
     )
     p_start = time.perf_counter()
+    # Per-phase timing breakdown for noetl/ai-meta#29.  Populated by
+    # ``_process_accepted_batch`` + ``engine.handle_event``.  Always-on,
+    # low-overhead (~microseconds per perf_counter call).  Operators
+    # can read the breakdown directly off the ``batch.completed``
+    # event's ``context`` JSONB.
+    timing_capture: dict = {}
     try:
         if _BATCH_PROCESSING_TIMEOUT_SECONDS > 0:
             cmd_gen = await asyncio.wait_for(
-                _process_accepted_batch(job),
+                _process_accepted_batch(job, timing_capture=timing_capture),
                 timeout=_BATCH_PROCESSING_TIMEOUT_SECONDS,
             )
         else:
-            cmd_gen = await _process_accepted_batch(job)
+            cmd_gen = await _process_accepted_batch(job, timing_capture=timing_capture)
     except asyncio.TimeoutError:
         _inc_batch_metric("processing_timeout_total")
         await _persist_batch_failed_event(
@@ -494,13 +564,28 @@ async def _process_batch_job(job: _BatchAcceptJob) -> None:
     p_sec = time.perf_counter() - p_start
     if p_sec > _BATCH_PROCESSING_WARN_SECONDS:
         logger.warning(
-            "[BATCH-EVENTS] Slow async batch processing request_id=%s exec_id=%s event_count=%s p_sec=%.3f cmd_gen=%s",
+            "[BATCH-EVENTS] Slow async batch processing request_id=%s exec_id=%s event_count=%s p_sec=%.3f cmd_gen=%s timing=%s",
             job.request_id,
             job.execution_id,
             len(job.events),
             p_sec,
             cmd_gen,
+            timing_capture,
         )
+    completed_context: dict = {
+        "request_id": job.request_id,
+        "commands_generated": cmd_gen,
+        "processing_ms": round(p_sec * 1000, 3),
+    }
+    if timing_capture:
+        # Promote each captured phase into the event context.  Existing
+        # consumers reading ``processing_ms`` / ``commands_generated``
+        # see the same fields; new operators can now read
+        # ``state_load_ms`` / ``engine_total_ms`` / ``pool_checkout_ms``
+        # / ``lock_acquire_ms`` / ``issue_commands_ms`` / ``commit_ms``
+        # / ``transaction_ms`` / ``actionable_event`` to localise
+        # per-execution finalization cost.  See noetl/ai-meta#29.
+        completed_context.update(timing_capture)
     await _persist_batch_status_event(
         job.execution_id,
         job.catalog_id,
@@ -509,11 +594,7 @@ async def _process_batch_job(job: _BatchAcceptJob) -> None:
         job.idempotency_key,
         "batch.completed",
         "COMPLETED",
-        {
-            "request_id": job.request_id,
-            "commands_generated": cmd_gen,
-            "processing_ms": round(p_sec * 1000, 3),
-        },
+        completed_context,
     )
 
 async def _batch_accept_worker_loop(worker_idx: int) -> None:


### PR DESCRIPTION
## Summary

First step of [noetl/ai-meta#29](https://github.com/noetl/ai-meta/issues/29).  Adds always-on, low-overhead per-phase wall-clock capture so the actual hot zone inside the **~180–1400ms final-batch tail** every execution incurs becomes auditable directly off the `batch.completed` event's `context` JSONB.

**No behavior change; pure observability.**  `processing_ms` and `commands_generated` continue to land in the context exactly as before.  Existing consumers see no difference.

## What the new fields measure

Promoted into the `batch.completed` event's `context` JSONB (in addition to the existing `processing_ms` + `commands_generated`):

| Field | What it measures |
|---|---|
| `pool_checkout_ms` | `get_pool_connection` wait time.  Reflects pool saturation. |
| `lock_acquire_ms` | `pg_advisory_xact_lock(execution_id)` SQL wall-clock.  Reflects lock contention against concurrent batches for the same execution. |
| `state_load_ms` | Wall-clock for the initial state read (`load_state_for_update` on the batch path; includes JSONB parse + playbook re-load).  **Hypothesized as the dominant hot zone** per the brief. |
| `engine_total_ms` | Total wall-clock inside `engine.handle_event` (captured via try/finally in a thin wrapper, so every return path lands the measurement). |
| `commit_ms` | Wall-clock between `engine.handle_event` returning and the transaction commit completing (covers state JSONB write + advisory-lock release + flush). |
| `transaction_ms` | Total time inside `engine_conn.transaction()`. |
| `issue_commands_ms` | `_issue_commands_for_batch` wall-clock. |
| `actionable_event` | `True` when `last_actionable_event` was non-None and the engine ran; `False` for the fast no-op path. |

`engine_walk_ms` (DSL state-machine walk + all `save_state` writes during this invocation) can be inferred at query time as `engine_total_ms - state_load_ms`.  A future PR may split `state_save_ms` out into its own field.

## Implementation

`batch.py`:

- `_process_accepted_batch` grew an optional `timing_capture: dict` parameter.  When supplied, captures the phase fields above and passes the dict through into `engine.handle_event`.
- `_process_batch_job` allocates the dict before invoking `_process_accepted_batch` and promotes every captured field into the `batch.completed` event's context.  The pre-existing `processing_ms` + `commands_generated` fields stay verbatim.
- Slow-batch warning log line (fires when `p_sec` exceeds `NOETL_BATCH_PROCESSING_WARN_SECONDS`, default 15s) now appends the timing dict so an operator triaging the rare slow case has the breakdown in the log line without needing to query `noetl.event`.

`events.py`:

- `handle_event` refactored into a thin wrapper around the existing body (renamed to `_handle_event_inner`).  Wrapper captures `engine_total_ms` in a try/finally so every return path lands the measurement.
- `_handle_event_inner` captures `state_load_ms` around the initial `state_store.load_state{,for_update}` call.

The other `engine.handle_event` caller (`events.py:402` — the synchronous events ingestion path) was left untouched; it doesn't pass `timing_capture`, so behavior is identical to today.  A follow-up can wire it through if we want symmetric measurement.

## Cost

- ~5 `perf_counter` calls per batch (microseconds).
- Memory: small dict (~8 fields × <100 bytes each).
- Safe to leave on permanently.

## Verification recipe (operators run after this lands)

```sql
SELECT execution_id,
       (result->'context'->>'processing_ms')::double precision    AS pms,
       (result->'context'->>'state_load_ms')::double precision    AS sl,
       (result->'context'->>'engine_total_ms')::double precision  AS et,
       (result->'context'->>'commit_ms')::double precision        AS cm,
       (result->'context'->>'pool_checkout_ms')::double precision AS pc,
       (result->'context'->>'lock_acquire_ms')::double precision  AS la
FROM noetl.event
WHERE event_type = 'batch.completed'
  AND created_at > NOW() - INTERVAL '30 minutes'
ORDER BY pms DESC
LIMIT 20;
```

The dominant column out of the first 100 captured batches tells us which mitigation candidate from [noetl/ai-meta#29](https://github.com/noetl/ai-meta/issues/29) to ship next:

| Dominant field | Mitigation to prioritize |
|---|---|
| `state_load_ms` close to `engine_total_ms` | Either slim the state JSONB, or skip the load entirely on terminal-event fast paths. |
| `engine_walk_ms` (inferred) close to `engine_total_ms` | DSL state-machine walk dominates — terminal-event fast path is the right lever. |
| `commit_ms` substantial | State writeback dominates — investigate write coalescing across drained jobs. |
| `pool_checkout_ms` substantial | Pool saturation — bump pool size or investigate hold-time. |
| `lock_acquire_ms` substantial | Lock contention — investigate whether terminal-event batches even need the lock. |

## Test plan

- [x] `pytest tests/unit/dsl/engine/test_engine.py` — 11 pass
- [x] `pytest tests/api/test_batch_event_mirror.py` — 11 pass + 1 pre-existing failure on `main` unrelated to these changes (`replay/service.py:685` — `'stage-1'` parsed as int; reproduces clean on `main` HEAD `5389757f`).
- [ ] After merge + image rebuild + GKE rollout: run the verification SQL above against a 30-min sample of `noetl.event` rows and pick the first mitigation PR from #29.
- [ ] Confirm no new fields cause downstream consumers (event-projector, batch-mirror, gateway forwarders) to choke on the larger context JSONB.

## Related

- Refs [noetl/ai-meta#29](https://github.com/noetl/ai-meta/issues/29) — profiling brief with mitigation candidates.
- Acceptance line on #29 explicitly calls out this PR's shape ("per-phase timing fields to the `batch.completed` context payload, always-on, low-overhead").

🤖 Generated with [Claude Code](https://claude.com/claude-code)