### PR TITLE
test(keda): drift guards for both worker-pool ScaledObject samples

### DIFF
--- a/tests/core/runtime/test_keda.py
+++ b/tests/core/runtime/test_keda.py
@@ -194,3 +194,76 @@ def test_dump_scaledobject_yaml_preserves_top_level_key_order():
     assert lines[3].startswith("spec:")
 
 
+# ----------------------------------------------------------------------------
+# Sample-manifest drift guards
+#
+# The ops repo at `noetl/ops/ci/manifests/keda/scaledobject-*.yaml` checks
+# in the generator output verbatim so operators can `kubectl apply -f` it
+# directly.  These fixtures under `tests/fixtures/keda/` are the test-side
+# source of truth — if a generator change moves the YAML body, this guard
+# fails and the operator must regenerate both the noetl/noetl fixture and
+# the noetl/ops manifest before the change can land.
+#
+# The fixtures intentionally omit any header comments (they're the YAML
+# body only).  The ops manifests wrap the same body in operator-facing
+# header comments documenting the regen recipe.
+#
+# Pool inventory (kept in lockstep with `noetl/ops/ci/manifests/keda/`):
+#
+#   - `worker-cpu-01` — Python `noetl-worker` deployment (the original
+#     single-pool sample from the v2-spec Phase 4 round).
+#   - `worker-rust-pool` — Rust `noetl-worker-rust` deployment (added
+#     2026-06-02 alongside R-3 Phase B-4 dual-scaling; both pools share
+#     the same NATS stream + consumer, so adding the Rust-pool scaler
+#     gives KEDA-driven autoscaling on both halves of the worker fleet).
+# ----------------------------------------------------------------------------
+
+import pathlib
+
+_FIXTURE_DIR = pathlib.Path(__file__).resolve().parents[2] / "fixtures" / "keda"
+
+
+@pytest.mark.parametrize(
+    "fixture_name, spec",
+    [
+        (
+            "scaledobject-worker-cpu-01.yaml",
+            ScaledObjectSpec(
+                worker_pool_urn=(
+                    "noetl://tenant/default/org/default/worker/worker-cpu-01"
+                ),
+                deployment="noetl-worker",
+                nats_consumer="noetl_worker_pool",
+            ),
+        ),
+        (
+            "scaledobject-worker-rust-pool.yaml",
+            ScaledObjectSpec(
+                worker_pool_urn=(
+                    "noetl://tenant/default/org/default/worker/worker-rust-pool"
+                ),
+                deployment="noetl-worker-rust",
+                nats_consumer="noetl_worker_pool",
+            ),
+        ),
+    ],
+    ids=["worker-cpu-01-python-pool", "worker-rust-pool-rust-pool"],
+)
+def test_sample_manifest_matches_generator_output(fixture_name, spec):
+    """Verify each checked-in pool sample matches what the generator emits.
+
+    Catches drift between the noetl/noetl fixtures + the noetl/ops manifests
+    + the live generator.  If this test fails, regenerate both files via
+    the recipe in `noetl/ops/ci/manifests/keda/README.md` before merging
+    any generator change.
+    """
+    fixture = _FIXTURE_DIR / fixture_name
+    expected = fixture.read_text()
+    actual = dump_scaledobject_yaml(build_worker_scaledobject(spec))
+    assert actual == expected, (
+        f"Drift detected for {fixture_name}.  Regenerate via the recipe "
+        f"in `noetl/ops/ci/manifests/keda/README.md` and update both the "
+        f"fixture under tests/fixtures/keda/ and the matching ops manifest."
+    )
+
+

--- a/tests/fixtures/keda/scaledobject-worker-cpu-01.yaml
+++ b/tests/fixtures/keda/scaledobject-worker-cpu-01.yaml
@@ -1,0 +1,26 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: noetl-worker-scaler-worker-cpu-01
+  namespace: noetl
+  labels:
+    app: noetl-worker
+    worker-pool: worker-cpu-01
+    managed-by: noetl
+spec:
+  scaleTargetRef:
+    name: noetl-worker
+  minReplicaCount: 1
+  maxReplicaCount: 20
+  pollingInterval: 10
+  cooldownPeriod: 30
+  triggers:
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: nats.nats.svc.cluster.local:8222
+      account: NOETL
+      stream: NOETL_COMMANDS
+      consumer: noetl_worker_pool
+      lagThreshold: '10'
+      activationLagThreshold: '1'
+      useHttps: 'false'

--- a/tests/fixtures/keda/scaledobject-worker-rust-pool.yaml
+++ b/tests/fixtures/keda/scaledobject-worker-rust-pool.yaml
@@ -1,0 +1,26 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: noetl-worker-rust-scaler-worker-rust-pool
+  namespace: noetl
+  labels:
+    app: noetl-worker-rust
+    worker-pool: worker-rust-pool
+    managed-by: noetl
+spec:
+  scaleTargetRef:
+    name: noetl-worker-rust
+  minReplicaCount: 1
+  maxReplicaCount: 20
+  pollingInterval: 10
+  cooldownPeriod: 30
+  triggers:
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: nats.nats.svc.cluster.local:8222
+      account: NOETL
+      stream: NOETL_COMMANDS
+      consumer: noetl_worker_pool
+      lagThreshold: '10'
+      activationLagThreshold: '1'
+      useHttps: 'false'


### PR DESCRIPTION
## Summary

- Adds two YAML fixtures under `tests/fixtures/keda/` capturing the generator output for each worker pool's KEDA `ScaledObject`:
  - `scaledobject-worker-cpu-01.yaml` — Python `noetl-worker` deployment (existing v2-spec Phase 4 sample).
  - `scaledobject-worker-rust-pool.yaml` — Rust `noetl-worker-rust` deployment (new for R-3 Phase B-4 dual-scaling).
- Adds a single parameterised drift-guard test `test_sample_manifest_matches_generator_output` that builds the ScaledObject for each pool's `ScaledObjectSpec`, dumps the YAML, and compares against the matching fixture.  Failure includes a regen-recipe pointer in the assertion message.

## Why

Today the `noetl/ops/ci/manifests/keda/scaledobject-worker-cpu-01.yaml` header advertises a drift guard ("Sample manifest committed verbatim so the `test_sample_manifest_matches_generator_output` drift guard catches any hand-edit"), but no such test actually existed in `tests/core/runtime/test_keda.py`.  This PR ships the missing guard + extends it to the new Rust-pool sample being added alongside [noetl/ai-meta#41](https://github.com/noetl/ai-meta/issues/41).

Both pools claim from the same NATS stream + consumer (`NOETL_COMMANDS` / `noetl_worker_pool`), so KEDA-driven autoscaling on both halves balances naturally — NATS dispatches each pending message to whichever pool sends the next pull request.

## Test plan

- [x] `pytest tests/core/runtime/test_keda.py` — 23/23 pass (21 pre-existing + 2 new parameterised cases).
- [ ] Reviewer can verify drift-guard fires correctly by hand-editing one of the fixture files (e.g. change `minReplicaCount` from 1 to 2) and confirming the test fails with the regen-recipe pointer.

## Sibling PR

The matching ops manifest ships in a sibling noetl/ops PR.  That PR's `ci/manifests/keda/scaledobject-worker-rust-pool.yaml` is identical to the fixture this PR commits at `tests/fixtures/keda/scaledobject-worker-rust-pool.yaml` (modulo header comments, which are operator-facing and only live on the ops side).

Refs noetl/ai-meta#41

🤖 Generated with [Claude Code](https://claude.com/claude-code)