### PR TITLE
fix(engine): emit workflow.completed for any terminal step, not just "end"

### DIFF
--- a/noetl/core/dsl/engine/executor/events.py
+++ b/noetl/core/dsl/engine/executor/events.py
@@ -30,23 +30,63 @@ class EventHandlingMixin:
                 (time.perf_counter() - t0) * 1000,
             )
 
-    async def _count_durable_pending_commands(self, execution_id: str, conn=None) -> Optional[int]:
-        """Return pending command count from noetl.command, or None if unavailable."""
-        query = """
-            SELECT COUNT(*) AS pending_count
-            FROM noetl.command
-            WHERE execution_id = %s
-              AND status NOT IN ('COMPLETED', 'FAILED', 'CANCELLED')
+    async def _count_durable_pending_commands(
+        self,
+        execution_id: str,
+        conn=None,
+        exclude_command_id: Optional[str] = None,
+    ) -> Optional[int]:
+        """Return pending command count from noetl.command, or None if unavailable.
+
+        ``exclude_command_id`` skips the row for the command that is currently
+        being finalised (e.g. the terminal step's command whose ``call.done``
+        triggered this completion check).  When ``call.done`` fires, the worker
+        has not yet posted ``command.completed``, so the command row is still
+        in RUNNING state and would be incorrectly counted as pending.
+        Excluding the triggering command avoids a false ``has_pending_commands``
+        that would suppress ``workflow.completed`` emission for any step whose
+        name is not ``"end"``.
         """
+        if exclude_command_id is not None:
+            try:
+                _exc_id = int(exclude_command_id)
+            except (TypeError, ValueError):
+                _exc_id = None
+            if _exc_id is not None:
+                query = """
+                    SELECT COUNT(*) AS pending_count
+                    FROM noetl.command
+                    WHERE execution_id = %s
+                      AND status NOT IN ('COMPLETED', 'FAILED', 'CANCELLED')
+                      AND command_id != %s
+                """
+                params: tuple = (int(execution_id), _exc_id)
+            else:
+                # Non-numeric command_id: fall back to unfiltered count.
+                query = """
+                    SELECT COUNT(*) AS pending_count
+                    FROM noetl.command
+                    WHERE execution_id = %s
+                      AND status NOT IN ('COMPLETED', 'FAILED', 'CANCELLED')
+                """
+                params = (int(execution_id),)
+        else:
+            query = """
+                SELECT COUNT(*) AS pending_count
+                FROM noetl.command
+                WHERE execution_id = %s
+                  AND status NOT IN ('COMPLETED', 'FAILED', 'CANCELLED')
+            """
+            params = (int(execution_id),)
         try:
             if conn is not None:
                 async with conn.cursor(row_factory=dict_row) as cur:
-                    await cur.execute(query, (int(execution_id),))
+                    await cur.execute(query, params)
                     row = await cur.fetchone()
             else:
                 async with get_pool_connection() as pool_conn:
                     async with pool_conn.cursor(row_factory=dict_row) as cur:
-                        await cur.execute(query, (int(execution_id),))
+                        await cur.execute(query, params)
                         row = await cur.fetchone()
             return int((row or {}).get("pending_count", 0) or 0)
         except Exception as exc:
@@ -2397,10 +2437,29 @@ class EventHandlingMixin:
         # Durable projection is the last word before a dead-end can complete an
         # execution. This keeps distributed pods from trusting an incomplete
         # in-memory issued/completed step set while command rows are still live.
+        #
+        # When the trigger is call.done, the worker has not yet posted
+        # command.completed, so the triggering command's row is still RUNNING.
+        # Exclude it from the count to avoid a false positive that would
+        # suppress workflow.completed for any terminal step whose name is not
+        # "end".  See noetl/ai-meta#37.
         if not has_pending_commands and is_completion_trigger:
+            _trigger_command_id: Optional[str] = None
+            if event.name in ("call.done", "call.error"):
+                _trigger_command_id = _extract_command_id_from_event_payload(
+                    normalized_payload, event.meta
+                )
+                logger.debug(
+                    "[COMPLETION] terminal step=%s excluding command_id=%s from durable pending check "
+                    "execution=%s",
+                    event.step,
+                    _trigger_command_id,
+                    event.execution_id,
+                )
             durable_pending_count = await self._count_durable_pending_commands(
                 event.execution_id,
                 conn=conn,
+                exclude_command_id=_trigger_command_id,
             )
             if durable_pending_count is not None:
                 has_pending_commands = durable_pending_count > 0
@@ -2487,6 +2546,12 @@ class EventHandlingMixin:
             and (is_terminal_step or is_failed_with_no_handler or is_dead_end_no_match)
             and not state.completed
         ):
+            if is_terminal_step:
+                logger.debug(
+                    "[COMPLETION] Terminal step reached: execution=%s step=%s — emitting workflow.completed",
+                    event.execution_id,
+                    event.step,
+                )
             # No more commands to execute - workflow and playbook are complete (or failed)
             state.completed = True
             # Check if ANY step failed during execution (state.failed) OR if this final step has error

--- a/noetl/server/api/core/execution.py
+++ b/noetl/server/api/core/execution.py
@@ -247,7 +247,12 @@ async def get_execution_status(execution_id: str, full: bool = False):
                     await cur.execute("SELECT node_name FROM noetl.event WHERE execution_id = %s AND event_type IN ('step.exit', 'loop.done') AND status = 'COMPLETED' ORDER BY event_id ASC", (exec_id_int,))
                     step_rows = await cur.fetchall()
                     pending_row = {"pending_count": 0}
-                    if terminal is None and latest["event_type"] == "batch.completed" and latest["status"] == "COMPLETED":
+                    if terminal is None and latest["status"] == "COMPLETED" and latest["event_type"] in {
+                        "batch.completed", "command.completed", "call.done", "step.exit"
+                    }:
+                        # Query pending count for any potential terminal event so we can apply
+                        # the "no pending commands" heuristic regardless of step name.
+                        # See noetl/ai-meta#37.
                         await cur.execute(PENDING_COMMAND_COUNT_SQL, {"execution_id": exec_id_int})
                         pending_row = await cur.fetchone()
             completed, failed, inferred = False, False, False
@@ -255,7 +260,9 @@ async def get_execution_status(execution_id: str, full: bool = False):
             if t_type in {"playbook.completed", "workflow.completed"}: completed = True
             elif t_type in {"playbook.failed", "workflow.failed", "execution.cancelled", "command.failed"}:
                 completed = t_type == "execution.cancelled"; failed = t_type != "execution.cancelled"
-            elif latest["node_name"] == "end" and latest["status"] == "COMPLETED" and latest["event_type"] in {"command.completed", "call.done", "step.exit"}:
+            elif latest["status"] == "COMPLETED" and latest["event_type"] in {"command.completed", "call.done", "step.exit"} and int((pending_row or {}).get("pending_count", 0) or 0) <= 0:
+                # Any completed terminal event with no pending commands qualifies.
+                # No longer restricted to node_name == "end".  See noetl/ai-meta#37.
                 completed, inferred = True, True
             elif latest["event_type"] == "batch.completed" and latest["status"] == "COMPLETED" and int((pending_row or {}).get("pending_count", 0) or 0) <= 0:
                 completed, inferred = True, True
@@ -290,17 +297,32 @@ async def get_execution_status(execution_id: str, full: bool = False):
                 )
                 terminal = await cur.fetchone()
                 pending_row = {"pending_count": 0}
-                if terminal is None and latest and latest["event_type"] == "batch.completed" and latest["status"] == "COMPLETED":
+                if terminal is None and latest and latest["status"] == "COMPLETED" and latest["event_type"] in {
+                    "batch.completed", "command.completed", "call.done", "step.exit"
+                }:
+                    # Query pending count for any potential terminal event so the
+                    # heuristic below applies regardless of step name.  See noetl/ai-meta#37.
                     await cur.execute(PENDING_COMMAND_COUNT_SQL, {"execution_id": exec_id_int})
                     pending_row = await cur.fetchone()
         if not completed:
-            if state.current_step == "end" and "end" in state.completed_steps and not failed: completed, inferred = True, True
+            # Check whether state.current_step is a terminal step (no outgoing
+            # transitions) that has already been marked completed.  Using
+            # state.get_step() instead of hardcoding "end" makes this work for
+            # any step name — including the "done" step in validation fixtures.
+            # See noetl/ai-meta#37.
+            _cs = state.current_step
+            _cs_def = state.get_step(_cs) if _cs else None
+            _step_is_terminal = bool(_cs_def and not _cs_def.next)
+            if _step_is_terminal and _cs in state.completed_steps and not failed:
+                completed, inferred = True, True
             else:
                 t_type = terminal["event_type"] if terminal else None
                 if t_type in {"playbook.completed", "workflow.completed"}: completed = True
                 elif t_type in {"playbook.failed", "workflow.failed", "execution.cancelled", "command.failed"}:
                     completed = t_type == "execution.cancelled"; failed = t_type != "execution.cancelled"
-                elif latest and latest["node_name"] == "end" and latest["status"] == "COMPLETED" and latest["event_type"] in {"command.completed", "call.done", "step.exit"}:
+                elif latest and latest["status"] == "COMPLETED" and latest["event_type"] in {"command.completed", "call.done", "step.exit"} and int((pending_row or {}).get("pending_count", 0) or 0) <= 0:
+                    # Any terminal-step completion with no pending commands qualifies.
+                    # No longer restricted to node_name == "end".  See noetl/ai-meta#37.
                     completed, inferred = True, True
                 elif latest and latest["event_type"] == "batch.completed" and latest["status"] == "COMPLETED" and int((pending_row or {}).get("pending_count", 0) or 0) <= 0:
                     completed, inferred = True, True

--- a/tests/unit/dsl/engine/test_terminal_step_completion.py
+++ b/tests/unit/dsl/engine/test_terminal_step_completion.py
@@ -1,0 +1,178 @@
+"""Regression tests for noetl/ai-meta#37.
+
+Two bugs, fixed together:
+
+  A. The engine did not emit ``workflow.completed`` when the terminal step
+     was named anything other than ``"end"``.  Root cause: the durable
+     pending-command count queried ``noetl.command`` without excluding the
+     current step's command, which is still RUNNING when ``call.done``
+     fires (the worker posts ``command.completed`` after ``call.done``).
+     The false positive caused ``has_pending_commands = True``, blocking
+     the completion gate.
+
+  B. The status endpoint inference hardcoded ``node_name == "end"`` in
+     two places.  Any terminal step with a different name would never be
+     inferred as complete.
+
+Both tests use a 3-step playbook whose terminal step is named ``"done"``
+(not ``"end"``), mirroring the ``rust-worker-r2-validation.yaml`` fixture.
+"""
+
+import pytest
+from unittest.mock import AsyncMock
+from noetl.core.dsl.engine.executor import ControlFlowEngine, PlaybookRepo, StateStore, ExecutionState
+from noetl.core.dsl.engine.models import Event
+from noetl.core.dsl.engine.parser import DSLParser
+
+
+_PLAYBOOK_YAML = """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: done_terminal_regression
+  path: tests/fixtures/done_terminal_regression
+
+workflow:
+  - step: step_a
+    tool:
+      kind: shell
+      command: 'echo step_a'
+    next:
+      arcs:
+        - step: step_b
+
+  - step: step_b
+    tool:
+      kind: shell
+      command: 'echo step_b'
+    next:
+      arcs:
+        - step: done
+
+  - step: done
+    tool:
+      kind: shell
+      command: 'echo done'
+"""
+
+
+@pytest.fixture
+def _engine_and_state(monkeypatch):
+    """Return a (engine, state) pair wired against a no-op DB/NATS."""
+    playbook = DSLParser().parse(_PLAYBOOK_YAML)
+    state = ExecutionState(
+        execution_id="9000000000000001",
+        playbook=playbook,
+        payload={},
+    )
+    playbook_repo = PlaybookRepo()
+    state_store = StateStore(playbook_repo)
+    engine = ControlFlowEngine(playbook_repo, state_store)
+
+    monkeypatch.setattr(state_store, "load_state", AsyncMock(return_value=state))
+    monkeypatch.setattr(state_store, "load_state_for_update", AsyncMock(return_value=state))
+    monkeypatch.setattr(state_store, "_save_state_inner", AsyncMock(return_value=None))
+    engine._persist_event = AsyncMock(return_value=None)
+
+    # Simulate that step_a and step_b completed prior to this test round.
+    state.completed_steps.add("step_a")
+    state.completed_steps.add("step_b")
+    # "done" was issued — it is in issued_steps but NOT yet in completed_steps.
+    state.issued_steps.add("done")
+
+    return engine, state
+
+
+@pytest.mark.asyncio
+async def test_engine_emits_workflow_completed_for_non_end_terminal_step(
+    _engine_and_state, monkeypatch
+):
+    """Engine must emit workflow.completed when the terminal step is named 'done'.
+
+    Regression for noetl/ai-meta#37 Fix A.
+
+    The durable pending-count query in ``_count_durable_pending_commands``
+    used to count the triggering command as still-pending (RUNNING status in
+    noetl.command), blocking the completion gate.  The fix excludes the
+    current command_id from the count.
+    """
+    engine, state = _engine_and_state
+
+    # Capture events persisted by the cascade.
+    persisted_events: list[Event] = []
+
+    async def _capture_persist(event, st, conn=None):
+        persisted_events.append(event)
+        # Advance last_event_id so chaining works.
+        st.last_event_id = (st.last_event_id or 0) + 1
+
+    engine._persist_event = _capture_persist
+
+    # Simulate call.done for the "done" terminal step.
+    # Include a command_id so the exclude path is exercised.
+    event = Event(
+        execution_id="9000000000000001",
+        step="done",
+        name="call.done",
+        payload={
+            "command_id": "1234567890",
+            "result": {"status": "COMPLETED"},
+        },
+    )
+
+    commands = await engine.handle_event(event, already_persisted=True)
+
+    # No further commands should be issued — the workflow is done.
+    assert commands == [], f"Expected no commands after terminal step, got {commands}"
+
+    # state.completed must be set.
+    assert state.completed is True, "state.completed should be True after terminal step"
+
+    # The cascade must have emitted workflow.completed and playbook.completed.
+    emitted_names = [e.name for e in persisted_events]
+    assert "workflow.completed" in emitted_names, (
+        f"workflow.completed not found in emitted events: {emitted_names}"
+    )
+    assert "playbook.completed" in emitted_names, (
+        f"playbook.completed not found in emitted events: {emitted_names}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_engine_terminal_step_debug_log_is_emitted(
+    _engine_and_state, monkeypatch, caplog
+):
+    """DEBUG log must fire when the is_terminal_step branch triggers.
+
+    Observability hook per agents/rules/observability.md Principle 1.
+    """
+    import logging
+
+    engine, state = _engine_and_state
+
+    async def _noop_persist(event, st, conn=None):
+        st.last_event_id = (st.last_event_id or 0) + 1
+
+    engine._persist_event = _noop_persist
+
+    event = Event(
+        execution_id="9000000000000001",
+        step="done",
+        name="call.done",
+        payload={
+            "command_id": "1234567891",
+            "result": {"status": "COMPLETED"},
+        },
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="noetl"):
+        await engine.handle_event(event, already_persisted=True)
+
+    terminal_logs = [r for r in caplog.records if "Terminal step reached" in r.message]
+    assert terminal_logs, (
+        "Expected a DEBUG log containing 'Terminal step reached' when is_terminal_step fires"
+    )
+    # Confirm execution_id and step are present in the log message.
+    log_msg = terminal_logs[0].message
+    assert "done" in log_msg, f"Expected step='done' in log: {log_msg}"
+    assert "9000000000000001" in log_msg, f"Expected execution_id in log: {log_msg}"

--- a/tests/unit/server/api/test_status_terminal_step_inference.py
+++ b/tests/unit/server/api/test_status_terminal_step_inference.py
@@ -1,0 +1,163 @@
+"""Regression tests for noetl/ai-meta#37 Fix B.
+
+The status endpoint's inference fallback hardcoded ``node_name == "end"`` in
+two places:
+
+  1. State-store path (``get_execution_status`` with loaded state):
+     ``state.current_step == "end" and "end" in state.completed_steps``
+
+  2. Event-log fallback path (no loaded state):
+     ``latest["node_name"] == "end"``
+
+Both checks must work for any terminal step name.  These tests verify the
+corrected logic on the state-store path (the primary production path) using a
+playbook whose terminal step is named ``"done"``.
+"""
+
+import pytest
+from noetl.core.dsl.engine.executor import ExecutionState
+from noetl.core.dsl.engine.parser import DSLParser
+
+
+_PLAYBOOK_YAML = """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: done_terminal_regression
+  path: tests/fixtures/done_terminal_regression
+
+workflow:
+  - step: step_a
+    tool:
+      kind: shell
+      command: 'echo step_a'
+    next:
+      arcs:
+        - step: step_b
+
+  - step: step_b
+    tool:
+      kind: shell
+      command: 'echo step_b'
+    next:
+      arcs:
+        - step: done
+
+  - step: done
+    tool:
+      kind: shell
+      command: 'echo done'
+"""
+
+
+def _make_state(*, completed: bool = False, failed: bool = False) -> ExecutionState:
+    playbook = DSLParser().parse(_PLAYBOOK_YAML)
+    state = ExecutionState(
+        execution_id="9000000000000002",
+        playbook=playbook,
+        payload={},
+    )
+    state.completed = completed
+    state.failed = failed
+    state.current_step = "done"
+    state.completed_steps = {"step_a", "step_b", "done"}
+    return state
+
+
+def _infer_completed(state: ExecutionState, *, failed: bool = False) -> tuple[bool, bool]:
+    """Pure Python version of the status-endpoint state-store inference logic.
+
+    Returns (completed, inferred) mirroring the corrected branch in
+    ``get_execution_status``.
+    """
+    if state.completed:
+        return True, False
+
+    _cs = state.current_step
+    _cs_def = state.get_step(_cs) if _cs else None
+    _step_is_terminal = bool(_cs_def and not _cs_def.next)
+    if _step_is_terminal and _cs in state.completed_steps and not failed:
+        return True, True
+
+    return False, False
+
+
+class TestTerminalStepInference:
+    """Unit tests for the corrected terminal-step inference logic."""
+
+    def test_done_step_is_detected_as_terminal(self):
+        """get_step('done') must return a step with no .next attribute."""
+        state = _make_state()
+        done_def = state.get_step("done")
+        assert done_def is not None, "Step 'done' must exist in the playbook"
+        assert not done_def.next, "Step 'done' must have no next transitions"
+
+    def test_end_step_would_be_detected_as_terminal_too(self):
+        """Sanity check: a step literally named 'end' is also terminal under the new logic."""
+        yaml_content = """
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: end_terminal
+
+workflow:
+  - step: start
+    tool:
+      kind: shell
+      command: 'echo start'
+    next:
+      arcs:
+        - step: end
+
+  - step: end
+    tool:
+      kind: shell
+      command: 'echo end'
+"""
+        playbook = DSLParser().parse(yaml_content)
+        state = ExecutionState(execution_id="9000000000000003", playbook=playbook, payload={})
+        state.current_step = "end"
+        state.completed_steps = {"start", "end"}
+
+        end_def = state.get_step("end")
+        assert end_def is not None
+        assert not end_def.next
+
+        completed, inferred = _infer_completed(state)
+        assert completed is True, "Inference must work for the 'end' step too"
+        assert inferred is True
+
+    def test_inference_returns_completed_for_done_terminal_step(self):
+        """With 'done' as current_step in completed_steps and not failed → completed=True."""
+        state = _make_state()
+        completed, inferred = _infer_completed(state)
+        assert completed is True, "Inference must return completed=True for terminal 'done' step"
+        assert inferred is True
+
+    def test_inference_returns_not_completed_when_state_already_true(self):
+        """If state.completed is already True the fast path fires."""
+        state = _make_state(completed=True)
+        completed, inferred = _infer_completed(state)
+        assert completed is True
+        assert inferred is False  # fast-path, not the heuristic
+
+    def test_inference_returns_not_completed_when_step_not_in_completed_steps(self):
+        """If 'done' is current_step but NOT in completed_steps, must NOT infer complete."""
+        state = _make_state()
+        state.completed_steps = {"step_a", "step_b"}  # done not yet marked
+        completed, inferred = _infer_completed(state)
+        assert completed is False
+
+    def test_inference_not_completed_when_failed(self):
+        """A failed execution must not be inferred as completed."""
+        state = _make_state(failed=True)
+        completed, inferred = _infer_completed(state, failed=True)
+        assert completed is False
+
+    def test_non_terminal_step_not_inferred_as_complete(self):
+        """A mid-workflow step with outgoing transitions must not trigger inference."""
+        state = _make_state()
+        state.current_step = "step_a"
+        state.completed_steps = {"step_a"}
+        completed, inferred = _infer_completed(state)
+        assert completed is False, "step_a has a next arc; it is not terminal"


### PR DESCRIPTION
## Summary

- **Fix A (engine)**: `_count_durable_pending_commands` was counting the currently-executing command as pending because the Rust worker posts `call.done` before `command.completed`. The command row is still RUNNING in `noetl.command` when `call.done` fires. Now the triggering command's ID is excluded from the durable count, removing the false `has_pending_commands=True` that suppressed `workflow.completed` emission for any terminal step not named `"end"`.
- **Fix B (status endpoint)**: Two `node_name == "end"` literals in `get_execution_status` are replaced with generic terminal-step detection: the state-store path uses `state.get_step(current_step).next is None`; the event-log fallback path uses `pending_count == 0`.
- **Observability**: added a DEBUG log at the `is_terminal_step` branch so the code path is visible in logs per `observability.md` Principle 1.

## Diagnosis

The `rust-worker-r2-validation.yaml` fixture has a terminal step named `done` (no `next` block). The Rust worker emits `call.done` → engine is invoked → `_count_durable_pending_commands` queries `noetl.command` for non-terminal rows → `done` command is still RUNNING (worker hasn't posted `command.completed` yet) → `durable_pending_count = 1` → `has_pending_commands = True` → completion gate blocked → `workflow.completed` never emitted. The status endpoint then falls back to `node_name == "end"` inference which also fails because the step is `done`.

## Files changed

- `noetl/core/dsl/engine/executor/events.py`: `_count_durable_pending_commands` + call site at the durable pending check.
- `noetl/server/api/core/execution.py`: status endpoint inference for both the state-store path (`:307`) and event-log fallback path (`:258`).
- `tests/unit/dsl/engine/test_terminal_step_completion.py` — new regression tests for Fix A + observability hook.
- `tests/unit/server/api/test_status_terminal_step_inference.py` — new regression tests for Fix B.

## Coordination

The parallel codex agent working on noetl/ai-meta#36 touches `noetl/server/api/core/batch.py` and `noetl/core/storage/arrow_ipc.py`. This PR stays clear of those files.

## Test plan

- [ ] `pytest tests/unit/dsl/engine/test_terminal_step_completion.py -v` — engine completion tests pass.
- [ ] `pytest tests/unit/server/api/test_status_terminal_step_inference.py -v` — status inference tests pass.
- [ ] `pytest tests/unit/dsl/engine/ -v` — no regressions in existing engine tests.
- [ ] Run `bash automation/development/validate-rust-worker-r2.sh` against kind cluster with `PIN_RUST_WORKER=1`. Confirm `workflow.completed` lands in `noetl.event` for the `done` step without needing the 30-tick fallback workaround.

Closes noetl/ai-meta#37

🤖 Generated with [Claude Code](https://claude.com/claude-code)