### PR TITLE
R-1.2 PR-EE-4: align EventEmitRequest with cross-stack envelope

### DIFF
--- a/noetl/server/api/broker/schema.py
+++ b/noetl/server/api/broker/schema.py
@@ -12,7 +12,7 @@ Supports ResultRef pattern for efficient result storage:
 
 from typing import Optional, Dict, Any, List, Union, Literal
 from datetime import datetime
-from pydantic import BaseModel, Field, field_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 
 # ============================================================================
@@ -115,29 +115,24 @@ class EventPayloadData(BaseModel):
 # Event Types and Status
 # ============================================================================
 
-# Event types - past tense to describe what happened
-EventType = Literal[
-    "playbook_started",
-    "playbook_completed",
-    "playbook_failed",
-    "workflow_initialized",
-    "step_started",
-    "step_completed",
-    "step_failed",
-    "step_skipped",
-    "step_result",
-    "action_started",
-    "action_completed",
-    "action_failed",
-    "iterator_started",      # Iterator/loop execution started
-    "iterator_completed",    # Iterator/loop completed all iterations
-    "iterator_failed",       # Iterator/loop failed
-    "iteration_completed",   # Single iteration within loop completed
-    "retry_scheduled",       # Retry attempt scheduled for failed action
-    "error",
-    "info",
-    "warning"
-]
+# Event types — free-form string with a recommended taxonomy.
+#
+# R-1.2 PR-EE-4: loosened from ``Literal[...]`` to ``str``.  The
+# original underscored Literal (``playbook_started``,
+# ``step_completed``, etc.) was already out of sync with what the
+# Python core code AND the worker / Rust noetl-server produce —
+# everything in production uses dot-notation (``step.enter``,
+# ``step.exit``, ``call.done``, ``command.completed``,
+# ``command.issued``, etc.).  Grep ``noetl/core/dsl/engine/executor/``
+# for the actual taxonomy.
+#
+# Type alias kept as ``EventType`` (rather than removing) so existing
+# annotations in this file and elsewhere don't need to change.
+# Validation now happens at the call site (orchestrator + projector)
+# against the dot-notation taxonomy.  Cross-repo reconciliation
+# tracked on `noetl/ai-meta#30
+# <https://github.com/noetl/ai-meta/issues/30>`_.
+EventType = str
 
 # Event status - uppercase to match worker/core status system
 EventStatus = Literal[
@@ -155,10 +150,31 @@ EventStatus = Literal[
 class EventEmitRequest(BaseModel):
     """
     Request schema for emitting an event to the event log.
-    
+
     Minimal schema for direct event emission without business logic processing.
+
+    R-1.2 PR-EE-4: aligned with the executor's ``ExecutorEvent``
+    shape (noetl-executor 0.3.1) + the Rust noetl-server's
+    ``EventRequest`` (PR-EE-2) per the cross-repo event envelope
+    reconciliation tracked on
+    `noetl/ai-meta#30 <https://github.com/noetl/ai-meta/issues/30>`_.
+
+    Validation aliases let producers send either the executor's
+    canonical field names or the worker's legacy field names:
+
+    - ``context`` field accepts ``payload`` as input alias (matches
+      worker's pre-EE ``WorkerEvent.payload``).
+    - ``node_name`` field accepts ``step`` as input alias (matches
+      the executor's ``ExecutorEvent.step``).
+    - New explicit ``worker_id`` top-level field (was buried in
+      ``meta``); aligns with the Rust server's ``EventRequest.worker_id``.
+
+    ``populate_by_name=True`` lets producers send EITHER the
+    canonical name OR the alias — both deserialize cleanly.
     """
-    
+
+    model_config = ConfigDict(populate_by_name=True)
+
     # Required fields
     execution_id: str = Field(
         ...,
@@ -167,7 +183,8 @@ class EventEmitRequest(BaseModel):
     )
     event_type: EventType = Field(
         ...,
-        description="Type of event being emitted"
+        description="Type of event being emitted",
+        validation_alias=AliasChoices("event_type", "name")
     )
     
     # Optional identification
@@ -197,7 +214,8 @@ class EventEmitRequest(BaseModel):
     )
     node_name: Optional[str] = Field(
         default=None,
-        description="Human-readable node/step name"
+        description="Human-readable node/step name",
+        validation_alias=AliasChoices("node_name", "step")
     )
     node_type: Optional[str] = Field(
         default=None,
@@ -215,7 +233,8 @@ class EventEmitRequest(BaseModel):
     )
     context: Optional[Dict[str, Any]] = Field(
         default=None,
-        description="Event context data (arbitrary JSON)"
+        description="Event context data (arbitrary JSON)",
+        validation_alias=AliasChoices("context", "payload")
     )
     result: Optional[Any] = Field(
         default=None,
@@ -284,7 +303,18 @@ class EventEmitRequest(BaseModel):
         default=True,
         description="If True, event is for logging/observability"
     )
-    
+
+    # Emitter identification
+    # R-1.2 PR-EE-4: lifted from ``meta`` to a top-level field so it
+    # matches the Rust noetl-server ``EventRequest.worker_id``
+    # shape.  Producers that send it nested under ``meta`` keep
+    # working — the server still reads ``meta.worker_id`` as a
+    # fallback.
+    worker_id: Optional[str] = Field(
+        default=None,
+        description="Worker ID that emitted this event (pod id, or 'cli-local' for CLI mode)"
+    )
+
     # Timestamps
     created_at: Optional[datetime] = Field(
         default=None,

--- a/tests/api/test_event_emit_request_aliases.py
+++ b/tests/api/test_event_emit_request_aliases.py
@@ -1,0 +1,148 @@
+"""Tests for the EventEmitRequest validation aliases introduced
+in R-1.2 PR-EE-4 (cross-repo event envelope reconciliation).
+
+Locks in three back-compat guarantees:
+
+1. Producers sending the executor's `ExecutorEvent` shape
+   (canonical names: `event_type`, `node_name`, `context`) round-
+   trip cleanly.
+2. Producers sending the worker's pre-EE `WorkerEvent` shape
+   (legacy names: `name`, `step`, `payload`) deserialize via the
+   `validation_alias=AliasChoices(...)` declarations.
+3. The new `worker_id` field is accepted as a top-level field.
+
+See `agents/rules/observability.md` Principle 3 for the
+`event_id` snowflake contract that this schema accepts but does
+not require.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from noetl.server.api.broker.schema import EventEmitRequest
+
+
+def _minimum_required() -> dict:
+    return {
+        "execution_id": "478775660589088776",
+        "event_type": "step.enter",
+    }
+
+
+class TestEventTypeAlias:
+    """`event_type` is the canonical name; `name` is the alias."""
+
+    def test_canonical_event_type_works(self):
+        req = EventEmitRequest.model_validate(_minimum_required())
+        assert req.event_type == "step.enter"
+
+    def test_legacy_name_alias_deserializes_into_event_type(self):
+        # Pre-PR-EE clients (worker before EE-3) might send `name`.
+        body = {"execution_id": "1", "name": "step.exit"}
+        req = EventEmitRequest.model_validate(body)
+        assert req.event_type == "step.exit"
+
+
+class TestNodeNameAlias:
+    """`node_name` is the canonical name; `step` is the alias."""
+
+    def test_canonical_node_name_works(self):
+        req = EventEmitRequest.model_validate(
+            {**_minimum_required(), "node_name": "fetch"}
+        )
+        assert req.node_name == "fetch"
+
+    def test_step_alias_deserializes_into_node_name(self):
+        # Executor's `ExecutorEvent.step` field should land in
+        # `node_name` on the server side.
+        req = EventEmitRequest.model_validate(
+            {**_minimum_required(), "step": "fetch_calendar"}
+        )
+        assert req.node_name == "fetch_calendar"
+
+
+class TestContextAlias:
+    """`context` is the canonical name; `payload` is the alias."""
+
+    def test_canonical_context_works(self):
+        req = EventEmitRequest.model_validate(
+            {**_minimum_required(), "context": {"foo": "bar"}}
+        )
+        assert req.context == {"foo": "bar"}
+
+    def test_payload_alias_deserializes_into_context(self):
+        # Worker's pre-EE `WorkerEvent.payload` should land in
+        # `context` on the server side.
+        req = EventEmitRequest.model_validate(
+            {**_minimum_required(), "payload": {"items": 42}}
+        )
+        assert req.context == {"items": 42}
+
+
+class TestWorkerId:
+    """`worker_id` is a new explicit top-level field (R-1.2 PR-EE-4)."""
+
+    def test_worker_id_accepted_as_top_level_field(self):
+        req = EventEmitRequest.model_validate(
+            {**_minimum_required(), "worker_id": "worker-prod-7"}
+        )
+        assert req.worker_id == "worker-prod-7"
+
+    def test_worker_id_defaults_to_none_when_omitted(self):
+        req = EventEmitRequest.model_validate(_minimum_required())
+        assert req.worker_id is None
+
+    def test_worker_id_omitted_from_serialized_when_none(self):
+        req = EventEmitRequest.model_validate(_minimum_required())
+        dumped = req.model_dump(exclude_none=True)
+        assert "worker_id" not in dumped
+
+
+class TestFullExecutorEnvelopeRoundTrips:
+    """The full ExecutorEvent shape (per noetl-executor 0.3.1)
+    deserializes cleanly via the aliases."""
+
+    def test_executor_shape_round_trip(self):
+        # This is the wire shape noetl-executor 0.3.1 produces
+        # AND the noetl-server (Rust, post-EE-2) accepts.  Python
+        # should also accept it now.
+        wire = {
+            "execution_id": "478775660589088776",
+            "event_type": "command.completed",
+            "step": "fetch_calendar",
+            "status": "COMPLETED",
+            "created_at": "2026-05-31T03:14:15Z",
+            "context": {"items": 42},
+            "event_id": "478775660589088777",
+            "worker_id": "worker-prod-7",
+            "meta": {"attempts": 2},
+        }
+        req = EventEmitRequest.model_validate(wire)
+        assert req.execution_id == "478775660589088776"
+        assert req.event_type == "command.completed"
+        assert req.node_name == "fetch_calendar"
+        assert req.status == "COMPLETED"
+        assert req.event_id == "478775660589088777"
+        assert req.worker_id == "worker-prod-7"
+        assert req.meta == {"attempts": 2}
+        assert req.context == {"items": 42}
+
+
+class TestLegacyWorkerShape:
+    """Pre-EE worker wire format (everything in payload, name not
+    event_type) deserializes via the aliases."""
+
+    def test_legacy_worker_shape(self):
+        # This is what the worker sends today (pre-EE-3).  Server
+        # should accept it without any changes on the worker side.
+        wire = {
+            "execution_id": "478775660589088776",
+            "name": "call.done",  # legacy field name
+            "step": "fetch",  # legacy field name
+            "payload": {"result": "ok"},  # legacy field name
+        }
+        req = EventEmitRequest.model_validate(wire)
+        assert req.event_type == "call.done"
+        assert req.node_name == "fetch"
+        assert req.context == {"result": "ok"}


### PR DESCRIPTION
## Summary

Third of four-PR **cross-repo event envelope reconciliation** series tracked on [noetl/ai-meta#30](https://github.com/noetl/ai-meta/issues/30).  Aligns the Python broker schema with the executor's enriched `ExecutorEvent` (noetl-cli#37, executor 0.3.1) + the Rust `noetl-server`'s `EventRequest` ([noetl/server#6](https://github.com/noetl/server/pull/6), v2.0.0).

After this PR ships, **all four shapes** (worker `WorkerEvent`, Python `EventEmitRequest`, Rust `EventRequest`, executor `ExecutorEvent`) accept the same wire format on input.

## Real finding while writing this PR

The Python `EventType = Literal[...]` was **already broken** against the worker AND the rest of the Python codebase:

```bash
grep -rn 'event_type.*step\.\|event_type.*command\.\|event_type.*call\.' noetl/

  noetl/core/dsl/engine/executor/lifecycle.py:51:   ... event_type = 'step.enter' ...
  noetl/core/dsl/engine/executor/events.py:2382:   ... event_type = 'command.issued'
  noetl/core/dsl/engine/executor/events.py:2387:   ... event_type = 'call.done'
  noetl/core/dsl/engine/executor/store.py:530:     if event_type == "command.failed":
  noetl/core/dsl/engine/executor/store.py:545:     if event_type not in {"step.exit", "call.done"}:
  noetl/server/api/core/execution.py:247:          ... event_type IN ('step.exit', 'loop.done') ...
  noetl/tools/agent/executor.py:621:               if evt.get("event_type") not in ("command.completed", "step.exit", "call.done"):
```

Production uses **dot-notation** everywhere (`step.exit`, `call.done`, `command.completed`).  The schema's strict `Literal["step_started", "step_completed", ...]` (underscored, past-tense) would have rejected every real event.  Either dead code or the validation never actually fired.  This PR replaces it with `EventType = str` and notes that semantic validation lives at the call site (orchestrator + projector) where the real taxonomy is enforced.

## What lands

### `EventType: Literal[...]` → `EventType = str`

The original Literal was out of sync with everything in production.  Loosening to `str` unblocks the cross-stack reconciliation.  Type alias kept (rather than removed) so existing annotations don't churn.

### `EventEmitRequest` validation aliases

Added `validation_alias=AliasChoices(...)` on three fields:

| Canonical (executor / Python) | Legacy alias (worker pre-EE / Rust pre-EE-2) |
| :----                          | :----                                         |
| `event_type`                   | `name`                                        |
| `node_name`                    | `step`                                        |
| `context`                      | `payload`                                     |

`model_config = ConfigDict(populate_by_name=True)` lets producers send either form.  Pydantic 2 idiom; no migration burden on existing consumers.

### `worker_id` as explicit top-level field

Lifted from `meta.worker_id` (where it was nested) to a top-level `worker_id: Optional[str]`.  Matches the Rust `EventRequest.worker_id` (post-EE-2) and the executor's `ExecutorEvent.worker_id`.  Producers that send it nested under `meta` keep working — the field is optional and `meta` is preserved as-is.

## Cross-stack envelope after this PR

| Source | `event_type` | `step` | `context` | `worker_id` | `event_id` |
| :---- | :---- | :---- | :---- | :---- | :---- |
| **noetl-executor 0.3.1** | `event_type` | `step` | `context` (alias: `payload`) | optional | optional i64 |
| **noetl-server (Rust) post EE-2** | `event_type` (alias: `name`) | `step` | `payload` (alias: `context`) | optional | optional String |
| **Python EventEmitRequest post-EE-4** | `event_type` (alias: `name`) | `node_name` (alias: `step`) | `context` (alias: `payload`) | optional | optional String |
| **noetl-worker (pre-EE-3)** | `event_type` | `node_name` | `payload` | (in meta) | (server-generated) |

All four shapes accept the same wire format now.  PR-EE-3 (worker switch to `ExecutorEvent` re-export) is the last step.

## Tests

11 new tests in `tests/api/test_event_emit_request_aliases.py`, organized by class:

- `TestEventTypeAlias` (2): canonical + `name` alias
- `TestNodeNameAlias` (2): canonical + `step` alias
- `TestContextAlias` (2): canonical + `payload` alias
- `TestWorkerId` (3): top-level acceptance, default `None`, omit-on-dump
- `TestFullExecutorEnvelopeRoundTrips` (1): full executor wire shape round-trips
- `TestLegacyWorkerShape` (1): pre-EE worker wire format deserializes cleanly via aliases

All 11 pass.  Existing `tests/api/test_broker_event_outbox.py` also passes (no regressions).

## Versioning

Semantic-release will pick up the `feat!:` prefix.  The breaking signal applies to the `EventType` Literal removal (a typing contract change for consumers that imported `EventType` directly and relied on it for static analysis).  Wire-format compatibility is preserved via the aliases, so the major bump is conservative.

## What's next

| PR | Repo | State |
|---|---|---|
| EE-1 | noetl/cli | ✅ merged |
| EE-2 | noetl/server (Rust) | ✅ merged (#6) |
| **EE-4 (this PR)** | noetl/noetl (Python) | 🟢 open |
| EE-3 | noetl/worker | ⏳ last — replace `WorkerEvent` with `ExecutorEvent` re-export; sends new wire shape |

After EE-4 merges and both servers accept the new shape, EE-3 flips the worker's canonical send shape.  Until then, the worker keeps sending its current wire format which now deserializes cleanly through every alias.

Refs [noetl/ai-meta#30](https://github.com/noetl/ai-meta/issues/30) — Appendix H umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
