### PR TITLE
feat(flight): mTLS client-cert validation (R-2.3 Phase C2.4 server)

### DIFF
--- a/noetl/server/api/result/flight_server.py
+++ b/noetl/server/api/result/flight_server.py
@@ -178,6 +178,21 @@ class NoetlFlightServer:
     from the playbook step.
 
     [exec]: https://github.com/noetl/ai-meta/blob/main/agents/rules/execution-model.md
+
+    ## mTLS (R-2.3 Phase C2.4)
+
+    Pass ``client_ca_path`` — or the env ``NOETL_FLIGHT_CLIENT_CA``
+    — to require client-cert validation on every Flight call
+    (mutual TLS).  The server then refuses connections that don't
+    present a cert chaining to the configured CA.  Requires TLS
+    to be active (i.e. ``tls_cert_path`` + ``tls_key_path`` set);
+    enabling mTLS without server TLS raises ``ValueError`` at
+    construction.
+
+    mTLS stacks on top of bearer-token auth — both run on the same
+    request.  A typical externally-exposed deployment turns on
+    server TLS + mTLS + bearer.  Internal deployments may stay on
+    bearer + plaintext or server-TLS-only.
     """
 
     def __init__(
@@ -186,11 +201,20 @@ class NoetlFlightServer:
         tls_cert_path: Optional[str] = None,
         tls_key_path: Optional[str] = None,
         bearer_tokens: Optional[set[str]] = None,
+        client_ca_path: Optional[str] = None,
     ):
         if (tls_cert_path is None) != (tls_key_path is None):
             raise ValueError(
                 "tls_cert_path and tls_key_path must both be set or both be None; "
                 f"got cert={tls_cert_path!r}, key={tls_key_path!r}"
+            )
+        if client_ca_path is not None and tls_cert_path is None:
+            # mTLS without server TLS is a misconfiguration — there's no
+            # TLS channel to mutually authenticate inside.  Fail fast.
+            raise ValueError(
+                "client_ca_path requires server TLS to be active "
+                "(tls_cert_path + tls_key_path); got client_ca_path="
+                f"{client_ca_path!r} but no server cert"
             )
         # When TLS is active, the location URL must use the
         # `grpc+tls://` scheme so pyarrow.flight knows to wrap the
@@ -201,6 +225,7 @@ class NoetlFlightServer:
         self.location = location
         self.tls_cert_path = tls_cert_path
         self.tls_key_path = tls_key_path
+        self.client_ca_path = client_ca_path
         # Empty set + None both mean "no auth".  Internally we keep
         # `None` to make the no-auth code path explicit.
         self.bearer_tokens: Optional[set[str]] = (
@@ -223,9 +248,15 @@ class NoetlFlightServer:
         - ``NOETL_FLIGHT_BEARER_TOKENS`` — comma-separated set of
           accepted bearer tokens.  Unset → no auth.  Use a set
           rather than a single value to rotate without downtime.
+        - ``NOETL_FLIGHT_CLIENT_CA`` (R-2.3 Phase C2.4) — path to a
+          PEM-encoded client-CA bundle.  When set, the server
+          requires + validates a client certificate (mTLS).
+          Requires TLS to be active; mTLS-without-TLS raises
+          ``ValueError`` at startup.
 
-        TLS + auth are independently opt-in: omit all three to keep
-        the plaintext + no-auth mode the kind manifest ships.
+        TLS + bearer + mTLS are independently opt-in: omit all four
+        TLS/auth env vars to keep the plaintext + no-auth mode the
+        kind manifest ships.
         """
         import os
 
@@ -233,11 +264,13 @@ class NoetlFlightServer:
         cert = os.getenv("NOETL_FLIGHT_TLS_CERT") or None
         key = os.getenv("NOETL_FLIGHT_TLS_KEY") or None
         tokens = _parse_bearer_tokens(os.getenv("NOETL_FLIGHT_BEARER_TOKENS"))
+        client_ca = os.getenv("NOETL_FLIGHT_CLIENT_CA") or None
         return cls(
             location=location,
             tls_cert_path=cert,
             tls_key_path=key,
             bearer_tokens=tokens or None,
+            client_ca_path=client_ca,
         )
 
     def _load_tls_certificates(self) -> Optional[list[tuple[bytes, bytes]]]:
@@ -255,6 +288,18 @@ class NoetlFlightServer:
         # entry per listening location.  Phase C2.1 binds a single
         # location.
         return [(cert_bytes, key_bytes)]
