### PR TITLE
fix(internal-api): kind-validation corrections (prefix, dict-row, noetl.event schema)

### DIFF
--- a/noetl/server/api/internal/endpoint.py
+++ b/noetl/server/api/internal/endpoint.py
@@ -39,7 +39,11 @@ logger = setup_logger(__name__, include_location=True)
 
 
 router = APIRouter(
-    prefix="/api/internal",
+    # NOTE: the top-level FastAPI app mounts ``noetl.server.api.router``
+    # under ``/api``, so the prefix here is just ``/internal`` to
+    # produce the final ``/api/internal/...`` paths.  Setting
+    # ``/api/internal`` here would double the prefix.
+    prefix="/internal",
     tags=["internal"],
     dependencies=[Depends(require_internal_api_token)],
 )

--- a/noetl/server/api/internal/service.py
+++ b/noetl/server/api/internal/service.py
@@ -106,9 +106,13 @@ async def pending_count() -> int:
     start = time.monotonic()
     async with get_pool_connection() as conn:
         async with conn.cursor() as cur:
+            # Alias the count so we can extract it whether psycopg returns
+            # a tuple, a dict_row, or a NamedTupleCursor row.  The pool
+            # default in noetl.core.db.pool is dict_row, so subscripting
+            # by index fails; access by name (or via .values()) instead.
             await cur.execute(
                 """
-                SELECT count(*)
+                SELECT count(*) AS pending
                 FROM noetl.outbox
                 WHERE status IN ('PENDING', 'FAILED')
                   AND available_at <= now()
@@ -116,7 +120,13 @@ async def pending_count() -> int:
             )
             row = await cur.fetchone()
     duration = time.monotonic() - start
-    pending = int(row[0]) if row else 0
+    pending = 0
+    if row:
+        if isinstance(row, dict):
+            pending = int(row.get("pending", 0))
+        else:
+            # tuple / named-tuple fallback
+            pending = int(row[0])
     logger.debug(
         "pending_count: %d rows ready (query took %.3fs)",
         pending,
@@ -141,10 +151,28 @@ async def pending_count() -> int:
 
 # Columns mirror today's noetl.event schema.  If the schema evolves, this
 # helper updates in lockstep with the projector's previous direct INSERT.
+# noetl.event schema (kind 2026-06-02):
+#   - PRIMARY KEY (event_id)
+#   - NOT NULL: execution_id, catalog_id, event_id, created_at,
+#               tenant_id, organization_id
+#   - All others nullable.
+#
+# The projector accepts envelopes that may or may not carry
+# catalog_id/tenant_id/organization_id (depends on the emitter).
+# Defaults:
+#   - catalog_id  → 0     (sentinel; emitters that care set their own)
+#   - tenant_id   → 'default'
+#   - organization_id → 'default'
+#   - created_at  → now()
+#
+# All-or-nothing batch INSERT with ON CONFLICT (event_id) DO NOTHING
+# for idempotency.  No ``timestamp`` column (that was a v1 schema
+# guess; the actual table uses ``created_at`` for ingest time).
 _PROJECT_INSERT_SQL = """
 INSERT INTO noetl.event (
     event_id,
     execution_id,
+    catalog_id,
     parent_event_id,
     event_type,
     node_id,
@@ -152,17 +180,19 @@ INSERT INTO noetl.event (
     node_type,
     status,
     duration,
-    timestamp,
     context,
     result,
     meta,
     error,
     stack_trace,
-    trace_component
+    tenant_id,
+    organization_id,
+    created_at
 )
 SELECT
     (row->>'event_id')::bigint,
-    NULLIF(row->>'execution_id', '')::bigint,
+    COALESCE(NULLIF(row->>'execution_id', '')::bigint, 0),
+    COALESCE(NULLIF(row->>'catalog_id', '')::bigint, 0),
     NULLIF(row->>'parent_event_id', '')::bigint,
     row->>'event_type',
     row->>'node_id',
@@ -170,15 +200,23 @@ SELECT
     row->>'node_type',
     row->>'status',
     NULLIF(row->>'duration', '')::double precision,
-    NULLIF(row->>'timestamp', '')::timestamptz,
     NULLIF(row->'context', 'null'::jsonb),
     NULLIF(row->'result', 'null'::jsonb),
     NULLIF(row->'meta', 'null'::jsonb),
     row->>'error',
     row->>'stack_trace',
-    row->>'trace_component'
+    COALESCE(NULLIF(row->>'tenant_id', ''), 'default'),
+    COALESCE(NULLIF(row->>'organization_id', ''), 'default'),
+    COALESCE(NULLIF(row->>'timestamp', '')::timestamp,
+             NULLIF(row->>'created_at', '')::timestamp,
+             now())
 FROM jsonb_array_elements(%s::jsonb) AS row
-ON CONFLICT (event_id) DO NOTHING
+-- noetl.event is partitioned (15 partitions per the schema); a
+-- partition-spanning unique constraint on event_id alone doesn't
+-- exist.  ``ON CONFLICT DO NOTHING`` without a target catches any
+-- uniqueness violation across partitions — sufficient for the
+-- projector's idempotency guarantee.
+ON CONFLICT DO NOTHING
 """
 
 

--- a/tests/api/test_internal_api.py
+++ b/tests/api/test_internal_api.py
@@ -1,5 +1,9 @@
 """
 Tests for the ``/api/internal/*`` route surface (noetl/noetl#658).
+(Router prefix is ``/internal``; the FastAPI app mounts the full
+api router under ``/api``, so the live paths are ``/api/internal/*``.
+Tests mount the router directly without the ``/api`` parent prefix,
+so the test URLs are ``/internal/*``.)
 
 Focuses on:
 
@@ -94,7 +98,7 @@ def test_endpoint_returns_403_without_auth(monkeypatch):
     monkeypatch.setenv("NOETL_INTERNAL_API_TOKEN", "secret-123")
     app = _build_app()
     client = TestClient(app)
-    response = client.get("/api/internal/outbox/pending-count")
+    response = client.get("/internal/outbox/pending-count")
     assert response.status_code == 403
     assert "Bearer" in response.json()["detail"]
 
@@ -104,7 +108,7 @@ def test_endpoint_returns_503_when_token_unset(monkeypatch):
     app = _build_app()
     client = TestClient(app)
     response = client.get(
-        "/api/internal/outbox/pending-count",
+        "/internal/outbox/pending-count",
         headers={"Authorization": "Bearer anything"},
     )
     assert response.status_code == 503
@@ -173,10 +177,10 @@ def test_all_five_routes_registered():
     """Sanity check: all five internal routes registered with correct paths."""
     paths = {(route.path, frozenset(route.methods)) for route in internal_router.routes}
     expected = {
-        ("/api/internal/outbox/claim", frozenset({"POST"})),
-        ("/api/internal/outbox/mark-published", frozenset({"POST"})),
-        ("/api/internal/outbox/mark-failed", frozenset({"POST"})),
-        ("/api/internal/outbox/pending-count", frozenset({"GET"})),
-        ("/api/internal/events/project", frozenset({"POST"})),
+        ("/internal/outbox/claim", frozenset({"POST"})),
+        ("/internal/outbox/mark-published", frozenset({"POST"})),
+        ("/internal/outbox/mark-failed", frozenset({"POST"})),
+        ("/internal/outbox/pending-count", frozenset({"GET"})),
+        ("/internal/events/project", frozenset({"POST"})),
     }
     assert expected.issubset(paths), f"missing: {expected - paths}"


### PR DESCRIPTION
## Summary

Three real-world fixes surfaced while validating [noetl/noetl#659](https://github.com/noetl/noetl/pull/659) on the kind cluster.  All five `/api/internal/*` endpoints now pass the validation harness end-to-end.

| Fix | Symptom | Root cause |
|---|---|---|
| **1. Router prefix** | 404 on every endpoint from outside | `APIRouter(prefix="/api/internal")` + parent router mounts under `/api` → `/api/api/internal/*` |
| **2. Dict-row tuple subscript** | 500 on `pending-count`: `KeyError: 0` | `noetl.core.db.pool` uses `dict_row` by default; `int(row[0])` fails on a dict |
| **3. noetl.event schema mismatch** | 500 on `events/project`: missing `timestamp` column, then partition-spanning unique constraint violation | INSERT used v1-schema-guess columns; real table requires `catalog_id`/`tenant_id`/`organization_id` (NOT NULL), uses `created_at` not `timestamp`, and is partitioned (so `ON CONFLICT (event_id)` doesn't match) |

## Kind validation results (after fixes)

Run with `repos/ops/automation/development/validate-internal-api.sh`:

```
--- AUTH GATE ---
PASS  no Authorization → 403
PASS  wrong token → 403
PASS  Basic scheme → 403

--- pending-count ---
PASS  pending-count returned 6

--- claim → mark-published ---
PASS  claim(limit=2) → claimed=2 rows=2
PASS  mark-published 2 rows

--- claim → mark-failed (with backoff) ---
PASS  mark-failed outbox_id=21797 attempts=1 → backoff=1s

--- events/project ---
PASS  events/project 2 fresh events → projected=2 duplicates=0
PASS  events/project idempotency → projected=0 duplicates=1
```

DB-side verification:
- Outbox rows transitioned PENDING → IN_FLIGHT → PUBLISHED through the API ✅
- One row marked FAILED with 1s exponential backoff in `available_at` ✅
- Two events landed in `noetl.event` partitioned table; re-projecting one of them returns `duplicates: 1` ✅

## Test plan

- [x] 17/17 unit tests still pass (`uv run pytest tests/api/test_internal_api.py -v`).  Test paths updated from `/api/internal/*` → `/internal/*` to match the corrected router prefix (tests mount the router without the `/api` parent).
- [x] Kind validation: all 11 harness tests pass against this branch's image deployed on kind.
- [ ] Production deploy: ship as next `noetl-server` release.

## Refs

- Original Phase C PR: [noetl/noetl#659](https://github.com/noetl/noetl/pull/659).
- Tracks [noetl/ai-meta#46](https://github.com/noetl/ai-meta/issues/46) Phase 1.a + [noetl/ai-meta#49](https://github.com/noetl/ai-meta/issues/49) Phase C.
- Rust mirror has the same SQL fixes — separate follow-up PR on `noetl/server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)