### PR TITLE
perf(batch): batch cascade event INSERTs in handle_event

### DIFF
--- a/noetl/core/dsl/engine/executor/events.py
+++ b/noetl/core/dsl/engine/executor/events.py
@@ -543,9 +543,6 @@ class EventHandlingMixin:
                         timestamp=datetime.now(timezone.utc),
                         parent_event_id=state.last_event_id
                     )
-                    await self._persist_event_compat(workflow_completion_event, state, conn=conn)
-                    logger.info(f"Workflow completed (after inline task): execution_id={event.execution_id}")
-
                     playbook_completion_event = Event(
                         execution_id=event.execution_id,
                         step=state.playbook.metadata.get("path", "playbook"),
@@ -557,10 +554,21 @@ class EventHandlingMixin:
                             error=None
                         ).model_dump(),
                         timestamp=datetime.now(timezone.utc),
-                        parent_event_id=state.last_event_id
+                        parent_event_id=None,  # chained by _persist_cascade_events
                     )
-                    await self._persist_event_compat(playbook_completion_event, state, conn=conn)
-                    logger.info(f"Playbook completed (after inline task): execution_id={event.execution_id}")
+                    # Round-4 (noetl/ai-meta#29): batch the cascading
+                    # workflow + playbook completion INSERTs into one
+                    # round-trip; persist_event_compat_ms is the dominant
+                    # cg=0 cost line.
+                    await self._persist_cascade_events(
+                        [workflow_completion_event, playbook_completion_event],
+                        state,
+                        conn=conn,
+                    )
+                    logger.info(
+                        "Workflow + playbook completed (after inline task): execution_id=%s",
+                        event.execution_id,
+                    )
 
                     await self.state_store.save_state(state, conn)
             return commands
@@ -2503,12 +2511,14 @@ class EventHandlingMixin:
         if not completion_events and not already_persisted:
             await self._persist_event_compat(event, state, conn=conn)
         
-        # Persist completion events in order with proper parent_event_id chain
-        for i, completion_event in enumerate(completion_events):
-            if i > 0:
-                # Set parent to previous completion event
-                completion_event.parent_event_id = state.last_event_id
-            await self._persist_event_compat(completion_event, state, conn=conn)
+        # Persist completion events in order with proper parent_event_id chain.
+        # Round-4 (noetl/ai-meta#29): one batched INSERT instead of N
+        # round-trips through ``_persist_event_compat``.  The helper sets
+        # the parent_event_id chain internally as it allocates new IDs.
+        if completion_events:
+            await self._persist_cascade_events(
+                completion_events, state, conn=conn
+            )
         
         # CRITICAL: Stop generating commands if this is a failure event
         # Check AFTER persisting and completion events so they're all stored
@@ -2536,8 +2546,6 @@ class EventHandlingMixin:
                     timestamp=datetime.now(timezone.utc),
                     parent_event_id=current_event_id,
                 )
-                await self._persist_event_compat(workflow_failed_event, state, conn=conn)
-
                 playbook_failed_event = Event(
                     execution_id=event.execution_id,
                     step=state.playbook.metadata.get("path", "playbook"),
@@ -2549,9 +2557,15 @@ class EventHandlingMixin:
                         error=event.payload.get("error"),
                     ).model_dump(),
                     timestamp=datetime.now(timezone.utc),
-                    parent_event_id=state.last_event_id,
+                    parent_event_id=None,  # chained by _persist_cascade_events
                 )
-                await self._persist_event_compat(playbook_failed_event, state, conn=conn)
+                # Round-4 (noetl/ai-meta#29): batch the failure cascade
+                # into one round-trip; same shape as the success cascade.
+                await self._persist_cascade_events(
+                    [workflow_failed_event, playbook_failed_event],
+                    state,
+                    conn=conn,
+                )
                 await self.state_store.save_state(state, conn)
 
             if event.name == "command.failed":

--- a/noetl/core/dsl/engine/executor/lifecycle.py
+++ b/noetl/core/dsl/engine/executor/lifecycle.py
@@ -139,6 +139,254 @@ class LifecycleMixin:
         else:
             await _do_persist(conn)
 
