### PR TITLE
feat(routing): widen NOETL_COMMANDS stream subjects for per-pool routing (PR-2a of 6)

### DIFF
--- a/noetl/core/messaging/nats_client.py
+++ b/noetl/core/messaging/nats_client.py
@@ -111,21 +111,41 @@ class NATSCommandPublisher:
             self._nc = await nats.connect(self.nats_url)
             self._js = self._nc.jetstream()
 
-            # Ensure stream exists
+            from noetl.core.runtime.pool_routing import command_stream_subjects
+            desired_subjects = command_stream_subjects(self.subject)
+
+            # Ensure stream exists with the widened subject list (legacy
+            # bare subject + the hierarchical wildcard for per-pool
+            # routing; see noetl/ai-meta#42 PR-2a).  Both shapes are
+            # required during the transition: bare for today's publishes
+            # while the routing flag is off, wildcard for the routed
+            # publishes that land at PR-5 cutover.
             try:
-                await self._js.stream_info(self.stream_name)
-                logger.debug(f"Using existing {self.stream_name} stream")
+                info = await self._js.stream_info(self.stream_name)
+                current_subjects = list(getattr(info.config, "subjects", None) or [])
+                missing = [s for s in desired_subjects if s not in current_subjects]
+                if missing:
+                    info.config.subjects = current_subjects + missing
+                    await self._js.update_stream(config=info.config)
+                    logger.info(
+                        "Widened %s stream subjects with %s for pool routing (noetl/ai-meta#42)",
+                        self.stream_name,
+                        missing,
+                    )
+                else:
+                    logger.debug(f"Using existing {self.stream_name} stream")
             except Exception:
                 # Create stream if it doesn't exist
                 await self._js.add_stream(
                     name=self.stream_name,
-                    subjects=[self.subject],
+                    subjects=desired_subjects,
                     max_age=3600,  # 1 hour retention
                     storage="memory"  # Memory for low latency
                 )
                 logger.info(
-                    "Created stream %s | connected to NATS at %s",
+                    "Created stream %s with subjects=%s | connected to NATS at %s",
                     self.stream_name,
+                    desired_subjects,
                     redact_url_credentials(self.nats_url),
                 )
 
@@ -707,20 +727,39 @@ class NATSCommandSubscriber:
                 self._inflight_semaphore.release()
 
         try:
-            # First ensure stream exists
+            from noetl.core.runtime.pool_routing import command_stream_subjects
+            desired_subjects = command_stream_subjects(self.subject)
+
+            # First ensure stream exists with the widened subjects (see
+            # noetl/ai-meta#42 PR-2a — same widening as the publisher
+            # side at NATSCommandPublisher.connect).  Subscribers tend
+            # to start after a publisher has already created the
+            # stream, but this branch handles the cold-start case
+            # (e.g. fresh kind cluster where the subscriber wins the
+            # race to connect first).
             try:
-                await self._js.stream_info(self.stream_name)
+                info = await self._js.stream_info(self.stream_name)
+                current_subjects = list(getattr(info.config, "subjects", None) or [])
+                missing = [s for s in desired_subjects if s not in current_subjects]
+                if missing:
+                    info.config.subjects = current_subjects + missing
+                    await self._js.update_stream(config=info.config)
+                    logger.info(
+                        "Widened %s stream subjects with %s for pool routing (noetl/ai-meta#42)",
+                        self.stream_name,
+                        missing,
+                    )
             except Exception:
                 await self._js.add_stream(
                     StreamConfig(
                         name=self.stream_name,
-                        subjects=[self.subject],
+                        subjects=desired_subjects,
                         retention="limits",
                         storage="memory",  # Memory for low latency
                         max_age=3600
                     )
                 )
-                logger.debug(f"Stream created: {self.stream_name}")
+                logger.debug(f"Stream created: {self.stream_name} with subjects={desired_subjects}")
 
             # Ensure consumer exists and current backpressure settings are applied.
             await self._ensure_consumer()

