### PR TITLE
feat(routing): per-pool NATSCommandSubscriber + Python worker multi-subscriber (PR-2b of 6)

### DIFF
--- a/noetl/core/messaging/nats_client.py
+++ b/noetl/core/messaging/nats_client.py
@@ -337,6 +337,7 @@ class NATSCommandSubscriber:
         callback_timeout_seconds: Optional[float] = None,
         message_decoder: Optional[Callable[[bytes], dict[str, Any]]] = None,
         message_action_observer: Optional[Callable[[str, Optional[float]], None]] = None,
+        filter_subject: Optional[str] = None,
     ):
         from noetl.core.config import get_worker_settings
         ws = get_worker_settings()
@@ -344,6 +345,13 @@ class NATSCommandSubscriber:
         self.subject = subject or ws.nats_subject
         self.consumer_name = consumer_name or ws.nats_consumer
         self.stream_name = stream_name or ws.nats_stream
+        # Optional consumer-side filter subject for per-pool routing
+        # (noetl/ai-meta#42 PR-2b).  None means the consumer sees all
+        # messages on the stream — that's the legacy single-consumer
+        # shape.  A subject pattern like ``noetl.commands.shared.>``
+        # makes JetStream filter at the broker, so the Rust worker
+        # never even sees Python-only commands.
+        self.filter_subject = filter_subject
         self.max_inflight = max(1, int(max_inflight or ws.max_inflight_commands))
         self.max_ack_pending = max(1, int(max_ack_pending or ws.nats_max_ack_pending))
         self.fetch_timeout = float(fetch_timeout if fetch_timeout is not None else ws.nats_fetch_timeout_seconds)
@@ -558,7 +566,7 @@ class NATSCommandSubscriber:
                 minimum_ack_wait_seconds,
                 ack_wait_seconds,
             )
