### PR TITLE
feat(flight): server-side TLS for Arrow Flight (R-2.3 Phase C2.1)

### DIFF
--- a/noetl/server/api/result/flight_server.py
+++ b/noetl/server/api/result/flight_server.py
@@ -123,13 +123,84 @@ class NoetlFlightServer:
     Start with ``server.start_in_thread()``; stop with
     ``server.shutdown()``.  Designed to run alongside the FastAPI
     process — gRPC and HTTP listen on different ports.
+
+    ## TLS mode (R-2.3 Phase C2.1)
+
+    Pass ``tls_cert_path`` + ``tls_key_path`` (or the env pair
+    ``NOETL_FLIGHT_TLS_CERT`` + ``NOETL_FLIGHT_TLS_KEY``, see
+    :py:meth:`from_env`) to terminate TLS at the Flight gRPC port.
+    The server presents the cert to every connecting client; the
+    location URL automatically switches from ``grpc://`` to
+    ``grpc+tls://`` so consumers receive a single source of truth
+    about the wire protocol from a future ``ListEndpoints`` call.
+
+    When both ``tls_cert_path`` and ``tls_key_path`` are unset the
+    server keeps the existing plaintext h2c mode — same default
+    behaviour the kind manifest ships, no migration burden.
+
+    Client-certificate validation (mTLS) is reserved for Phase C2.4.
     """
 
-    def __init__(self, location: str = "grpc://0.0.0.0:8083"):
+    def __init__(
+        self,
+        location: str = "grpc://0.0.0.0:8083",
+        tls_cert_path: Optional[str] = None,
+        tls_key_path: Optional[str] = None,
+    ):
+        if (tls_cert_path is None) != (tls_key_path is None):
+            raise ValueError(
+                "tls_cert_path and tls_key_path must both be set or both be None; "
+                f"got cert={tls_cert_path!r}, key={tls_key_path!r}"
+            )
+        # When TLS is active, the location URL must use the
+        # `grpc+tls://` scheme so pyarrow.flight knows to wrap the
+        # listening socket in OpenSSL.  We accept callers passing
+        # either scheme + normalise here.
+        if tls_cert_path is not None and location.startswith("grpc://"):
+            location = "grpc+tls://" + location[len("grpc://") :]
         self.location = location
+        self.tls_cert_path = tls_cert_path
+        self.tls_key_path = tls_key_path
         self._server: Any = None  # pyarrow.flight.FlightServerBase instance
         self._thread: Optional[threading.Thread] = None
         self._serve_exception: Optional[BaseException] = None
+
+    @classmethod
+    def from_env(cls, default_location: str = "grpc://0.0.0.0:8083") -> "NoetlFlightServer":
+        """Construct from environment variables.
+
+        Reads:
+        - ``NOETL_FLIGHT_LOCATION`` — listening location (default
+          plaintext on 0.0.0.0:8083).  When ``NOETL_FLIGHT_TLS_CERT`` is
+          set the scheme auto-upgrades to ``grpc+tls://``.
+        - ``NOETL_FLIGHT_TLS_CERT`` — path to PEM-encoded server cert.
+        - ``NOETL_FLIGHT_TLS_KEY`` — path to PEM-encoded private key.
+
+        TLS is opt-in: omit both env vars to keep the plaintext h2c
+        mode the kind manifest ships.
+        """
+        import os
+
+        location = os.getenv("NOETL_FLIGHT_LOCATION", default_location)
+        cert = os.getenv("NOETL_FLIGHT_TLS_CERT") or None
+        key = os.getenv("NOETL_FLIGHT_TLS_KEY") or None
+        return cls(location=location, tls_cert_path=cert, tls_key_path=key)
+
+    def _load_tls_certificates(self) -> Optional[list[tuple[bytes, bytes]]]:
+        """Read the cert + key from disk as bytes for FlightServerBase.
+
+        Returns ``None`` when TLS is not configured (plaintext mode).
+        """
+        if self.tls_cert_path is None or self.tls_key_path is None:
+            return None
+        with open(self.tls_cert_path, "rb") as cf:
+            cert_bytes = cf.read()
+        with open(self.tls_key_path, "rb") as kf:
+            key_bytes = kf.read()
+        # FlightServerBase accepts a list of (cert, key) pairs — one
+        # entry per listening location.  Phase C2.1 binds a single
+        # location.
+        return [(cert_bytes, key_bytes)]
 
     def _build_server(self) -> Any:
         """Construct the pyarrow.flight server.  Lazy-imported."""
@@ -243,7 +314,10 @@ class NoetlFlightServer:
                     total_bytes=len(payload),
                 )
 
-        return _Server(location=outer.location)
+        # TLS certs (Phase C2.1) — None in plaintext mode, otherwise
+        # the single (cert, key) pair loaded from disk.
+        tls_certs = outer._load_tls_certificates()
+        return _Server(location=outer.location, tls_certificates=tls_certs)
 
     def start_in_thread(self) -> None:
         """Spawn the Flight server in a daemon thread.  Returns immediately."""
@@ -251,14 +325,17 @@ class NoetlFlightServer:
             return
         self._server = self._build_server()
 
+        tls_mode = "tls" if self.tls_cert_path else "plaintext"
+
         def _run() -> None:
             try:
                 logger.info(
-                    "Arrow Flight server starting at %s (R-2.3 Phase A)",
+                    "Arrow Flight server starting at %s (mode=%s, R-2.3)",
                     self.location,
+                    tls_mode,
                 )
                 self._server.serve()
-                logger.info("Arrow Flight server stopped")
+                logger.info("Arrow Flight server stopped (mode=%s)", tls_mode)
             except BaseException as exc:  # noqa: BLE001
                 logger.exception("Arrow Flight server crashed: %s", exc)
                 self._serve_exception = exc

--- a/noetl/server/app.py
+++ b/noetl/server/app.py
@@ -367,20 +367,21 @@ def _create_app(settings: Settings) -> FastAPI:
             # NOETL_FLIGHT_LOCATION (default grpc://0.0.0.0:8083);
             # NOETL_FLIGHT_DISABLED=1 turns the spawn off for hosts
             # where pyarrow.flight is unavailable or the port conflicts.
+            #
+            # R-2.3 Phase C2.1: optional TLS via NOETL_FLIGHT_TLS_CERT
+            # + NOETL_FLIGHT_TLS_KEY (server-side cert).  Unset both
+            # to stay in plaintext h2c mode — same default the kind
+            # manifest ships, no migration burden.
             flight_server: Optional[NoetlFlightServer] = None
             try:
                 if os.getenv("NOETL_FLIGHT_DISABLED", "").strip() in ("1", "true", "True"):
                     logger.info("Arrow Flight server disabled via NOETL_FLIGHT_DISABLED")
                 else:
-                    flight_location = os.getenv(
-                        "NOETL_FLIGHT_LOCATION",
-                        "grpc://0.0.0.0:8083",
-                    )
-                    flight_server = NoetlFlightServer(location=flight_location)
+                    flight_server = NoetlFlightServer.from_env()
                     flight_server.start_in_thread()
                     logger.info(
-                        "Arrow Flight server background thread started (R-2.3 Phase A): %s",
-                        flight_location,
+                        "Arrow Flight server background thread started (R-2.3): %s",
+                        flight_server.location,
                     )
             except Exception as e:
                 logger.error(

--- a/tests/unit/server/api/test_flight_server.py
+++ b/tests/unit/server/api/test_flight_server.py
@@ -298,3 +298,125 @@ def test_arrow_stream_media_type_matches_python_constant():
     )
     assert ARROW_STREAM_MEDIA_TYPE == STORAGE_MEDIA_TYPE
     assert ARROW_STREAM_MEDIA_TYPE == "application/vnd.apache.arrow.stream"
+
+
+# ---------------------------------------------------------------------------
+# R-2.3 Phase C2.1 — Server-side TLS
+# ---------------------------------------------------------------------------
+
+
+def test_tls_construction_requires_both_cert_and_key():
+    """tls_cert_path + tls_key_path must be set together — one without
+    the other is a misconfiguration that would silently degrade to
+    plaintext otherwise."""
+    with pytest.raises(ValueError, match="must both be set or both be None"):
+        NoetlFlightServer(
+            location="grpc://0.0.0.0:8083",
+            tls_cert_path="/etc/noetl/flight.crt",
+            tls_key_path=None,
+        )
+    with pytest.raises(ValueError, match="must both be set or both be None"):
+        NoetlFlightServer(
+            location="grpc://0.0.0.0:8083",
+            tls_cert_path=None,
+            tls_key_path="/etc/noetl/flight.key",
+        )
+
+
+def test_tls_normalises_location_scheme_to_grpc_tls(tmp_path):
+    """When TLS certs are present the location URL auto-upgrades from
+    grpc:// to grpc+tls:// — pyarrow.flight uses the scheme as the
+    signal to wrap the listener in OpenSSL.  Callers that already
+    pass grpc+tls:// stay untouched."""
+    cert = tmp_path / "flight.crt"
+    key = tmp_path / "flight.key"
+    cert.write_bytes(b"dummy")
+    key.write_bytes(b"dummy")
+
+    upgraded = NoetlFlightServer(
+        location="grpc://0.0.0.0:8083",
+        tls_cert_path=str(cert),
+        tls_key_path=str(key),
+    )
+    assert upgraded.location == "grpc+tls://0.0.0.0:8083"
+
+    passthrough = NoetlFlightServer(
+        location="grpc+tls://0.0.0.0:8083",
+        tls_cert_path=str(cert),
+        tls_key_path=str(key),
+    )
+    assert passthrough.location == "grpc+tls://0.0.0.0:8083"
+
+
+def test_plaintext_mode_keeps_grpc_scheme():
+    """No TLS env → location URL stays grpc:// — kind default, no
+    migration burden."""
+    server = NoetlFlightServer(location="grpc://0.0.0.0:8083")
+    assert server.location == "grpc://0.0.0.0:8083"
+    assert server.tls_cert_path is None
+    assert server.tls_key_path is None
+    assert server._load_tls_certificates() is None
+
+
+def test_tls_load_certificates_reads_pem_bytes(tmp_path):
+    """_load_tls_certificates returns the on-disk cert + key as a
+    single (cert_bytes, key_bytes) pair — FlightServerBase's wire
+    shape for the tls_certificates= kwarg."""
+    cert = tmp_path / "flight.crt"
+    key = tmp_path / "flight.key"
+    cert.write_bytes(b"-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----")
+    key.write_bytes(b"-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----")
+
+    server = NoetlFlightServer(
+        location="grpc://0.0.0.0:8083",
+        tls_cert_path=str(cert),
+        tls_key_path=str(key),
+    )
+    certs = server._load_tls_certificates()
+    assert certs is not None
+    assert len(certs) == 1
+    cert_bytes, key_bytes = certs[0]
+    assert b"BEGIN CERTIFICATE" in cert_bytes
+    assert b"BEGIN PRIVATE KEY" in key_bytes
+
+
+def test_from_env_plaintext_default(monkeypatch):
+    """Unset TLS env vars → plaintext server with the default
+    location.  Same behaviour the kind manifest depends on."""
+    monkeypatch.delenv("NOETL_FLIGHT_LOCATION", raising=False)
+    monkeypatch.delenv("NOETL_FLIGHT_TLS_CERT", raising=False)
+    monkeypatch.delenv("NOETL_FLIGHT_TLS_KEY", raising=False)
+    server = NoetlFlightServer.from_env()
+    assert server.location == "grpc://0.0.0.0:8083"
+    assert server.tls_cert_path is None
+    assert server.tls_key_path is None
+
+
+def test_from_env_tls_pair(monkeypatch, tmp_path):
+    """NOETL_FLIGHT_TLS_CERT + NOETL_FLIGHT_TLS_KEY → TLS-enabled
+    server with grpc+tls:// scheme."""
+    cert = tmp_path / "flight.crt"
+    key = tmp_path / "flight.key"
+    cert.write_bytes(b"dummy")
+    key.write_bytes(b"dummy")
+
+    monkeypatch.setenv("NOETL_FLIGHT_LOCATION", "grpc://0.0.0.0:8083")
+    monkeypatch.setenv("NOETL_FLIGHT_TLS_CERT", str(cert))
+    monkeypatch.setenv("NOETL_FLIGHT_TLS_KEY", str(key))
+    server = NoetlFlightServer.from_env()
+    assert server.location == "grpc+tls://0.0.0.0:8083"
+    assert server.tls_cert_path == str(cert)
+    assert server.tls_key_path == str(key)
+
+
+def test_from_env_partial_tls_raises(monkeypatch, tmp_path):
+    """NOETL_FLIGHT_TLS_CERT without KEY (or vice versa) → ValueError
+    so a misconfigured pod fails fast rather than serving plaintext
+    after the operator thought they'd enabled TLS."""
+    cert = tmp_path / "flight.crt"
+    cert.write_bytes(b"dummy")
+
+    monkeypatch.setenv("NOETL_FLIGHT_TLS_CERT", str(cert))
+    monkeypatch.delenv("NOETL_FLIGHT_TLS_KEY", raising=False)
+    with pytest.raises(ValueError, match="must both be set or both be None"):
+        NoetlFlightServer.from_env()


