### PR TITLE
feat(keda): multi-trigger ScaledObject for per-pool routing (PR-4a of 6)

### DIFF
--- a/noetl/core/runtime/keda.py
+++ b/noetl/core/runtime/keda.py
@@ -138,6 +138,22 @@ class ScaledObjectSpec:
     nats_consumer: Optional[str] = None
     lag_threshold: int = DEFAULT_LAG_THRESHOLD
     activation_lag_threshold: int = DEFAULT_ACTIVATION_LAG_THRESHOLD
+    # Additional NATS JetStream consumer names that share the same
+    # Deployment's autoscaling envelope.  Per noetl/ai-meta#42 PR-4a,
+    # the Python noetl-worker pool now subscribes to three consumers
+    # (legacy + shared + python segments); KEDA needs to take the MAX
+    # of their backlogs as the scaling signal.  KEDA's
+    # ``ScaledObject`` natively supports multiple ``triggers`` on a
+    # single Deployment — the HPA reconciliation picks the largest
+    # desired-replica count across them.
+    #
+    # Each entry adds one ``nats-jetstream`` trigger to the resulting
+    # ScaledObject with the same threshold/account/stream as the
+    # primary (``nats_consumer``).  Empty list / None ⇒ single-trigger
+    # behaviour, identical to today's output.  See
+    # `agents/rules/wiki-maintenance.md` for the keda wiki page that
+    # documents this surface.
+    additional_consumers: tuple[str, ...] = ()
 
 
 def build_worker_scaledobject(spec: ScaledObjectSpec) -> dict[str, Any]:
@@ -230,12 +246,17 @@ def build_worker_scaledobject(spec: ScaledObjectSpec) -> dict[str, Any]:
                         "natsServerMonitoringEndpoint": spec.nats_monitoring_endpoint,
                         "account": spec.nats_account,
                         "stream": spec.nats_stream,
-                        "consumer": nats_consumer,
+                        "consumer": consumer_name,
                         "lagThreshold": str(spec.lag_threshold),
                         "activationLagThreshold": str(spec.activation_lag_threshold),
                         "useHttps": "false",
                     },
                 }
+                # Primary consumer + any additional consumers stacked
+                # in declared order.  Triggers ride the same threshold
+                # + monitoring endpoint — operators tune by editing the
+                # spec, not by hand-editing per-trigger metadata.
+                for consumer_name in [nats_consumer, *spec.additional_consumers]
             ],
         },
     }

--- a/tests/core/runtime/test_keda.py
+++ b/tests/core/runtime/test_keda.py
@@ -175,6 +175,64 @@ def test_build_worker_scaledobject_min_replicas_zero_allowed():
     assert out["spec"]["minReplicaCount"] == 0
 
 
+def test_build_worker_scaledobject_default_single_trigger():
+    """Default spec (no additional_consumers) emits a single trigger.
+
+    Back-compat: existing callers that don't know about
+    `additional_consumers` continue to get today's single-trigger
+    ScaledObject shape.
+    """
+    out = build_worker_scaledobject(_default_spec(nats_consumer="noetl_worker_pool"))
+    triggers = out["spec"]["triggers"]
+    assert len(triggers) == 1
+    assert triggers[0]["metadata"]["consumer"] == "noetl_worker_pool"
+
+
+def test_build_worker_scaledobject_additional_consumers_emit_extra_triggers():
+    """Per noetl/ai-meta#42 PR-4a: additional_consumers stack into
+    extra triggers, primary first.  KEDA picks MAX(replicas) across
+    triggers so the pool scales on whichever consumer has the
+    largest backlog.
+    """
+    out = build_worker_scaledobject(
+        _default_spec(
+            nats_consumer="noetl_worker_pool",
+            additional_consumers=(
+                "noetl_worker_pool_shared",
+                "noetl_worker_pool_python",
+            ),
+        )
+    )
+    triggers = out["spec"]["triggers"]
+    assert len(triggers) == 3
+    consumers = [trigger["metadata"]["consumer"] for trigger in triggers]
+    assert consumers == [
+        "noetl_worker_pool",
+        "noetl_worker_pool_shared",
+        "noetl_worker_pool_python",
+    ]
+    # All triggers share the same threshold + monitoring endpoint
+    # (the spec's defaults).
+    for trigger in triggers:
+        assert trigger["type"] == "nats-jetstream"
+        assert trigger["metadata"]["lagThreshold"] == "10"
+        assert trigger["metadata"]["account"] == "NOETL"
+
+
+def test_build_worker_scaledobject_empty_additional_consumers_is_single_trigger():
+    """Empty tuple for `additional_consumers` is equivalent to the
+    default (single-trigger), not "primary + zero extras = some other
+    shape".
+    """
+    out = build_worker_scaledobject(
+        _default_spec(
+            nats_consumer="noetl_worker_pool",
+            additional_consumers=(),
+        )
+    )
+    assert len(out["spec"]["triggers"]) == 1
+
+
 def test_dump_scaledobject_yaml_round_trip():
     out = build_worker_scaledobject(_default_spec())
     rendered = dump_scaledobject_yaml(out)
