### PR TITLE
perf(batch): terminal-event fast path skips state JSONB rewrite

### DIFF
--- a/noetl/core/dsl/engine/executor/events.py
+++ b/noetl/core/dsl/engine/executor/events.py
@@ -384,7 +384,18 @@ class EventHandlingMixin:
             )
             if not already_persisted:
                 await self._persist_event_compat(event, state, conn=conn)
-                await self.state_store.save_state(state, conn)
+                # Terminal-event fast path.  state is unchanged — completion
+                # was already persisted when the execution first reached
+                # this terminal status.  Skip the heavy state-JSONB rewrite
+                # (which dominates the no-op batch.completed tail; see
+                # noetl/ai-meta#29) and only advance last_event_id so
+                # cache-staleness checks and replay consumers see the new
+                # event ordering.
+                await self.state_store.save_state_terminal_lightweight(
+                    state.execution_id,
+                    state.last_event_id,
+                    conn=conn,
+                )
             return commands
         
         # Get current step

--- a/noetl/core/dsl/engine/executor/store.py
+++ b/noetl/core/dsl/engine/executor/store.py
@@ -249,6 +249,46 @@ class StateStore:
 
         logger.debug(f"[STATE-SAVE] State saved to Postgres for execution {state.execution_id}")
 
+    async def save_state_terminal_lightweight(
+        self,
+        execution_id: Any,
+        last_event_id: Optional[int],
+        conn=None,
+    ) -> None:
+        """Lightweight save for already-terminal executions.
+
+        When an event arrives for an execution that is already
+        ``state.completed`` on entry to ``Engine._handle_event_inner``, the
+        state JSONB is unchanged — status is already terminal, step_results
+        will not be touched, end_time was set when the execution first
+        completed. The full ``save_state`` UPDATE rewrites the state column
+        anyway, which for orchestrator executions means re-serializing and
+        re-TOASTing a potentially-megabyte-sized blob on every late-arriving
+        event. That's the dominant cost in the no-op batch.completed tail
+        documented in noetl/ai-meta#29 (engine_total_ms = 1237ms while
+        state_load_ms = 5ms and issue_commands_ms = 0).
+
+        This method advances only ``last_event_id`` + ``updated_at``, which
+        is all the state-store cache layer + replay consumers need to
+        invalidate any cached state and observe the event ordering. The
+        terminal-event fast path in ``Engine._handle_event_inner`` calls it
+        instead of the full ``save_state`` for terminal re-entries.
+        """
+        sql = """
+            UPDATE noetl.execution
+            SET updated_at = CURRENT_TIMESTAMP,
+                last_event_id = GREATEST(COALESCE(last_event_id, 0), %s)
+            WHERE execution_id = %s
+        """
+        params = (int(last_event_id or 0), int(execution_id))
+        if conn is None:
+            async with get_pool_connection() as c:
+                async with c.cursor() as cur:
+                    await cur.execute(sql, params)
+        else:
+            async with conn.cursor() as cur:
+                await cur.execute(sql, params)
+
     async def should_refresh_cached_state(self, execution_id: str, last_event_id: Optional[int], allowed_missing_events: int = 1) -> bool:
         return False
 

--- a/tests/unit/dsl/engine/test_engine.py
+++ b/tests/unit/dsl/engine/test_engine.py
@@ -485,3 +485,93 @@ workflow:
     # TempStore is not mocked — that's an integration test concern)
     context = state.get_render_context(Event(execution_id=execution_id, step="process_rows", name="loop_init"))
     assert context["claim_rows"]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_terminal_event_skips_heavy_state_save(engine_setup, monkeypatch):