--- a/noetl/core/runtime/pool_routing.py
+++ b/noetl/core/runtime/pool_routing.py
@@ -97,10 +97,29 @@ def route_subject(
     return f"{base_subject}.{pool}.{execution_id}"
 
 
+def command_stream_subjects(base_subject: str) -> list[str]:
+    """Return the JetStream subject list a command stream must accept.
+
+    Includes both the legacy bare subject (``noetl.commands`` — what
+    publishes use when routing is disabled or for the transitional
+    period before PR-5 flag flip) AND the hierarchical wildcard
+    (``noetl.commands.>`` — what :func:`route_subject` derives when
+    routing is enabled, e.g. ``noetl.commands.python.<execution_id>``).
+
+    A NATS subject like ``X.>`` matches one-or-more tokens after the
+    dot but NOT the bare ``X``, so both entries are required during
+    the transition.  The cleanup PR (PR-6 per the noetl/ai-meta#42
+    plan) drops the bare entry once all publishes have moved to the
+    hierarchical form.
+    """
+    return [base_subject, f"{base_subject}.>"]
+
+
 __all__ = [
     "POOL_FILTER_MAP",
     "DEFAULT_POOL_SEGMENT",
     "ROUTING_ENABLED_ENV",
+    "command_stream_subjects",
     "is_routing_enabled",
     "pool_segment_for_kind",
     "route_subject",

--- a/tests/core/runtime/test_pool_routing.py
+++ b/tests/core/runtime/test_pool_routing.py
@@ -15,6 +15,7 @@ from noetl.core.runtime.pool_routing import (
     DEFAULT_POOL_SEGMENT,
     POOL_FILTER_MAP,
     ROUTING_ENABLED_ENV,
+    command_stream_subjects,
     is_routing_enabled,
     pool_segment_for_kind,
     route_subject,
@@ -126,3 +127,25 @@ def test_route_subject_handles_none_kind_when_flag_on(routing_on):
         route_subject("noetl.commands", None, 42)
         == "noetl.commands.shared.42"
     )
+
+
+def test_command_stream_subjects_includes_bare_and_wildcard():
+    """The stream must accept both the legacy bare subject AND the
+    hierarchical wildcard so publishes work during the rollout window
+    when the routing flag is mid-flip.  See noetl/ai-meta#42 PR-2a.
+    """
+    subjects = command_stream_subjects("noetl.commands")
+    assert "noetl.commands" in subjects
+    assert "noetl.commands.>" in subjects
+
+
+def test_command_stream_subjects_preserves_base_for_other_streams():
+    """The helper is generic over base subject — works for any stream name."""
+    subjects = command_stream_subjects("foo.bar")
+    assert subjects == ["foo.bar", "foo.bar.>"]
+
+
+def test_command_stream_subjects_no_duplicate_entries():
+    """No duplicate entries even if called repeatedly with the same base."""
+    subjects = command_stream_subjects("x.y")
+    assert len(subjects) == len(set(subjects))


### PR DESCRIPTION
## Summary

PR-2a of the six-PR sequence under [noetl/ai-meta#42](https://github.com/noetl/ai-meta/issues/42).  Stream-config half of what was originally one PR (PR-2 in the plan); the new per-pool consumers + Python multi-subscriber lifecycle land in PR-2b as a separately reviewable change.

## What this PR adds

- **`pool_routing.command_stream_subjects(base)`** — helper returning `[base, f"{base}.>"]`.  Both entries are required during the rollout: bare for today's publishes while `NOETL_COMMAND_ROUTING_ENABLED` is off, wildcard for the routed publishes that land at PR-5 cutover.
- **`NATSCommandPublisher.connect`** — replaces bare `subjects=[self.subject]` with `command_stream_subjects(self.subject)`.  On existing streams (the common case), reads the current subject list and calls `update_stream(config=...)` to add the wildcard if missing.  Idempotent.
- **`NATSCommandSubscriber.subscribe`** — same widening at the subscriber-side stream-creation block (cold-start case where the subscriber wins the race against the publisher).
- 3 new unit tests for `command_stream_subjects`.

## What this PR does NOT change

- **No behaviour change in production.**  `route_subject` (from PR-1) still returns the bare subject because the routing env flag defaults off.  All publishes still go to `noetl.commands`; consumers drain it the same way.  The stream just *also* accepts `noetl.commands.>`-shaped publishes (which nothing emits yet).
- **No new consumers.**  PR-2b creates `noetl_worker_pool_shared` + `noetl_worker_pool_python` and wires the Python worker's multi-subscriber lifecycle.
- **No Rust worker changes.**  PR-3 handles those.

## Test plan

- [x] `pytest tests/core/runtime/test_pool_routing.py` — **23/23 pass** (20 from PR-1 + 3 new).
- [x] `pytest tests/core/runtime/test_pool_routing.py tests/api/test_batch_event_mirror.py tests/api/test_replay_routes.py tests/core/runtime/test_keda.py tests/core/test_replay_state_projector.py` — **99/99 pass**; no regression in the broader command-publish + replay surface.

Refs noetl/ai-meta#42

🤖 Generated with [Claude Code](https://claude.com/claude-code)