### PR TITLE
feat(flight): bearer-token middleware (R-2.3 Phase C2.3 server side)

### DIFF
--- a/noetl/server/api/result/flight_server.py
+++ b/noetl/server/api/result/flight_server.py
@@ -112,6 +112,18 @@ def _extract_rows(data: Any) -> Optional[list[dict[str, Any]]]:
     return rows  # type: ignore[return-value]
 
 
+def _parse_bearer_tokens(raw: Optional[str]) -> set[str]:
+    """Parse a comma-separated list of bearer tokens into a set.
+
+    Empty / None input returns an empty set (no-auth mode).  Empty
+    entries after splitting are dropped — callers can use trailing
+    commas + whitespace without surprises.
+    """
+    if not raw:
+        return set()
+    return {t.strip() for t in raw.split(",") if t.strip()}
+
+
 class NoetlFlightServer:
     """Arrow Flight gRPC server for result-store reads.
 
@@ -139,6 +151,33 @@ class NoetlFlightServer:
     behaviour the kind manifest ships, no migration burden.
 
     Client-certificate validation (mTLS) is reserved for Phase C2.4.
+
+    ## Bearer-token auth (R-2.3 Phase C2.3)
+
+    Pass ``bearer_tokens`` (a set of valid token strings) — or the
+    env ``NOETL_FLIGHT_BEARER_TOKENS`` (comma-separated set, see
+    :py:meth:`from_env`) — to require an ``Authorization: Bearer
+    <token>`` header on every Flight call.  A request whose token
+    isn't in the configured set raises ``FlightUnauthenticatedError``
+    before reaching ``do_get`` / ``get_flight_info``.
+
+    Tokens are a **set** rather than a single value so an operator
+    can rotate without downtime: deploy v2 with both v1 + v2 valid,
+    rotate clients, then drop v1.  Empty / unset → no auth (the
+    Phase A default; same trust boundary as the HTTP
+    ``/api/result/resolve`` endpoint).
+
+    Auth is independent of TLS: bearer auth + plaintext is fine for
+    in-cluster deployments behind a separate TLS terminator; bearer
+    auth + TLS is the typical externally-exposed shape.
+
+    Per [`agents/rules/execution-model.md`][exec] the server-side
+    *set of valid tokens* is policy data (env / configmap / k8s
+    Secret); the *token a client sends* is a business-logic
+    credential and belongs in the NoETL keychain referenced by alias
+    from the playbook step.
+
+    [exec]: https://github.com/noetl/ai-meta/blob/main/agents/rules/execution-model.md
     """
 
     def __init__(
@@ -146,6 +185,7 @@ class NoetlFlightServer:
         location: str = "grpc://0.0.0.0:8083",
         tls_cert_path: Optional[str] = None,
         tls_key_path: Optional[str] = None,
+        bearer_tokens: Optional[set[str]] = None,
     ):
         if (tls_cert_path is None) != (tls_key_path is None):
             raise ValueError(
@@ -161,6 +201,11 @@ class NoetlFlightServer:
         self.location = location
         self.tls_cert_path = tls_cert_path
         self.tls_key_path = tls_key_path
+        # Empty set + None both mean "no auth".  Internally we keep
+        # `None` to make the no-auth code path explicit.
+        self.bearer_tokens: Optional[set[str]] = (
+            bearer_tokens if bearer_tokens else None
+        )
         self._server: Any = None  # pyarrow.flight.FlightServerBase instance
         self._thread: Optional[threading.Thread] = None
         self._serve_exception: Optional[BaseException] = None
@@ -175,16 +220,25 @@ class NoetlFlightServer:
           set the scheme auto-upgrades to ``grpc+tls://``.
         - ``NOETL_FLIGHT_TLS_CERT`` — path to PEM-encoded server cert.
         - ``NOETL_FLIGHT_TLS_KEY`` — path to PEM-encoded private key.
+        - ``NOETL_FLIGHT_BEARER_TOKENS`` — comma-separated set of
+          accepted bearer tokens.  Unset → no auth.  Use a set
+          rather than a single value to rotate without downtime.
 
-        TLS is opt-in: omit both env vars to keep the plaintext h2c
-        mode the kind manifest ships.
+        TLS + auth are independently opt-in: omit all three to keep
+        the plaintext + no-auth mode the kind manifest ships.
         """
         import os
 
         location = os.getenv("NOETL_FLIGHT_LOCATION", default_location)
         cert = os.getenv("NOETL_FLIGHT_TLS_CERT") or None
         key = os.getenv("NOETL_FLIGHT_TLS_KEY") or None
-        return cls(location=location, tls_cert_path=cert, tls_key_path=key)
+        tokens = _parse_bearer_tokens(os.getenv("NOETL_FLIGHT_BEARER_TOKENS"))
+        return cls(
+            location=location,
+            tls_cert_path=cert,
+            tls_key_path=key,
+            bearer_tokens=tokens or None,
+        )
 
     def _load_tls_certificates(self) -> Optional[list[tuple[bytes, bytes]]]:
         """Read the cert + key from disk as bytes for FlightServerBase.
@@ -201,6 +255,66 @@ class NoetlFlightServer:
         # entry per listening location.  Phase C2.1 binds a single
         # location.
         return [(cert_bytes, key_bytes)]
+
+    def _build_middleware(self) -> Optional[dict[str, Any]]:
+        """Construct the `pyarrow.flight` middleware mapping.
+
+        Phase C2.3 adds a single bearer-token validator middleware
+        when ``self.bearer_tokens`` is set.  No-auth mode (empty /
+        None) returns ``None`` and ``FlightServerBase`` runs without
+        any per-call middleware.
+        """
+        if not self.bearer_tokens:
+            return None
+        import pyarrow.flight as flight
+
+        tokens = self.bearer_tokens
+
+        class BearerTokenMiddlewareFactory(flight.ServerMiddlewareFactory):
+            """Validates an incoming `Authorization: Bearer <token>`
+            header against the configured token set.
+
+            Returns ``None`` (no per-call middleware needed) on
+            success; raises ``FlightUnauthenticatedError`` on missing
+            or invalid token — pyarrow.flight surfaces that as a
+            gRPC `UNAUTHENTICATED` status to the client.
+
+            Header lookup is case-insensitive per HTTP/2 spec
+            (`grpc-metadata` is always lowercase on the wire) and
+            tolerates the `Bearer ` prefix in either canonical or
+            lowercased form.
+            """
+
+            def start_call(self, info: Any, headers: Any) -> Optional[Any]:
+                # `headers` is a multi-valued mapping (`dict[str, list[str]]`).
+                # The actual key shape pyarrow.flight produces is
+                # lowercased per HTTP/2 / gRPC convention.
+                auth_values: list[str] = []
+                # Try a few common casings to be robust against
+                # transport differences.
+                for key in ("authorization", "Authorization"):
+                    if key in headers:
+                        v = headers[key]
+                        if isinstance(v, (list, tuple)):
+                            auth_values.extend(v)
+                        else:
+                            auth_values.append(v)
+
+                for value in auth_values:
+                    # Tolerate `Bearer <token>` + `bearer <token>` casings.
+                    parts = value.split(None, 1)
+                    if len(parts) == 2 and parts[0].lower() == "bearer":
+                        token = parts[1].strip()
+                        if token in tokens:
+                            return None  # accept; no per-call middleware
+
+                raise flight.FlightUnauthenticatedError(
+                    "Missing or invalid bearer token; expected "
+                    "Authorization: Bearer <token> with a token from "
+                    "NOETL_FLIGHT_BEARER_TOKENS."
+                )
+
+        return {"bearer-auth": BearerTokenMiddlewareFactory()}
 
     def _build_server(self) -> Any:
         """Construct the pyarrow.flight server.  Lazy-imported."""
@@ -317,7 +431,16 @@ class NoetlFlightServer:
         # TLS certs (Phase C2.1) — None in plaintext mode, otherwise
         # the single (cert, key) pair loaded from disk.
         tls_certs = outer._load_tls_certificates()
-        return _Server(location=outer.location, tls_certificates=tls_certs)
+        # Auth middleware (Phase C2.3) — None when bearer-tokens is
+        # empty / unset.
+        middleware = outer._build_middleware()
+        kwargs: dict[str, Any] = {
+            "location": outer.location,
+            "tls_certificates": tls_certs,
+        }
+        if middleware is not None:
+            kwargs["middleware"] = middleware
+        return _Server(**kwargs)
 
     def start_in_thread(self) -> None:
         """Spawn the Flight server in a daemon thread.  Returns immediately."""
@@ -326,16 +449,26 @@ class NoetlFlightServer:
         self._server = self._build_server()
 
         tls_mode = "tls" if self.tls_cert_path else "plaintext"
+        auth_mode = (
+            f"bearer({len(self.bearer_tokens)})"
+            if self.bearer_tokens
+            else "none"
+        )
 
         def _run() -> None:
             try:
                 logger.info(
-                    "Arrow Flight server starting at %s (mode=%s, R-2.3)",
+                    "Arrow Flight server starting at %s (tls=%s, auth=%s, R-2.3)",
                     self.location,
                     tls_mode,
+                    auth_mode,
                 )
                 self._server.serve()
-                logger.info("Arrow Flight server stopped (mode=%s)", tls_mode)
+                logger.info(
+                    "Arrow Flight server stopped (tls=%s, auth=%s)",
+                    tls_mode,
+                    auth_mode,
+                )
             except BaseException as exc:  # noqa: BLE001
                 logger.exception("Arrow Flight server crashed: %s", exc)
                 self._serve_exception = exc

--- a/tests/unit/server/api/test_flight_server.py
+++ b/tests/unit/server/api/test_flight_server.py
@@ -420,3 +420,180 @@ def test_from_env_partial_tls_raises(monkeypatch, tmp_path):
     monkeypatch.delenv("NOETL_FLIGHT_TLS_KEY", raising=False)
     with pytest.raises(ValueError, match="must both be set or both be None"):
         NoetlFlightServer.from_env()
+
+
+# ---------------------------------------------------------------------------
+# R-2.3 Phase C2.3 — Bearer-token middleware
+# ---------------------------------------------------------------------------
+
+
+def test_parse_bearer_tokens_empty_returns_empty_set():
+    """Empty / None input → empty set (no-auth mode)."""
+    from noetl.server.api.result.flight_server import _parse_bearer_tokens
+
+    assert _parse_bearer_tokens(None) == set()
+    assert _parse_bearer_tokens("") == set()
+    assert _parse_bearer_tokens("   ") == set()
+
+
+def test_parse_bearer_tokens_splits_and_trims():
+    """Comma-separated, trims whitespace, drops empty entries."""
+    from noetl.server.api.result.flight_server import _parse_bearer_tokens
+
+    assert _parse_bearer_tokens("alpha,beta") == {"alpha", "beta"}
+    assert _parse_bearer_tokens("alpha , beta , ") == {"alpha", "beta"}
+    assert _parse_bearer_tokens(", ,, alpha,,") == {"alpha"}
+
+
+def test_bearer_tokens_none_means_no_auth():
+    """Constructing without bearer_tokens leaves auth disabled."""
+    server = NoetlFlightServer(location="grpc://0.0.0.0:8083")
+    assert server.bearer_tokens is None
+    assert server._build_middleware() is None
+
+
+def test_bearer_tokens_empty_set_normalised_to_none():
+    """Empty set ⇒ None (no-auth) — falsy values collapse to the
+    same internal shape so the build path has one branch to check."""
+    server = NoetlFlightServer(
+        location="grpc://0.0.0.0:8083",
+        bearer_tokens=set(),
+    )
+    assert server.bearer_tokens is None
+    assert server._build_middleware() is None
+
+
+def test_bearer_tokens_builds_middleware_factory():
+    """Populated set ⇒ middleware mapping with `bearer-auth` key
+    bound to a `ServerMiddlewareFactory`."""
+    server = NoetlFlightServer(
+        location="grpc://0.0.0.0:8083",
+        bearer_tokens={"alpha", "beta"},
+    )
+    middleware = server._build_middleware()
+    assert middleware is not None
+    assert set(middleware.keys()) == {"bearer-auth"}
+    factory = middleware["bearer-auth"]
+    assert hasattr(factory, "start_call"), "expected a ServerMiddlewareFactory subclass"
+
+
+def test_bearer_middleware_accepts_valid_token():
+    """`Authorization: Bearer <token>` with a configured token →
+    `start_call` returns None (accept; no per-call middleware)."""
+    server = NoetlFlightServer(
+        location="grpc://0.0.0.0:8083",
+        bearer_tokens={"sk-test-valid"},
+    )
+    middleware = server._build_middleware()
+    factory = middleware["bearer-auth"]
+    result = factory.start_call(
+        info=None,
+        headers={"authorization": ["Bearer sk-test-valid"]},
+    )
+    assert result is None
+
+
+def test_bearer_middleware_accepts_lowercase_bearer():
+    """`bearer ` casing (gRPC-metadata frequently lowercases) is
+    accepted."""
+    server = NoetlFlightServer(
+        location="grpc://0.0.0.0:8083",
+        bearer_tokens={"sk-test"},
+    )
+    factory = server._build_middleware()["bearer-auth"]
+    assert (
+        factory.start_call(info=None, headers={"authorization": ["bearer sk-test"]})
+        is None
+    )
+
+
+def test_bearer_middleware_rejects_missing_header(monkeypatch):
+    """No `Authorization` header → `FlightUnauthenticatedError`."""
+    server = NoetlFlightServer(
+        location="grpc://0.0.0.0:8083",
+        bearer_tokens={"sk-test"},
+    )
+    factory = server._build_middleware()["bearer-auth"]
+    with pytest.raises(pyarrow_flight.FlightUnauthenticatedError):
+        factory.start_call(info=None, headers={})
+
+
+def test_bearer_middleware_rejects_wrong_token():
+    """Wrong token → `FlightUnauthenticatedError`."""
+    server = NoetlFlightServer(
+        location="grpc://0.0.0.0:8083",
+        bearer_tokens={"sk-test"},
+    )
+    factory = server._build_middleware()["bearer-auth"]
+    with pytest.raises(pyarrow_flight.FlightUnauthenticatedError):
+        factory.start_call(
+            info=None,
+            headers={"authorization": ["Bearer sk-wrong"]},
+        )
+
+
+def test_bearer_middleware_rejects_basic_auth():
+    """Non-Bearer schemes (Basic, etc.) → `FlightUnauthenticatedError`
+    even when a configured token happens to match the scheme value.
+    Locks in that we only honor the `Bearer` scheme."""
+    server = NoetlFlightServer(
+        location="grpc://0.0.0.0:8083",
+        bearer_tokens={"YWxwaGE6YmV0YQ=="},  # base64("alpha:beta")
+    )
+    factory = server._build_middleware()["bearer-auth"]
+    with pytest.raises(pyarrow_flight.FlightUnauthenticatedError):
+        factory.start_call(
+            info=None,
+            headers={"authorization": ["Basic YWxwaGE6YmV0YQ=="]},
+        )
+
+
+def test_bearer_middleware_token_rotation():
+    """Multiple tokens in the set → any one of them accepted.
+    Locks in the rotation pattern: deploy v2 with {v1, v2}, rotate
+    clients, then drop v1."""
+    server = NoetlFlightServer(
+        location="grpc://0.0.0.0:8083",
+        bearer_tokens={"old-token", "new-token"},
+    )
+    factory = server._build_middleware()["bearer-auth"]
+    assert (
+        factory.start_call(info=None, headers={"authorization": ["Bearer old-token"]})
+        is None
+    )
+    assert (
+        factory.start_call(info=None, headers={"authorization": ["Bearer new-token"]})
+        is None
+    )
+
+
+def test_from_env_picks_up_bearer_tokens(monkeypatch):
+    """`NOETL_FLIGHT_BEARER_TOKENS` populates the bearer_tokens set."""
+    monkeypatch.delenv("NOETL_FLIGHT_LOCATION", raising=False)
+    monkeypatch.delenv("NOETL_FLIGHT_TLS_CERT", raising=False)
+    monkeypatch.delenv("NOETL_FLIGHT_TLS_KEY", raising=False)
+    monkeypatch.setenv("NOETL_FLIGHT_BEARER_TOKENS", "tok-1, tok-2, tok-3")
+    server = NoetlFlightServer.from_env()
+    assert server.bearer_tokens == {"tok-1", "tok-2", "tok-3"}
+
+
+def test_from_env_no_tokens_means_no_auth(monkeypatch):
+    """Unset `NOETL_FLIGHT_BEARER_TOKENS` → bearer_tokens is None."""
+    monkeypatch.delenv("NOETL_FLIGHT_LOCATION", raising=False)
+    monkeypatch.delenv("NOETL_FLIGHT_TLS_CERT", raising=False)
+    monkeypatch.delenv("NOETL_FLIGHT_TLS_KEY", raising=False)
+    monkeypatch.delenv("NOETL_FLIGHT_BEARER_TOKENS", raising=False)
+    server = NoetlFlightServer.from_env()
+    assert server.bearer_tokens is None
+
+
+def test_bearer_tokens_independent_of_tls(monkeypatch, tmp_path):
+    """Auth + TLS are independently opt-in — bearer-on + plaintext
+    is a valid combo (auth handled by a separate TLS terminator)."""
+    monkeypatch.delenv("NOETL_FLIGHT_TLS_CERT", raising=False)
+    monkeypatch.delenv("NOETL_FLIGHT_TLS_KEY", raising=False)
+    monkeypatch.setenv("NOETL_FLIGHT_BEARER_TOKENS", "the-token")
+    server = NoetlFlightServer.from_env()
+    assert server.tls_cert_path is None
+    assert server.bearer_tokens == {"the-token"}
+    assert server.location.startswith("grpc://"), "no TLS, no scheme upgrade"


### PR DESCRIPTION
## Summary

Third slice of R-2.3 Phase C2 — the Arrow Flight server gains a server-middleware-based bearer-token validator so it can require `Authorization: Bearer <token>` on every Flight call.  Pairs with a matching client-side change (separate PR against `noetl/cli` + `noetl/tools`) once this lands.

- `NoetlFlightServer.from_env()` reads `NOETL_FLIGHT_BEARER_TOKENS` (comma-separated rotation set — deploy `{v1, v2}`, rotate clients, drop v1).
- New `BearerTokenMiddlewareFactory` subclasses `pyarrow.flight.ServerMiddlewareFactory`; `start_call` looks for `Authorization` (any case), parses `Bearer <token>` (any case on the scheme), and checks against the configured set.
- Reject → `FlightUnauthenticatedError` (gRPC `UNAUTHENTICATED` on the wire).
- Auth + TLS are **independently opt-in** — bearer-on + plaintext, bearer-on + TLS, or the original auth-off + plaintext all work.
- Server startup log now carries `tls=<mode> auth=<mode>` for operator visibility.

## Boundary discipline

Per `agents/rules/execution-model.md`:

- Server-side **set of valid tokens** = policy data → env / configmap / k8s Secret.
- Client-side **token a client sends** = business-logic credential → NoETL keychain referenced by alias.

## Test plan

- [x] 14 new unit tests pin: parser semantics, none/empty equivalence, middleware factory construction, accept/reject for various header shapes, multi-token rotation, `from_env` integration, auth-independent-of-TLS.
- [x] `pytest tests/unit/server/api/test_flight_server.py` → 33/33 passing (19 prior + 14 new).

## Followup

Tracked under noetl/ai-meta#33:
- C2.3 client side — `FlightTlsConfig::bearer_token(token)` on the Rust client + tonic interceptor; `ResultFetchTool` reads token alias from keychain.
- C2.4 — mTLS client identity (`FlightTlsConfig::identity(...)`).
- C2.5 — K8s manifests + cert / Secret provisioning.
- C2.6 — Kind validation rig for the full TLS+auth combo.

Refs noetl/ai-meta#33

🤖 Generated with [Claude Code](https://claude.com/claude-code)