### PR TITLE
perf(batch): coalesce intermediate save_state inside one handle_event

### DIFF
--- a/noetl/core/dsl/engine/executor/common.py
+++ b/noetl/core/dsl/engine/executor/common.py
@@ -939,4 +939,49 @@ def accumulate_engine_phase_ms(field: str, elapsed_ms: float) -> None:
     capture[calls_field] = int(capture.get(calls_field, 0)) + 1
 
 
+# ---------------------------------------------------------------------------
+# Per-event save_state coalescing buffer (round-5, see noetl/ai-meta#29)
+# ---------------------------------------------------------------------------
+#
+# Round-3 instrumentation showed ``save_state`` fires 2x per ``handle_event``
+# call on the cg=0 path (the cascading-completion code emits multiple events
+# and saves state after each one).  Each call rewrites the full state JSONB
+# in ``noetl.execution`` — the intermediate writes are not load-bearing
+# because ``noetl.event`` is the source-of-truth event log, and the
+# in-memory ``state`` object always carries the latest version for any
+# downstream logic in this invocation.  See:
+# https://github.com/noetl/docs/blob/main/docs/architecture/ephemeral_blueprints.md
+#
+# Round-5 wraps ``handle_event`` with a coalescing buffer.  ``save_state``
+# calls during the invocation stash the latest ``(state, conn)`` in the
+# buffer instead of issuing the UPDATE.  At ``handle_event`` exit we issue
+# ONE final UPDATE with the final state.  The intermediate UPDATEs are
+# elided — they would have rewritten state that immediately got overwritten
+# by the next save_state call anyway.
+#
+# Unbound contextvar (the default outside ``handle_event``) means
+# ``save_state`` writes immediately.  Tests + ad-hoc callers see identical
+# behavior to before.
+
+_current_save_state_buffer: contextvars.ContextVar[Optional[dict]] = (
+    contextvars.ContextVar("noetl_engine_save_state_buffer", default=None)
+)
+
+
+def get_current_save_state_buffer() -> Optional[dict]:
+    """Return the save_state coalescing buffer for the active handle_event
+    invocation, or None if none is bound."""
+    return _current_save_state_buffer.get()
+
+
+def bind_save_state_buffer(buffer: Optional[dict]) -> Any:
+    """Bind a ``save_state`` coalescing buffer for the active context."""
+    return _current_save_state_buffer.set(buffer)
+
+
+def unbind_save_state_buffer(token: Any) -> None:
+    """Restore the previous contextvar value using a bind token."""
+    _current_save_state_buffer.reset(token)
+
+
 __all__ = [name for name in globals() if not name.startswith("__")]

--- a/noetl/core/dsl/engine/executor/events.py
+++ b/noetl/core/dsl/engine/executor/events.py
@@ -313,6 +313,17 @@ class EventHandlingMixin:
         # without threading the dict through every call site.  See
         # noetl/ai-meta#29.
         timing_token = bind_engine_timing_capture(timing_capture)
+        # Round-5 (noetl/ai-meta#29): bind a coalescing buffer so
+        # intermediate save_state calls during this invocation stash the
+        # latest state instead of issuing the heavy JSONB UPDATE.  We
+        # flush once at the end with the final state.
+        save_state_buffer: dict = {
+            "pending": False,
+            "state": None,
+            "conn": None,
+            "coalesced_count": 0,
+        }
+        save_buffer_token = bind_save_state_buffer(save_state_buffer)
         try:
             return await self._handle_event_inner(
                 event,
@@ -321,11 +332,37 @@ class EventHandlingMixin:
                 timing_capture=timing_capture,
             )
         finally:
+            # Unbind the save-state buffer BEFORE flushing so the flush
+            # itself doesn't recurse into the coalescing branch.
+            unbind_save_state_buffer(save_buffer_token)
+            if save_state_buffer.get("pending"):
+                try:
+                    await self.state_store.save_state(
+                        save_state_buffer["state"],
+                        save_state_buffer["conn"],
+                    )
+                except Exception:
+                    # The flush failing would shadow the original
+                    # exception (or commit an inconsistent projection).
+                    # Log and continue — noetl.execution is rebuildable
+                    # from the event log, which is the source of truth.
+                    logger.exception(
+                        "[STATE-COALESCE] Final save_state flush failed for "
+                        "execution=%s; projection will be rebuilt by replay.",
+                        getattr(save_state_buffer.get("state"), "execution_id", "?"),
+                    )
             unbind_engine_timing_capture(timing_token)
             if timing_capture is not None:
                 timing_capture["engine_total_ms"] = round(
                     (time.perf_counter() - engine_start_ts) * 1000, 3
                 )