@@ -227,6 +285,10 @@ _FIXTURE_DIR = pathlib.Path(__file__).resolve().parents[2] / "fixtures" / "keda"
     "fixture_name, spec",
     [
         (
+            # Python pool: three triggers (legacy + shared + python
+            # consumers) per noetl/ai-meta#42 PR-4a.  KEDA picks the
+            # MAX desired-replicas across the triggers so the pool
+            # scales on whichever consumer has the largest backlog.
             "scaledobject-worker-cpu-01.yaml",
             ScaledObjectSpec(
                 worker_pool_urn=(
@@ -234,16 +296,22 @@ _FIXTURE_DIR = pathlib.Path(__file__).resolve().parents[2] / "fixtures" / "keda"
                 ),
                 deployment="noetl-worker",
                 nats_consumer="noetl_worker_pool",
+                additional_consumers=(
+                    "noetl_worker_pool_shared",
+                    "noetl_worker_pool_python",
+                ),
             ),
         ),
         (
+            # Rust pool: single trigger on the shared consumer (Rust
+            # workers only subscribe to .shared.> per PR-2b/PR-3).
             "scaledobject-worker-rust-pool.yaml",
             ScaledObjectSpec(
                 worker_pool_urn=(
                     "noetl://tenant/default/org/default/worker/worker-rust-pool"
                 ),
                 deployment="noetl-worker-rust",
-                nats_consumer="noetl_worker_pool",
+                nats_consumer="noetl_worker_pool_shared",
             ),
         ),
     ],

--- a/tests/fixtures/keda/scaledobject-worker-cpu-01.yaml
+++ b/tests/fixtures/keda/scaledobject-worker-cpu-01.yaml
@@ -24,3 +24,21 @@ spec:
       lagThreshold: '10'
       activationLagThreshold: '1'
       useHttps: 'false'
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: nats.nats.svc.cluster.local:8222
+      account: NOETL
+      stream: NOETL_COMMANDS
+      consumer: noetl_worker_pool_shared
+      lagThreshold: '10'
+      activationLagThreshold: '1'
+      useHttps: 'false'
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: nats.nats.svc.cluster.local:8222
+      account: NOETL
+      stream: NOETL_COMMANDS
+      consumer: noetl_worker_pool_python
+      lagThreshold: '10'
+      activationLagThreshold: '1'
+      useHttps: 'false'

--- a/tests/fixtures/keda/scaledobject-worker-rust-pool.yaml
+++ b/tests/fixtures/keda/scaledobject-worker-rust-pool.yaml
@@ -20,7 +20,7 @@ spec:
       natsServerMonitoringEndpoint: nats.nats.svc.cluster.local:8222
       account: NOETL
       stream: NOETL_COMMANDS
-      consumer: noetl_worker_pool
+      consumer: noetl_worker_pool_shared
       lagThreshold: '10'
       activationLagThreshold: '1'
       useHttps: 'false'


### PR DESCRIPTION
## Summary

PR-4a of the six-PR sequence under [noetl/ai-meta#42](https://github.com/noetl/ai-meta/issues/42).  Extends the KEDA generator so the Python pool's ScaledObject can scale on the MAX backlog across all three consumers (legacy + shared + python) instead of only the legacy one.

Without this PR, PR-5's cutover flag flip would leave the Python pool blind to `.shared.>` / `.python.>` backlog and scale it down to `minReplicas` — a real production-traffic failure mode.

## What this PR adds

- **`ScaledObjectSpec.additional_consumers`** — new optional `tuple[str, ...]` field (default `()` = single-trigger output, back-compat).  Each entry stacks into `spec.triggers`, primary consumer first.
- **`build_worker_scaledobject`** emits one `nats-jetstream` trigger per consumer.  KEDA's HPA reconciliation picks `MAX(desired_replicas)` across triggers.
- **Fixtures updated**:
  - `tests/fixtures/keda/scaledobject-worker-cpu-01.yaml` — Python pool: 3 triggers (legacy + shared + python).
  - `tests/fixtures/keda/scaledobject-worker-rust-pool.yaml` — Rust pool: 1 trigger, consumer renamed to `noetl_worker_pool_shared`.
- **Drift-guard test** parameters updated; 3 new unit tests covering single/multi/empty additional_consumers.

## What this PR does NOT change

- **No ops manifest changes.**  PR-4b ships the matching `noetl/ops/ci/manifests/keda/scaledobject-*.yaml` updates + the Rust deployment env var.
- **No publisher / worker behavior change.**  PR-1's routing flag still off; only the legacy consumer has backlog today.

## Test plan

- [x] `pytest tests/core/runtime/test_keda.py` — **26/26 pass** (23 pre-existing + 3 new for multi-trigger).
- [x] `pytest tests/core/runtime/test_keda.py tests/core/runtime/test_pool_routing.py tests/core/test_nats_command_subscriber.py tests/core/test_nats_command_publisher.py` — **71/71 pass**; no regression.

Refs noetl/ai-meta#42

🤖 Generated with [Claude Code](https://claude.com/claude-code)