### PR TITLE
feat(events)!: complete EE-4 — accept EE-3 wire shape on /api/events

### DIFF
--- a/noetl/server/api/core/models.py
+++ b/noetl/server/api/core/models.py
@@ -1,5 +1,5 @@
 from typing import Any, Optional
-from pydantic import BaseModel, Field, model_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 from .core import _BATCH_MAX_EVENTS_PER_REQUEST, _BATCH_MAX_PAYLOAD_BYTES
 from .utils import _estimate_json_size
 
@@ -34,15 +34,67 @@ class ExecuteResponse(BaseModel):
     commands_generated: int
 
 class EventRequest(BaseModel):
-    """Worker event - reports task completion with result."""
-    execution_id: str
-    step: str
-    name: str  # step.enter, call.done, step.exit
-    payload: dict[str, Any] = Field(default_factory=dict)
+    """Worker event - reports task completion with result.
+
+    R-1.2 PR-EE-4 finalisation: accepts BOTH the legacy field
+    names (``name``, ``payload``, ``execution_id: str``) AND the
+    EE-3 / EE-4 canonical names (``event_type``, ``context``,
+    ``execution_id: int|str``) on the wire so the Rust worker's
+    ``ExecutorEvent`` shape lands cleanly without an extra
+    translation layer.  Internally we still expose ``name`` /
+    ``payload`` so the engine handlers in
+    ``core/events.py::handle_event`` don't need to change.
+
+    The companion ``broker/endpoint.py::emit_event(payload:
+    EventEmitRequest)`` route was dead code that never got
+    mounted; this change makes the actual mounted ``/api/events``
+    endpoint (``core/events.py``) accept the EE wire shape
+    directly via Pydantic ``validation_alias`` declarations.
+    Surfaced 2026-05-31 by the noetl-worker (Rust) kind-validation
+    pass against this broker.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    execution_id: str = Field(
+        ...,
+        description="Execution ID.  Accepts JSON string OR JSON "
+        "integer on the wire; stringified before storage to "
+        "match the bigint-string convention used by the rest of "
+        "the API surface.",
+    )
+    step: str = Field(
+        ...,
+        description="Step / node name.",
+        validation_alias=AliasChoices("step", "node_name"),
+    )
+    name: str = Field(
+        ...,
+        description="Event type (e.g. ``step.enter``, ``call.done``, "
+        "``step.exit``, ``command.completed``).  The legacy field "
+        "name; EE-4 producers may send ``event_type`` instead.",
+        validation_alias=AliasChoices("name", "event_type"),
+    )
+    payload: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Event payload / result data.  EE-4 producers "
+        "may send ``context`` instead.",
+        validation_alias=AliasChoices("payload", "context"),
+    )
     meta: Optional[dict[str, Any]] = None
     worker_id: Optional[str] = None
     actionable: bool = True
     informative: bool = True
+
+    @field_validator("execution_id", mode="before")
+    @classmethod
+    def _coerce_execution_id_to_string(cls, v):
+        """Accept JSON integer or string for execution_id; the
+        rest of the engine treats it as ``str`` (and parses to
+        ``int`` only at the SQL boundary)."""
+        if v is None:
+            return v
+        return str(v)
 
 class EventResponse(BaseModel):
     """Response for event."""
@@ -51,10 +103,30 @@ class EventResponse(BaseModel):
     commands_generated: int
 
 class BatchEventItem(BaseModel):
-    """A single event within a batch."""
-    step: str
-    name: str
-    payload: dict[str, Any] = Field(default_factory=dict)
+    """A single event within a batch.
+
+    Same EE-4 wire-shape compatibility as :class:`EventRequest` —
+    accepts both legacy (``name`` / ``payload``) and EE-3 / EE-4
+    canonical (``event_type`` / ``context``) field names.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    step: str = Field(
+        ...,
+        description="Step / node name.",
+        validation_alias=AliasChoices("step", "node_name"),
+    )
+    name: str = Field(
+        ...,
+        description="Event type.",
+        validation_alias=AliasChoices("name", "event_type"),
+    )
+    payload: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Event payload / result data.",
+        validation_alias=AliasChoices("payload", "context"),
+    )
     actionable: bool = False
     informative: bool = True
     meta: Optional[dict[str, Any]] = None