-        return ConsumerConfig(
+        config_kwargs: dict[str, Any] = dict(
             durable_name=self.consumer_name,
             ack_policy="explicit",
             max_deliver=max(1, int(ws.nats_max_deliver)),
@@ -567,6 +575,12 @@ class NATSCommandSubscriber:
             replay_policy="instant",
             max_ack_pending=self.max_ack_pending,
         )
+        # Only attach filter_subject when set — None / empty leaves
+        # the consumer wide open (legacy single-consumer behaviour).
+        # See noetl/ai-meta#42 PR-2b.
+        if self.filter_subject:
+            config_kwargs["filter_subject"] = self.filter_subject
+        return ConsumerConfig(**config_kwargs)
 
     async def _add_or_validate_consumer(self) -> None:
         """Create consumer if missing; tolerate races where another worker creates it first."""

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -187,6 +187,15 @@ class Worker:
         self.server_url = server_url  # Fallback, usually comes from notification
         self._running = False
         self._http_client: Optional[httpx.AsyncClient] = None
+        # Multi-subscriber list per noetl/ai-meta#42 PR-2b: the Python
+        # worker subscribes to one NATSCommandSubscriber per pool
+        # segment listed in ``NOETL_WORKER_POOL_SEGMENTS``.  Default
+        # is ``"legacy,shared,python"`` so the Python pool drains all
+        # three subjects during the routing rollout window.
+        self._nats_subscribers: list[NATSCommandSubscriber] = []
+        # Backward-compat single-subscriber attribute for callers
+        # outside this module that reach in (worker tests, debug
+        # commands).  Points at the first subscriber in the list.
         self._nats_subscriber: Optional[NATSCommandSubscriber] = None
         self._heartbeat_task: Optional[asyncio.Task] = None
         self._registered = False
@@ -965,35 +974,79 @@ class Worker:
         logger.info(f"Worker {self.worker_id} heartbeat loop stopped")
     
     async def start(self):
-        """Start the worker NATS subscription."""
+        """Start the worker NATS subscription.
+
+        Subscribes to one NATSCommandSubscriber per pool segment listed
+        in ``NOETL_WORKER_POOL_SEGMENTS`` (default
+        ``"legacy,shared,python"`` for the Python worker; the Rust
+        worker overrides this to ``"shared"`` via its deployment env).
+        Per-segment durable name + filter subject:
+
+        - ``legacy`` — durable=``$NATS_CONSUMER``, no filter (drains
+          everything published on the bare subject; this is today's
+          behaviour, kept active until PR-6 cleanup).
+        - ``shared`` — durable=``$NATS_CONSUMER_shared``,
+          filter=``$NATS_SUBJECT.shared.>``.
+        - ``python`` — durable=``$NATS_CONSUMER_python``,
+          filter=``$NATS_SUBJECT.python.>``.
+
+        See noetl/ai-meta#42 PR-2b for the design.
+        """
         from noetl.core.config import get_worker_settings
         worker_settings = get_worker_settings()
         self._running = True
         self._http_client = httpx.AsyncClient(timeout=worker_settings.http_client_timeout)
-        self._nats_subscriber = NATSCommandSubscriber(
-            nats_url=self.nats_url,
-            subject=worker_settings.nats_subject,
-            consumer_name=worker_settings.nats_consumer,
-            stream_name=worker_settings.nats_stream,
-            max_inflight=self._max_inflight_commands,
-            max_ack_pending=worker_settings.nats_max_ack_pending,
-            fetch_timeout=worker_settings.nats_fetch_timeout_seconds,
-            fetch_heartbeat=worker_settings.nats_fetch_heartbeat_seconds,
-        )
+
+        segments_env = os.getenv("NOETL_WORKER_POOL_SEGMENTS", "legacy,shared,python")
+        segments = [s.strip() for s in segments_env.split(",") if s.strip()]
+        if not segments:
+            segments = ["legacy"]
+
+        for segment in segments:
+            if segment == "legacy":
+                consumer_name = worker_settings.nats_consumer
+                filter_subject = None
+            else:
+                consumer_name = f"{worker_settings.nats_consumer}_{segment}"
+                filter_subject = f"{worker_settings.nats_subject}.{segment}.>"
+            subscriber = NATSCommandSubscriber(
+                nats_url=self.nats_url,
+                subject=worker_settings.nats_subject,
+                consumer_name=consumer_name,
+                stream_name=worker_settings.nats_stream,
+                max_inflight=self._max_inflight_commands,
+                max_ack_pending=worker_settings.nats_max_ack_pending,
+                fetch_timeout=worker_settings.nats_fetch_timeout_seconds,
+                fetch_heartbeat=worker_settings.nats_fetch_heartbeat_seconds,
+                filter_subject=filter_subject,
+            )
+            self._nats_subscribers.append(subscriber)
+
+        # Back-compat for callers that reach in for the first subscriber.
+        self._nats_subscriber = self._nats_subscribers[0]
 
         logger.info(
-            "Worker %s starting (NATS: %s, inflight=%s, db_inflight=%s, max_ack_pending=%s)",
+            "Worker %s starting (NATS: %s, inflight=%s, db_inflight=%s, max_ack_pending=%s, pool_segments=%s)",
             self.worker_id,
             redact_url_credentials(self.nats_url),
             self._max_inflight_commands,
             self._max_inflight_db_commands,
             worker_settings.nats_max_ack_pending,
+            segments,
         )
-        
-        # Connect to NATS
-        await self._nats_subscriber.connect()
-        logger.info("Connected to NATS and subscribing to command notifications")
-        
+
+        # Connect each subscriber serially — each opens its own NATS
+        # connection (a future PR can consolidate to a shared
+        # connection if the per-subscriber overhead becomes a
+        # concern; for now 1-3 connections per pod is fine).
+        for subscriber in self._nats_subscribers:
+            await subscriber.connect()
+            logger.info(
+                "Connected NATS subscriber consumer=%s filter_subject=%s",
+                subscriber.consumer_name,
+                subscriber.filter_subject or "(none)",
+            )
+
         # Register worker in runtime table
         server_url = _normalize_server_base_url(self.server_url or worker_settings.server_url)
         if server_url:
@@ -1007,8 +1060,27 @@ class Worker:
         if server_url and self._http_client:
             await self._concurrency.start(self._http_client, server_url)
 
-        # Subscribe to command notifications (this should never return)
-        await self._nats_subscriber.subscribe(self._handle_command_notification)
+        # Run all subscriber loops in parallel.  ``return_exceptions=True``
+        # so one subscriber failing doesn't cancel the others — each
+        # pool segment is independent.  The gather call blocks until
+        # every subscriber's pull loop exits (which they shouldn't
+        # during normal operation; ``subscribe()`` is an infinite
+        # async loop).
+        results = await asyncio.gather(
+            *[
+                subscriber.subscribe(self._handle_command_notification)
+                for subscriber in self._nats_subscribers
+            ],
+            return_exceptions=True,
+        )
+        for subscriber, result in zip(self._nats_subscribers, results):
+            if isinstance(result, Exception):
+                logger.error(
+                    "Subscriber loop exited with exception: consumer=%s error=%s",
+                    subscriber.consumer_name,
+                    result,
+                    exc_info=result,
+                )
     
     async def cleanup(self):
         """Cleanup resources."""
@@ -1032,8 +1104,21 @@ class Worker:
         if server_url and self._http_client and self._registered:
             await self._deregister_worker(server_url)
         
-        if self._nats_subscriber:
-            await self._nats_subscriber.close()
+        # Close all per-segment subscribers.  Each runs its own NATS
+        # connection (per noetl/ai-meta#42 PR-2b); close them
+        # individually + tolerate per-subscriber close errors so one
+        # failure doesn't block the others.
+        for subscriber in self._nats_subscribers:
+            try:
+                await subscriber.close()
+            except Exception as close_error:
+                logger.warning(
+                    "Failed to close subscriber consumer=%s: %s",
+                    getattr(subscriber, "consumer_name", "<unknown>"),
+                    close_error,
+                )
+        self._nats_subscribers.clear()
+        self._nats_subscriber = None
         if self._http_client:
             await self._http_client.aclose()
         

--- a/tests/core/test_nats_command_subscriber.py
+++ b/tests/core/test_nats_command_subscriber.py
@@ -42,6 +42,61 @@ class _FakeJetStream:
         return SimpleNamespace(subject=subject, durable=durable)
 
 
+# -- noetl/ai-meta#42 PR-2b: per-pool filter_subject coverage ---------------
+
+
+def test_subscriber_default_filter_subject_is_none():
+    """Backward compat — omitting filter_subject leaves it unset."""
+    subscriber = NATSCommandSubscriber(
+        consumer_name="legacy-consumer",
+        stream_name="NOETL_COMMANDS",
+        max_ack_pending=64,
+    )
+    assert subscriber.filter_subject is None
+
+
+def test_subscriber_accepts_filter_subject():
+    """Per-pool routing: filter_subject is captured on the subscriber."""
+    subscriber = NATSCommandSubscriber(
+        consumer_name="shared-consumer",
+        stream_name="NOETL_COMMANDS",
+        max_ack_pending=64,
+        filter_subject="noetl.commands.shared.>",
+    )
+    assert subscriber.filter_subject == "noetl.commands.shared.>"
+
+
+def test_consumer_config_omits_filter_when_none():
+    """ConsumerConfig must NOT carry a filter_subject when None.
+
+    Setting filter_subject="" on the JetStream consumer would silently
+    filter to the empty subject and drop everything; omission is the
+    right shape for the legacy single-consumer case.
+    """
+    subscriber = NATSCommandSubscriber(
+        consumer_name="legacy-consumer",
+        stream_name="NOETL_COMMANDS",
+        max_ack_pending=64,
+    )
+    config = subscriber._consumer_config()
+    assert getattr(config, "filter_subject", None) is None
+
+
+def test_consumer_config_emits_filter_when_set():
+    """ConsumerConfig carries filter_subject when set on the subscriber."""
+    subscriber = NATSCommandSubscriber(
+        consumer_name="python-consumer",
+        stream_name="NOETL_COMMANDS",
+        max_ack_pending=64,
+        filter_subject="noetl.commands.python.>",
+    )
+    config = subscriber._consumer_config()
+    assert getattr(config, "filter_subject", None) == "noetl.commands.python.>"
+
+
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_ensure_consumer_creates_when_missing():
     subscriber = NATSCommandSubscriber(


### PR DESCRIPTION
## Summary

PR-2b of the six-PR sequence under [noetl/ai-meta#42](https://github.com/noetl/ai-meta/issues/42).  Completes the PR-2 work that PR-2a (stream subject widening) left half-done: the Python worker now subscribes to one `NATSCommandSubscriber` per pool segment, so the new per-pool consumers (`*_shared`, `*_python`) come into existence + start draining their filter subjects.

## What this PR adds

- **`NATSCommandSubscriber.__init__`** gains an optional `filter_subject` parameter.  `_consumer_config()` attaches the corresponding `filter_subject` field on `ConsumerConfig` when set; when None (legacy shape) the consumer remains wide-open.
- **`NoetlWorker.start()`** reads `NOETL_WORKER_POOL_SEGMENTS` (comma-separated, default `"legacy,shared,python"`) and builds one `NATSCommandSubscriber` per listed segment with the per-segment durable + filter conventions from the plan.  Runs them in parallel via `asyncio.gather(..., return_exceptions=True)` so one subscriber failing doesn't kill the others.
- **`NoetlWorker.cleanup()`** iterates over all subscribers + closes each defensively.  Back-compat `self._nats_subscriber` shim retained for in-module callers.

## Naming + filter conventions

| Segment | Durable name | Filter subject |
|---|---|---|
| `legacy` | `$NATS_CONSUMER` | _none_ (wide-open, drains today's bare publishes) |
| `shared` | `$NATS_CONSUMER_shared` | `$NATS_SUBJECT.shared.>` |
| `python` | `$NATS_CONSUMER_python` | `$NATS_SUBJECT.python.>` |

## What this PR does NOT change

- **No behaviour change in production.**  The PR-1 routing flag defaults off; all publishes go to bare `noetl.commands`; only the legacy subscriber claims them.  Shared + python subscribers exist + their pull loops run, but their filter subjects match no traffic until PR-5 cutover.
- **No Rust worker changes.**  PR-3 swaps the Rust worker's hard-coded subject + sets `NOETL_WORKER_POOL_SEGMENTS=shared` via the deployment env.
- **Per-subscriber connection sharing.**  Each subscriber opens its own NATS connection — 1-3 connections per Python worker pod.  Acceptable for now; a future PR can consolidate.

## Test plan

- [x] `pytest tests/core/test_nats_command_subscriber.py` — 4 new `filter_subject` tests + the existing 14, all pass.
- [x] `pytest tests/core/test_nats_command_subscriber.py tests/core/test_nats_command_publisher.py tests/core/runtime/test_pool_routing.py` — **45/45 pass**.
- [x] `pytest tests/core/test_nats_command_subscriber.py tests/core/test_nats_command_publisher.py tests/core/runtime/test_pool_routing.py tests/api/test_batch_event_mirror.py tests/api/test_replay_routes.py tests/core/runtime/test_keda.py` — **93/93 pass**; no regression in the broader command-publish + replay surface.
- [ ] Reviewer: confirm a fresh worker pod starts cleanly with the default segments and the two new durable consumers show up via `nats consumer ls NOETL_COMMANDS`.

Refs noetl/ai-meta#42

🤖 Generated with [Claude Code](https://claude.com/claude-code)