+
+    def _load_client_ca(self) -> Optional[bytes]:
+        """Read the client-CA PEM bundle for mTLS (Phase C2.4).
+
+        Returns ``None`` when mTLS is not configured.  Constructor
+        already guarantees the CA path is only set when server TLS
+        is active, so the caller doesn't have to re-check.
+        """
+        if self.client_ca_path is None:
+            return None
+        with open(self.client_ca_path, "rb") as f:
+            return f.read()
 
     def _build_middleware(self) -> Optional[dict[str, Any]]:
         """Construct the `pyarrow.flight` middleware mapping.
@@ -434,12 +479,19 @@ class NoetlFlightServer:
         # Auth middleware (Phase C2.3) — None when bearer-tokens is
         # empty / unset.
         middleware = outer._build_middleware()
+        # Client CA bundle (Phase C2.4) — None when mTLS disabled;
+        # otherwise pass with `verify_client=True` so pyarrow.flight
+        # demands a client cert chaining to the bundle.
+        client_ca = outer._load_client_ca()
         kwargs: dict[str, Any] = {
             "location": outer.location,
             "tls_certificates": tls_certs,
         }
         if middleware is not None:
             kwargs["middleware"] = middleware
+        if client_ca is not None:
+            kwargs["verify_client"] = True
+            kwargs["root_certificates"] = client_ca
         return _Server(**kwargs)
 
     def start_in_thread(self) -> None:
@@ -448,7 +500,14 @@ class NoetlFlightServer:
             return
         self._server = self._build_server()
 
-        tls_mode = "tls" if self.tls_cert_path else "plaintext"
+        # mTLS (Phase C2.4) reads as a third independent mode on
+        # top of TLS — when on, server-tls is also necessarily on.
+        if self.client_ca_path:
+            tls_mode = "mtls"
+        elif self.tls_cert_path:
+            tls_mode = "tls"
+        else:
+            tls_mode = "plaintext"
         auth_mode = (
             f"bearer({len(self.bearer_tokens)})"
             if self.bearer_tokens

--- a/tests/unit/server/api/test_flight_server.py
+++ b/tests/unit/server/api/test_flight_server.py
@@ -597,3 +597,132 @@ def test_bearer_tokens_independent_of_tls(monkeypatch, tmp_path):
     assert server.tls_cert_path is None
     assert server.bearer_tokens == {"the-token"}
     assert server.location.startswith("grpc://"), "no TLS, no scheme upgrade"
+
+
+# ---------------------------------------------------------------------------
+# R-2.3 Phase C2.4 — mTLS (client-cert validation)
+# ---------------------------------------------------------------------------
+
+
+def test_mtls_requires_server_tls():
+    """`client_ca_path` without `tls_cert_path` is a misconfiguration
+    — there's no TLS channel to mutually authenticate inside.  Fail
+    fast at construction so an operator notices before the server
+    accepts traffic."""
+    with pytest.raises(ValueError, match="client_ca_path requires server TLS"):
+        NoetlFlightServer(
+            location="grpc://0.0.0.0:8083",
+            client_ca_path="/etc/noetl/client-ca.pem",
+        )
+
+
+def test_mtls_construction_with_server_tls(tmp_path):
+    """Server TLS + client CA together → valid mTLS config."""
+    cert = tmp_path / "server.crt"
+    key = tmp_path / "server.key"
+    cca = tmp_path / "client-ca.crt"
+    for f, label in [(cert, "server-cert"), (key, "server-key"), (cca, "client-ca")]:
+        f.write_bytes(f"-----BEGIN CERTIFICATE-----\n{label}\n-----END CERTIFICATE-----".encode())
+
+    server = NoetlFlightServer(
+        location="grpc://0.0.0.0:8083",
+        tls_cert_path=str(cert),
+        tls_key_path=str(key),
+        client_ca_path=str(cca),
+    )
+    assert server.client_ca_path == str(cca)
+    # TLS still upgrades the location URL.
+    assert server.location == "grpc+tls://0.0.0.0:8083"
+
+
+def test_mtls_load_client_ca_reads_pem(tmp_path):
+    """_load_client_ca returns the on-disk PEM bytes."""
+    cert = tmp_path / "server.crt"
+    key = tmp_path / "server.key"
+    cca = tmp_path / "client-ca.crt"
+    cert.write_bytes(b"-----BEGIN CERTIFICATE-----\nserver\n-----END CERTIFICATE-----")
+    key.write_bytes(b"-----BEGIN PRIVATE KEY-----\nserver\n-----END PRIVATE KEY-----")
+    cca.write_bytes(b"-----BEGIN CERTIFICATE-----\nclient-ca\n-----END CERTIFICATE-----")
+
+    server = NoetlFlightServer(
+        location="grpc://0.0.0.0:8083",
+        tls_cert_path=str(cert),
+        tls_key_path=str(key),
+        client_ca_path=str(cca),
+    )
+    ca_bytes = server._load_client_ca()
+    assert ca_bytes is not None
+    assert b"client-ca" in ca_bytes
+
+
+def test_mtls_load_client_ca_returns_none_when_disabled():
+    """No client_ca_path → _load_client_ca returns None.  Caller's
+    `_build_server` then doesn't pass `verify_client` so pyarrow
+    stays in server-tls-only mode."""
+    server = NoetlFlightServer(location="grpc://0.0.0.0:8083")
+    assert server._load_client_ca() is None
+
+
+def test_from_env_mtls(monkeypatch, tmp_path):
+    """`NOETL_FLIGHT_CLIENT_CA` populates the client_ca_path field
+    when server TLS is also active."""
+    cert = tmp_path / "server.crt"
+    key = tmp_path / "server.key"
+    cca = tmp_path / "client-ca.crt"
+    cert.write_bytes(b"dummy")
+    key.write_bytes(b"dummy")
+    cca.write_bytes(b"dummy")
+
+    monkeypatch.setenv("NOETL_FLIGHT_LOCATION", "grpc://0.0.0.0:8083")
+    monkeypatch.setenv("NOETL_FLIGHT_TLS_CERT", str(cert))
+    monkeypatch.setenv("NOETL_FLIGHT_TLS_KEY", str(key))
+    monkeypatch.setenv("NOETL_FLIGHT_CLIENT_CA", str(cca))
+    server = NoetlFlightServer.from_env()
+    assert server.client_ca_path == str(cca)
+    assert server.location == "grpc+tls://0.0.0.0:8083"
+
+
+def test_from_env_mtls_without_tls_raises(monkeypatch, tmp_path):
+    """`NOETL_FLIGHT_CLIENT_CA` without server TLS env → ValueError
+    via `from_env` so a misconfigured pod fails fast at startup."""
+    cca = tmp_path / "client-ca.crt"
+    cca.write_bytes(b"dummy")
+
+    monkeypatch.delenv("NOETL_FLIGHT_TLS_CERT", raising=False)
+    monkeypatch.delenv("NOETL_FLIGHT_TLS_KEY", raising=False)
+    monkeypatch.setenv("NOETL_FLIGHT_CLIENT_CA", str(cca))
+    with pytest.raises(ValueError, match="client_ca_path requires server TLS"):
+        NoetlFlightServer.from_env()
+
+
+def test_mtls_independent_of_bearer(monkeypatch, tmp_path):
+    """mTLS + bearer are independently opt-in — a deployment can
+    enable mTLS without bearer (cert-only auth) or both (the
+    typical externally-exposed shape)."""
+    cert = tmp_path / "server.crt"
+    key = tmp_path / "server.key"
+    cca = tmp_path / "client-ca.crt"
+    cert.write_bytes(b"dummy")
+    key.write_bytes(b"dummy")
+    cca.write_bytes(b"dummy")
+
+    # mTLS only, no bearer.
+    s = NoetlFlightServer(
+        location="grpc://0.0.0.0:8083",
+        tls_cert_path=str(cert),
+        tls_key_path=str(key),
+        client_ca_path=str(cca),
+    )
+    assert s.bearer_tokens is None
+    assert s.client_ca_path is not None
+
+    # mTLS + bearer.
+    s2 = NoetlFlightServer(
+        location="grpc://0.0.0.0:8083",
+        tls_cert_path=str(cert),
+        tls_key_path=str(key),
+        client_ca_path=str(cca),
+        bearer_tokens={"tok"},
+    )
+    assert s2.bearer_tokens == {"tok"}
+    assert s2.client_ca_path is not None


### PR DESCRIPTION
## Summary

Server-side half of R-2.3 Phase C2.4 — the Arrow Flight server can now require a client certificate on every Flight call (mutual TLS) on top of the server cert it already presents (Phase C2.1).

- `NoetlFlightServer.__init__` accepts `client_ca_path`; pyarrow.flight gets `verify_client=True` + `root_certificates=<bundle>`.
- mTLS requires server TLS to be active — partial config (mTLS without server TLS) raises `ValueError` at construction so a misconfigured pod fails fast.
- `NoetlFlightServer.from_env()` reads `NOETL_FLIGHT_CLIENT_CA`; same fail-fast rule via env.
- Startup log mode flag now `tls=plaintext|tls|mtls`.
- mTLS stacks cleanly with bearer auth — independent knobs.

## Boundary discipline

Per `agents/rules/execution-model.md`:
- Server TLS cert + client-CA bundle = platform-runtime credentials (k8s Secret / env var paths).
- Client cert + key (what the WORKER presents) = business-logic credentials — landing on the matching `noetl/cli` + `noetl/tools` PRs.

## Test plan

- [x] 7 new unit tests pin: mTLS-without-TLS rejected, TLS+CA composes, PEM load, env-driven config, env-level fail-fast, mTLS+bearer independence.
- [x] `pytest tests/unit/server/api/test_flight_server.py` → 40/40 passing.

## Followup

Tracked under noetl/ai-meta#33:
- C2.4 client side — `FlightTlsConfig::identity(cert_pem, key_pem)` builder + `connect_with_tls` plumbing.
- C2.4 noetl-tools wiring — `ResultFetchConfig.client_cert_path` + `client_key_path` filesystem fields.
- C2.5 — K8s manifests + Secret provisioning for the cert chain.
- C2.6 — Kind validation rig for the full TLS+auth+mTLS combo.

Refs noetl/ai-meta#33

🤖 Generated with [Claude Code](https://claude.com/claude-code)