--- a/tests/api/test_event_request_aliases.py
+++ b/tests/api/test_event_request_aliases.py
@@ -1,0 +1,149 @@
+"""Tests for the EventRequest validation aliases added in the
+EE-4 broker-endpoint completion (2026-05-31).
+
+The legacy ``EventRequest`` model in ``noetl.server.api.core.models``
+backs the mounted ``/api/events`` endpoint.  Pre-fix it only accepted
+the legacy field shape (``name``, ``payload``, ``execution_id: str``);
+the EE-4 ``EventEmitRequest`` schema with aliases lived in
+``broker/endpoint.py`` but was dead code (never mounted).
+
+This change makes the actual mounted endpoint honor the EE-3 / EE-4
+wire shape (the Rust noetl-worker now sends ``event_type`` /
+``context`` / ``execution_id: int|str``).  These tests lock that in.
+
+See ``tests/api/test_event_emit_request_aliases.py`` for the
+companion tests on the dead-code broker schema.
+"""
+
+from __future__ import annotations
+
+from noetl.server.api.core.models import EventRequest
+
+
+def _minimum_required() -> dict:
+    """Just the truly required fields, in the canonical (EE-4) shape."""
+    return {
+        "execution_id": "478775660589088776",
+        "event_type": "step.enter",
+        "step": "fetch_calendar",
+    }
+
+
+class TestEventTypeAlias:
+    """``name`` is the canonical EventRequest field; ``event_type`` is
+    accepted as an alias so EE-3 workers don't need to translate."""
+
+    def test_canonical_name_works(self):
+        req = EventRequest.model_validate({**_minimum_required(), "name": "step.enter"})
+        assert req.name == "step.enter"
+
+    def test_event_type_alias_deserializes_into_name(self):
+        # EE-3 / EE-4 producers send `event_type`.
+        req = EventRequest.model_validate(_minimum_required())
+        assert req.name == "step.enter"
+
+
+class TestStepAlias:
+    """``step`` is the canonical EventRequest field; ``node_name`` is
+    accepted as an alias.  Matches the Python broker's
+    ``EventEmitRequest`` shape (where ``node_name`` is canonical)."""
+
+    def test_canonical_step_works(self):
+        body = {**_minimum_required(), "step": "fetch"}
+        req = EventRequest.model_validate(body)
+        assert req.step == "fetch"
+
+    def test_node_name_alias_deserializes_into_step(self):
+        body = {**_minimum_required(), "node_name": "fetch_calendar_alt"}
+        body.pop("step")
+        req = EventRequest.model_validate(body)
+        assert req.step == "fetch_calendar_alt"
+
+
+class TestPayloadContextAlias:
+    """``payload`` is the canonical EventRequest field; ``context`` is
+    accepted as an alias (EE-3 Rust worker emits ``context``)."""
+
+    def test_canonical_payload_works(self):
+        req = EventRequest.model_validate(
+            {**_minimum_required(), "payload": {"items": 1}}
+        )
+        assert req.payload == {"items": 1}
+
+    def test_context_alias_deserializes_into_payload(self):
+        req = EventRequest.model_validate(
+            {**_minimum_required(), "context": {"items": 42}}
+        )
+        assert req.payload == {"items": 42}
+
+
+class TestExecutionIdCoercion:
+    """``execution_id`` accepts JSON string OR integer on the wire and
+    stringifies before storage so the rest of the engine keeps its
+    ``str`` invariant."""
+
+    def test_string_passthrough(self):
+        req = EventRequest.model_validate(
+            {**_minimum_required(), "execution_id": "12345"}
+        )
+        assert req.execution_id == "12345"
+
+    def test_integer_coerced_to_string(self):
+        # The Rust noetl-worker's `ExecutorEvent.execution_id: i64`
+        # serialises to a JSON number.  Pre-fix the engine rejected
+        # it with `Input should be a valid string`.
+        body = _minimum_required()
+        body["execution_id"] = 638758527854445253
+        req = EventRequest.model_validate(body)
+        assert req.execution_id == "638758527854445253"
+
+
+class TestFullExecutorEnvelopeRoundTrips:
+    """The complete EE-3 wire shape (per noetl-executor 0.3.1 +
+    noetl-worker 3.0.0+) deserializes cleanly via the aliases AND
+    integer coercion."""
+
+    def test_executor_envelope(self):
+        wire = {
+            "execution_id": 478775660589088776,
+            "event_type": "command.completed",
+            "step": "fetch_calendar",
+            "status": "COMPLETED",
+            "created_at": "2026-05-31T03:14:15Z",
+            "context": {"items": 42},
+            "event_id": "478775660589088777",
+            "worker_id": "noetl-worker-rust-prod-7",
+            "meta": {"attempts": 2},
+        }
+        req = EventRequest.model_validate(wire)
+        assert req.execution_id == "478775660589088776"
+        assert req.name == "command.completed"
+        assert req.step == "fetch_calendar"
+        assert req.payload == {"items": 42}
+        assert req.meta == {"attempts": 2}
+        assert req.worker_id == "noetl-worker-rust-prod-7"
+        # `event_id`, `status`, `created_at` aren't fields on
+        # EventRequest — they're silently dropped (Pydantic's
+        # default behaviour for extra fields).  The handler does
+        # not consume them today; if/when it needs them, add the
+        # fields to the model.
+
+
+class TestLegacyShape:
+    """The pre-EE wire format (what the Python noetl-worker has been
+    sending for years) keeps working bit-for-bit."""
+
+    def test_legacy_worker_payload(self):
+        wire = {
+            "execution_id": "478775660589088776",
+            "name": "call.done",
+            "step": "fetch",
+            "payload": {"result": "ok"},
+            "worker_id": "noetl-worker-py-1",
+        }
+        req = EventRequest.model_validate(wire)
+        assert req.execution_id == "478775660589088776"
+        assert req.name == "call.done"
+        assert req.step == "fetch"
+        assert req.payload == {"result": "ok"}
+        assert req.worker_id == "noetl-worker-py-1"