+    async def _persist_cascade_events(
+        self,
+        events: list[Event],
+        state: ExecutionState,
+        conn=None,
+    ) -> None:
+        """Persist a cascade of related events with one batched ``INSERT``.
+
+        Cascading completion chains (``workflow.completed`` ->
+        ``playbook.completed`` and ``workflow.failed`` ->
+        ``playbook.failed``) emit two events back-to-back inside one
+        ``Engine.handle_event`` call.  Calling ``_persist_event_compat``
+        twice does ~8 DB round-trips total (snowflake SELECT + duration
+        SELECT + INSERT + outbox enqueue, x2).  Round-3 verification
+        (noetl/ai-meta#29) measured ``persist_event_compat_ms`` p90 = 272ms
+        for ``cg=0`` events — the single largest cost line.
+
+        This method:
+        - looks up ``catalog_id`` once (when missing)
+        - allocates all snowflake IDs in one query
+        - looks up the ``workflow_initialized`` / ``playbook_initialized``
+          timestamp once and reuses it for every completion-shaped event
+          in the cascade
+        - chains ``parent_event_id`` through the batch in order
+        - issues one ``executemany`` ``INSERT INTO noetl.event``
+        - enqueues outbox rows in the same cursor
+        - updates ``state.last_event_id`` to the final event's id
+
+        For a 1-event "cascade" this falls through to the single-event
+        path so callers can hand off a variable-length list without
+        special-casing.
+        """
+        if not events:
+            return
+        if len(events) == 1 or conn is None:
+            # Fallback path:
+            # - single event: the batched path's reduced round-trips only
+            #   pay off for cascades; one event has nothing to batch.
+            # - no conn: the test environments that monkeypatch
+            #   ``_persist_event`` drive the engine without a real DB
+            #   connection.  Routing through ``_persist_event_compat`` lets
+            #   those tests see cascade members the same way they see any
+            #   other persisted event (via call_args / fake closures), and
+            #   preserves the ``parent_event_id`` chain produced by the
+            #   real ``_persist_event`` setting ``state.last_event_id``
+            #   between calls.
+            for event in events:
+                await self._persist_event_compat(event, state, conn=conn)
+            return
+
+        catalog_id = state.catalog_id
+
+        async def _do_persist_batch(c):
+            nonlocal catalog_id
+            if not catalog_id:
+                async with c.cursor() as cur:
+                    await cur.execute(
+                        "SELECT catalog_id FROM noetl.event WHERE execution_id = %s LIMIT 1",
+                        (int(events[0].execution_id),),
+                    )
+                    result = await cur.fetchone()
+                    catalog_id = result["catalog_id"] if result else None
+            if not catalog_id:
+                logger.error(
+                    "Cannot persist cascade events - no catalog_id for execution %s",
+                    events[0].execution_id,
+                )
+                return
+
+            # Pre-allocate one snowflake_id per event in a single query.
+            async with c.cursor() as cur:
+                await cur.execute(
+                    "SELECT noetl.snowflake_id() AS snowflake_id "
+                    "FROM generate_series(1, %s)",
+                    (len(events),),
+                )
+                rows = await cur.fetchall()
+                if not rows or len(rows) != len(events):
+                    raise RuntimeError(
+                        "Failed to allocate snowflake IDs for cascade batch"
+                    )
+                allocated_ids = [int(r["snowflake_id"]) for r in rows]
+
+            # Resolve the shared init-event timestamp once per init kind.
+            # workflow.* events look up workflow_initialized; playbook.*
+            # events look up playbook_initialized.  Cache so a cascade of
+            # workflow + playbook events does at most TWO lookups instead
+            # of two per event.
+            init_ts_cache: dict[str, Any] = {}
+
+            async def _resolve_init_ts(event_name: str) -> Optional[Any]:
+                init_event_type = (
+                    "workflow_initialized"
+                    if "workflow_" in event_name
+                    else "playbook_initialized"
+                )
+                if init_event_type in init_ts_cache:
+                    return init_ts_cache[init_event_type]
+                async with c.cursor() as cur:
+                    await cur.execute(
+                        "SELECT created_at FROM noetl.event "
+                        "WHERE execution_id = %s AND event_type = %s "
+                        "ORDER BY event_id ASC LIMIT 1",
+                        (int(events[0].execution_id), init_event_type),
+                    )
+                    init_row = await cur.fetchone()
+                created_at = (
+                    init_row["created_at"] if init_row else None
+                )
+                init_ts_cache[init_event_type] = created_at
+                return created_at
+
+            insert_rows: list[tuple] = []
+            outbox_rows: list[dict[str, Any]] = []
+            previous_event_id = state.last_event_id
+
+            for idx, event in enumerate(events):
+                new_event_id = allocated_ids[idx]
+                parent_event_id = event.parent_event_id
+                if parent_event_id is None:
+                    if event.step:
+                        parent_event_id = state.step_event_ids.get(event.step)
+                    if not parent_event_id:
+                        parent_event_id = previous_event_id
+
+                event_timestamp = event.timestamp or datetime.now(timezone.utc)
+
+                duration_ms = 0
+                if "completed" in event.name or "failed" in event.name:
+                    init_ts = await _resolve_init_ts(event.name)
+                    if init_ts:
+                        duration_ms = int(
+                            (event_timestamp - init_ts).total_seconds() * 1000
+                        )
+
+                status = event.payload.get("status") if event.payload else None
+                if not status and "completed" in event.name:
+                    status = "COMPLETED"
+                elif not status and "failed" in event.name:
+                    status = "FAILED"
+                elif not status:
+                    status = "RUNNING"
+
+                payload_dict = event.payload if isinstance(event.payload, dict) else {}
+                context_val = payload_dict
+                result_val = (
+                    payload_dict.get("result")
+                    if isinstance(payload_dict.get("result"), dict)
+                    and "status" in payload_dict["result"]
+                    else None
+                )
+
+                insert_rows.append(
+                    (
+                        int(event.execution_id),
+                        catalog_id,
+                        new_event_id,
+                        parent_event_id,
+                        state.parent_execution_id,
+                        event_timestamp,
+                        event.name,
+                        event.step,
+                        event.step,
+                        status,
+                        duration_ms,
+                        Json(context_val) if context_val else None,
+                        Json(result_val) if result_val else None,
+                        Json(event.meta) if event.meta else None,
+                        event.payload.get("error")
+                        if isinstance(event.payload, dict)
+                        else None,
+                        event.worker_id,
+                    )
+                )
+                outbox_rows.append(
+                    {
+                        "event_id": new_event_id,
+                        "execution_id": int(event.execution_id),
+                        "catalog_id": catalog_id,
+                        "parent_event_id": parent_event_id,
+                        "parent_execution_id": state.parent_execution_id,
+                        "event_type": event.name,
+                        "node_id": event.step,
+                        "node_name": event.step,
+                        "status": status,
+                        "duration": duration_ms,
+                        "context": context_val,
+                        "result": result_val,
+                        "meta": event.meta or {},
+                        "error": event.payload.get("error")
+                        if isinstance(event.payload, dict)
+                        else None,
+                        "worker_id": event.worker_id,
+                        "event_time": event_timestamp,
+                        "ingest_time": event_timestamp,
+                        "created_at": event_timestamp,
+                    }
+                )
+                # Subsequent events in the cascade chain to this id.
+                previous_event_id = new_event_id
+
+            async with c.cursor() as cur:
+                await cur.executemany(
+                    """
+                    INSERT INTO noetl.event (
+                        execution_id, catalog_id, event_id, parent_event_id, parent_execution_id,
+                        created_at, event_type, node_id, node_name, status, duration,
+                        context, result, meta, error, worker_id
+                    ) VALUES (
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+                    )
+                    """,
+                    insert_rows,
+                )
+                for outbox_event in outbox_rows:
+                    await enqueue_executor_outbox(cur, outbox_event)
+
+            # Update in-memory state to the final event in the cascade.
+            for idx, event in enumerate(events):
+                event_id = allocated_ids[idx]
+                if event.step:
+                    state.step_event_ids[event.step] = event_id
+            state.last_event_id = allocated_ids[-1]
+
+        t0 = time.perf_counter()
+        try:
+            if conn is None:
+                async with get_pool_connection() as c:
+                    await _do_persist_batch(c)
+                await drain_executor_outbox()
+            else:
+                await _do_persist_batch(conn)
+        finally:
+            # Round-3 instrumentation: this batched path replaces 2x
+            # _persist_event_compat calls.  Account for it under the same
+            # field so operators can compare apples to apples in
+            # batch.completed context.  We bump the call counter by the
+            # number of events the cascade fused so the avg-calls metric
+            # remains meaningful.
+            elapsed = (time.perf_counter() - t0) * 1000
+            accumulate_engine_phase_ms("persist_event_compat_ms", elapsed)
+            # Bump the counter for any extra events beyond the first so
+            # the *_calls average reflects the logical event count
+            # (otherwise operators would see avg=1 once we cut over and
+            # mistake it for "the events disappeared").
+            for _ in range(len(events) - 1):
+                accumulate_engine_phase_ms("persist_event_compat_ms", 0.0)
+
     async def start_execution(
         self,
         playbook_path: str,

--- a/tests/unit/dsl/engine/test_engine.py
+++ b/tests/unit/dsl/engine/test_engine.py
@@ -5,6 +5,7 @@ Tests for NoETL DSL Engine Control Flow
 import pytest
 import json
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from noetl.core.dsl.engine.executor import ControlFlowEngine, PlaybookRepo, StateStore, ExecutionState
 from noetl.core.dsl.engine.models import Event, Command, Playbook
@@ -682,3 +683,154 @@ workflow:
     assert capture.get("save_state_ms", -1) >= 0
     assert capture.get("persist_event_compat_ms_calls", 0) >= 1
     assert capture.get("persist_event_compat_ms", -1) >= 0
+
+
+@pytest.mark.asyncio
+async def test_persist_cascade_events_no_events_is_noop(engine_setup, monkeypatch):
+    """Empty cascade list returns immediately without touching the DB
+    or _persist_event."""
+    engine, _playbook_repo, state_store = engine_setup
+    playbook = _make_minimal_playbook("cascade_noop")
+    state = ExecutionState(execution_id="200000000000044440", playbook=playbook, payload={})
+    persist = AsyncMock(return_value=None)
+    monkeypatch.setattr(engine, "_persist_event", persist)
+
+    await engine._persist_cascade_events([], state, conn=None)
+
+    persist.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_persist_cascade_events_single_falls_through(engine_setup, monkeypatch):
+    """A 1-event cascade routes through _persist_event_compat (single-row
+    path) — the batched optimisation only pays off for 2+ events."""
+    engine, _playbook_repo, state_store = engine_setup
+    playbook = _make_minimal_playbook("cascade_single")
+    state = ExecutionState(execution_id="200000000000044441", playbook=playbook, payload={})
+    persist = AsyncMock(return_value=None)
+    monkeypatch.setattr(engine, "_persist_event", persist)
+
+    one_event = Event(
+        execution_id="200000000000044441",
+        step="workflow",
+        name="workflow.completed",
+        payload={"status": "completed"},
+    )
+    await engine._persist_cascade_events([one_event], state, conn=None)
+
+    persist.assert_awaited_once()
+    persisted_event = persist.call_args.args[0]
+    assert persisted_event.name == "workflow.completed"
+
+
+@pytest.mark.asyncio
+async def test_persist_cascade_events_no_conn_iterates_per_event(engine_setup, monkeypatch):
+    """A multi-event cascade with conn=None (the test-environment shape)
+    routes each event through _persist_event_compat in order so test
+    monkeypatches on _persist_event see every cascade member."""
+    engine, _playbook_repo, state_store = engine_setup
+    playbook = _make_minimal_playbook("cascade_iter")
+    state = ExecutionState(execution_id="200000000000044442", playbook=playbook, payload={})
+    persist = AsyncMock(return_value=None)
+    monkeypatch.setattr(engine, "_persist_event", persist)
+
+    workflow_evt = Event(
+        execution_id="200000000000044442",
+        step="workflow",
+        name="workflow.completed",
+        payload={"status": "completed"},
+    )
+    playbook_evt = Event(
+        execution_id="200000000000044442",
+        step="my_playbook",
+        name="playbook.completed",
+        payload={"status": "completed"},
+    )
+
+    await engine._persist_cascade_events(
+        [workflow_evt, playbook_evt], state, conn=None
+    )
+
+    assert persist.await_count == 2
+    emitted_names = [c.args[0].name for c in persist.call_args_list]
+    assert emitted_names == ["workflow.completed", "playbook.completed"]
+
+
+@pytest.mark.asyncio
+async def test_persist_cascade_events_batched_path_with_conn(engine_setup, monkeypatch):
+    """A multi-event cascade with a real ``conn`` takes the batched path:
+    one SELECT for N snowflake IDs, one ``executemany`` INSERT, no
+    fallthrough to ``_persist_event``.  This is the production shape from
+    batch.py and the round-4 mitigation surface (noetl/ai-meta#29)."""
+    engine, _playbook_repo, state_store = engine_setup
+    playbook = _make_minimal_playbook("cascade_batched")
+    state = ExecutionState(
+        execution_id="200000000000044443",
+        playbook=playbook,
+        payload={},
+        catalog_id=42,
+    )
+
+    # _persist_event must NOT be called in the batched path.
+    persist = AsyncMock(return_value=None)
+    monkeypatch.setattr(engine, "_persist_event", persist)
+
+    # Record what the batched SQL execution looked like.
+    seen_queries: list[str] = []
+    seen_param_lengths: list[int] = []
+
+    class _FakeCursor:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *_): return False
+        async def execute(self, query, params=None):
+            seen_queries.append(query)
+        async def executemany(self, query, params_seq):
+            seen_queries.append(query)
+            params_list = list(params_seq)
+            seen_param_lengths.append(len(params_list))
+        async def fetchone(self):
+            # Stage-aware fake: queries that ask for catalog_id never run
+            # here (state.catalog_id is set on the state above), and the
+            # init-event lookup runs once per init kind.  Return a sentinel
+            # the cascade can use as ``created_at``.
+            return {"created_at": datetime.now(timezone.utc)}
+        async def fetchall(self):
+            # Return two snowflake ids — matches len(events)=2.
+            return [{"snowflake_id": 9001}, {"snowflake_id": 9002}]
+
+    class _FakeConn:
+        def cursor(self, *args, **kwargs):
+            return _FakeCursor()
+
+    fake_conn = _FakeConn()
+
+    # Production cascade emissions set timestamp=datetime.now(timezone.utc);
+    # the test mirrors that so the duration calculation against the
+    # init-event lookup (also tz-aware in the fake cursor) doesn't trip
+    # on naive-vs-aware datetime subtraction.
+    now_utc = datetime.now(timezone.utc)
+    wf_evt = Event(
+        execution_id="200000000000044443",
+        step="workflow",
+        name="workflow.completed",
+        payload={"status": "completed"},
+        timestamp=now_utc,
+    )
+    pb_evt = Event(
+        execution_id="200000000000044443",
+        step="my_playbook",
+        name="playbook.completed",
+        payload={"status": "completed"},
+        timestamp=now_utc,
+    )
+
+    await engine._persist_cascade_events([wf_evt, pb_evt], state, conn=fake_conn)
+
+    # Batched path was taken: _persist_event was bypassed.
+    persist.assert_not_awaited()
+    # Exactly one ``executemany`` INSERT with two rows.
+    assert seen_param_lengths == [2], seen_param_lengths
+    insert_queries = [q for q in seen_queries if "INSERT INTO noetl.event" in q]
+    assert len(insert_queries) == 1
+    # The cascade allocated both snowflake ids and chained the parent.
+    assert state.last_event_id == 9002


