### PR TITLE
fix(api): drop redundant /api/ prefix on result + temp routers

### DIFF
--- a/noetl/server/api/result/endpoint.py
+++ b/noetl/server/api/result/endpoint.py
@@ -30,7 +30,14 @@ from noetl.core.sanitize import redact_keychain_values
 
 logger = setup_logger(__name__, include_location=True)
 
-router = APIRouter(prefix="/api/result", tags=["result"])
+# NOTE: this router is mounted by `noetl/server/api/__init__.py` under
+# the parent router, which is then mounted by `noetl/server/app.py` +
+# `wiring.py` with `prefix="/api"`.  So this router's prefix must NOT
+# also include `/api/` — otherwise the actual surfaced paths come out as
+# `/api/api/result/...`, which is the double-prefix bug surfaced by the
+# Rust worker's R-2.1 kind validation on 2026-06-01 (PUT /api/result
+# returned HTTP 404).
+router = APIRouter(prefix="/result", tags=["result"])
 
 
 # === Request/Response Models ===

--- a/noetl/server/api/temp/endpoint.py
+++ b/noetl/server/api/temp/endpoint.py
@@ -28,7 +28,9 @@ from noetl.core.sanitize import redact_keychain_values
 
 logger = setup_logger(__name__, include_location=True)
 
-router = APIRouter(prefix="/api/temp", tags=["temp"])
+# See the matching comment in `result/endpoint.py` — the parent router
+# already adds `/api`, so this prefix must NOT also include `/api/`.
+router = APIRouter(prefix="/temp", tags=["temp"])
 
 
 # === Request/Response Models ===


### PR DESCRIPTION
## Summary

Both `result/endpoint.py` and `temp/endpoint.py` declared their inner `APIRouter` with `prefix=\"/api/result\"` (resp. `/api/temp`). These routers are mounted by `server/api/__init__.py`'s `router.include_router(...)` under the parent api router, which is then mounted by `app.py` + `wiring.py` with `prefix=\"/api\"`. The result was that every surfaced path came out doubly-prefixed:

```
PUT  /api/api/result/{execution_id}
GET  /api/api/result/{execution_id}/{step_name}
GET  /api/api/result/resolve
...  /api/api/temp/...
```

The endpoint files' own docstrings document the intended URLs as `/api/result/{execution_id}` (no double `/api/`), so the prefixes were just wrong.

## How this surfaced

The bug was latent because Python in-process callers go through `default_store.put` directly + bypass the HTTP layer, and there were no integration tests hitting the HTTP surface on these routers.

The Rust noetl-worker's R-2.1 cross-node durable result-store path ([noetl/worker#29](https://github.com/noetl/worker/pull/29)) is the first HTTP caller. The kind-cluster validation on 2026-06-01 surfaced the bug as:

```
put_result failed: HTTP 404 {\"detail\":\"Not Found\"}
```

with the worker correctly falling back to its shm-only branch (R-2.1 colocated path still works without the durable backup).

## Fix

Change `prefix=\"/api/result\"` → `prefix=\"/result\"` and `prefix=\"/api/temp\"` → `prefix=\"/temp\"`. The parent router still mounts under `/api`, so the surfaced paths come out as `/api/result/...` and `/api/temp/...` — matching the docstrings and the Rust worker's URL.

## Test plan

- [x] OpenAPI surface inspected with the patched file → paths now correct (`/api/result/{execution_id}`, no double `/api/`).
- [ ] Kind validation re-run to confirm end-to-end durable PUT works (will follow up after the image rebuild + worker pointer bump in ai-meta).
- [ ] Worker /metrics: `noetl_worker_result_store_put_errors_total` stops climbing, `noetl_worker_result_store_put_bytes_total` starts climbing.

## Compatibility notes

- **Python in-process callers**: unaffected (they go through `default_store` directly).
- **HTTP callers that built `/api/api/result/...` URLs as a workaround**: would need to update. The Rust worker doesn't have this workaround — it uses the documented path, so it just starts working post-merge.
- **OpenAPI consumers**: paths shift from `/api/api/result/...` to `/api/result/...`.

Refs noetl/ai-meta#30

🤖 Generated with [Claude Code](https://claude.com/claude-code)