### PR DESCRIPTION
## Summary

EE-4 ([noetl/noetl#639](https://github.com/noetl/noetl/pull/639)) added \`EventEmitRequest\` with \`validation_alias=AliasChoices(...)\` declarations for the cross-stack event envelope reconciliation tracked on [noetl/ai-meta#30](https://github.com/noetl/ai-meta/issues/30).

**However**, the schema landed in \`noetl.server.api.broker.schema\` but the companion endpoint in \`noetl.server.api.broker.endpoint::emit_event\` was **never wired into the FastAPI app**.  Only the legacy \`core/events.py::handle_event\` endpoint serves traffic at \`/api/events\`, and it uses the legacy \`EventRequest\` model (no aliases, \`execution_id: str\` only).

So the EE-4 schema was effectively dead code; the wire-shape promise from the EE umbrella ("all four producers / consumers accept the same wire format on \`/api/events\`") didn't hold in practice.

## Surfaced by

The noetl-worker (Rust) kind-validation pass on 2026-05-31.  After the worker (post EE-3, v3.0.0+) was updated to emit the canonical \`ExecutorEvent\` shape, every event-emission attempt failed with:

\`\`\`
{\"detail\":[
  {\"type\":\"string_type\",\"loc\":[\"body\",\"execution_id\"],
   \"msg\":\"Input should be a valid string\",\"input\":638758527854445253},
  {\"type\":\"missing\",\"loc\":[\"body\",\"name\"],\"msg\":\"Field required\",...}
]}
\`\`\`

## What this PR does

### \`noetl/server/api/core/models.py::EventRequest\`

Adds Pydantic \`validation_alias=AliasChoices(...)\` declarations matching the EE-4 \`EventEmitRequest\` shape:

| Canonical field | Alias (EE-3 / EE-4 wire) |
| :----           | :----                    |
| \`name\`          | \`event_type\`             |
| \`step\`          | \`node_name\`              |
| \`payload\`       | \`context\`                |

Plus \`model_config = ConfigDict(populate_by_name=True)\` so producers may send EITHER the canonical name OR the alias.

\`execution_id\` field gains a \`mode='before'\` field validator that coerces JSON-integer input to \`str\` — matches the Rust worker's \`ExecutorEvent.execution_id: i64\` serialisation without breaking the rest of the engine's \`str\` invariant (SQL boundary still casts to \`int\`).

### \`BatchEventItem\`

Same treatment so the \`/events/batch\` endpoint accepts the new wire shape too.

## Tests

**21 tests pass** (10 new in \`tests/api/test_event_request_aliases.py\`, 11 existing in \`tests/api/test_event_emit_request_aliases.py\`):

- Canonical field-name acceptance (\`name\`, \`step\`, \`payload\`).
- EE-3 alias acceptance (\`event_type\`, \`node_name\`, \`context\`).
- \`execution_id\` integer-to-string coercion.
- Full EE-3 \`ExecutorEvent\` envelope round-trip.
- Legacy worker wire format round-trip (no regression).

## Why this completes EE-4

Before this change, the EE umbrella was schema-only on the Python side — the live endpoint was still pinned to the legacy shape.  After this change:

| Source | event_type | step / node_name | context / payload | worker_id | execution_id |
|---|---|---|---|---|---|
| noetl-executor 0.3.1 | event_type | step | context (alias: payload) | optional | i64 |
| noetl-server (Rust) 2.0.1+ | event_type (alias: name) | step | payload (alias: context) | optional | String |
| **Python broker (this PR)** | name (alias: event_type) | step (alias: node_name) | payload (alias: context) | optional | str (coerces from int) |
| noetl-worker 5.1.1+ | event_type | step | context | top-level | i64 |

All four producers / consumers now really do accept the same wire format on \`/api/events\`.

## Versioning

\`feat!:\` prefix — semantic-release will major-bump.  The aliases themselves are additive but the \`execution_id\` coercion changes the model's behaviour for clients that previously got a 422 on numeric input (highly unlikely — the field has always been described as a stringified snowflake).

Refs [noetl/ai-meta#30](https://github.com/noetl/ai-meta/issues/30) — Appendix H R-1.2 EE umbrella.  Closes the noetl-side gap surfaced during the EE-3 kind-validation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)