### PR TITLE
perf(batch): round-3 sub-phase timings for handle_event

### DIFF
--- a/noetl/core/dsl/engine/executor/common.py
+++ b/noetl/core/dsl/engine/executor/common.py
@@ -10,6 +10,7 @@ Event-driven control flow engine that:
 Canonical format only - no case/when/then blocks.
 """
 
+import contextvars
 import logging
 import os
 import time
@@ -883,6 +884,59 @@ class TemplateCache:
         self._hits = 0
         self._misses = 0
         self._evictions = 0
+
+
+# ---------------------------------------------------------------------------
+# Per-event timing capture (round-3 instrumentation, see noetl/ai-meta#29)
+# ---------------------------------------------------------------------------
+#
+# ``Engine.handle_event`` accepts a ``timing_capture`` dict that downstream
+# code populates with per-phase wall-clock measurements.  Threading that dict
+# through every ``save_state`` / ``_persist_event_compat`` call site would
+# touch ~25 callers across ``events.py`` and ``store.py``.  Instead we stash
+# the active dict in a contextvar for the duration of one ``handle_event``
+# invocation, and the timed methods read it back via
+# ``accumulate_engine_phase_ms``.  Concurrent ``handle_event`` calls run on
+# separate asyncio tasks and therefore get independent contextvar values.
+#
+# The contextvar is unset (returns ``None``) outside of a ``handle_event``
+# call, so the accumulators are a no-op for callers that bypass the engine
+# (test fixtures, ad-hoc state writes, etc).
+
+_current_engine_timing_capture: contextvars.ContextVar[Optional[dict]] = (
+    contextvars.ContextVar("noetl_engine_timing_capture", default=None)
+)
+
+
+def get_current_engine_timing_capture() -> Optional[dict]:
+    """Return the timing_capture dict for the active handle_event call."""
+    return _current_engine_timing_capture.get()
+
+
+def bind_engine_timing_capture(timing_capture: Optional[dict]) -> Any:
+    """Bind ``timing_capture`` to the current context; return a reset token."""
+    return _current_engine_timing_capture.set(timing_capture)
+
+
+def unbind_engine_timing_capture(token: Any) -> None:
+    """Restore the previous contextvar value using a bind token."""
+    _current_engine_timing_capture.reset(token)
+
+
+def accumulate_engine_phase_ms(field: str, elapsed_ms: float) -> None:
+    """Add ``elapsed_ms`` to ``timing_capture[field]`` and bump
+    ``timing_capture[field + "_calls"]``.  Silent no-op when no capture is
+    bound (i.e. the caller is not inside ``Engine.handle_event``).
+
+    Multiple call sites for the same ``field`` sum their durations into the
+    single field — operators read the total time spent in that sub-phase
+    across all calls during one event."""
+    capture = _current_engine_timing_capture.get()
+    if capture is None:
+        return
+    capture[field] = round(float(capture.get(field, 0.0)) + float(elapsed_ms), 3)
+    calls_field = field + "_calls"
+    capture[calls_field] = int(capture.get(calls_field, 0)) + 1
 
 
 __all__ = [name for name in globals() if not name.startswith("__")]

--- a/noetl/core/dsl/engine/executor/events.py
+++ b/noetl/core/dsl/engine/executor/events.py
@@ -9,13 +9,26 @@ from .transitions import _get_next_arcs, _get_next_mode
 
 class EventHandlingMixin:
     async def _persist_event_compat(self, event: Event, state: ExecutionState, conn=None):
-        """Call _persist_event while tolerating older monkeypatched test doubles."""
+        """Call _persist_event while tolerating older monkeypatched test doubles.
+
+        Wall-clock for each call is accumulated into the active
+        ``timing_capture`` dict under ``persist_event_compat_ms`` (round-3
+        instrumentation; see noetl/ai-meta#29).  No-op when no capture is
+        bound — i.e. when called outside ``Engine.handle_event``.
+        """
+        t0 = time.perf_counter()
         try:
-            return await self._persist_event(event, state, conn=conn)
-        except TypeError as exc:
-            if "unexpected keyword argument 'conn'" not in str(exc):
-                raise
-            return await self._persist_event(event, state)
+            try:
+                return await self._persist_event(event, state, conn=conn)
+            except TypeError as exc:
+                if "unexpected keyword argument 'conn'" not in str(exc):
+                    raise
+                return await self._persist_event(event, state)
+        finally:
+            accumulate_engine_phase_ms(
+                "persist_event_compat_ms",
+                (time.perf_counter() - t0) * 1000,
+            )
 
     async def _count_durable_pending_commands(self, execution_id: str, conn=None) -> Optional[int]:
         """Return pending command count from noetl.command, or None if unavailable."""
@@ -276,13 +289,30 @@ class EventHandlingMixin:
                 - ``engine_total_ms``: wall-clock for this entire
                   ``handle_event`` invocation, captured at function exit.
 
-                ``engine_walk_ms`` can be inferred as
-                ``engine_total_ms - state_load_ms`` and aggregates the
-                DSL state-machine walk plus all ``save_state`` calls
-                made during this invocation.  A future PR may split
-                ``state_save_ms`` out into its own field.
+                Round-3 (noetl/ai-meta#29) adds three sub-phase
+                accumulators populated automatically when the dict is
+                bound to the active context.  Each sums wall-clock time
+                across every call site inside this invocation:
+
+                - ``save_state_ms`` + ``save_state_ms_calls``
+                - ``save_state_terminal_lightweight_ms`` +
+                  ``save_state_terminal_lightweight_ms_calls``
+                - ``persist_event_compat_ms`` +
+                  ``persist_event_compat_ms_calls``
+
+                ``orchestrate_ms`` (the DSL state-machine walk minus
+                state load and side-effect writes) can be inferred as
+                ``engine_total_ms - state_load_ms - save_state_ms -
+                save_state_terminal_lightweight_ms -
+                persist_event_compat_ms``.
         """
         engine_start_ts = time.perf_counter()
+        # Round-3 instrumentation: bind the timing_capture dict to a
+        # contextvar so save_state / save_state_terminal_lightweight /
+        # _persist_event_compat can accumulate their sub-phase wall-clocks
+        # without threading the dict through every call site.  See
+        # noetl/ai-meta#29.
+        timing_token = bind_engine_timing_capture(timing_capture)
         try:
             return await self._handle_event_inner(
                 event,
@@ -291,6 +321,7 @@ class EventHandlingMixin:
                 timing_capture=timing_capture,
             )
         finally:
+            unbind_engine_timing_capture(timing_token)
             if timing_capture is not None:
                 timing_capture["engine_total_ms"] = round(
                     (time.perf_counter() - engine_start_ts) * 1000, 3

--- a/noetl/core/dsl/engine/executor/store.py
+++ b/noetl/core/dsl/engine/executor/store.py
@@ -128,7 +128,18 @@ class StateStore:
         import logging
         log = logging.getLogger(__name__)
         t0 = time.perf_counter()
-        
+        try:
+            return await self._save_state_inner(state, conn=conn, log=log, t0=t0)
+        finally:
+            # Round-3 instrumentation: sum wall-clock for every save_state
+            # call across one Engine.handle_event invocation into the active
+            # timing_capture (see noetl/ai-meta#29).
+            accumulate_engine_phase_ms(
+                "save_state_ms",
+                (time.perf_counter() - t0) * 1000,
+            )
+
+    async def _save_state_inner(self, state: ExecutionState, conn=None, *, log, t0):
         state_dict = state.to_dict()
         t1 = time.perf_counter()
         
@@ -274,20 +285,31 @@ class StateStore:
         terminal-event fast path in ``Engine._handle_event_inner`` calls it
         instead of the full ``save_state`` for terminal re-entries.
         """
-        sql = """
-            UPDATE noetl.execution
-            SET updated_at = CURRENT_TIMESTAMP,
-                last_event_id = GREATEST(COALESCE(last_event_id, 0), %s)
-            WHERE execution_id = %s
-        """
-        params = (int(last_event_id or 0), int(execution_id))
-        if conn is None:
-            async with get_pool_connection() as c:
-                async with c.cursor() as cur:
+        t0 = time.perf_counter()
+        try:
+            sql = """
+                UPDATE noetl.execution
+                SET updated_at = CURRENT_TIMESTAMP,
+                    last_event_id = GREATEST(COALESCE(last_event_id, 0), %s)
+                WHERE execution_id = %s
+            """
+            params = (int(last_event_id or 0), int(execution_id))
+            if conn is None:
+                async with get_pool_connection() as c:
+                    async with c.cursor() as cur:
+                        await cur.execute(sql, params)
+            else:
+                async with conn.cursor() as cur:
                     await cur.execute(sql, params)
-        else:
-            async with conn.cursor() as cur:
-                await cur.execute(sql, params)
+        finally:
+            # Round-3 instrumentation: track time spent in the terminal-
+            # event fast path separately from the heavy save_state so we
+            # can see the patch's effect (or lack thereof) in
+            # batch.completed context (see noetl/ai-meta#29).
+            accumulate_engine_phase_ms(
+                "save_state_terminal_lightweight_ms",
+                (time.perf_counter() - t0) * 1000,
+            )
 
     async def should_refresh_cached_state(self, execution_id: str, last_event_id: Optional[int], allowed_missing_events: int = 1) -> bool:
         return False

--- a/tests/unit/dsl/engine/test_engine.py
+++ b/tests/unit/dsl/engine/test_engine.py
@@ -575,3 +575,110 @@ async def test_terminal_event_already_persisted_does_not_double_save(engine_setu
     persist_compat.assert_not_awaited()
     full_save.assert_not_awaited()
     lightweight_save.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_timing_capture_accumulates_subphases(engine_setup, monkeypatch):
+    """Round-3 instrumentation: handle_event binds the timing_capture dict
+    to a contextvar so save_state / _persist_event_compat accumulate their
+    wall-clock into the dict.  See noetl/ai-meta#29."""
+    from noetl.core.dsl.engine.executor.common import (
+        accumulate_engine_phase_ms,
+        bind_engine_timing_capture,
+        get_current_engine_timing_capture,
+        unbind_engine_timing_capture,
+    )
+
+    engine, _playbook_repo, state_store = engine_setup
+
+    # When no capture is bound, accumulators are silent.
+    assert get_current_engine_timing_capture() is None
+    accumulate_engine_phase_ms("save_state_ms", 12.34)  # no-op, no crash
+
+    capture: dict = {}
+    token = bind_engine_timing_capture(capture)
+    try:
+        accumulate_engine_phase_ms("save_state_ms", 12.34)
+        accumulate_engine_phase_ms("save_state_ms", 7.66)  # second call accumulates
+        accumulate_engine_phase_ms("persist_event_compat_ms", 3.5)
+    finally:
+        unbind_engine_timing_capture(token)
+
+    assert capture["save_state_ms"] == 20.0
+    assert capture["save_state_ms_calls"] == 2
+    assert capture["persist_event_compat_ms"] == 3.5
+    assert capture["persist_event_compat_ms_calls"] == 1
+    # Contextvar is restored after unbind.
+    assert get_current_engine_timing_capture() is None
+
+
+@pytest.mark.asyncio
+async def test_handle_event_populates_subphase_timings(engine_setup, monkeypatch):
+    """End-to-end: handle_event with a timing_capture dict and a happy-path
+    event must populate persist_event_compat_ms + save_state_ms (with
+    matching _calls counters) by the time the wrapper returns."""
+    engine, playbook_repo, state_store = engine_setup
+
+    yaml_content = """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: subphase_timing_test
+
+workflow:
+  - step: start
+    tool:
+      kind: python
+      code: "def main(): return {'ok': True}"
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: end
+          when: "{{ event.name == 'call.done' }}"
+
+  - step: end
+    tool:
+      kind: python
+      code: "def main(): return {'done': True}"
+"""
+    playbook = DSLParser().parse(yaml_content)
+    state = ExecutionState(
+        execution_id="200000000000033333",
+        playbook=playbook,
+        payload={},
+    )
+    monkeypatch.setattr(state_store, "load_state", AsyncMock(return_value=state))
+    monkeypatch.setattr(state_store, "load_state_for_update", AsyncMock(return_value=state))
+    # save_state and _persist_event are real method calls — the accumulators
+    # fire from inside the methods themselves.  We replace the underlying
+    # IO with no-ops so the tests don't need a database.
+    monkeypatch.setattr(state_store, "_save_state_inner", AsyncMock(return_value=None))
+    engine._persist_event = AsyncMock(return_value=None)
+
+    event = Event(
+        execution_id="200000000000033333",
+        step="start",
+        name="call.done",
+        payload={"result": {"ok": True}},
+    )
+
+    capture: dict = {}
+    # Drive with already_persisted=False so the inbound event itself flows
+    # through _persist_event_compat — that exercises both accumulators in
+    # a single handle_event call.
+    commands = await engine.handle_event(event, already_persisted=False, timing_capture=capture)
+
+    assert [c.step for c in commands] == ["end"]
+    # The wrapper always populates engine_total_ms.
+    assert "engine_total_ms" in capture
+    # state_load_ms comes from _handle_event_inner.
+    assert "state_load_ms" in capture
+    # Round-3 sub-phases: both accumulators must have fired on the happy
+    # path.  Wall-clock can be vanishingly small with mocked IO so we
+    # check the *_calls counter for the existence assertion and the *_ms
+    # field for non-negativity.
+    assert capture.get("save_state_ms_calls", 0) >= 1
+    assert capture.get("save_state_ms", -1) >= 0
+    assert capture.get("persist_event_compat_ms_calls", 0) >= 1
+    assert capture.get("persist_event_compat_ms", -1) >= 0


### PR DESCRIPTION
## Summary

Round-3 instrumentation PR for [noetl/ai-meta#29](https://github.com/noetl/ai-meta/issues/29) and its sub-issue [noetl/noetl#632](https://github.com/noetl/noetl/issues/632).  Follows up [#629](https://github.com/noetl/noetl/pull/629) (per-batch timings) and [#630](https://github.com/noetl/noetl/pull/630) (terminal-event fast path).

[Round-2 verification on GKE](https://github.com/noetl/ai-meta/issues/29#issuecomment-4578523595) showed that the dominant cg=0 `batch.completed` tail is **not** the terminal-event re-entry branch — that branch had 0 log hits during the verification window. The bulk of the `engine_total_ms - state_load_ms` budget lives in the main orchestration path (state.completed=False on entry, commands=[] on exit) and the existing `engine_total_ms` collapses three very different costs into one number.

This PR splits the budget so the next mitigation can pick itself from production data.

## New fields in `batch.completed.context`

- `save_state_ms` + `save_state_ms_calls` — total time across all `StateStore.save_state` calls within one `handle_event` invocation.
- `save_state_terminal_lightweight_ms` + `save_state_terminal_lightweight_ms_calls` — time in the #630 lightweight UPDATE.  Separately tracked so #630's effect is visible in production data.
- `persist_event_compat_ms` + `persist_event_compat_ms_calls` — time in the event-log INSERT across all call sites.

`orchestrate_ms` can be inferred client-side as `engine_total_ms - state_load_ms - save_state_ms - save_state_terminal_lightweight_ms - persist_event_compat_ms`.

## Implementation

`timing_capture` is bound to a `contextvars.ContextVar` for the duration of one `handle_event` call.  The wrapped methods read it in a `finally:` block and accumulate via `accumulate_engine_phase_ms(field, elapsed_ms)`.  Concurrent `handle_event` calls run on separate asyncio tasks and get independent contextvar values.  When no capture is bound (test fixtures, ad-hoc writes from outside the engine), the accumulators are a silent no-op — no overhead, no allocation.

This sidesteps the ~25 call-site touch that a thread-the-dict approach would have required.

## Tests

Two new tests in `tests/unit/dsl/engine/test_engine.py`:

- `test_timing_capture_accumulates_subphases` — direct test of the `bind` / `accumulate` / `unbind` plumbing, including the silent-no-op behavior when no dict is bound.
- `test_handle_event_populates_subphase_timings` — end-to-end: `handle_event` against a real playbook DSL with mocked IO produces non-zero `*_calls` counters for both new accumulators by the time the wrapper returns.

Full `tests/unit/dsl/engine/` (89 tests, +2 from round 2) passes:

```
89 passed, 88 warnings in 0.90s
```

## Verification after rollout

```sql
SELECT (result->'context'->>'commands_generated')::int AS cg,
       COUNT(*) AS n,
       ROUND((PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY (result->'context'->>'engine_total_ms')::double precision))::numeric, 2) AS et_p90,
       ROUND((PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY (result->'context'->>'save_state_ms')::double precision))::numeric, 2) AS ss_p90,
       ROUND((PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY (result->'context'->>'persist_event_compat_ms')::double precision))::numeric, 2) AS pec_p90,
       ROUND(AVG((result->'context'->>'save_state_ms_calls')::int)::numeric, 2) AS ss_calls_avg,
       ROUND(AVG((result->'context'->>'persist_event_compat_ms_calls')::int)::numeric, 2) AS pec_calls_avg
FROM noetl.event
WHERE event_type = 'batch.completed'
  AND created_at > NOW() - INTERVAL '1 hour'
  AND (result->'context'->>'save_state_ms') IS NOT NULL
GROUP BY 1
ORDER BY 1;
```

The dominant `*_ms` column out of the first 100 captured batches tells us the round-4 mitigation target:

| Dominant column | Round-4 target |
|---|---|
| `save_state_ms` | Skip-if-state-unchanged guard on the main `save_state` path (same shape as #630 but on the main branch). |
| `persist_event_compat_ms` | Batch the event-log inserts when one `handle_event` emits multiple events. |
| `orchestrate_ms` (residual) | Profile the DSL state-machine walk itself — likely the playbook-cache / arc-evaluation hot zone. |

Closes noetl/noetl#632
Refs noetl/ai-meta#29

🤖 Generated with [Claude Code](https://claude.com/claude-code)