### PR TITLE
feat(routing): pool_routing scaffold for tool-kind-aware NATS subjects (PR-1 of 6)

### DIFF
--- a/noetl/core/messaging/nats_client.py
+++ b/noetl/core/messaging/nats_client.py
@@ -91,10 +91,19 @@ class NATSCommandPublisher:
                     await self._reset_connection_state()
             await self.connect()
 
-    async def _publish_payload(self, payload: bytes) -> None:
+    async def _publish_payload(self, payload: bytes, *, subject: Optional[str] = None) -> None:
+        """Publish ``payload`` to ``subject`` (defaults to ``self.subject``).
+
+        The optional ``subject`` parameter is the hook point for the
+        pool-routing work in noetl/ai-meta#42 — :meth:`publish_command`
+        derives a per-tool-kind subject when routing is enabled and
+        passes it through here.  Callers that don't care about routing
+        (e.g. internal control messages) keep using ``self.subject`` by
+        omitting the argument.
+        """
         if not self._js:
             raise RuntimeError("Not connected to NATS")
-        await self._js.publish(self.subject, payload)
+        await self._js.publish(subject or self.subject, payload)
 
     async def connect(self):
         """Connect to NATS and setup JetStream."""
@@ -130,7 +139,8 @@ class NATSCommandPublisher:
         event_id: int,
         command_id: str,
         step: str,
-        server_url: str
+        server_url: str,
+        tool_kind: Optional[str] = None,
     ):
         """
         Publish command notification to NATS.
@@ -139,8 +149,21 @@ class NATSCommandPublisher:
         - event_id: Points to command.issued event with full command details
         - command_id: Unique identifier for atomic claiming
         - Workers claim by emitting command.claimed event (idempotent)
+
+        ``tool_kind`` is the playbook step's ``tool.kind`` value — when
+        the pool-routing scheme is enabled (see
+        :func:`noetl.core.runtime.pool_routing.is_routing_enabled`), the
+        subject is derived as ``<base>.<pool>.<execution_id>`` so that
+        Python-only kinds (e.g. ``agent``) land on a consumer the Rust
+        pool doesn't subscribe to.  Until the cutover env flag flips,
+        this argument is captured + threaded through but the legacy
+        subject is used verbatim — no behaviour change.  See
+        noetl/ai-meta#42 for the full plan.
         """
         await self.ensure_connected()
+
+        from noetl.core.runtime.pool_routing import route_subject
+        subject = route_subject(self.subject, tool_kind, execution_id)
 
         message = {
             "execution_id": execution_id,
@@ -152,7 +175,7 @@ class NATSCommandPublisher:
         payload = json.dumps(message).encode()
 
         try:
-            await self._publish_payload(payload)
+            await self._publish_payload(payload, subject=subject)
             logger.debug(f"Published command notification: event_id={event_id} command_id={command_id}")
 
         except Exception as e:
@@ -164,7 +187,7 @@ class NATSCommandPublisher:
             )
             await self.ensure_connected(force=True)
             try:
