### PR TITLE
feat(server): get_flight_info discovery on Arrow Flight endpoint (R-2.3 Phase C1)

### DIFF
--- a/noetl/server/api/result/flight_server.py
+++ b/noetl/server/api/result/flight_server.py
@@ -178,18 +178,69 @@ class NoetlFlightServer:
                 return iter([])
 
             def get_flight_info(self, context: Any, descriptor: Any) -> Any:
-                # Phase A: we don't expose flights by listing; consumers
-                # already have the ref URI from `result.reference.ref`.
-                # Raise as FlightServerError — pyarrow.flight in this
-                # version doesn't ship an `Unimplemented` variant, but
-                # the message + the FlightServerError type are enough
-                # for clients to distinguish "not supported" from a
-                # transient outage.
-                raise flight.FlightServerError(
-                    "FlightInfo lookup is not implemented in Phase A.  "
-                    "Consumers submit Tickets directly to DoGet using the "
-                    "noetl:// URI from `result.reference.ref` on the "
-                    "call.done event."
+                # R-2.3 Phase C1: return a FlightInfo summary so the
+                # consumer can read schema + row count without
+                # materialising the full payload.  Useful for clients
+                # that want to size buffers, pick a backend, or skip
+                # the fetch entirely for non-tabular refs.
+                #
+                # Wire convention: the descriptor's `cmd` field carries
+                # the same `noetl://execution/<eid>/result/<step>/<id>`
+                # URI bytes the Ticket uses (Phase A).  Path-shaped
+                # descriptors aren't supported in Phase C1.
+                if not getattr(descriptor, "command", None):
+                    raise flight.FlightServerError(
+                        "FlightInfo requires a Cmd-shaped descriptor whose "
+                        "command bytes are the noetl:// ref URI.  Path-"
+                        "shaped descriptors are not supported in Phase C1."
+                    )
+                ref_uri = bytes(descriptor.command).decode("utf-8", errors="replace")
+                logger.debug("Flight get_flight_info: ref=%s", ref_uri)
+
+                loop = asyncio.new_event_loop()
+                try:
+                    data = loop.run_until_complete(default_store.resolve(ref_uri))
+                finally:
+                    loop.close()
+
+                rows = _extract_rows(data)
+                if rows is None:
+                    # Same signal Phase A do_get raises for non-
+                    # tabular refs.  Consumers fall back to HTTP.
+                    raise flight.FlightUnavailableError(
+                        f"FlightInfo lookup found a non-tabular result for "
+                        f"ref={ref_uri}; consumer should fall back to HTTP "
+                        f"/api/result/resolve."
+                    )
+
+                # Encode a sample to extract the Arrow schema +
+                # row_count without paying the full materialisation
+                # cost twice — `rows_to_arrow_ipc` returns
+                # (payload, _digest, row_count) AND the FlightInfo
+                # carries the schema bytes inline, so we run the same
+                # encode here that do_get would.  For multi-MB results
+                # a future optimisation can compute the schema from
+                # rows[:1] and persist row_count metadata in the store
+                # to skip the full encode.
+                import pyarrow as pa
+                payload, _digest, row_count = rows_to_arrow_ipc(rows)
+                with pa.ipc.open_stream(payload) as reader:
+                    schema = reader.schema
+
+                # Single endpoint pointing back at this server.  The
+                # ticket is the same bytes the consumer would submit
+                # to do_get directly — clients with a known ref URI
+                # can skip get_flight_info and call do_get straight.
+                endpoint = flight.FlightEndpoint(
+                    ticket=flight.Ticket(ref_uri.encode("utf-8")),
+                    locations=[outer.location],
+                )
+                return flight.FlightInfo(
+                    schema=schema,
+                    descriptor=descriptor,
+                    endpoints=[endpoint],
+                    total_records=row_count,
+                    total_bytes=len(payload),
                 )
 
         return _Server(location=outer.location)

--- a/tests/unit/server/api/test_flight_server.py
+++ b/tests/unit/server/api/test_flight_server.py
@@ -182,11 +182,60 @@ def test_flight_do_get_non_tabular_raises_unavailable(monkeypatch):
         server.shutdown()
 
 
-def test_flight_get_flight_info_returns_unimplemented(monkeypatch):
-    """Phase A doesn't expose FlightInfo — consumers must submit
-    Tickets directly.  The server raises FlightServerError with a
-    descriptive message (this pyarrow version doesn't expose a
-    dedicated `Unimplemented` variant)."""
+def test_flight_get_flight_info_returns_schema_and_endpoint(monkeypatch):
+    """R-2.3 Phase C1: `get_flight_info(descriptor)` returns a
+    FlightInfo carrying the Arrow schema + row count + a single
+    endpoint pointing back at this server.  The descriptor's `cmd`
+    field carries the noetl:// ref URI bytes (same convention as
+    Tickets in Phase A)."""
+    port = _find_free_port()
+    expected_rows = [
+        {"id": 1, "username": "user_001", "password": "[REDACTED]"},
+        {"id": 2, "username": "user_002", "password": "[REDACTED]"},
+        {"id": 3, "username": "user_003", "password": "[REDACTED]"},
+    ]
+
+    async def fake_resolve(ref: Any) -> Any:
+        assert isinstance(ref, str) and ref.startswith("noetl://")
+        return {"data": {"columns": ["id", "username", "password"], "rows": expected_rows}}
+
+    monkeypatch.setattr(
+        "noetl.server.api.result.flight_server.default_store",
+        type("StubStore", (), {"resolve": staticmethod(fake_resolve)}),
+    )
+
+    server = NoetlFlightServer(location=f"grpc://127.0.0.1:{port}")
+    server.start_in_thread()
+    _wait_until_listening(port)
+    try:
+        client = pyarrow_flight.connect(f"grpc://127.0.0.1:{port}")
+        descriptor = pyarrow_flight.FlightDescriptor.for_command(
+            b"noetl://execution/12345/result/big_select/abcd1234"
+        )
+        info = client.get_flight_info(descriptor)
+
+        assert info.total_records == 3
+        assert info.total_bytes > 0
+        assert len(info.endpoints) == 1
+        endpoint = info.endpoints[0]
+        # The ticket the FlightInfo hands back is exactly the bytes
+        # a client would submit to do_get directly — consumers with
+        # a known ref URI can skip get_flight_info entirely.
+        assert (
+            bytes(endpoint.ticket.ticket)
+            == b"noetl://execution/12345/result/big_select/abcd1234"
+        )
+        # Schema field names match the Python row dicts (DictionaryArrow
+        # type inference falls back to Utf8 + Int64 here).
+        assert info.schema.names == ["id", "username", "password"]
+    finally:
+        server.shutdown()
+
+
+def test_flight_get_flight_info_rejects_path_descriptor(monkeypatch):
+    """Phase C1 only supports Cmd-shaped descriptors.  Path-shaped
+    descriptors raise so consumers see a clear error rather than a
+    silent fallback."""
     port = _find_free_port()
 
     async def fake_resolve(ref: Any) -> Any:  # pragma: no cover - not reached
@@ -203,11 +252,39 @@ def test_flight_get_flight_info_returns_unimplemented(monkeypatch):
     try:
         client = pyarrow_flight.connect(f"grpc://127.0.0.1:{port}")
         descriptor = pyarrow_flight.FlightDescriptor.for_path("any", "path")
-        with pytest.raises((pyarrow_flight.FlightServerError, pyarrow_flight.FlightInternalError)) as exc_info:
+        with pytest.raises(
+            (pyarrow_flight.FlightServerError, pyarrow_flight.FlightInternalError)
+        ) as exc_info:
             client.get_flight_info(descriptor)
-        # The descriptive message round-trips through gRPC so consumers
-        # can log it.
-        assert "Phase A" in str(exc_info.value)
+        assert "Cmd-shaped descriptor" in str(exc_info.value)
+    finally:
+        server.shutdown()
+
+
+def test_flight_get_flight_info_non_tabular_raises_unavailable(monkeypatch):
+    """Same fallback signal as do_get — non-tabular result → server
+    raises FlightUnavailableError so the client falls back to HTTP."""
+    port = _find_free_port()
+
+    async def fake_resolve(ref: Any) -> Any:
+        # Shell-tool shape: no rows.
+        return {"stdout": "hello", "exit_code": 0}
+
+    monkeypatch.setattr(
+        "noetl.server.api.result.flight_server.default_store",
+        type("StubStore", (), {"resolve": staticmethod(fake_resolve)}),
+    )
+
+    server = NoetlFlightServer(location=f"grpc://127.0.0.1:{port}")
+    server.start_in_thread()
+    _wait_until_listening(port)
+    try:
+        client = pyarrow_flight.connect(f"grpc://127.0.0.1:{port}")
+        descriptor = pyarrow_flight.FlightDescriptor.for_command(
+            b"noetl://execution/12345/result/shell_step/x"
+        )
+        with pytest.raises(pyarrow_flight.FlightUnavailableError):
+            client.get_flight_info(descriptor)
     finally:
         server.shutdown()
 


### PR DESCRIPTION
## Summary

Promotes `get_flight_info(descriptor)` from a placeholder `FlightServerError` into a real discovery surface.  Consumers can read the Arrow schema + row count + endpoint location for a ref URI without materialising the full payload via `do_get`.  Useful for clients that want to size buffers, pick a backend, or skip the fetch entirely for non-tabular refs.

## Wire shape

The descriptor's `cmd` field carries the same `noetl://execution/<eid>/result/<step>/<id>` URI bytes the Ticket uses (Phase A).  Phase C1 only supports Cmd-shaped descriptors — Path-shaped descriptors raise `FlightServerError` so consumers see a clear error rather than a silent fallback.

```
FlightInfo
  ├── schema       : Arrow schema bytes (inferred from rows_to_arrow_ipc)
  ├── endpoints[0]
  │     ├── ticket    : same noetl:// URI bytes
  │     └── locations : [<this server's location>]
  ├── total_records : row_count (from the resolved data)
  └── total_bytes   : encoded payload bytes
```

The endpoint's ticket is exactly the bytes a client would submit to `do_get` directly — consumers with a known ref URI can skip `get_flight_info` and call `do_get` straight.

## Fallback semantics

| Situation | Behaviour |
|-----------|-----------|
| Tabular result | FlightInfo as above. |
| Non-tabular result | `FlightUnavailableError` (same signal as do_get). |
| Path-shaped descriptor | `FlightServerError` with \"Cmd-shaped descriptor required\". |

## Test plan

- [x] **12/12 unit tests pass** in `tests/unit/server/api/test_flight_server.py`:
  - 3 new for `get_flight_info` (success, path-descriptor reject, non-tabular fallback)
  - 1 updated to reflect the new success behavior
  - 8 existing (extract_rows, do_get, media-type constant)

## Phase scope

| Phase | Status |
|-------|--------|
| A — `do_get` | ✅ landed |
| B — Rust client crate | ✅ landed on crates.io |
| **C1 — `get_flight_info` discovery (this PR)** | ✅ ready for review |
| C2 — mTLS + token auth | Deferred — gate on external-exposure deployment |
| Multi-endpoint sharding | Deferred — fires when result-store grows beyond one Python pod |

Pair with the matching Rust client PR (next, on noetl/cli) that adds `FlightResolver::get_flight_info(ref_uri)`.

Refs noetl/ai-meta#30

🤖 Generated with [Claude Code](https://claude.com/claude-code)