### PR DESCRIPTION
## Summary

Round-4 mitigation PR for [noetl/ai-meta#29](https://github.com/noetl/ai-meta/issues/29) and its sub-issue [noetl/noetl#634](https://github.com/noetl/noetl/issues/634).  Follows the round-1 timing instrumentation ([#629](https://github.com/noetl/noetl/pull/629)), round-2 terminal-event fast path ([#630](https://github.com/noetl/noetl/pull/630)), and round-3 sub-phase instrumentation ([#633](https://github.com/noetl/noetl/pull/633)).

[Round-3 verification on GKE](https://github.com/noetl/ai-meta/issues/29#issuecomment-4579800281) (n=60 batch.completed events, image `subphase-20260529183255`) identified `persist_event_compat_ms` as the #1 cost line:

| metric | cg=0 (no-op tail, n=20) | cg=1 (productive, n=40) |
|---|---|---|
| persist_event_compat_ms **p90/max** | **272 / 581** | n/a |
| save_state_ms p90/max | 197 / 342 | 84 / 149 |
| persist_event_compat **calls/event** | **2.0** | 0 |
| save_state calls/event | 2.0 | 2.0 |

The 2.0 calls/event on cg=0 events is the smoking gun: when an execution terminates, the engine emits a cascading completion chain (`workflow.completed` → `playbook.completed`, or `workflow.failed` → `playbook.failed`) and each member does its own snowflake SELECT + duration SELECT + INSERT + outbox INSERT.

## What this changes

New helper `LifecycleMixin._persist_cascade_events(events, state, conn)`:

- looks up `catalog_id` once
- allocates N snowflake IDs in **one query** (`SELECT noetl.snowflake_id() FROM generate_series(1, N)`)
- caches the `workflow_initialized` / `playbook_initialized` timestamp lookup per init kind (so the cascade does **2 lookups max**, not 2 per event)
- chains `parent_event_id` through the batch as new IDs are allocated
- issues **one `executemany` INSERT** for all events
- enqueues outbox rows on the same cursor

Three cascade call sites in `events.py` rewritten:

| site | before | after |
|---|---|---|
| inline-task success (~L533-580) | 2x `_persist_event_compat` + 2x SQL setup | 1x `_persist_cascade_events([wf, pb])` |
| main success path (~L2477-2511) | for-loop calling `_persist_event_compat` per item + manual parent chain | 1x `_persist_cascade_events(completion_events)` |
| failure cascade (~L2526-2554) | 2x `_persist_event_compat` for workflow.failed + playbook.failed | 1x `_persist_cascade_events([wf_failed, pb_failed])` |

## Why this is safe

- **Tests still observe per-event emissions.** When `conn=None` (the test-environment shape — tests monkeypatch `_persist_event` and drive the engine without a real DB), the helper falls through to per-event `_persist_event_compat`. All existing tests that assert on `engine._persist_event.call_args_list` continue to work unmodified.
- **Parent_event_id chain preserved.** First event in the cascade picks up `state.last_event_id`; each subsequent event chains to the previous batch member's freshly-allocated id. Same ordering invariant the previous for-loop maintained, just resolved without a DB round-trip between events.
- **Timestamp + status semantics unchanged.** Per-event status derivation (`completed` → `COMPLETED`, `failed` → `FAILED`, `result` extraction) is copied verbatim from `_persist_event`.
- **Outbox writes happen on the same cursor.** Sequential within the transaction; same drain semantics on commit.

## Round-3 instrumentation continuity

The batched path accumulates wall-clock into the existing `persist_event_compat_ms` field so before/after comparisons are direct. The `persist_event_compat_ms_calls` counter is bumped by the cascade length (rather than 1) so the `avg_calls_per_event` metric continues to reflect the logical event count after cut-over.

## Tests

Four new tests in `tests/unit/dsl/engine/test_engine.py`:

- `test_persist_cascade_events_no_events_is_noop` — empty list returns without touching anything.
- `test_persist_cascade_events_single_falls_through` — 1-event cascade goes through the single-row path.
- `test_persist_cascade_events_no_conn_iterates_per_event` — 2+ events with conn=None route through `_persist_event_compat` per item.
- `test_persist_cascade_events_batched_path_with_conn` — 2+ events with a real `conn` take the batched path: one INSERT with two rows via `executemany`, `_persist_event` NOT called, `state.last_event_id` advances to the final allocated snowflake id.

Full `tests/unit/dsl/engine/` (93 tests, +4 from round 3) passes:

```
93 passed, 91 warnings in 1.06s
```

## Verification after rollout

```sql
SELECT (result->'context'->>'commands_generated')::int AS cg,
       COUNT(*) AS n,
       ROUND((PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY (result->'context'->>'persist_event_compat_ms')::double precision))::numeric, 2) AS pec_p90,
       ROUND(MAX((result->'context'->>'persist_event_compat_ms')::double precision)::numeric, 2) AS pec_max,
       ROUND(AVG((result->'context'->>'persist_event_compat_ms_calls')::double precision)::numeric, 2) AS pec_calls_avg
FROM noetl.event
WHERE event_type = 'batch.completed'
  AND created_at > NOW() - INTERVAL '30 minutes'
  AND (result->'context'->>'persist_event_compat_ms') IS NOT NULL
GROUP BY 1 ORDER BY 1;
```

Expected: `pec_p90` for cg=0 drops from 272ms → ~135ms (one INSERT round-trip instead of two). `pec_calls_avg` stays at 2.0 (logical count). The unrelated `save_state_ms` should be unchanged — that's the round-5 mitigation target if the no-op tail still has headroom after this lands.

Closes noetl/noetl#634
Refs noetl/ai-meta#29

🤖 Generated with [Claude Code](https://claude.com/claude-code)