### PR TITLE
feat(dsl): allow tool.kind='result_fetch' in ToolSpec Literal

### DIFF
--- a/noetl/core/dsl/engine/models/tools.py
+++ b/noetl/core/dsl/engine/models/tools.py
@@ -159,6 +159,7 @@ class ToolSpec(BaseModel):
         "noop",           # No-operation tool for routing/initialization
         "task_sequence",  # Task sequence execution
         "rhai",           # Rhai scripting engine
+        "result_fetch",   # Cross-step / cross-node result-store fetch (R-2.3, noetl-tools 2.11.0+)
     ] = Field(
         ..., description="Tool type"
     )


### PR DESCRIPTION
## Summary

The `result_fetch` tool kind shipped in [noetl-tools 2.11.0](https://github.com/noetl/tools/pull/8) for playbook-driven cross-step / cross-node fetches per [`agents/rules/execution-model.md`](https://github.com/noetl/ai-meta/blob/main/agents/rules/execution-model.md).  Without this Literal entry, the broker rejects playbooks that declare `tool.kind: result_fetch`:

```
422 Unprocessable Entity
workflow.N.tool.ToolSpec.kind: Input should be 'http', ..., 'rhai'
```

Surfaced by the kind-validation rig in `repos/ops` — the `result_fetch_validation` playbook fixture failed to register until the schema was extended.

## Change

```diff
     "task_sequence",  # Task sequence execution
     "rhai",           # Rhai scripting engine
+    "result_fetch",   # Cross-step / cross-node result-store fetch (R-2.3, noetl-tools 2.11.0+)
```

## Pattern note

Mirrors the EE-4 fix where `event_type` was likewise a closed Literal that needed extending per new kind.  Longer-term improvement would be to validate `tool.kind` against the actual Rust `noetl-tools` registry at runtime instead of a hardcoded Literal — but that's a separate refactor.

Refs noetl/ai-meta#30

🤖 Generated with [Claude Code](https://claude.com/claude-code)