### PR TITLE
fix(arrow-ipc): handle nested mixed types + outbox encoder tolerates failure

### DIFF
--- a/noetl/core/outbox.py
+++ b/noetl/core/outbox.py
@@ -59,18 +59,43 @@ async def ensure_outbox_schema() -> None:
 
 
 async def enqueue_outbox(cur: Any, event: dict[str, Any], *, subject: str | None = None) -> None:
-    """Enqueue a mirrored event in the caller's current database transaction."""
+    """Enqueue a mirrored event in the caller's current database transaction.
+
+    The arrow-feather encoded ``payload_bytes`` is best-effort: the JSONB
+    ``payload`` column is the source of truth (NATS publishes from it
+    directly per ``publish_outbox_batch``), and the projector's NATS
+    consumer falls back to JSON when feather bytes are missing.  If the
+    feather encode fails — typically a pyarrow type-inference error on
+    a deeply nested payload that the safe-table helper still can't
+    coerce — we record NULL for payload_bytes + ``payload_codec='json'``
+    so direct-table readers know to use the JSONB column.  The outbox
+    insert must never fail the surrounding batch transaction over an
+    accelerator format that the consumer side already treats as
+    optional.  See noetl/ai-meta#36.
+    """
 
     event_id = event.get("event_id")
     if event_id is None:
         raise ValueError("outbox requires event_id")
     payload = normalize_outbox_payload(event)
-    payload_bytes, _schema_digest, _row_count = rows_to_arrow_feather([payload])
+    try:
+        payload_bytes, _schema_digest, _row_count = rows_to_arrow_feather([payload])
+        payload_codec = "arrow-feather"
+    except Exception as exc:
+        logger.warning(
+            "[OUTBOX] Arrow-feather encoding failed for event_id=%s execution_id=%s; "
+            "falling back to NULL payload_bytes + payload_codec='json'.  Error: %s",
+            event_id,
+            payload.get("execution_id"),
+            exc,
+        )
+        payload_bytes = None
+        payload_codec = "json"
     execution_id = payload.get("execution_id")
     await cur.execute(
         """
         INSERT INTO noetl.outbox (execution_id, event_id, subject, payload, payload_bytes, payload_codec)
-        VALUES (%s, %s, %s, %s, %s, 'arrow-feather')
+        VALUES (%s, %s, %s, %s, %s, %s)
         ON CONFLICT (execution_id, event_id) DO NOTHING
         """,
         (
@@ -79,6 +104,7 @@ async def enqueue_outbox(cur: Any, event: dict[str, Any], *, subject: str | None
             subject,
             Json(payload),
             payload_bytes,
+            payload_codec,
         ),
     )
 

--- a/noetl/core/storage/arrow_ipc.py
+++ b/noetl/core/storage/arrow_ipc.py
@@ -82,28 +82,64 @@ def _build_safe_arrow_table(rows: list[dict[str, Any]], columns: list[str]):
         col for col, types in type_groups.items() if len(types) > 1
     }
 
-    if not mixed_columns:
-        # All columns are pure-type but the original `from_pylist` call
-        # still failed — re-raise so the caller sees the underlying
-        # pyarrow error rather than papering over an unrelated problem.
-        return pa.Table.from_pylist(rows, schema=None)
+    # Cross-row mixed-type case: stringify just the offending columns,
+    # keep pure-typed columns at their natural Arrow type.  Fast path
+    # for the common DuckDB-rowset shape that triggered the original
+    # bug.
+    if mixed_columns:
+        coerced_rows = []
+        for row in rows:
+            new_row = dict(row)
+            for col in mixed_columns:
+                value = new_row.get(col)
+                if value is None:
+                    continue
+                new_row[col] = str(value)
+            coerced_rows.append(new_row)
 
-    coerced_rows = []
+        logger.info(
+            "[ARROW-IPC] Coerced %d mixed-type column(s) to string: %s",
+            len(mixed_columns),
+            sorted(mixed_columns),
+        )
+        try:
+            return pa.Table.from_pylist(coerced_rows, schema=None)
+        except (pa.ArrowInvalid, pa.ArrowTypeError):
+            # Fall through to the nested-column case below.
+            pass
+
+    # Nested mixed-type case: no cross-row column variance (or even
+    # after the simple stringification the encode still fails), so the
+    # offending types are nested INSIDE one of the column values — e.g.
+    # the outbox encodes a single-row table where one column carries a
+    # nested `result.context.data.rows` list whose elements have mixed
+    # types for the same field across rows.  Stringify (via JSON) every
+    # non-scalar column value so pyarrow only has to infer string/int/
+    # float/bool primitives.  Last-resort fallback; logged at INFO so
+    # operators see when it fires.
+    import json as _json
+
+    nested_columns: set[str] = set()
+    nested_rows = []
     for row in rows:
         new_row = dict(row)
-        for col in mixed_columns:
-            value = new_row.get(col)
-            if value is None:
-                continue
-            new_row[col] = str(value)
-        coerced_rows.append(new_row)
+        for col, value in list(new_row.items()):
+            if isinstance(value, (dict, list)):
+                nested_columns.add(col)
+                try:
+                    new_row[col] = _json.dumps(value, default=str, sort_keys=True)
+                except (TypeError, ValueError):
+                    new_row[col] = str(value)
+        nested_rows.append(new_row)
 