+    """Re-entry against an already-completed execution must take the
+    terminal-event fast path: persist the event, advance last_event_id via
+    ``save_state_terminal_lightweight``, and skip the full ``save_state``
+    JSONB rewrite. See noetl/ai-meta#29 for the timing data motivating this
+    fast path."""
+    engine, playbook_repo, state_store = engine_setup
+
+    playbook = _make_minimal_playbook("terminal_re_entry")
+    state = ExecutionState(
+        execution_id="200000000000022222",
+        playbook=playbook,
+        payload={},
+    )
+    # Pretend the execution is already terminal on entry.
+    state.completed = True
+    state.last_event_id = 4242
+
+    monkeypatch.setattr(state_store, "load_state", AsyncMock(return_value=state))
+    monkeypatch.setattr(state_store, "load_state_for_update", AsyncMock(return_value=state))
+    full_save = AsyncMock(return_value=None)
+    lightweight_save = AsyncMock(return_value=None)
+    monkeypatch.setattr(state_store, "save_state", full_save)
+    monkeypatch.setattr(state_store, "save_state_terminal_lightweight", lightweight_save)
+    persist_compat = AsyncMock(return_value=None)
+    monkeypatch.setattr(engine, "_persist_event_compat", persist_compat)
+
+    event = Event(
+        execution_id="200000000000022222",
+        step="fetch_data",
+        name="call.done",
+        payload={"result": {"ok": True}},
+    )
+
+    commands = await engine.handle_event(event, already_persisted=False)
+
+    assert commands == []
+    # The terminal-event fast path must persist the event (event-sourcing
+    # log is append-only) but skip the heavy state JSONB rewrite.
+    persist_compat.assert_awaited_once()
+    full_save.assert_not_awaited()
+    lightweight_save.assert_awaited_once()
+    args, kwargs = lightweight_save.call_args
+    # save_state_terminal_lightweight(execution_id, last_event_id, conn=...)
+    assert args[0] == state.execution_id
+    assert args[1] == state.last_event_id
+
+
+@pytest.mark.asyncio
+async def test_terminal_event_already_persisted_does_not_double_save(engine_setup, monkeypatch):
+    """When ``already_persisted=True`` (the batch.completed -> handle_event
+    path), the terminal-event branch must NOT call save_state at all
+    (heavy or lightweight) — the event is already in the log and no state
+    has changed."""
+    engine, playbook_repo, state_store = engine_setup
+
+    playbook = _make_minimal_playbook("terminal_already_persisted")
+    state = ExecutionState(
+        execution_id="200000000000022223",
+        playbook=playbook,
+        payload={},
+    )
+    state.completed = True
+    state.last_event_id = 9999
+
+    monkeypatch.setattr(state_store, "load_state", AsyncMock(return_value=state))
+    monkeypatch.setattr(state_store, "load_state_for_update", AsyncMock(return_value=state))
+    full_save = AsyncMock(return_value=None)
+    lightweight_save = AsyncMock(return_value=None)
+    monkeypatch.setattr(state_store, "save_state", full_save)
+    monkeypatch.setattr(state_store, "save_state_terminal_lightweight", lightweight_save)
+    persist_compat = AsyncMock(return_value=None)
+    monkeypatch.setattr(engine, "_persist_event_compat", persist_compat)
+
+    event = Event(
+        execution_id="200000000000022223",
+        step="fetch_data",
+        name="call.done",
+        payload={"result": {"ok": True}},
+    )
+
+    commands = await engine.handle_event(event, already_persisted=True)
+
+    assert commands == []
+    persist_compat.assert_not_awaited()
+    full_save.assert_not_awaited()
+    lightweight_save.assert_not_awaited()


### PR DESCRIPTION
## Summary

