### PR TITLE
feat(server): Arrow Flight gRPC do_get endpoint for result-store reads (R-2.3 Phase A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Port forwarding is configured in `ci/kind/config.yaml`. Do **NOT** use kubectl p
 | Service          | Host Port | Container Port | URL                               |
 |------------------|-----------|----------------|-----------------------------------|
 | NoETL Server     | 8082      | 30082          | http://localhost:8082             |
+| NoETL Flight gRPC| 8083      | 30083          | grpc://localhost:8083             |
 | Gateway API      | 8090      | 30090          | http://localhost:8090             |
 | Gateway UI       | 8080      | 30080          | http://localhost:8080             |
 | PostgreSQL       | 54321     | 30321          | localhost:54321                   |

--- a/ci/kind/config.yaml
+++ b/ci/kind/config.yaml
@@ -5,10 +5,17 @@ nodes:
   - role: control-plane
     extraPortMappings:
         # NOETL
-      - containerPort: 30082 
+      - containerPort: 30082
         hostPort: 8082
         listenAddress: "0.0.0.0" # optional: set the bind address on the host. 0.0.0.0 is the current default
         protocol: TCP # optional: set the protocol to one of TCP, UDP, SCTP. TCP is the default
+
+        # NOETL Arrow Flight (R-2.3 Phase A) — gRPC endpoint for
+        # the columnar result-store fetch path.
+      - containerPort: 30083
+        hostPort: 8083
+        listenAddress: "0.0.0.0"
+        protocol: TCP
 
         # Postgers
       - containerPort: 30321

--- a/noetl/server/api/result/flight_server.py
+++ b/noetl/server/api/result/flight_server.py
@@ -1,0 +1,242 @@
+"""Arrow Flight gRPC endpoint for the noetl result store (R-2.3).
+
+This module exposes a `pyarrow.flight.FlightServerBase` subclass that
+serves the same data as the HTTP `GET /api/result/resolve?ref=...`
+endpoint, but as an Arrow IPC stream over gRPC.
+
+## Why Arrow Flight
+
+The R-2.1 cross-node durable path ships tabular results through
+`/api/result/resolve` as JSON.  For tabular tool outputs (DuckDB /
+Postgres / Snowflake rowsets) this round-trips through:
+
+    rows (in-memory)  ── server.put_result ──>  default_store.put
+                                                      |
+                                                      v
+                                  rows ── JSON serialize ── tier write
+                                  ↑
+                                  └── server resolves ── JSON deserialize
+                                                      |
+                                                      v
+                              Rust worker / Python consumer JSON-parses
+                                              back to rows
+
+For R-2.2 columnar tool outputs the worker already stages Arrow IPC
+bytes in shm; the durable path however falls back to JSON because the
+HTTP endpoint doesn't speak Arrow.
+
+Arrow Flight closes that gap.  A consumer that knows it wants tabular
+data calls `pyarrow.flight.connect(...).do_get(Ticket(ref_uri))`,
+the server reads the stored data via `default_store.resolve`, encodes
+it once via `rows_to_arrow_ipc`, and streams the IPC bytes back.  The
+consumer reads with `RecordBatchStreamReader` — zero-copy, columnar.
+
+## Wire format
+
+- **Ticket**: the `noetl://execution/<eid>/result/<step>/<id>` URI as
+  raw bytes.  Consumers already have it from `result.reference.ref`
+  on the call.done event — no separate lookup needed.
+- **DoGet response**: Arrow IPC stream of the materialized RecordBatch.
+  For tabular results → encoded via `rows_to_arrow_ipc` (the same
+  function the worker uses for the shm fast path, so the wire format
+  is identical regardless of producer).
+- **Non-tabular results**: returned via `FlightError::Unimplemented`
+  for Phase A — consumers fall back to `/api/result/resolve` HTTP.
+
+## Boundary discipline
+
+This endpoint is a thin Flight wrapper around the existing
+`default_store.resolve`.  All scrubbing + tier dispatch + auth
+happens in the underlying store; the Flight server adds no new
+trust boundary.  The cluster-internal gRPC port (default 8083) is
+not exposed publicly — same trust model as the existing
+`/api/result/resolve`.
+
+## R-2.3 follow-up scope
+
+Phase A (this module):
+  - `do_get(ticket)` for tabular results.
+  - Single in-cluster endpoint; no `FlightInfo` indirection yet.
+  - Spawned alongside the FastAPI server in `app.py`'s lifespan.
+
+Phase B (deferred):
+  - Rust consumer via `arrow-flight` crate in noetl-worker.
+  - Benchmark vs HTTP/JSON path.
+
+Phase C (deferred):
+  - Multi-endpoint `FlightInfo` for sharded result tiers.
+  - mTLS + token auth for non-cluster-internal callers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import Any, Optional
+
+from noetl.core.storage import default_store
+from noetl.core.storage.arrow_ipc import ARROW_STREAM_MEDIA_TYPE, rows_to_arrow_ipc
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_rows(data: Any) -> Optional[list[dict[str, Any]]]:
+    """Try to pull a list-of-dict rowset out of a resolved result.
+
+    Accepts the two shapes the worker emits:
+    - **wrapped**: ``{"columns": [...], "rows": [{...}, ...]}``
+    - **nested under data**: ``{"data": {"columns": [...], "rows": [...]}}``
+
+    Returns ``None`` if the data doesn't have a tabular shape, signalling
+    to ``do_get`` that the consumer should fall back to the HTTP JSON path.
+    """
+    if not isinstance(data, dict):
+        return None
+
+    payload = data
+    if "rows" not in payload:
+        nested = payload.get("data")
+        if isinstance(nested, dict) and "rows" in nested:
+            payload = nested
+        else:
+            return None
+
+    rows = payload.get("rows")
+    if not isinstance(rows, list):
+        return None
+    # Row-array shape (e.g. DuckDB as_objects=False) — would need to
+    # combine with `columns`, but we don't support that in Phase A.
+    if rows and not isinstance(rows[0], dict):
+        return None
+    return rows  # type: ignore[return-value]
+
+
+class NoetlFlightServer:
+    """Arrow Flight gRPC server for result-store reads.
+
+    Wraps `pyarrow.flight.FlightServerBase`.  Lazy-imported here so
+    the noetl-server can start even on a host where pyarrow.flight
+    is broken (it should be available wherever pyarrow is, but
+    defensive imports keep startup robust).
+
+    Start with ``server.start_in_thread()``; stop with
+    ``server.shutdown()``.  Designed to run alongside the FastAPI
+    process — gRPC and HTTP listen on different ports.
+    """
+
+    def __init__(self, location: str = "grpc://0.0.0.0:8083"):
+        self.location = location
+        self._server: Any = None  # pyarrow.flight.FlightServerBase instance
+        self._thread: Optional[threading.Thread] = None
+        self._serve_exception: Optional[BaseException] = None
+
+    def _build_server(self) -> Any:
+        """Construct the pyarrow.flight server.  Lazy-imported."""
+        import pyarrow.flight as flight
+
+        outer = self
+
+        class _Server(flight.FlightServerBase):
+            def do_get(self, context: Any, ticket: Any) -> Any:
+                ref_uri = ticket.ticket.decode("utf-8")
+                logger.debug("Flight do_get: ref=%s", ref_uri)
+                # Run the async resolve on the store's event loop —
+                # FlightServerBase.do_get is called on a worker thread,
+                # so we use asyncio.run_coroutine_threadsafe via a
+                # newly-created loop (default_store.resolve is async).
+                # This keeps the Flight server independent of the
+                # FastAPI app's loop.
+                loop = asyncio.new_event_loop()
+                try:
+                    data = loop.run_until_complete(default_store.resolve(ref_uri))
+                finally:
+                    loop.close()
+
+                rows = _extract_rows(data)
+                if rows is None:
+                    raise flight.FlightUnavailableError(
+                        f"Flight do_get only serves tabular results; ref={ref_uri} "
+                        "has no row data.  Consumer should fall back to HTTP "
+                        "/api/result/resolve."
+                    )
+
+                payload, _digest, _row_count = rows_to_arrow_ipc(rows)
+
+                # Stream the IPC bytes back.  RecordBatchStream reads
+                # from a pyarrow Buffer / file-like, so we wrap the
+                # already-encoded bytes.
+                import pyarrow as pa
+                buffer = pa.py_buffer(payload)
+                reader = pa.ipc.open_stream(buffer)
+                return flight.RecordBatchStream(reader)
+
+            def list_actions(self, context: Any) -> list[Any]:
+                return []
+
+            def list_flights(self, context: Any, criteria: Any) -> Any:
+                return iter([])
+
+            def get_flight_info(self, context: Any, descriptor: Any) -> Any:
+                # Phase A: we don't expose flights by listing; consumers
+                # already have the ref URI from `result.reference.ref`.
+                # Raise as FlightServerError — pyarrow.flight in this
+                # version doesn't ship an `Unimplemented` variant, but
+                # the message + the FlightServerError type are enough
+                # for clients to distinguish "not supported" from a
+                # transient outage.
+                raise flight.FlightServerError(
+                    "FlightInfo lookup is not implemented in Phase A.  "
+                    "Consumers submit Tickets directly to DoGet using the "
+                    "noetl:// URI from `result.reference.ref` on the "
+                    "call.done event."
+                )
+
+        return _Server(location=outer.location)
+
+    def start_in_thread(self) -> None:
+        """Spawn the Flight server in a daemon thread.  Returns immediately."""
+        if self._thread is not None:
+            return
+        self._server = self._build_server()
+
+        def _run() -> None:
+            try:
+                logger.info(
+                    "Arrow Flight server starting at %s (R-2.3 Phase A)",
+                    self.location,
+                )
+                self._server.serve()
+                logger.info("Arrow Flight server stopped")
+            except BaseException as exc:  # noqa: BLE001
+                logger.exception("Arrow Flight server crashed: %s", exc)
+                self._serve_exception = exc
+
+        self._thread = threading.Thread(
+            target=_run,
+            name="noetl-arrow-flight",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def shutdown(self) -> None:
+        """Gracefully stop the Flight server + join the thread."""
+        if self._server is not None:
+            try:
+                self._server.shutdown()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Flight server shutdown error: %s", exc)
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+        if self._serve_exception is not None:
+            logger.warning(
+                "Arrow Flight server exited with exception: %s",
+                self._serve_exception,
+            )
+
+
+__all__ = [
+    "NoetlFlightServer",
+    "ARROW_STREAM_MEDIA_TYPE",
+]

--- a/noetl/server/app.py
+++ b/noetl/server/app.py
@@ -15,6 +15,7 @@ from noetl.core.db.pool import init_pool, close_pool
 from noetl.core.logger import setup_logger
 from noetl.core.urls import normalize_server_base_url
 from noetl.server.api import router as api_router
+from noetl.server.api.result.flight_server import NoetlFlightServer
 from noetl.server.middleware import catch_exceptions_middleware
 
 # Import core execution API
@@ -359,6 +360,35 @@ def _create_app(settings: Settings) -> FastAPI:
             except Exception as e:
                 logger.error(f"Command reaper startup failed (non-fatal): {e}", exc_info=True)
 
+            # R-2.3 Phase A: spawn the Arrow Flight gRPC server in a
+            # background thread alongside the FastAPI process.  Provides
+            # a columnar zero-copy DoGet path for tabular result-store
+            # reads (R-2.1 cross-node durable refs).  Listens on
+            # NOETL_FLIGHT_LOCATION (default grpc://0.0.0.0:8083);
+            # NOETL_FLIGHT_DISABLED=1 turns the spawn off for hosts
+            # where pyarrow.flight is unavailable or the port conflicts.
+            flight_server: Optional[NoetlFlightServer] = None
+            try:
+                if os.getenv("NOETL_FLIGHT_DISABLED", "").strip() in ("1", "true", "True"):
+                    logger.info("Arrow Flight server disabled via NOETL_FLIGHT_DISABLED")
+                else:
+                    flight_location = os.getenv(
+                        "NOETL_FLIGHT_LOCATION",
+                        "grpc://0.0.0.0:8083",
+                    )
+                    flight_server = NoetlFlightServer(location=flight_location)
+                    flight_server.start_in_thread()
+                    logger.info(
+                        "Arrow Flight server background thread started (R-2.3 Phase A): %s",
+                        flight_location,
+                    )
+            except Exception as e:
+                logger.error(
+                    f"Arrow Flight server startup failed (non-fatal): {e}",
+                    exc_info=True,
+                )
+                flight_server = None
+
             yield
             # Shutdown
             stop_event.set()
@@ -390,6 +420,15 @@ def _create_app(settings: Settings) -> FastAPI:
                         await command_reaper_task
                 except Exception as e:
                     logger.exception(f"Critical error during command reaper task shutdown: {e}")
+            # R-2.3 Phase A: stop the Flight server thread.  Shutdown
+            # is best-effort — if the join times out the daemon thread
+            # is reclaimed by interpreter exit.
+            if flight_server is not None:
+                try:
+                    flight_server.shutdown()
+                    logger.info("Arrow Flight server background thread stopped")
+                except Exception as e:
+                    logger.exception(f"Arrow Flight server shutdown error: {e}")
             try:
                 await shutdown_publish_recovery_tasks()
             except Exception as e:

--- a/tests/unit/server/api/test_flight_server.py
+++ b/tests/unit/server/api/test_flight_server.py
@@ -1,0 +1,223 @@
+"""Unit tests for R-2.3 Phase A Arrow Flight do_get server."""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+import time
+from typing import Any, Optional
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# pyarrow.flight is part of the standard pyarrow distribution; if it's
+# unavailable on the test host we skip the whole module.
+pyarrow_flight = pytest.importorskip("pyarrow.flight")
+pa = pytest.importorskip("pyarrow")
+
+from noetl.server.api.result.flight_server import (
+    ARROW_STREAM_MEDIA_TYPE,
+    NoetlFlightServer,
+    _extract_rows,
+)
+
+
+# ---------------------------------------------------------------------------
+# _extract_rows
+# ---------------------------------------------------------------------------
+
+
+def test_extract_rows_wrapped_shape():
+    """Top-level {columns, rows} → returns the rows list."""
+    data = {
+        "columns": ["a", "b"],
+        "rows": [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}],
+    }
+    rows = _extract_rows(data)
+    assert rows == [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+
+
+def test_extract_rows_nested_under_data():
+    """{"data": {columns, rows}} → returns the nested rows."""
+    data = {
+        "status": "Success",
+        "data": {"columns": ["x"], "rows": [{"x": 42}]},
+        "duration_ms": 12,
+    }
+    rows = _extract_rows(data)
+    assert rows == [{"x": 42}]
+
+
+def test_extract_rows_no_rows_field():
+    """Object missing `rows` at every level → None."""
+    assert _extract_rows({"stdout": "hello", "exit_code": 0}) is None
+    assert _extract_rows({"data": {"columns": ["x"]}}) is None
+
+
+def test_extract_rows_array_rows_returns_none():
+    """Array-row shape (rows[0] not a dict) is unsupported in Phase A."""
+    data = {"columns": ["a", "b"], "rows": [[1, "x"], [2, "y"]]}
+    assert _extract_rows(data) is None
+
+
+def test_extract_rows_non_object_input():
+    """Non-object inputs return None."""
+    assert _extract_rows([1, 2, 3]) is None  # type: ignore[arg-type]
+    assert _extract_rows("hello") is None  # type: ignore[arg-type]
+    assert _extract_rows(None) is None  # type: ignore[arg-type]
+
+
+def test_extract_rows_empty_list_returns_empty_list():
+    """Empty rows list is still tabular shape; returns []."""
+    # Callers can decide whether to encode an empty batch or fall through;
+    # the function itself preserves the shape.
+    assert _extract_rows({"rows": []}) == []
+
+
+# ---------------------------------------------------------------------------
+# NoetlFlightServer round-trip
+# ---------------------------------------------------------------------------
+
+
+def _find_free_port() -> int:
+    """Pick a free TCP port — Flight server's port is set at start_in_thread."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_until_listening(port: int, timeout_seconds: float = 5.0) -> None:
+    """Poll until the Flight server's port accepts a connection."""
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(0.2)
+        try:
+            s.connect(("127.0.0.1", port))
+            s.close()
+            return
+        except OSError:
+            time.sleep(0.05)
+        finally:
+            s.close()
+    raise TimeoutError(f"Flight server on port {port} never started")
+
+
+@pytest.fixture
+def flight_server_with_stub_store(monkeypatch):
+    """Spin up a NoetlFlightServer on a free port with a stubbed
+    `default_store.resolve` returning a deterministic rowset.
+    Yields ``(server, port, expected_rows)`` and tears the server
+    down on exit.
+    """
+    port = _find_free_port()
+    expected_rows = [
+        {"id": 1, "username": "user_001", "password": "[REDACTED]"},
+        {"id": 2, "username": "user_002", "password": "[REDACTED]"},
+        {"id": 3, "username": "user_003", "password": "[REDACTED]"},
+    ]
+
+    async def fake_resolve(ref: Any) -> Any:
+        # The Flight server passes the ticket bytes decoded as the URI.
+        assert isinstance(ref, str)
+        assert ref.startswith("noetl://"), ref
+        return {"data": {"columns": ["id", "username", "password"], "rows": expected_rows}}
+
+    monkeypatch.setattr(
+        "noetl.server.api.result.flight_server.default_store",
+        type("StubStore", (), {"resolve": staticmethod(fake_resolve)}),
+    )
+
+    server = NoetlFlightServer(location=f"grpc://127.0.0.1:{port}")
+    server.start_in_thread()
+    _wait_until_listening(port)
+    try:
+        yield server, port, expected_rows
+    finally:
+        server.shutdown()
+
+
+def test_flight_do_get_round_trip_returns_rows(flight_server_with_stub_store):
+    """End-to-end: client submits a noetl:// ticket → server resolves
+    via the (stubbed) store + streams Arrow IPC back → client reads
+    rows that match what the store returned."""
+    _server, port, expected_rows = flight_server_with_stub_store
+
+    client = pyarrow_flight.connect(f"grpc://127.0.0.1:{port}")
+    ticket = pyarrow_flight.Ticket(b"noetl://execution/12345/result/big_select/abcd1234")
+    reader = client.do_get(ticket)
+    table = reader.read_all()
+
+    assert table.num_rows == 3
+    decoded = table.to_pylist()
+    assert decoded == expected_rows
+
+
+def test_flight_do_get_non_tabular_raises_unavailable(monkeypatch):
+    """Non-tabular result → server raises FlightUnavailableError so the
+    client can fall back to HTTP `/api/result/resolve`."""
+    port = _find_free_port()
+
+    async def fake_resolve(ref: Any) -> Any:
+        # Shell-tool result shape: no `rows` field at any level.
+        return {"stdout": "hello world", "exit_code": 0, "duration_ms": 12}
+
+    monkeypatch.setattr(
+        "noetl.server.api.result.flight_server.default_store",
+        type("StubStore", (), {"resolve": staticmethod(fake_resolve)}),
+    )
+
+    server = NoetlFlightServer(location=f"grpc://127.0.0.1:{port}")
+    server.start_in_thread()
+    _wait_until_listening(port)
+    try:
+        client = pyarrow_flight.connect(f"grpc://127.0.0.1:{port}")
+        ticket = pyarrow_flight.Ticket(b"noetl://execution/12345/result/shell_step/x")
+        with pytest.raises(pyarrow_flight.FlightUnavailableError):
+            client.do_get(ticket).read_all()
+    finally:
+        server.shutdown()
+
+
+def test_flight_get_flight_info_returns_unimplemented(monkeypatch):
+    """Phase A doesn't expose FlightInfo — consumers must submit
+    Tickets directly.  The server raises FlightServerError with a
+    descriptive message (this pyarrow version doesn't expose a
+    dedicated `Unimplemented` variant)."""
+    port = _find_free_port()
+
+    async def fake_resolve(ref: Any) -> Any:  # pragma: no cover - not reached
+        return {}
+
+    monkeypatch.setattr(
+        "noetl.server.api.result.flight_server.default_store",
+        type("StubStore", (), {"resolve": staticmethod(fake_resolve)}),
+    )
+
+    server = NoetlFlightServer(location=f"grpc://127.0.0.1:{port}")
+    server.start_in_thread()
+    _wait_until_listening(port)
+    try:
+        client = pyarrow_flight.connect(f"grpc://127.0.0.1:{port}")
+        descriptor = pyarrow_flight.FlightDescriptor.for_path("any", "path")
+        with pytest.raises((pyarrow_flight.FlightServerError, pyarrow_flight.FlightInternalError)) as exc_info:
+            client.get_flight_info(descriptor)
+        # The descriptive message round-trips through gRPC so consumers
+        # can log it.
+        assert "Phase A" in str(exc_info.value)
+    finally:
+        server.shutdown()
+
+
+def test_arrow_stream_media_type_matches_python_constant():
+    """The constant re-exported from this module matches the Python
+    storage layer's own constant so cross-stack consumers can switch
+    on a single string."""
+    from noetl.core.storage.arrow_ipc import (
+        ARROW_STREAM_MEDIA_TYPE as STORAGE_MEDIA_TYPE,
+    )
+    assert ARROW_STREAM_MEDIA_TYPE == STORAGE_MEDIA_TYPE
+    assert ARROW_STREAM_MEDIA_TYPE == "application/vnd.apache.arrow.stream"


### PR DESCRIPTION
## Summary

Adds a `pyarrow.flight.FlightServerBase` subclass that serves the same data as `GET /api/result/resolve?ref=...` but as an Arrow IPC stream over gRPC. Closes the R-2.x columnar data-plane loop: the worker already stages Arrow IPC bytes in shm + ships a durable `result_ref` for cross-node consumers ([noetl/worker#28](https://github.com/noetl/worker/pull/28), [#29](https://github.com/noetl/worker/pull/29), [#30](https://github.com/noetl/worker/pull/30)); this gives the cross-node fetch path the same columnar wire format the shm path uses.

## Why R-2.3

The R-2.1 cross-node durable path round-trips tabular results through JSON:

```
rows (in-memory)
    ── server.put_result ── JSON serialize ── store.put
    ── server.resolve     ── JSON deserialize ── consumer JSON parse
```

Each leg is O(rows × columns) and re-allocates. For 6000-row DuckDB outputs (~700 KB JSON in the validation rig) that's measurable overhead on every read. Arrow Flight short-circuits the consumer leg: server resolves, encodes via the existing `rows_to_arrow_ipc`, streams `FlightData` back; consumer reads with `RecordBatchStreamReader` — zero JSON deserialisation, typed columnar batch.

For tabular tools this is the same wire format the worker's R-2.2 shm fast path uses, so cross-node + colocated consumers share a single decoder.

## What ships in Phase A

| File | Scope |
|------|-------|
| `noetl/server/api/result/flight_server.py` | `NoetlFlightServer` (daemon-thread Flight server) + `_extract_rows` shape detector. |
| `noetl/server/app.py` | Spawn in lifespan startup; shutdown in lifespan teardown. Env knobs `NOETL_FLIGHT_LOCATION` (default `grpc://0.0.0.0:8083`) + `NOETL_FLIGHT_DISABLED=1`. |
| `ci/kind/config.yaml` | kind extraPortMappings: host `8083` → nodePort `30083` → container `8083`. |
| `CLAUDE.md` | Port table extended with `NoETL Flight gRPC`. |
| `tests/unit/server/api/test_flight_server.py` | **10 unit tests** — shape detection, round-trip with stubbed store, non-tabular `FlightUnavailableError`, `get_flight_info` `FlightServerError`, cross-stack media-type parity. |

## Wire shape

- **Ticket** = `noetl://execution/<eid>/result/<step>/<id>` URI as raw bytes (consumers already have it from `call.done.result.reference.ref`).
- **DoGet response** = Arrow IPC stream of the materialized RecordBatch — same as R-2.2 shm encoding.
- **Non-tabular result** → `FlightUnavailableError` so consumers fall back to HTTP `/api/result/resolve`.
- **FlightInfo lookup** → `FlightServerError` (Phase A doesn't expose discovery; deferred to Phase C).

## Phase A non-goals (deferred)

- **Rust consumer** (`arrow-flight` crate in noetl-worker) — Phase B.
- **Multi-endpoint `FlightInfo`** for sharded tiers — Phase C.
- **mTLS / token auth** for non-cluster-internal callers — Phase C.

For now the Flight server lives behind the same cluster boundary as `/api/result/resolve`; same trust model.

## Test plan

- [x] `pytest tests/unit/server/api/test_flight_server.py` — **10/10 pass**.
- [ ] Kind validation (next): rebuild noetl image, exec a `pyarrow.flight.connect(\"grpc://localhost:8083\").do_get(Ticket(ref_uri))` against the existing big_select payload, assert 6000 rows returned with `password = [REDACTED]`. Sidecar PR on noetl/ops extends the validation rig.

Refs noetl/ai-meta#30

🤖 Generated with [Claude Code](https://claude.com/claude-code)