### PR TITLE
fix(replay): tolerate non-numeric projection identifiers in sort keys

### DIFF
--- a/noetl/server/api/replay/service.py
+++ b/noetl/server/api/replay/service.py
@@ -589,10 +589,35 @@ def _normalized_frame_projection_row(row: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _projection_sort_key(value: Any) -> tuple[int, Any]:
+    """Sort key for projection-row identifiers that tolerates both shapes.
+
+    Production identifiers (frame_id / stage_id / command_id) are
+    snowflake-style numeric strings (e.g. ``"639947948205277573"``), so
+    sorting them numerically preserves event-log ordering.  Test
+    fixtures and synthetic identifiers commonly use semantic strings
+    (e.g. ``"stage-1"``, ``"frame-A"``) that can't be coerced to int —
+    the previous ``int(row["X"])`` lambdas raised ``ValueError`` on
+    those, breaking the entire normaliser.  Closes noetl/noetl#638.
+
+    Strategy: tuple-sort.  Int-coercible values share a leading 0 + sort
+    by their numeric value; non-coercible values share a leading 1 +
+    sort lexicographically.  Within a single projection run callers
+    won't usually mix shapes, but the tuple ordering is well-defined
+    when they do (numeric first, then strings).
+    """
+
+    text = "" if value is None else str(value)
+    try:
+        return (0, int(text))
+    except (TypeError, ValueError):
+        return (1, text)
+
+
 def normalize_live_frame_projection(rows: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
     return sorted(
         (_normalized_frame_projection_row(row) for row in rows),
-        key=lambda row: int(row["frame_id"]),
+        key=lambda row: _projection_sort_key(row["frame_id"]),
     )
 
 
@@ -624,7 +649,7 @@ def normalize_replayed_frame_projection(state: Mapping[str, Any]) -> list[dict[s
             for frame_id, frame in frames.items()
             if isinstance(frame, Mapping)
         ),
-        key=lambda row: int(row["frame_id"]),
+        key=lambda row: _projection_sort_key(row["frame_id"]),
     )
 
 
@@ -663,7 +688,7 @@ def _normalized_stage_projection_row(row: Mapping[str, Any]) -> dict[str, Any]:
 def normalize_live_stage_projection(rows: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
     return sorted(
         (_normalized_stage_projection_row(row) for row in rows),
-        key=lambda row: int(row["stage_id"]),
+        key=lambda row: _projection_sort_key(row["stage_id"]),
     )
 
 
@@ -682,7 +707,7 @@ def normalize_replayed_stage_projection(state: Mapping[str, Any]) -> list[dict[s
             for stage_id, stage in stages.items()
             if isinstance(stage, Mapping)
         ),
-        key=lambda row: int(row["stage_id"]),
+        key=lambda row: _projection_sort_key(row["stage_id"]),
     )
 
 
@@ -725,7 +750,7 @@ def _normalized_command_projection_row(row: Mapping[str, Any]) -> dict[str, Any]
 def normalize_live_command_projection(rows: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
     return sorted(
         (_normalized_command_projection_row(row) for row in rows),
-        key=lambda row: int(row["command_id"]),
+        key=lambda row: _projection_sort_key(row["command_id"]),
     )
 
 
@@ -744,7 +769,7 @@ def normalize_replayed_command_projection(state: Mapping[str, Any]) -> list[dict
             for command_id, command in commands.items()
             if isinstance(command, Mapping)
         ),
-        key=lambda row: int(row["command_id"]),
+        key=lambda row: _projection_sort_key(row["command_id"]),
     )
 
 

--- a/tests/api/test_replay_projection_sort_key.py
+++ b/tests/api/test_replay_projection_sort_key.py
@@ -1,0 +1,57 @@
+"""Unit tests for `_projection_sort_key` — closes noetl/noetl#638.
+
+The replay service sorts projection rows (frames, stages, commands) by
+identifier.  Production identifiers are snowflake-style numeric strings
+(e.g. ``"639947948205277573"``); test fixtures and synthetic data use
+semantic strings (e.g. ``"stage-1"``).  The previous
+``int(row["X"])`` lambdas raised ``ValueError`` on non-numeric ids,
+breaking the whole normaliser.  The helper tuple-sorts so both shapes
+coexist: numeric first by int value, then non-numeric lexicographically.
+"""
+
+from __future__ import annotations
+
+from noetl.server.api.replay.service import _projection_sort_key
+
+
+def test_numeric_strings_get_numeric_sort_bucket():
+    assert _projection_sort_key("100") == (0, 100)
+    assert _projection_sort_key("9") == (0, 9)
+
+
+def test_numeric_strings_sort_numerically_not_lexically():
+    """Without numeric coercion, "10" would sort before "9" lex.
+
+    Snowflake IDs (long numeric strings) must keep numeric ordering so
+    event-log replay produces a deterministic event sequence.
+    """
+    keys = [_projection_sort_key(value) for value in ("10", "2", "100", "9")]
+    sorted_keys = sorted(keys)
+    assert sorted_keys == [(0, 2), (0, 9), (0, 10), (0, 100)]
+
+
+def test_non_numeric_strings_get_string_sort_bucket():
+    assert _projection_sort_key("stage-1") == (1, "stage-1")
+    assert _projection_sort_key("frame-A") == (1, "frame-A")
+
+
+def test_numeric_sort_before_non_numeric_when_mixed():
+    """Defined ordering when a single projection mixes shapes.
+
+    Realistically callers don't mix shapes inside a single normaliser
+    run (production = all snowflakes, tests = all semantic strings),
+    but the tuple sort gives a well-defined order if they ever do.
+    """
+    mixed = ["stage-2", "100", "stage-1", "9"]
+    sorted_mixed = sorted(mixed, key=_projection_sort_key)
+    assert sorted_mixed == ["9", "100", "stage-1", "stage-2"]
+
+
+def test_int_input_works_too():
+    """Some callers pass int directly (not via dict.get on a JSON column)."""
+    assert _projection_sort_key(42) == (0, 42)
+
+
+def test_none_input_sorts_as_empty_string():
+    """Defensive: a missing identifier shouldn't blow up; falls back to ''."""
+    assert _projection_sort_key(None) == (1, "")


### PR DESCRIPTION
## Summary

- Add `_projection_sort_key(value) -> tuple[int, Any]` helper in `noetl/server/api/replay/service.py` that handles both shapes of projection identifier:
  - Int-coercible strings (production snowflake IDs like `"639947948205277573"`): `(0, int(value))` — preserves numeric ordering.
  - Non-coercible strings (test fixtures like `"stage-1"`, semantic ids): `(1, str(value))` — lexicographic in a separate sort bucket.
- Replace the 6 `key=lambda row: int(row["X"])` lambdas with `_projection_sort_key(row["X"])` across `normalize_live_frame_projection`, `normalize_replayed_frame_projection`, `normalize_live_stage_projection`, `normalize_replayed_stage_projection`, `normalize_live_command_projection`, `normalize_replayed_command_projection`.

## Why

[noetl/noetl#638](https://github.com/noetl/noetl/issues/638) — `tests/api/test_batch_event_mirror.py::test_batch_mirror_envelopes_feed_replay_state_projector` has been red on `main` since at least v2.103.0.  First documented in PR #629's body, never opened as a tracked issue until #638 made it durable.  The failure:

```
ValueError: invalid literal for int() with base 10: 'stage-1'
noetl/server/api/replay/service.py:685: ValueError
```

The contract was already internally inconsistent — `_stage_id`, `_frame_id`, `_command_id` (lines 159-187) all return `str`, but the sort keys assumed numeric.  Production happened to satisfy both assumptions because snowflake IDs are int-coercible strings; the failure only surfaced in test fixtures with semantic identifiers.

## Test plan

- [x] `pytest tests/api/test_batch_event_mirror.py` — **5/5 pass** (was 4/5 with the `stage_id='stage-1'` failure before).
- [x] `pytest tests/api/test_replay_projection_sort_key.py` — **6/6 pass** (new unit tests covering numeric strings, non-numeric strings, mixed-shape ordering, int input, None input).
- [x] `pytest tests/core/test_replay_state_projector.py tests/core/test_replay_golden_corpus.py tests/api/test_replay_routes.py tests/api/test_batch_event_mirror.py` — **54/54 pass** across the broader replay surface; no regression.

## Out of scope

- The broader test suite cleanup that #638's body alludes to ("The full `tests/` suite has no unexplained failures on main HEAD") — this PR fixes the specific failure cited; if other pre-existing failures show up in CI they should be tracked as separate issues.
- The other 5 `sorted(... key=lambda row: ...)` calls that DON'T touch numeric ids (lines 811, 830, 855, 874, 920 — sort by `object_key` / `loop_id` / `execution_id` strings).  Those already do lexicographic sort which is the right thing.

Closes noetl/noetl#638

🤖 Generated with [Claude Code](https://claude.com/claude-code)