-                await self._publish_payload(payload)
+                await self._publish_payload(payload, subject=subject)
                 logger.info(
                     "Published command notification after reconnect: event_id=%s command_id=%s",
                     event_id,

--- a/noetl/core/runtime/pool_routing.py
+++ b/noetl/core/runtime/pool_routing.py
@@ -1,0 +1,107 @@
+"""Pool routing for tool kinds — see noetl/ai-meta#42.
+
+The Rust noetl-worker can dispatch most tool kinds via the shared
+`noetl-tools` registry, but a handful are Python-runtime-bound and
+can only run on the Python pool (the `agent` LLM-framework bridge
+today; the `container` K8s-Job dispatcher per noetl/ai-meta#43 once
+it switches to a callback shape; possibly others later).
+
+This module is the source of truth for which kinds are Python-only.
+Adding a new Python-only kind is a one-line entry in
+:data:`POOL_FILTER_MAP`; no Rust-side change required because the
+worker pools learn what they support by *which NATS consumer they
+subscribe to*, not by querying a runtime contract.
+
+The actual subject-routing logic ships in three phases per the
+[noetl/ai-meta#42](https://github.com/noetl/ai-meta/issues/42)
+plan; this module is the no-behaviour-change scaffold for PR-1.
+:func:`route_subject` returns the legacy single subject until the
+:envvar:`NOETL_COMMAND_ROUTING_ENABLED` env flag flips at cutover.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+# Tool kinds that ONLY the Python worker pool can dispatch.  Default
+# for anything not in this map: ``"shared"`` (both pools claim).
+#
+# Adding a new Python-only kind: one line here, plus the kind itself
+# under ``noetl/tools/<kind>/``.  No Rust changes needed.
+POOL_FILTER_MAP: dict[str, str] = {
+    # `agent` — LLM agent framework bridge (ADK / LangChain / custom
+    # callables) via dynamic Python module import.  Rust can't
+    # replicate the ``importlib.import_module`` + ``getattr`` shape;
+    # routes to Python pool only.
+    "agent": "python",
+}
+
+# Default segment for kinds not in POOL_FILTER_MAP.  Both worker
+# pools subscribe to the consumer bound to the ``shared`` subject
+# branch, so today's "any pool claims any kind" behaviour is
+# preserved for kinds with Rust parity.
+DEFAULT_POOL_SEGMENT = "shared"
+
+# Env-var gate.  Default off so PR-1 ships as a no-behaviour-change
+# scaffold; :func:`route_subject` returns the legacy subject when the
+# flag is off.  The cutover (PR-5) flips this to ``true`` after the
+# consumer migration + worker-side env realignment land.  Accepted
+# truthy values: ``"1"``, ``"true"``, ``"yes"`` (case-insensitive).
+ROUTING_ENABLED_ENV = "NOETL_COMMAND_ROUTING_ENABLED"
+
+
+def is_routing_enabled() -> bool:
+    """Return ``True`` iff subject-segmented routing is enabled.
+
+    See :data:`ROUTING_ENABLED_ENV` for the env-var contract.
+    """
+    return os.getenv(ROUTING_ENABLED_ENV, "").strip().lower() in {"1", "true", "yes"}
+
+
+def pool_segment_for_kind(tool_kind: Optional[str]) -> str:
+    """Return the pool segment (``"python"`` or ``"shared"``) for a tool kind.
+
+    ``None`` / empty / unknown kinds map to :data:`DEFAULT_POOL_SEGMENT`
+    so the routing is backward-compatible with commands that don't
+    declare a tool kind (or declare one not yet in the map).
+    """
+    if not tool_kind:
+        return DEFAULT_POOL_SEGMENT
+    return POOL_FILTER_MAP.get(tool_kind, DEFAULT_POOL_SEGMENT)
+
+
+def route_subject(
+    base_subject: str,
+    tool_kind: Optional[str],
+    execution_id: int,
+) -> str:
+    """Derive the NATS subject for a command notification.
+
+    When routing is disabled (default), returns ``base_subject``
+    verbatim — no behaviour change vs. today's single-subject scheme.
+
+    When enabled, returns the hierarchical subject::
+
+        <base_subject>.<pool>.<execution_id>
+
+    The ``execution_id`` suffix is for future NATS-level tracing (a
+    consumer can subscribe to a single execution's commands without
+    parsing payloads); workers ignore the trailing token because
+    their consumer's ``filter_subject`` matches the ``<pool>``
+    segment.
+    """
+    if not is_routing_enabled():
+        return base_subject
+    pool = pool_segment_for_kind(tool_kind)
+    return f"{base_subject}.{pool}.{execution_id}"
+
+
+__all__ = [
+    "POOL_FILTER_MAP",
+    "DEFAULT_POOL_SEGMENT",
+    "ROUTING_ENABLED_ENV",
+    "is_routing_enabled",
+    "pool_segment_for_kind",
+    "route_subject",
+]

--- a/noetl/server/api/core/batch.py
+++ b/noetl/server/api/core/batch.py
@@ -419,8 +419,14 @@ async def _issue_commands_for_batch(job: _BatchAcceptJob, commands: list) -> Non
 
     await _drain_batch_outbox()
 
-    # 5. Parallel NATS publish
-    publish_items = [(p["execution_id"], p["evt_id"], p["cmd_id"], p["step"]) for p in prepared_commands]
+    # 5. Parallel NATS publish.  Tuple is 5-wide:
+    # ``(execution_id, evt_id, cmd_id, step, tool_kind)``.  The trailing
+    # ``tool_kind`` drives the NATS subject derivation when pool
+    # routing is enabled — see noetl/ai-meta#42 + the route_subject
+    # helper in noetl.core.runtime.pool_routing.  Today the field is
+    # captured but the subject stays single until the cutover env
+    # flag flips.
+    publish_items = [(p["execution_id"], p["evt_id"], p["cmd_id"], p["step"], p.get("tool_kind")) for p in prepared_commands]
     await _publish_commands_with_recovery(publish_items, server_url=server_url)
 
 async def _process_accepted_batch(

--- a/noetl/server/api/core/events.py
+++ b/noetl/server/api/core/events.py
@@ -465,7 +465,10 @@ async def handle_event(req: EventRequest) -> EventResponse:
                         "frame_id": frame_id,
                         "created_at": _now,
                     })
-                    command_events.append((int(cmd.execution_id), new_evt_id, cmd_id, cmd.step))
+                    # 5-tuple per noetl/ai-meta#42 — trailing tool_kind
+                    # drives NATS subject derivation when pool routing
+                    # is enabled.
+                    command_events.append((int(cmd.execution_id), new_evt_id, cmd_id, cmd.step, cmd.tool.kind))
                     supervisor_commands.append((str(cmd.execution_id), cmd_id, cmd.step, int(new_evt_id), dict(meta)))
                 await conn.commit()
 

--- a/noetl/server/api/core/execution.py
+++ b/noetl/server/api/core/execution.py
@@ -186,7 +186,10 @@ async def execute(req: ExecuteRequest) -> ExecuteResponse:
                         "frame_id": frame_id,
                         "created_at": now,
                     })
-                    command_events.append((int(execution_id), evt_id, cmd_id, cmd.step))
+                    # 5-tuple per noetl/ai-meta#42 — trailing tool_kind
+                    # drives NATS subject derivation when pool routing
+                    # is enabled.
+                    command_events.append((int(execution_id), evt_id, cmd_id, cmd.step, cmd.tool.kind))
                     await _enqueue_execution_outbox(
                         cur,
                         _command_issued_envelope(

--- a/noetl/server/api/core/recovery.py
+++ b/noetl/server/api/core/recovery.py
@@ -17,7 +17,7 @@ async def shutdown_publish_recovery_tasks() -> None:
     for t in tasks: t.cancel()
     await asyncio.gather(*tasks, return_exceptions=True)
 
-async def _recover_unclaimed_command_after_delay(execution_id: int, event_id: int, command_id: str, step: str, server_url: str, delay_seconds: float) -> None:
+async def _recover_unclaimed_command_after_delay(execution_id: int, event_id: int, command_id: str, step: str, server_url: str, delay_seconds: float, tool_kind: Optional[str] = None) -> None:
     await asyncio.sleep(delay_seconds)
     try:
         from noetl.core.db.pool import get_pool_connection
@@ -36,11 +36,16 @@ async def _recover_unclaimed_command_after_delay(execution_id: int, event_id: in
                 if (await cur.fetchone() or {'count': 0}).get('total', 0) > 0: return
         logger.warning("[PUBLISH-RECOVERY] Command unclaimed after %.1fs; re-publishing execution_id=%s command_id=%s", delay_seconds, execution_id, command_id)
         nats_pub = await get_nats_publisher()
-        await nats_pub.publish_command(execution_id=execution_id, event_id=event_id, command_id=command_id, step=step, server_url=server_url)
+        await nats_pub.publish_command(execution_id=execution_id, event_id=event_id, command_id=command_id, step=step, server_url=server_url, tool_kind=tool_kind)
     except Exception as exc:
         logger.error("[PUBLISH-RECOVERY] Recovery failed for %s: %s", command_id, exc, exc_info=True)
 
-async def _publish_commands_with_recovery(command_events: list[tuple[int, int, str, str]], *, server_url: str) -> None:
+# Per noetl/ai-meta#42 the publish tuple is a 5-tuple (the trailing
+# ``tool_kind`` drives the NATS subject derivation when pool routing
+# is enabled).  Old 4-tuple callers stay compatible: the helper
+# unpacks defensively and treats missing ``tool_kind`` as ``None``
+# (which routes to the shared subject, same as today's behaviour).
+async def _publish_commands_with_recovery(command_events: list[tuple], *, server_url: str) -> None:
     if not command_events: return
     nats_pub = None
     try:
@@ -48,17 +53,19 @@ async def _publish_commands_with_recovery(command_events: list[tuple[int, int, s
     except Exception as exc:
         logger.warning("[PUBLISH-RECOVERY] NATS publisher unavailable; scheduling delayed recovery: %s", exc)
 
-    async def _safe_publish(exec_id, evt_id, cid, step):
+    async def _safe_publish(exec_id, evt_id, cid, step, tool_kind=None):
         if nats_pub:
             try:
-                await nats_pub.publish_command(execution_id=exec_id, event_id=evt_id, command_id=cid, step=step, server_url=server_url)
+                await nats_pub.publish_command(execution_id=exec_id, event_id=evt_id, command_id=cid, step=step, server_url=server_url, tool_kind=tool_kind)
             except Exception as exc:
                 logger.warning("[PUBLISH-RECOVERY] Initial publish failed for %s: %s", cid, exc)
-        
+
         recovery_task = asyncio.create_task(
             _recover_unclaimed_command_after_delay(
                 execution_id=exec_id, event_id=evt_id, command_id=cid,
-                step=step, server_url=server_url, delay_seconds=_COMMAND_PUBLISH_RECOVERY_DELAY_SECONDS
+                step=step, server_url=server_url,
+                delay_seconds=_COMMAND_PUBLISH_RECOVERY_DELAY_SECONDS,
+                tool_kind=tool_kind,
             ),
             name=f"command-publish-recovery:{exec_id}:{cid}",
         )
@@ -67,6 +74,7 @@ async def _publish_commands_with_recovery(command_events: list[tuple[int, int, s
     publish_semaphore = asyncio.Semaphore(50) # Max 50 parallel NATS publishes
     async def _sem_publish(args):
         async with publish_semaphore:
+            # Defensive unpack — accept legacy 4-tuple or new 5-tuple.
             await _safe_publish(*args)
-            
+
     await asyncio.gather(*[_sem_publish(args) for args in command_events])

--- a/tests/core/runtime/test_pool_routing.py
+++ b/tests/core/runtime/test_pool_routing.py
@@ -1,0 +1,128 @@
+"""Unit tests for `noetl.core.runtime.pool_routing` — see noetl/ai-meta#42.
+
+PR-1 ships the routing helper as a no-behaviour-change scaffold gated
+behind the ``NOETL_COMMAND_ROUTING_ENABLED`` env flag.  These tests
+exercise both the flag-off path (subject returned verbatim) and the
+flag-on path (hierarchical subject with pool segment).
+"""
+
+from __future__ import annotations
+
+import os
+import pytest
+
+from noetl.core.runtime.pool_routing import (
+    DEFAULT_POOL_SEGMENT,
+    POOL_FILTER_MAP,
+    ROUTING_ENABLED_ENV,
+    is_routing_enabled,
+    pool_segment_for_kind,
+    route_subject,
+)
+
+
+@pytest.fixture
+def routing_off(monkeypatch):
+    """Force routing flag off regardless of host env."""
+    monkeypatch.delenv(ROUTING_ENABLED_ENV, raising=False)
+    return monkeypatch
+
+
+@pytest.fixture
+def routing_on(monkeypatch):
+    """Force routing flag on regardless of host env."""
+    monkeypatch.setenv(ROUTING_ENABLED_ENV, "true")
+    return monkeypatch
+
+
+def test_pool_filter_map_includes_agent():
+    """The agent kind is Python-only by design (noetl/ai-meta#42)."""
+    assert POOL_FILTER_MAP["agent"] == "python"
+
+
+def test_default_segment_is_shared():
+    """Anything not in POOL_FILTER_MAP defaults to the shared queue."""
+    assert DEFAULT_POOL_SEGMENT == "shared"
+
+
+@pytest.mark.parametrize(
+    "env_value, expected",
+    [
+        (None, False),
+        ("", False),
+        ("0", False),
+        ("false", False),
+        ("no", False),
+        ("True", True),
+        ("true", True),
+        ("1", True),
+        ("YES", True),
+    ],
+)
+def test_is_routing_enabled_parses_flag(monkeypatch, env_value, expected):
+    if env_value is None:
+        monkeypatch.delenv(ROUTING_ENABLED_ENV, raising=False)
+    else:
+        monkeypatch.setenv(ROUTING_ENABLED_ENV, env_value)
+    assert is_routing_enabled() is expected
+
+
+def test_pool_segment_for_known_python_kind():
+    assert pool_segment_for_kind("agent") == "python"
+
+
+def test_pool_segment_for_known_shared_kind():
+    """Shared kinds default to "shared" (they're not in the map)."""
+    for kind in ("http", "postgres", "duckdb", "nats", "mcp"):
+        assert pool_segment_for_kind(kind) == DEFAULT_POOL_SEGMENT
+
+
+def test_pool_segment_for_unknown_kind():
+    """Unknown kinds default to "shared" — safer than failing."""
+    assert pool_segment_for_kind("some-future-kind") == DEFAULT_POOL_SEGMENT
+
+
+def test_pool_segment_for_none_or_empty():
+    """Missing tool_kind argument routes to the shared queue."""
+    assert pool_segment_for_kind(None) == DEFAULT_POOL_SEGMENT
+    assert pool_segment_for_kind("") == DEFAULT_POOL_SEGMENT
+
+
+def test_route_subject_returns_base_when_flag_off(routing_off):
+    """No-behaviour-change guarantee for PR-1."""
+    assert route_subject("noetl.commands", "agent", 12345) == "noetl.commands"
+    assert route_subject("noetl.commands", "http", 12345) == "noetl.commands"
+    assert route_subject("noetl.commands", None, 12345) == "noetl.commands"
+
+
+def test_route_subject_segments_when_flag_on_agent(routing_on):
+    """When the flag flips, agent commands route to the python branch."""
+    assert (
+        route_subject("noetl.commands", "agent", 12345)
+        == "noetl.commands.python.12345"
+    )
+
+
+def test_route_subject_segments_when_flag_on_shared(routing_on):
+    """All non-Python-only kinds land on the shared branch."""
+    for kind in ("http", "postgres", "duckdb", "nats", "mcp"):
+        assert (
+            route_subject("noetl.commands", kind, 67890)
+            == "noetl.commands.shared.67890"
+        )
+
+
+def test_route_subject_segments_when_flag_on_unknown(routing_on):
+    """Unknown kinds default to shared even with the flag on."""
+    assert (
+        route_subject("noetl.commands", "some-future-kind", 999)
+        == "noetl.commands.shared.999"
+    )
+
+
+def test_route_subject_handles_none_kind_when_flag_on(routing_on):
+    """Missing tool_kind argument still routes to shared with the flag on."""
+    assert (
+        route_subject("noetl.commands", None, 42)
+        == "noetl.commands.shared.42"
+    )


### PR DESCRIPTION
## Summary

PR-1 of the six-PR sequence designed in [noetl/ai-meta#42](https://github.com/noetl/ai-meta/issues/42).  Ships the **no-behaviour-change scaffold** that future PRs build on.  Nothing about production dispatch changes until the env flag flips at PR-5.

## Why

The Rust noetl-worker can dispatch most tool kinds via the shared `noetl-tools` registry, but `agent` (and eventually `container` per [#43](https://github.com/noetl/ai-meta/issues/43)) are Python-runtime-bound.  Today both pools claim from the same NATS consumer, so `agent` commands hit the Rust pool ~50% of the time and error out.  This sequence migrates to per-pool subject filtering so the Rust pool never sees Python-only kinds.

Full plan: [noetl/ai-meta#42 comment](https://github.com/noetl/ai-meta/issues/42#issuecomment-4598559218).

## What this PR adds

- **`noetl/core/runtime/pool_routing.py`** (new) — source of truth for which kinds are Python-only.  Today: `{"agent": "python"}`.  Three helpers: `is_routing_enabled()`, `pool_segment_for_kind()`, `route_subject()`.
- **`noetl/core/messaging/nats_client.py`** — `publish_command` accepts a new optional `tool_kind` arg; derives subject via `route_subject()`; passes through to `_publish_payload` (which gains an optional `subject` parameter, including in the reconnect-retry path).
- **`noetl/server/api/core/recovery.py`** — `_publish_commands_with_recovery` now accepts 5-tuples `(execution_id, evt_id, cmd_id, step, tool_kind)`; defensive 4-tuple compat via `*args` unpack.  `_recover_unclaimed_command_after_delay` gains `tool_kind` so the delayed re-publish uses the same subject as the first attempt.
- **Three call sites** updated to the 5-tuple shape: `batch.py:423`, `execution.py:189`, `events.py:468`.

## What this PR does NOT change

- **No behaviour change in production.**  `NOETL_COMMAND_ROUTING_ENABLED` defaults off → `route_subject` returns the legacy single subject (`noetl.commands`) → NATS publish behaves identically to today.  Both pools continue to claim from the same shared consumer.
- **Stream / consumer config unchanged.**  PR-2 widens the stream subjects to `noetl.commands.>` and adds the two per-segment consumers.
- **Rust worker unchanged.**  PR-3 swaps the worker's hard-coded subject for env-driven config.
- **No KEDA / ops manifest changes.**  PR-4 ships those.

## Test plan

- [x] `pytest tests/core/runtime/test_pool_routing.py` — **20/20 pass** (new unit tests: env-flag parser across 9 truthy/falsy cases, `POOL_FILTER_MAP` content, `route_subject` derivation both flag-off and flag-on).
- [x] `pytest tests/api/test_batch_event_mirror.py tests/api/test_replay_routes.py tests/core/runtime/test_keda.py tests/core/test_replay_state_projector.py tests/core/runtime/test_pool_routing.py` — **96/96 pass**; no regression in the broader surface.

## Observability deferred

Per the plan, the `noetl_command_publish_total{pool_segment=...}` counter + `pool_segment` span attribute land alongside the cutover (PR-5) when the flag actually starts segmenting commands.  Adding them now would emit `{pool_segment="shared"}` only — not useful until routing is on.

Refs noetl/ai-meta#42

🤖 Generated with [Claude Code](https://claude.com/claude-code)