+                if save_state_buffer.get("coalesced_count"):
+                    # Surface the coalescing count in batch.completed
+                    # context so operators can see how many save_state
+                    # calls were elided per handle_event.
+                    timing_capture["save_state_coalesced_count"] = int(
+                        save_state_buffer["coalesced_count"]
+                    )
 
     async def _handle_event_inner(
         self,

--- a/noetl/core/dsl/engine/executor/store.py
+++ b/noetl/core/dsl/engine/executor/store.py
@@ -129,11 +129,30 @@ class StateStore:
         log = logging.getLogger(__name__)
         t0 = time.perf_counter()
         try:
+            # Round-5 (noetl/ai-meta#29): when a coalescing buffer is
+            # bound (i.e. we're inside Engine.handle_event), stash the
+            # latest state + conn and return without doing the heavy
+            # JSONB rewrite.  Engine.handle_event flushes the buffer
+            # ONCE on exit so intermediate UPDATEs that would
+            # immediately be overwritten by the next save_state call
+            # are elided.  The event log remains the source of truth;
+            # noetl.execution is a projection that's rebuilt by replay.
+            buffer = get_current_save_state_buffer()
+            if buffer is not None:
+                buffer["state"] = state
+                buffer["conn"] = conn
+                buffer["pending"] = True
+                buffer["coalesced_count"] = int(buffer.get("coalesced_count", 0)) + 1
+                return
             return await self._save_state_inner(state, conn=conn, log=log, t0=t0)
         finally:
             # Round-3 instrumentation: sum wall-clock for every save_state
             # call across one Engine.handle_event invocation into the active
-            # timing_capture (see noetl/ai-meta#29).
+            # timing_capture (see noetl/ai-meta#29).  Coalesced calls record
+            # the (near-zero) buffer-stash time so the *_calls counter still
+            # reflects the LOGICAL number of save_state requests during the
+            # event — operators can compare ``save_state_ms_calls`` against
+            # the unchanged 2.0/event round-3 baseline.
             accumulate_engine_phase_ms(
                 "save_state_ms",
                 (time.perf_counter() - t0) * 1000,

--- a/tests/unit/dsl/engine/test_engine.py
+++ b/tests/unit/dsl/engine/test_engine.py
@@ -834,3 +834,95 @@ async def test_persist_cascade_events_batched_path_with_conn(engine_setup, monke
     assert len(insert_queries) == 1
     # The cascade allocated both snowflake ids and chained the parent.
     assert state.last_event_id == 9002
+
+
+@pytest.mark.asyncio
+async def test_save_state_buffer_unbound_is_immediate(engine_setup, monkeypatch):
+    """Outside Engine.handle_event the coalescing buffer is unbound and
+    save_state writes immediately.  Ad-hoc callers and test fixtures
+    that bypass the engine see identical behavior to pre-round-5."""
+    from noetl.core.dsl.engine.executor.common import (
+        get_current_save_state_buffer,
+    )
+    engine, _playbook_repo, state_store = engine_setup
+    inner = AsyncMock(return_value=None)
+    monkeypatch.setattr(state_store, "_save_state_inner", inner)
+
+    playbook = _make_minimal_playbook("save_state_immediate")
+    state = ExecutionState(execution_id="200000000000055551", playbook=playbook, payload={})
+
+    assert get_current_save_state_buffer() is None
+    await state_store.save_state(state)
+
+    inner.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_coalesces_intermediate_save_state(engine_setup, monkeypatch):
+    """End-to-end: a handle_event call that issues multiple intermediate
+    save_state calls (e.g. the cascading-completion path) hits the heavy
+    JSONB UPDATE EXACTLY ONCE.  The round-5 invariant we ship on
+    noetl/ai-meta#29."""
+    engine, playbook_repo, state_store = engine_setup
+
+    yaml_content = """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: coalesce_test
+
+workflow:
+  - step: start
+    tool:
+      kind: python
+      code: "def main(): return {'ok': True}"
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: end
+          when: "{{ event.name == 'call.done' }}"
+
+  - step: end
+    tool:
+      kind: python
+      code: "def main(): return {'done': True}"
+"""
+    playbook = DSLParser().parse(yaml_content)
+    state = ExecutionState(
+        execution_id="200000000000055552",
+        playbook=playbook,
+        payload={},
+    )
+    monkeypatch.setattr(state_store, "load_state", AsyncMock(return_value=state))
+    monkeypatch.setattr(state_store, "load_state_for_update", AsyncMock(return_value=state))
+
+    # Replace the heavy JSONB UPDATE so the test runs without a DB; the
+    # number of calls to ``_save_state_inner`` IS what we're asserting.
+    inner = AsyncMock(return_value=None)
+    monkeypatch.setattr(state_store, "_save_state_inner", inner)
+    engine._persist_event = AsyncMock(return_value=None)
+
+    event = Event(
+        execution_id="200000000000055552",
+        step="start",
+        name="call.done",
+        payload={"result": {"ok": True}},
+    )
+
+    capture: dict = {}
+    commands = await engine.handle_event(
+        event, already_persisted=True, timing_capture=capture
+    )
+
+    # The orchestration path runs to completion.
+    assert [c.step for c in commands] == ["end"]
+    # Coalesced intermediate save_state calls happened (logical count
+    # surfaced via the timing_capture counter).  The exact value depends
+    # on the orchestration path; we assert "at least one was coalesced
+    # AND the heavy UPDATE ran exactly once for the final flush".
+    assert capture.get("save_state_ms_calls", 0) >= 1
+    coalesced = capture.get("save_state_coalesced_count", 0)
+    assert coalesced >= 1, capture
+    # The heavy JSONB UPDATE ran ONCE — the round-5 win.
+    assert inner.await_count == 1, inner.await_count

--- a/tests/unit/dsl/engine/test_task_sequence_loop_completion.py
+++ b/tests/unit/dsl/engine/test_task_sequence_loop_completion.py
@@ -456,7 +456,26 @@ async def test_task_sequence_loop_persists_event_before_early_return_when_needed
 
     assert len(commands) == 1
     assert commands[0].step == parent_step
-    assert call_order[-2:] == ["save_state", "persist:call.done"]
+    # Both the call.done event AND state must land before handle_event
+    # returns.  Pre-round-5 (noetl/ai-meta#29) the engine saved state
+    # IMMEDIATELY before persisting the event, so the invariant was the
+    # exact-order pair ``[save_state, persist:call.done]``.  Round-5
+    # coalesces intermediate save_state calls and flushes ONCE at
+    # handle_event exit so the projection catches up after the event
+    # log — the textbook event-sourcing order.  The event log is the
+    # source of truth and is rebuildable into the projection, so this
+    # is safe.  We assert both side effects happened and that the
+    # event landed BEFORE the final save flush.
+    assert "save_state" in call_order, call_order
+    assert "persist:call.done" in call_order, call_order
+    # Round-5: the FINAL operation in handle_event is the projection
+    # flush.  Intermediate save_state requests are coalesced (the
+    # tracking wrapper still observes them but they do not hit the DB),
+    # so call_order shows both the coalesced intercept(s) AND the final
+    # flush.  The event MUST have landed before the final flush so the
+    # post-crash event log is at least as new as the projection.
+    assert call_order[-1] == "save_state", call_order
+    assert "persist:call.done" in call_order[: -1], call_order
 
 
 def test_normalize_loop_collection_does_not_split_unresolved_template():


### PR DESCRIPTION
## Summary

Round-5 mitigation PR for [noetl/ai-meta#29](https://github.com/noetl/ai-meta/issues/29) and its sub-issue [noetl/noetl#636](https://github.com/noetl/noetl/issues/636).  Follows [#629](https://github.com/noetl/noetl/pull/629) (per-batch timings), [#630](https://github.com/noetl/noetl/pull/630) (terminal-event fast path), [#633](https://github.com/noetl/noetl/pull/633) (sub-phase instrumentation), and [#635](https://github.com/noetl/noetl/pull/635) (cascade event-log batching).

[Round-4 verification on GKE](https://github.com/noetl/ai-meta/issues/29#issuecomment-4580418617) brought `save_state_ms` p90 from 197ms → 91ms as a secondary effect of reduced DB contention.  But it's still p90=91ms / max=157ms with **2.0 calls/event** for cg=0 events.  Round-3 instrumentation made the call counter visible: every cg=0 `handle_event` issues two `save_state` UPDATEs back-to-back as the cascading completion path emits multiple events and saves state after each.

Each `save_state` rewrites the full state JSONB.  For cascading completions the intermediate write is **immediately overwritten** by the next save_state call.  The event log is the source of truth; `noetl.execution` is a projection that's rebuildable by replay — so intermediate UPDATEs that the next call will overwrite anyway are dead work.

## What this changes

Coalescing buffer mirroring the round-3 timing-capture contextvar pattern:

- `Engine.handle_event` binds a per-invocation buffer in a contextvar.
- `StateStore.save_state` consults the buffer.  When bound, it **stashes** `(state, conn)` and returns immediately.  When unbound (the default — outside `handle_event`), it executes the UPDATE.
- At `handle_event` exit, the buffer is unbound and then **flushed with ONE final `save_state(latest_state, conn)` call**.
- Flush failures are logged but do not shadow the original handler exception; the projection will be rebuilt from the event log on next replay.

A new field `save_state_coalesced_count` appears in `batch.completed.context` so operators can see how many save_state calls were elided per handle_event.  The existing `save_state_ms_calls` counter still reflects the LOGICAL count (the buffered intercept records its near-zero wall clock), keeping post-cut-over comparisons against the round-3 baseline (2.0/event) meaningful.

## Ordering invariant change

Pre-round-5 the engine could save state immediately, then persist events.  Post-round-5 the projection flush is the LAST operation in `handle_event`, after all events have been persisted.  This is the **textbook event-sourcing order**: append to the log first, project afterwards.

If a crash falls between event-log append and projection flush, recovery rebuilds the projection by replay.  The event log (`noetl.event`) is the source of truth; `noetl.execution.state` is a rebuildable cache.  See [execution-model.md](https://github.com/noetl/ai-meta/blob/main/agents/rules/execution-model.md).

The relevant in-process test `test_task_sequence_loop_persists_event_before_early_return_when_needed` is updated to assert the new ordering (event lands; final operation is the projection flush) with an explanatory comment.

## Tests

Two new tests in `tests/unit/dsl/engine/test_engine.py`:

- `test_save_state_buffer_unbound_is_immediate` — outside `handle_event` the buffer is unset and save_state writes immediately.  Preserves test fixtures and ad-hoc callers.
- `test_handle_event_coalesces_intermediate_save_state` — end-to-end: a handle_event call that triggers multiple intermediate save_state requests hits the heavy `_save_state_inner` **exactly ONCE**.  Round-5 win, asserted.

Full `tests/unit/dsl/engine/` (95 tests, +2 from round-4) passes:

```
95 passed, 93 warnings in 0.89s
```

## Verification after rollout

```sql
SELECT (result->'context'->>'commands_generated')::int AS cg,
       COUNT(*) AS n,
       ROUND((PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY (result->'context'->>'save_state_ms')::double precision))::numeric, 2) AS ss_p90,
       ROUND(MAX((result->'context'->>'save_state_ms')::double precision)::numeric, 2) AS ss_max,
       ROUND(AVG((result->'context'->>'save_state_ms_calls')::double precision)::numeric, 2) AS ss_calls_avg,
       ROUND(AVG((result->'context'->>'save_state_coalesced_count')::double precision)::numeric, 2) AS ss_coalesced_avg
FROM noetl.event
WHERE event_type = 'batch.completed'
  AND created_at > NOW() - INTERVAL '30 minutes'
  AND (result->'context'->>'save_state_ms') IS NOT NULL
GROUP BY 1 ORDER BY 1;
```

Expected after rollout:
- `ss_p90` for cg=0 drops 91ms → ~45ms (one UPDATE round-trip instead of two).
- `ss_calls_avg` stays at 2.0 (logical count).
- `ss_coalesced_avg` shows ~1.0 (one of the two save_state requests per event was elided).

`engine_total_ms` should drop further as a result.  `persist_event_compat_ms` (round-4 surface) should remain stable.

Closes noetl/noetl#636
Refs noetl/ai-meta#29

🤖 Generated with [Claude Code](https://claude.com/claude-code)