-    logger.info(
-        "[ARROW-IPC] Coerced %d mixed-type column(s) to string: %s",
-        len(mixed_columns),
-        sorted(mixed_columns),
-    )
-    return pa.Table.from_pylist(coerced_rows, schema=None)
+    if nested_columns:
+        logger.info(
+            "[ARROW-IPC] JSON-stringified %d nested column(s) for Arrow encoding: %s",
+            len(nested_columns),
+            sorted(nested_columns),
+        )
+
+    return pa.Table.from_pylist(nested_rows, schema=None)
 
 
 def rows_to_arrow_ipc(

--- a/tests/core/test_arrow_ipc_serialization.py
+++ b/tests/core/test_arrow_ipc_serialization.py
@@ -127,3 +127,54 @@ def test_rows_to_arrow_feather_handles_mixed_type_column():
     assert row_count == 2
     assert decoded[0]["id"] == "1"
     assert decoded[1]["id"] == "two"
+
+
+def test_rows_to_arrow_ipc_handles_nested_mixed_types_in_single_row():
+    """Regression for the outbox-encoder branch of noetl/ai-meta#36.
+
+    The outbox encodes a single-row table where one column carries a
+    nested payload (e.g. an event's `result.context.data.rows` list).
+    Within that nested list the rows have mixed types for the same
+    field (an `id` that's int in row 0 and str in row 1).  Pyarrow's
+    cross-row inference at the top level sees no variance — there's
+    only ONE top-level row — so the original mixed-column fallback
+    didn't fire.  The nested-stringify fallback covers this case by
+    JSON-encoding any column whose value is a dict or list.
+    """
+    from noetl.core.storage import arrow_ipc_to_rows, rows_to_arrow_ipc
+
+    # One row, but the `result` column has nested mixed types that
+    # trip pyarrow's struct-type inference.
+    rows = [
+        {
+            "event_id": 100,
+            "event_type": "call.done",
+            "result": {
+                "context": {
+                    "data": {
+                        "rows": [
+                            {"id": 1, "username": "user_1"},
+                            {"id": "two", "username": "user_2"},
+                        ]
+                    }
+                }
+            },
+        }
+    ]
+
+    # Must not raise — even though `rows_to_arrow_feather([payload])`
+    # would have failed before the nested-stringify fallback.
+    payload, _digest, row_count = rows_to_arrow_ipc(rows)
+    assert row_count == 1
+    decoded = arrow_ipc_to_rows(payload)
+    assert decoded[0]["event_id"] == 100
+    assert decoded[0]["event_type"] == "call.done"
+    # The `result` column is now a JSON string (the nested fallback
+    # serialized it).  Operators / projector consumers reading the
+    # arrow-feather payload_bytes get the same structural info, just
+    # as a stringified JSON sub-object.  The JSONB column on the
+    # outbox row stays the source of truth for native dict access.
+    import json
+    decoded_result = json.loads(decoded[0]["result"])
+    assert decoded_result["context"]["data"]["rows"][0]["id"] == 1
+    assert decoded_result["context"]["data"]["rows"][1]["id"] == "two"


### PR DESCRIPTION
## Summary

Follow-up to [noetl/noetl#650](https://github.com/noetl/noetl/pull/650). Kind validation after #650 merged revealed a second flavor of the [noetl/ai-meta#36](https://github.com/noetl/ai-meta/issues/36) regression that the original fix didn't cover: the outbox encoder feeds `pa.Table.from_pylist([payload])` (single-row table) where the payload's nested `result.context.data.rows` list contains mixed-type fields. With only one top-level row there's no cross-row variance for `_build_safe_arrow_table` to detect, so the fallback didn't fire.

Confirmed via the `logger.exception` traceback added in #650 — the trail led directly to `outbox.py:68 → arrow_ipc.py:89 (re-raise)`.

Two complementary fixes:

1. **Nested-stringify fallback in `_build_safe_arrow_table`** — when the cross-row mixed-column path finds no variance (or still fails), JSON-serialize every column value that's a dict/list. Pyarrow then only infers string/int/float/bool primitives.
2. **Outbox tolerates encoding failure** — `payload_bytes` is best-effort by design (JSONB is the source of truth, NATS publishes from it, the projector's NATS consumer falls back to JSON when feather is missing). Catch any encoder exception → record NULL `payload_bytes` + `payload_codec='json'`. Insert never fails over an accelerator format.

## Test plan

- [x] `pytest tests/core/test_arrow_ipc_serialization.py` — 7/7 pass (6 from #650 + 1 new nested-case regression).
- [x] **Kind-validated end-to-end** against the rebuilt server image with `PIN_RUST_WORKER=0` (Python noetl-worker path that originally exposed the bug):
  - `small_select → big_select → done` full lifecycle complete (no `batch.failed`).
  - `workflow.completed` + `playbook.completed` fire ~50ms after `done.command.completed`.
  - `/api/executions/{id}/status` reports `completed=True, failed=False, inferred=False` (the real terminal events, not the inference fallback).
  - Both [noetl/ai-meta#36](https://github.com/noetl/ai-meta/issues/36) (already closed by #650) and [noetl/ai-meta#37](https://github.com/noetl/ai-meta/issues/37) (already closed by #649) paths green on the Python worker.

## Observability

The nested-stringify fallback path logs at INFO with the column names it stringified. The outbox fallback logs at WARNING with `event_id` + `execution_id` per `agents/rules/observability.md` Principle 4. Both are one-shot per occurrence, no log flood.

Refs noetl/ai-meta#36

🤖 Generated with [Claude Code](https://claude.com/claude-code)