Round-2 mitigation PR for [noetl/ai-meta#29](https://github.com/noetl/ai-meta/issues/29) (per-execution `batch.completed` tail latency). Follows the [round-1 instrumentation PR #629](https://github.com/noetl/noetl/pull/629) which exposed `state_load_ms` / `engine_total_ms` / `issue_commands_ms` etc. in the `batch.completed` event context.

The round-1 measurement (n=84 events on GKE) showed:

- `state_load_ms` is **flat ~3–7ms** across the entire population (p90=11ms). NOT the hot zone.
- The worst no-op tail (`commands_generated=0`, `processing_ms=1261ms`) has `engine_total_ms=1237ms`, `state_load_ms=5ms`, `issue_commands_ms=0`. So ~1227ms is being burned **inside** `_handle_event_inner` between state load and the final commit, with no commands generated.

That work is the `state.completed` early-return branch (`noetl/core/dsl/engine/executor/events.py` lines 378-388) which still runs `_persist_event_compat` + `state_store.save_state` on the already-completed execution. `save_state` rewrites the full state JSONB on every call — for orchestrator executions that's a megabyte-sized TOAST rewrite, repeated on every late-arriving event.

## What this changes

- Adds `StateStore.save_state_terminal_lightweight(execution_id, last_event_id, conn)` — an UPDATE that touches only `last_event_id` + `updated_at`. No `state` column write, no `to_dict()` serialization, no `json.dumps` of the megabyte blob.
- Replaces the `save_state` call in the terminal-event branch of `_handle_event_inner` with the lightweight variant.
- Leaves every other `save_state` call site untouched (main orchestration loop, recovery arcs, completion emission) because state genuinely changes there.

## Why this is safe

- Status is already terminal (`COMPLETED` / `FAILED` / `CANCELLED`) — the full `save_state` SQL has a `CASE WHEN status IN ('COMPLETED','FAILED','CANCELLED') THEN status ELSE EXCLUDED.status END` guard, so the status column wouldn't change anyway.
- `end_time` was set when the execution first reached terminal — same `CASE WHEN end_time IS NULL ...` guard means subsequent calls don't update it.
- `state` JSONB is unchanged because the terminal branch sets no fields on `state` before returning.
- `last_event_id` still advances via `GREATEST(...)` so cache-staleness checks (`should_refresh_cached_state`) and replay consumers observe the new event ordering.
- `_persist_event_compat` still runs — the event-sourcing log is append-only and the late event still goes in.

## Tests

Two new tests in `tests/unit/dsl/engine/test_engine.py`:

- `test_terminal_event_skips_heavy_state_save` — `state.completed=True`, `already_persisted=False`: must call `save_state_terminal_lightweight` (not `save_state`) with the expected `execution_id` + `last_event_id`.
- `test_terminal_event_already_persisted_does_not_double_save` — `state.completed=True`, `already_persisted=True`: must skip both saves entirely because the event is already in the log.

Full `tests/unit/dsl/engine/` suite (87 tests) passes:

```
87 passed, 86 warnings in 0.87s
```

## Verification after rollout

After this image rolls out on GKE, re-run the same query from #629's body and compare the **NO COMMANDS** column (cg=0) before/after:

```sql
SELECT (result->'context'->>'processing_ms')::double precision AS pms,
       (result->'context'->>'engine_total_ms')::double precision AS et,
       (result->'context'->>'state_load_ms')::double precision AS sl,
       (result->'context'->>'issue_commands_ms')::double precision AS ic,
       (result->'context'->>'commands_generated')::int AS cg
FROM noetl.event
WHERE event_type = 'batch.completed'
  AND created_at > NOW() - INTERVAL '1 hour'
  AND (result->'context'->>'commands_generated')::int = 0
ORDER BY pms DESC NULLS LAST
LIMIT 30
```

Expected: the `engine_total_ms` column collapses toward the `state_load_ms + commit_ms` floor (~10ms) for cg=0 events. The `processing_ms` p90/max for no-op tails should drop from ~210ms / 1261ms to ~20ms.

## Test plan

- [ ] Cloud Build the noetl image for this branch
- [ ] Helm upgrade noetl on GKE
- [ ] Drive 20+ executions (mix of orchestrator + fast-path firestore_mcp calls)
- [ ] Run the verification SQL; compare p50/p90/max of `processing_ms` for cg=0 events
- [ ] Post the before/after table back to noetl/ai-meta#29
- [ ] Close noetl/ai-meta#29 if the no-op tail collapses; otherwise pick the next mitigation from `issue_commands_ms` (the dominant cg>0 cost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes noetl/noetl#631
Refs noetl/ai-meta#29