### PR DESCRIPTION
## Summary

First slice of R-2.3 Phase C2 — adds server-side TLS to the Arrow Flight gRPC endpoint.  Client-side validation (C2.2), bearer-token auth (C2.3), and mTLS (C2.4) ship as follow-ups against the same umbrella issue (noetl/ai-meta#33).

- `NoetlFlightServer.__init__` accepts `tls_cert_path` + `tls_key_path` (matched pair).
- `NoetlFlightServer.from_env()` reads `NOETL_FLIGHT_TLS_CERT` + `NOETL_FLIGHT_TLS_KEY`.  Unset both → plaintext h2c (kind default, no migration burden); partial pair → `ValueError` so a misconfigured pod fails fast.
- Location URL auto-upgrades `grpc://` → `grpc+tls://` when TLS is active (pyarrow.flight's signal).
- `app.py` lifespan switches to `NoetlFlightServer.from_env()` — env is now the single source of truth.
- Startup log carries `mode=tls` or `mode=plaintext` for operator visibility.

## Test plan

- [x] 7 new unit tests pin the TLS construction surface (partial-pair → ValueError, scheme upgrade, PEM read + bytes shape, `from_env` defaults).
- [x] `pytest tests/unit/server/api/test_flight_server.py` — 19/19 passing.

## Followup

Tracked under noetl/ai-meta#33:
- C2.2 — Rust `FlightResolver::connect` accepts CA bundle (`tonic::transport::ClientTlsConfig`).
- C2.3 — Bearer-token middleware (Python `ServerAuthHandler` + Rust interceptor).
- C2.4 — mTLS (client cert via `verify_client=True`).
- C2.5 — K8s manifests + cert provisioning.
- C2.6 — Kind validation rig for the TLS+auth combo.

Refs noetl/ai-meta#33

🤖 Generated with [Claude Code](https://claude.com/claude-code)