### PR TITLE
feat(routing): path-based pool routing for system/* playbooks (Phase 2.a.2)

### DIFF
--- a/noetl/core/messaging/nats_client.py
+++ b/noetl/core/messaging/nats_client.py
@@ -161,6 +161,7 @@ class NATSCommandPublisher:
         step: str,
         server_url: str,
         tool_kind: Optional[str] = None,
+        playbook_path: Optional[str] = None,
     ):
         """
         Publish command notification to NATS.
@@ -179,11 +180,24 @@ class NATSCommandPublisher:
         this argument is captured + threaded through but the legacy
         subject is used verbatim — no behaviour change.  See
         noetl/ai-meta#42 for the full plan.
+
+        ``playbook_path`` is the catalog path of the playbook issuing
+        the command.  When set + the path starts with a privileged
+        prefix (today: ``system/``), the subject routes to a
+        dedicated pool segment regardless of ``tool_kind``.  Lets the
+        system worker pool claim ``system/outbox_publisher`` commands
+        even though they use the generic ``tool: http`` /
+        ``tool: nats`` kinds.  See noetl/ai-meta#46 Phase 2.a.2.
         """
         await self.ensure_connected()
 
         from noetl.core.runtime.pool_routing import route_subject
-        subject = route_subject(self.subject, tool_kind, execution_id)
+        subject = route_subject(
+            self.subject,
+            tool_kind,
+            execution_id,
+            playbook_path=playbook_path,
+        )
 
         message = {
             "execution_id": execution_id,

--- a/noetl/core/runtime/pool_routing.py
+++ b/noetl/core/runtime/pool_routing.py
@@ -1,22 +1,32 @@
-"""Pool routing for tool kinds — see noetl/ai-meta#42.
+"""Pool routing for tool kinds and privileged playbook paths.
 
-The Rust noetl-worker can dispatch most tool kinds via the shared
-`noetl-tools` registry, but a handful are Python-runtime-bound and
-can only run on the Python pool (the `agent` LLM-framework bridge
-today; the `container` K8s-Job dispatcher per noetl/ai-meta#43 once
-it switches to a callback shape; possibly others later).
+Two routing keys, applied in order:
 
-This module is the source of truth for which kinds are Python-only.
-Adding a new Python-only kind is a one-line entry in
-:data:`POOL_FILTER_MAP`; no Rust-side change required because the
-worker pools learn what they support by *which NATS consumer they
-subscribe to*, not by querying a runtime contract.
+1. **Catalog path prefix** (:data:`POOL_PATH_PREFIX_MAP`) — a playbook
+   whose catalog path starts with a privileged prefix (today:
+   ``system/*``, see noetl/ai-meta#46 Phase 2.a.2) routes to a
+   dedicated pool segment regardless of tool kind.  This is how the
+   system worker pool claims platform-internal playbooks
+   (``system/outbox_publisher``, ``system/projector``, …) without
+   needing every step to declare a ``system_*`` tool kind.
+2. **Tool kind** (:data:`POOL_FILTER_MAP`, see noetl/ai-meta#42) —
+   anything not picked up by path-based routing falls back to
+   kind-based routing.  The Rust noetl-worker can dispatch most tool
+   kinds via the shared `noetl-tools` registry; a handful are
+   Python-runtime-bound (e.g. ``agent``) and route to the Python
+   pool only.
 
-The actual subject-routing logic ships in three phases per the
-[noetl/ai-meta#42](https://github.com/noetl/ai-meta/issues/42)
-plan; this module is the no-behaviour-change scaffold for PR-1.
+Both maps are the source of truth — the worker pools learn what they
+support by *which NATS consumer they subscribe to*, not by querying
+a runtime contract.  Adding a new privileged namespace or a new
+Python-only kind is a one-line entry here.
+
 :func:`route_subject` returns the legacy single subject until the
-:envvar:`NOETL_COMMAND_ROUTING_ENABLED` env flag flips at cutover.
+:envvar:`NOETL_COMMAND_ROUTING_ENABLED` env flag flips.  Once
+enabled, the hierarchical subject ``<base>.<pool>.<execution_id>``
+is used; the system pool's NATS consumer
+(``filter_subject=noetl.commands.system.>``) picks up the
+privileged stream.
 """
 
 from __future__ import annotations
@@ -35,6 +45,20 @@ POOL_FILTER_MAP: dict[str, str] = {
     # replicate the ``importlib.import_module`` + ``getattr`` shape;
     # routes to Python pool only.
     "agent": "python",
+}
+
+# Catalog-path prefixes that route to a privileged pool regardless of
+# tool kind.  The system worker pool (see noetl/ai-meta#46) runs
+# platform-internal playbooks under the ``system/`` namespace; every
+# command issued by such a playbook is routed to the
+# ``system`` pool segment so user-pool workers cannot claim it.
+#
+# Order matters only if two prefixes overlap — they don't today.
+# Adding a new privileged namespace: one entry here, plus a worker
+# pool whose NATS consumer's ``filter_subject`` matches
+# ``noetl.commands.<segment>.>``.
+POOL_PATH_PREFIX_MAP: dict[str, str] = {
+    "system/": "system",
 }
 
 # Default segment for kinds not in POOL_FILTER_MAP.  Both worker
@@ -71,10 +95,41 @@ def pool_segment_for_kind(tool_kind: Optional[str]) -> str:
     return POOL_FILTER_MAP.get(tool_kind, DEFAULT_POOL_SEGMENT)
 
 
+def pool_segment_for_path(playbook_path: Optional[str]) -> Optional[str]:
+    """Return the pool segment for a privileged playbook path, or ``None``.
+
+    A playbook whose catalog path starts with any of the prefixes in
+    :data:`POOL_PATH_PREFIX_MAP` routes to a dedicated pool segment
+    regardless of tool kind.  The system worker pool (see
+    noetl/ai-meta#46) uses this for the ``system/`` namespace so that
+    ``system/outbox_publisher`` (with ``tool: http`` + ``tool: nats``
+    steps that would otherwise route to ``shared``) lands on the
+    privileged consumer.
+
+    Returns ``None`` when the path doesn't match a privileged prefix
+    so the caller can fall back to :func:`pool_segment_for_kind`.
+
+    Leading slashes are stripped before matching, so both
+    ``"system/outbox_publisher"`` and ``"/system/outbox_publisher"``
+    resolve identically.
+    """
+    if not playbook_path:
+        return None
+    normalized = playbook_path.lstrip("/")
+    if not normalized:
+        return None
+    for prefix, segment in POOL_PATH_PREFIX_MAP.items():
+        if normalized.startswith(prefix):
+            return segment
+    return None
+
+
 def route_subject(
     base_subject: str,
     tool_kind: Optional[str],
     execution_id: int,
+    *,
+    playbook_path: Optional[str] = None,
 ) -> str:
     """Derive the NATS subject for a command notification.
 
@@ -90,10 +145,19 @@ def route_subject(
     parsing payloads); workers ignore the trailing token because
     their consumer's ``filter_subject`` matches the ``<pool>``
     segment.
+
+    Pool resolution order:
+
+    1. :func:`pool_segment_for_path` — privileged playbook paths
+       (``system/*`` etc.) win regardless of tool kind.  This is how
+       a ``system/outbox_publisher`` playbook's ``tool: http`` steps
+       reach the system pool instead of being claimed by a user pool.
+    2. :func:`pool_segment_for_kind` — falls back to tool-kind-based
+       routing (``agent`` → ``python``, everything else → ``shared``).
     """
     if not is_routing_enabled():
         return base_subject
-    pool = pool_segment_for_kind(tool_kind)
+    pool = pool_segment_for_path(playbook_path) or pool_segment_for_kind(tool_kind)
     return f"{base_subject}.{pool}.{execution_id}"
 
 
@@ -117,10 +181,12 @@ def command_stream_subjects(base_subject: str) -> list[str]:
 
 __all__ = [
     "POOL_FILTER_MAP",
+    "POOL_PATH_PREFIX_MAP",
     "DEFAULT_POOL_SEGMENT",
     "ROUTING_ENABLED_ENV",
     "command_stream_subjects",
     "is_routing_enabled",
     "pool_segment_for_kind",
+    "pool_segment_for_path",
     "route_subject",
 ]

--- a/noetl/server/api/core/batch.py
+++ b/noetl/server/api/core/batch.py
@@ -419,14 +419,18 @@ async def _issue_commands_for_batch(job: _BatchAcceptJob, commands: list) -> Non
 
     await _drain_batch_outbox()
 
-    # 5. Parallel NATS publish.  Tuple is 5-wide:
-    # ``(execution_id, evt_id, cmd_id, step, tool_kind)``.  The trailing
-    # ``tool_kind`` drives the NATS subject derivation when pool
-    # routing is enabled — see noetl/ai-meta#42 + the route_subject
-    # helper in noetl.core.runtime.pool_routing.  Today the field is
-    # captured but the subject stays single until the cutover env
-    # flag flips.
-    publish_items = [(p["execution_id"], p["evt_id"], p["cmd_id"], p["step"], p.get("tool_kind")) for p in prepared_commands]
+    # 5. Parallel NATS publish.  Tuple is 6-wide:
+    # ``(execution_id, evt_id, cmd_id, step, tool_kind, playbook_path)``.
+    # The trailing two fields drive the NATS subject derivation when
+    # pool routing is enabled — ``tool_kind`` for noetl/ai-meta#42's
+    # ``agent``→python carve-out, ``playbook_path`` for noetl/ai-meta
+    # #46 Phase 2.a.2's ``system/*`` privileged routing.  Both fields
+    # are captured but the subject stays single until the cutover env
+    # flag flips.  ``catalog_path_for`` hits an in-process LRU cache so
+    # the lookup is free after the first batch for any given playbook.
+    from .catalog_path import catalog_path_for
+    playbook_path = await catalog_path_for(cat_id)
+    publish_items = [(p["execution_id"], p["evt_id"], p["cmd_id"], p["step"], p.get("tool_kind"), playbook_path) for p in prepared_commands]
     await _publish_commands_with_recovery(publish_items, server_url=server_url)
 
 async def _process_accepted_batch(

--- a/noetl/server/api/core/catalog_path.py
+++ b/noetl/server/api/core/catalog_path.py
@@ -1,0 +1,123 @@
+"""Resolve catalog_id → playbook path (with in-process LRU cache).
+
+Used by command-emit call sites that need the playbook path for
+:func:`noetl.core.runtime.pool_routing.route_subject` but only have
+``catalog_id`` in scope (the batch + event endpoints already passed
+``cat_id`` through every command).
+
+Catalog rows are immutable per ``(path, version)`` tuple — once a
+``catalog_id`` is assigned its ``path`` never changes — so the cache
+has no TTL.  An LRU bound keeps memory predictable across the long-
+lived server process.
+
+If the cache miss query fails (DB unavailable, row deleted), the
+helper logs a warning and returns ``None``; the caller falls back to
+tool-kind-based routing, which preserves today's behaviour.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Bound the cache size.  Server typically sees < 100 active playbook
+# paths per tenant per day; 1024 entries keeps every realistic
+# workload pinned without growing the heap unboundedly under
+# pathological load.
+_CACHE_MAX_ENTRIES = 1024
+
+# OrderedDict gives us O(1) LRU: ``move_to_end`` on hit, ``popitem``
+# on overflow.  Keyed by ``int(catalog_id)``; value is the path
+# string or ``None`` (negative cache for catalog_ids that don't
+# exist, so a misconfigured caller doesn't hammer the DB).
+_cache: "OrderedDict[int, Optional[str]]" = OrderedDict()
+
+
+def _cache_get(catalog_id: int) -> tuple[bool, Optional[str]]:
+    """Return ``(hit, value)`` — ``hit=False`` means miss, ``value`` is meaningless."""
+    if catalog_id in _cache:
+        value = _cache[catalog_id]
+        _cache.move_to_end(catalog_id)
+        return True, value
+    return False, None
+
+
+def _cache_set(catalog_id: int, path: Optional[str]) -> None:
+    _cache[catalog_id] = path
+    _cache.move_to_end(catalog_id)
+    while len(_cache) > _CACHE_MAX_ENTRIES:
+        _cache.popitem(last=False)
+
+
+def cache_clear() -> None:
+    """Drop every cached entry.  Used by tests."""
+    _cache.clear()
+
+
+async def catalog_path_for(catalog_id: Optional[int]) -> Optional[str]:
+    """Return the playbook catalog path for ``catalog_id``, or ``None``.
+
+    Hits a process-local LRU cache (no TTL — catalog rows are
+    immutable per id) backed by a single-row ``SELECT path FROM
+    noetl.catalog WHERE catalog_id = %s`` on miss.
+
+    ``None`` input or DB error → ``None`` (the caller's routing falls
+    back to tool-kind-based segmentation, same as today).
+    """
+    if catalog_id is None:
+        return None
+    try:
+        cid = int(catalog_id)
+    except (TypeError, ValueError):
+        return None
+
+    hit, value = _cache_get(cid)
+    if hit:
+        return value
+
+    try:
+        # Import here to avoid a circular import at module load time
+        # (noetl.core.db.pool → server config → this module via the
+        # core package's re-exports).
+        from noetl.core.db.pool import get_pool_connection
+
+        async with get_pool_connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT path FROM noetl.catalog WHERE catalog_id = %s",
+                    (cid,),
+                )
+                row = await cur.fetchone()
+    except Exception as exc:
+        logger.warning(
+            "catalog_path_for lookup failed for catalog_id=%s: %s",
+            cid,
+            exc,
+        )
+        return None
+
+    path: Optional[str] = None
+    if row is not None:
+        # psycopg's default for our pool is ``dict_row`` but some call
+        # sites override; accept either shape defensively.
+        if isinstance(row, dict):
+            path = row.get("path")
+        else:
+            try:
+                path = row[0]
+            except (IndexError, TypeError):
+                path = None
+        if path is not None:
+            path = str(path)
+
+    _cache_set(cid, path)
+    return path
+
+
+__all__ = [
+    "cache_clear",
+    "catalog_path_for",
+]

--- a/noetl/server/api/core/events.py
+++ b/noetl/server/api/core/events.py
@@ -465,17 +465,31 @@ async def handle_event(req: EventRequest) -> EventResponse:
                         "frame_id": frame_id,
                         "created_at": _now,
                     })
-                    # 5-tuple per noetl/ai-meta#42 — trailing tool_kind
-                    # drives NATS subject derivation when pool routing
-                    # is enabled.
-                    command_events.append((int(cmd.execution_id), new_evt_id, cmd_id, cmd.step, cmd.tool.kind))
+                    # 6-tuple per noetl/ai-meta#42 + #46 Phase 2.a.2 —
+                    # trailing ``(tool_kind, playbook_path)`` drives
+                    # NATS subject derivation when pool routing is
+                    # enabled.  Carry ``cat_id`` alongside so we can
+                    # resolve the playbook path per command after the
+                    # DB transaction commits (commands in this batch
+                    # may span multiple executions / catalog_ids when
+                    # the engine returns cross-execution work).
+                    command_events.append((int(cmd.execution_id), new_evt_id, cmd_id, cmd.step, cmd.tool.kind, cat_id))
                     supervisor_commands.append((str(cmd.execution_id), cmd_id, cmd.step, int(new_evt_id), dict(meta)))
                 await conn.commit()
 
         await _drain_core_outbox()
         for s_exec, s_cmd, s_step, s_evt, s_meta in supervisor_commands:
             await supervise_command_issued(s_exec, s_cmd, s_step, event_id=s_evt, meta=s_meta)
-        await _publish_commands_with_recovery(command_events, server_url=server_url)
+        # Resolve the playbook path per command's catalog_id (the
+        # helper caches per catalog_id so repeats are free).  Swap the
+        # trailing cat_id slot in each tuple for the resolved path.
+        from .catalog_path import catalog_path_for
+        resolved_events = []
+        for ev in command_events:
+            *prefix, ev_cat_id = ev
+            path = await catalog_path_for(ev_cat_id)
+            resolved_events.append((*prefix, path))
+        await _publish_commands_with_recovery(resolved_events, server_url=server_url)
         
         if req.name == "command.completed" and req.step.lower() != "end":
             try:

--- a/noetl/server/api/core/execution.py
+++ b/noetl/server/api/core/execution.py
@@ -186,10 +186,12 @@ async def execute(req: ExecuteRequest) -> ExecuteResponse:
                         "frame_id": frame_id,
                         "created_at": now,
                     })
-                    # 5-tuple per noetl/ai-meta#42 — trailing tool_kind
-                    # drives NATS subject derivation when pool routing
-                    # is enabled.
-                    command_events.append((int(execution_id), evt_id, cmd_id, cmd.step, cmd.tool.kind))
+                    # 6-tuple per noetl/ai-meta#42 + #46 Phase 2.a.2 —
+                    # trailing ``(tool_kind, playbook_path)`` drives NATS
+                    # subject derivation when pool routing is enabled.
+                    # ``path`` here is the catalog row's path, captured
+                    # above when resolving ``req.path`` / ``req.catalog_id``.
+                    command_events.append((int(execution_id), evt_id, cmd_id, cmd.step, cmd.tool.kind, path))
                     await _enqueue_execution_outbox(
                         cur,
                         _command_issued_envelope(

--- a/noetl/server/api/core/recovery.py
+++ b/noetl/server/api/core/recovery.py
@@ -17,7 +17,7 @@ async def shutdown_publish_recovery_tasks() -> None:
     for t in tasks: t.cancel()
     await asyncio.gather(*tasks, return_exceptions=True)
 
-async def _recover_unclaimed_command_after_delay(execution_id: int, event_id: int, command_id: str, step: str, server_url: str, delay_seconds: float, tool_kind: Optional[str] = None) -> None:
+async def _recover_unclaimed_command_after_delay(execution_id: int, event_id: int, command_id: str, step: str, server_url: str, delay_seconds: float, tool_kind: Optional[str] = None, playbook_path: Optional[str] = None) -> None:
     await asyncio.sleep(delay_seconds)
     try:
         from noetl.core.db.pool import get_pool_connection
@@ -36,15 +36,19 @@ async def _recover_unclaimed_command_after_delay(execution_id: int, event_id: in
                 if (await cur.fetchone() or {'count': 0}).get('total', 0) > 0: return
         logger.warning("[PUBLISH-RECOVERY] Command unclaimed after %.1fs; re-publishing execution_id=%s command_id=%s", delay_seconds, execution_id, command_id)
         nats_pub = await get_nats_publisher()
-        await nats_pub.publish_command(execution_id=execution_id, event_id=event_id, command_id=command_id, step=step, server_url=server_url, tool_kind=tool_kind)
+        await nats_pub.publish_command(execution_id=execution_id, event_id=event_id, command_id=command_id, step=step, server_url=server_url, tool_kind=tool_kind, playbook_path=playbook_path)
     except Exception as exc:
         logger.error("[PUBLISH-RECOVERY] Recovery failed for %s: %s", command_id, exc, exc_info=True)
 
-# Per noetl/ai-meta#42 the publish tuple is a 5-tuple (the trailing
-# ``tool_kind`` drives the NATS subject derivation when pool routing
-# is enabled).  Old 4-tuple callers stay compatible: the helper
-# unpacks defensively and treats missing ``tool_kind`` as ``None``
-# (which routes to the shared subject, same as today's behaviour).
+# The publish tuple is 6-wide:
+#   ``(execution_id, evt_id, cmd_id, step, tool_kind, playbook_path)``.
+# The trailing two fields drive the NATS subject derivation when pool
+# routing is enabled (noetl/ai-meta#42 for tool_kind +
+# noetl/ai-meta#46 Phase 2.a.2 for playbook_path).  Old 4-tuple and
+# 5-tuple callers stay compatible: the helper unpacks defensively and
+# treats missing ``tool_kind`` / ``playbook_path`` as ``None`` (routes
+# to the shared subject, same as today's behaviour for non-privileged
+# playbooks).
 async def _publish_commands_with_recovery(command_events: list[tuple], *, server_url: str) -> None:
     if not command_events: return
     nats_pub = None
@@ -53,10 +57,10 @@ async def _publish_commands_with_recovery(command_events: list[tuple], *, server
     except Exception as exc:
         logger.warning("[PUBLISH-RECOVERY] NATS publisher unavailable; scheduling delayed recovery: %s", exc)
 
-    async def _safe_publish(exec_id, evt_id, cid, step, tool_kind=None):
+    async def _safe_publish(exec_id, evt_id, cid, step, tool_kind=None, playbook_path=None):
         if nats_pub:
             try:
-                await nats_pub.publish_command(execution_id=exec_id, event_id=evt_id, command_id=cid, step=step, server_url=server_url, tool_kind=tool_kind)
+                await nats_pub.publish_command(execution_id=exec_id, event_id=evt_id, command_id=cid, step=step, server_url=server_url, tool_kind=tool_kind, playbook_path=playbook_path)
             except Exception as exc:
                 logger.warning("[PUBLISH-RECOVERY] Initial publish failed for %s: %s", cid, exc)
 
@@ -66,6 +70,7 @@ async def _publish_commands_with_recovery(command_events: list[tuple], *, server
                 step=step, server_url=server_url,
                 delay_seconds=_COMMAND_PUBLISH_RECOVERY_DELAY_SECONDS,
                 tool_kind=tool_kind,
+                playbook_path=playbook_path,
             ),
             name=f"command-publish-recovery:{exec_id}:{cid}",
         )
@@ -74,7 +79,7 @@ async def _publish_commands_with_recovery(command_events: list[tuple], *, server
     publish_semaphore = asyncio.Semaphore(50) # Max 50 parallel NATS publishes
     async def _sem_publish(args):
         async with publish_semaphore:
-            # Defensive unpack — accept legacy 4-tuple or new 5-tuple.
+            # Defensive unpack — accept legacy 4-tuple, 5-tuple or new 6-tuple.
             await _safe_publish(*args)
 
     await asyncio.gather(*[_sem_publish(args) for args in command_events])

--- a/noetl/server/command_reaper.py
+++ b/noetl/server/command_reaper.py
@@ -142,7 +142,11 @@ async def _find_stale_active_commands(
     * the claim has lived past ``healthy_hard_timeout_seconds``.
 
     Each returned row carries the fields needed to republish via NATS:
-    ``event_id``, ``execution_id``, ``command_id`` (string), ``step``.
+    ``event_id``, ``execution_id``, ``command_id`` (string), ``step``,
+    plus ``tool_kind`` + ``playbook_path`` for pool-routing (see
+    noetl/ai-meta#42 + #46 Phase 2.a.2 — without these, re-published
+    notifications would route to ``shared`` even for ``system/*``
+    playbooks and the wrong pool could claim them).
     """
     async with get_bg_pool_connection(timeout=5.0) as conn:
         async with conn.cursor(row_factory=dict_row) as cur:
@@ -152,11 +156,15 @@ async def _find_stale_active_commands(
                     c.event_id AS event_id,
                     c.execution_id AS execution_id,
                     c.command_id::text AS command_id,
-                    c.step_name AS step
+                    c.step_name AS step,
+                    c.tool_kind AS tool_kind,
+                    cat.path AS playbook_path
                 FROM noetl.command c
                 LEFT JOIN noetl.runtime r
                     ON r.kind = 'worker_pool'
                    AND r.name = c.worker_id
+                LEFT JOIN noetl.catalog cat
+                    ON cat.catalog_id = c.catalog_id
                 WHERE c.status = ANY(%s)
                   AND c.worker_id IS NOT NULL
                   AND c.claimed_at IS NOT NULL
@@ -208,8 +216,12 @@ async def _find_stranded_pending_commands(
                     c.event_id AS event_id,
                     c.execution_id AS execution_id,
                     c.command_id::text AS command_id,
-                    c.step_name AS step
+                    c.step_name AS step,
+                    c.tool_kind AS tool_kind,
+                    cat.path AS playbook_path
                 FROM noetl.command c
+                LEFT JOIN noetl.catalog cat
+                    ON cat.catalog_id = c.catalog_id
                 WHERE c.status = 'PENDING'
                   AND c.created_at < (NOW() - make_interval(secs => %s))
                   AND NOT EXISTS (
@@ -290,6 +302,8 @@ async def reap_orphaned_commands_once(server_url: str) -> int:
                 command_id=str(cmd["command_id"]),
                 step=str(cmd["step"]),
                 server_url=server_url,
+                tool_kind=cmd.get("tool_kind"),
+                playbook_path=cmd.get("playbook_path"),
             )
             republished += 1
             logger.info(

--- a/tests/core/runtime/test_keda.py
+++ b/tests/core/runtime/test_keda.py
@@ -274,6 +274,12 @@ def test_dump_scaledobject_yaml_preserves_top_level_key_order():
 #     2026-06-02 alongside R-3 Phase B-4 dual-scaling; both pools share
 #     the same NATS stream + consumer, so adding the Rust-pool scaler
 #     gives KEDA-driven autoscaling on both halves of the worker fleet).
+#   - `worker-system-pool` — Rust `noetl-worker-system-pool` deployment
+#     (added 2026-06-02 alongside noetl/ai-meta#46 Phase 1.b).  Distinct
+#     NATS consumer (`noetl_worker_pool_system`) with
+#     `filter_subject=noetl.commands.system.>`; Phase 2.a.2 (this PR)
+#     teaches the server to publish privileged ``system/*`` playbook
+#     commands to that subject branch.
 # ----------------------------------------------------------------------------
 
 import pathlib
@@ -314,8 +320,28 @@ _FIXTURE_DIR = pathlib.Path(__file__).resolve().parents[2] / "fixtures" / "keda"
                 nats_consumer="noetl_worker_pool_shared",
             ),
         ),
+        (
+            # System pool: single trigger on the system consumer.  The
+            # consumer's filter subject is `noetl.commands.system.>`,
+            # set on the deployment side in
+            # noetl/ops/ci/manifests/noetl/worker-system-pool-deployment.yaml.
+            # Phase 2.a.2 lets the server publish privileged `system/*`
+            # playbook commands to that branch.
+            "scaledobject-worker-system-pool.yaml",
+            ScaledObjectSpec(
+                worker_pool_urn=(
+                    "noetl://tenant/default/org/default/worker/worker-system-pool"
+                ),
+                deployment="noetl-worker-system-pool",
+                nats_consumer="noetl_worker_pool_system",
+            ),
+        ),
     ],
-    ids=["worker-cpu-01-python-pool", "worker-rust-pool-rust-pool"],
+    ids=[
+        "worker-cpu-01-python-pool",
+        "worker-rust-pool-rust-pool",
+        "worker-system-pool-system-pool",
+    ],
 )
 def test_sample_manifest_matches_generator_output(fixture_name, spec):
     """Verify each checked-in pool sample matches what the generator emits.

--- a/tests/core/runtime/test_pool_routing.py
+++ b/tests/core/runtime/test_pool_routing.py
@@ -14,10 +14,12 @@ import pytest
 from noetl.core.runtime.pool_routing import (
     DEFAULT_POOL_SEGMENT,
     POOL_FILTER_MAP,
+    POOL_PATH_PREFIX_MAP,
     ROUTING_ENABLED_ENV,
     command_stream_subjects,
     is_routing_enabled,
     pool_segment_for_kind,
+    pool_segment_for_path,
     route_subject,
 )
 
@@ -149,3 +151,134 @@ def test_command_stream_subjects_no_duplicate_entries():
     """No duplicate entries even if called repeatedly with the same base."""
     subjects = command_stream_subjects("x.y")
     assert len(subjects) == len(set(subjects))
+
+
+# ---------------------------------------------------------------------------
+# Path-based routing (noetl/ai-meta#46 Phase 2.a.2)
+# ---------------------------------------------------------------------------
+
+
+def test_pool_path_prefix_map_includes_system():
+    """The ``system/`` prefix routes to the privileged system pool."""
+    assert POOL_PATH_PREFIX_MAP["system/"] == "system"
+
+
+def test_pool_segment_for_path_none_or_empty():
+    """Missing playbook path returns ``None`` so the caller falls back to kind."""
+    assert pool_segment_for_path(None) is None
+    assert pool_segment_for_path("") is None
+    assert pool_segment_for_path("/") is None  # only a slash → empty after lstrip
+
+
+def test_pool_segment_for_path_system_namespace():
+    """Paths under the ``system/`` namespace route to the system pool."""
+    assert pool_segment_for_path("system/outbox_publisher") == "system"
+    assert pool_segment_for_path("system/projector") == "system"
+    assert pool_segment_for_path("system/nested/deep/playbook") == "system"
+
+
+def test_pool_segment_for_path_strips_leading_slash():
+    """Catalog paths sometimes carry a leading slash — match identically."""
+    assert pool_segment_for_path("/system/outbox_publisher") == "system"
+    assert pool_segment_for_path("//system/foo") == "system"
+
+
+def test_pool_segment_for_path_user_namespace_returns_none():
+    """User playbooks return ``None`` so kind-based routing decides the pool."""
+    for path in (
+        "user/foo",
+        "tenants/acme/etl",
+        "tests/fixtures/rust_worker_r2_validation",
+        "playbooks/duffel_search",
+    ):
+        assert pool_segment_for_path(path) is None
+
+
+def test_pool_segment_for_path_requires_trailing_slash_boundary():
+    """``system`` without a trailing slash is NOT a system playbook — guards against
+    accidental matches like ``systems_dashboard`` or just ``system``.
+    """
+    assert pool_segment_for_path("system") is None
+    assert pool_segment_for_path("systems_dashboard") is None
+    assert pool_segment_for_path("systemd") is None
+
+
+def test_route_subject_path_wins_over_kind_when_flag_on(routing_on):
+    """A ``system/*`` playbook with a normally-shared tool kind still
+    routes to the system pool — the whole point of Phase 2.a.2.
+    """
+    # ``http`` would normally route to shared, but the system/ path forces system.
+    assert (
+        route_subject(
+            "noetl.commands",
+            "http",
+            12345,
+            playbook_path="system/outbox_publisher",
+        )
+        == "noetl.commands.system.12345"
+    )
+
+
+def test_route_subject_path_wins_even_for_agent_kind(routing_on):
+    """Even ``agent`` (which would otherwise force python) is overridden
+    by the privileged path — system playbooks always claim the system
+    pool, no exceptions.
+    """
+    assert (
+        route_subject(
+            "noetl.commands",
+            "agent",
+            99,
+            playbook_path="system/some_agent_playbook",
+        )
+        == "noetl.commands.system.99"
+    )
+
+
+def test_route_subject_falls_back_to_kind_for_non_system_paths(routing_on):
+    """Non-system paths route by tool kind, same as before."""
+    assert (
+        route_subject(
+            "noetl.commands",
+            "agent",
+            42,
+            playbook_path="user/my_agent",
+        )
+        == "noetl.commands.python.42"
+    )
+    assert (
+        route_subject(
+            "noetl.commands",
+            "http",
+            42,
+            playbook_path="user/my_http",
+        )
+        == "noetl.commands.shared.42"
+    )
+
+
+def test_route_subject_no_path_falls_back_to_kind(routing_on):
+    """Omitting ``playbook_path`` preserves the legacy kind-only behaviour."""
+    assert (
+        route_subject("noetl.commands", "http", 7)
+        == "noetl.commands.shared.7"
+    )
+    assert (
+        route_subject("noetl.commands", "agent", 7)
+        == "noetl.commands.python.7"
+    )
+
+
+def test_route_subject_path_routing_disabled_when_flag_off(routing_off):
+    """Even a ``system/*`` path returns the base subject when the
+    routing flag is off — kept off in tests + before the cutover.
+    """
+    assert (
+        route_subject(
+            "noetl.commands",
+            "http",
+            12345,
+            playbook_path="system/outbox_publisher",
+        )
+        == "noetl.commands"
+    )

--- a/tests/fixtures/keda/scaledobject-worker-system-pool.yaml
+++ b/tests/fixtures/keda/scaledobject-worker-system-pool.yaml
@@ -1,0 +1,26 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: noetl-worker-system-pool-scaler-worker-system-pool
+  namespace: noetl
+  labels:
+    app: noetl-worker-system-pool
+    worker-pool: worker-system-pool
+    managed-by: noetl
+spec:
+  scaleTargetRef:
+    name: noetl-worker-system-pool
+  minReplicaCount: 1
+  maxReplicaCount: 20
+  pollingInterval: 10
+  cooldownPeriod: 30
+  triggers:
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: nats.nats.svc.cluster.local:8222
+      account: NOETL
+      stream: NOETL_COMMANDS
+      consumer: noetl_worker_pool_system
+      lagThreshold: '10'
+      activationLagThreshold: '1'
+      useHttps: 'false'

--- a/tests/server/api/core/test_catalog_path.py
+++ b/tests/server/api/core/test_catalog_path.py
@@ -1,0 +1,186 @@
+"""Unit tests for ``noetl.server.api.core.catalog_path`` — see
+noetl/ai-meta#46 Phase 2.a.2.
+
+Exercises the in-process LRU cache without touching a real Postgres
+connection.  The DB miss path is patched via ``monkeypatch`` so the
+tests run anywhere ``pytest`` runs.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, Optional
+
+import pytest
+
+from noetl.server.api.core import catalog_path as catalog_path_module
+from noetl.server.api.core.catalog_path import (
+    _CACHE_MAX_ENTRIES,
+    cache_clear,
+    catalog_path_for,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache():
+    """Each test starts and ends with an empty cache."""
+    cache_clear()
+    yield
+    cache_clear()
+
+
+class _StubCursor:
+    """Mimics the slice of psycopg's cursor surface ``catalog_path_for`` uses."""
+
+    def __init__(self, fixture: dict[int, Optional[str]], call_log: list[int]):
+        self._fixture = fixture
+        self._call_log = call_log
+        self._next: Optional[Any] = None
+
+    async def execute(self, sql: str, params: tuple) -> None:  # noqa: D401
+        # params is (catalog_id,) per the helper's SQL.
+        cid = int(params[0])
+        self._call_log.append(cid)
+        path = self._fixture.get(cid)
+        # Mirror our default ``dict_row`` cursor shape.
+        self._next = {"path": path} if path is not None else None
+
+    async def fetchone(self) -> Optional[dict]:
+        return self._next
+
+    async def __aenter__(self) -> "_StubCursor":
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        return None
+
+
+class _StubConnection:
+    def __init__(self, fixture: dict[int, Optional[str]], call_log: list[int]):
+        self._fixture = fixture
+        self._call_log = call_log
+
+    def cursor(self) -> _StubCursor:
+        return _StubCursor(self._fixture, self._call_log)
+
+    async def __aenter__(self) -> "_StubConnection":
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        return None
+
+
+def _stub_pool(fixture: dict[int, Optional[str]], call_log: list[int]):
+    @asynccontextmanager
+    async def _get_pool_connection():
+        yield _StubConnection(fixture, call_log)
+
+    return _get_pool_connection
+
+
+@pytest.mark.asyncio
+async def test_catalog_path_for_none_input_returns_none():
+    assert await catalog_path_for(None) is None
+
+
+@pytest.mark.asyncio
+async def test_catalog_path_for_non_numeric_returns_none():
+    assert await catalog_path_for("not-a-number") is None
+
+
+@pytest.mark.asyncio
+async def test_catalog_path_for_hits_db_then_caches(monkeypatch):
+    fixture = {42: "system/outbox_publisher"}
+    call_log: list[int] = []
+    monkeypatch.setattr(
+        "noetl.core.db.pool.get_pool_connection",
+        _stub_pool(fixture, call_log),
+    )
+
+    # First call: cache miss → DB query.
+    assert await catalog_path_for(42) == "system/outbox_publisher"
+    assert call_log == [42]
+
+    # Second call for same id: served from cache, no DB query.
+    assert await catalog_path_for(42) == "system/outbox_publisher"
+    assert call_log == [42]
+
+
+@pytest.mark.asyncio
+async def test_catalog_path_for_caches_misses_too(monkeypatch):
+    """Unknown catalog_ids cache as None to avoid re-querying a missing row."""
+    fixture: dict[int, Optional[str]] = {}
+    call_log: list[int] = []
+    monkeypatch.setattr(
+        "noetl.core.db.pool.get_pool_connection",
+        _stub_pool(fixture, call_log),
+    )
+
+    assert await catalog_path_for(999) is None
+    assert call_log == [999]
+
+    # Negative cache: the second miss does not hit the DB again.
+    assert await catalog_path_for(999) is None
+    assert call_log == [999]
+
+
+@pytest.mark.asyncio
+async def test_catalog_path_for_distinct_ids(monkeypatch):
+    fixture = {1: "user/foo", 2: "system/projector", 3: None}
+    call_log: list[int] = []
+    monkeypatch.setattr(
+        "noetl.core.db.pool.get_pool_connection",
+        _stub_pool(fixture, call_log),
+    )
+
+    assert await catalog_path_for(1) == "user/foo"
+    assert await catalog_path_for(2) == "system/projector"
+    assert await catalog_path_for(3) is None
+    assert sorted(call_log) == [1, 2, 3]
+    # Repeats hit cache.
+    assert await catalog_path_for(1) == "user/foo"
+    assert await catalog_path_for(2) == "system/projector"
+    assert sorted(call_log) == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_catalog_path_for_db_error_returns_none(monkeypatch):
+    """DB exception → ``None`` (caller falls back to kind-based routing)."""
+
+    @asynccontextmanager
+    async def _broken_pool():
+        raise RuntimeError("pool unavailable")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(
+        "noetl.core.db.pool.get_pool_connection",
+        _broken_pool,
+    )
+
+    assert await catalog_path_for(7) is None
+    # Error path does NOT cache — next call retries.  (Important so a
+    # transient DB blip doesn't pin a stale None for the session.)
+    assert 7 not in catalog_path_module._cache  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_catalog_path_for_lru_eviction(monkeypatch):
+    """Cache stays bounded — oldest entries get evicted past the cap."""
+    fixture = {i: f"user/path_{i}" for i in range(_CACHE_MAX_ENTRIES + 5)}
+    call_log: list[int] = []
+    monkeypatch.setattr(
+        "noetl.core.db.pool.get_pool_connection",
+        _stub_pool(fixture, call_log),
+    )
+
+    for cid in range(_CACHE_MAX_ENTRIES + 5):
+        await catalog_path_for(cid)
+
+    # Cache is bounded.
+    assert len(catalog_path_module._cache) == _CACHE_MAX_ENTRIES  # type: ignore[attr-defined]
+    # The oldest 5 ids were evicted.
+    for cid in range(5):
+        assert cid not in catalog_path_module._cache  # type: ignore[attr-defined]
+    # The most recent ids are still resident.
+    for cid in range(_CACHE_MAX_ENTRIES, _CACHE_MAX_ENTRIES + 5):
+        assert cid in catalog_path_module._cache  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- Extends `noetl/core/runtime/pool_routing.py` with a second routing key — **catalog path prefix** (`POOL_PATH_PREFIX_MAP`).  A playbook whose catalog path starts with `system/` now routes to the system pool segment regardless of tool kind.
- Threads `playbook_path` through the four command-emit call sites (`execution.py`, `events.py`, `batch.py`, `command_reaper.py`) and through the `_publish_commands_with_recovery` → `nats_client.publish_command` → `route_subject` chain.
- Adds `noetl.server.api.core.catalog_path.catalog_path_for()` — a tiny in-process LRU cache (1024 entries, no TTL since catalog rows are immutable per id, negative caching) so the per-batch lookup is free after the first miss.
- 11 new `test_pool_routing.py` tests + 7 new `test_catalog_path.py` tests + a drift-guard entry for `scaledobject-worker-system-pool.yaml` in `test_keda.py`.

Closes noetl/ai-meta#46 Phase 2.a.2.

## Why path-based and not new `system_*` tool kinds

Path-based captures intent at the right layer: playbook authors keep using normal tool kinds (`tool: http`, `tool: nats`) and the **playbook itself** is the source of privilege.  Adding `system_http`, `system_nats`, etc. would require parallel tool implementations and would let a user playbook accidentally use a privileged kind.  Decision is documented in noetl/ai-meta#50.

## Routing precedence

`route_subject(base, tool_kind, execution_id, *, playbook_path)` applies both keys in order:

1. `pool_segment_for_path(playbook_path)` — non-`None` → that segment wins.
2. `pool_segment_for_kind(tool_kind)` — fallback (today's behaviour).

So a `system/outbox_publisher` playbook with `tool: http` steps routes to `noetl.commands.system.<eid>` instead of `noetl.commands.shared.<eid>`.  The `agent` → `python` carve-out still works for everything outside `system/`.

## Kind validation (this PR)

Companion script in [noetl/ops](https://github.com/noetl/ops) at `automation/development/validate-system-pool-routing.sh`:

\`\`\`
==> Sampling consumer deltas
    system pool delivered (after):  3  (delta=1)
    shared pool delivered (after):  599  (delta=1)

    ✅ system pool received system-playbook command: delta=1 (≥ 1)
    ✅ shared pool received user-playbook command: delta=1 (≥ 1)

==> Probing noetl.event for command.issued events
    exec=640685381582586090 type=command.issued step=start tool=python path=system/routing_test
    exec=640685384325660911 type=command.issued step=start tool=python path=tests/fixtures/routing_test

==> All routing assertions passed
\`\`\`

Two trivial single-step `tool: python` playbooks (one under `system/`, one under `tests/fixtures/`) register + execute on kind, and the NATS HTTP monitoring endpoint confirms each pool's consumer received exactly one new delivery.

## Test plan

- [x] `tests/core/runtime/test_pool_routing.py` — 11 new path-based tests (32 tests total in file).
- [x] `tests/server/api/core/test_catalog_path.py` — 7 new tests for the LRU cache.
- [x] `tests/core/runtime/test_keda.py` — drift guard for `scaledobject-worker-system-pool.yaml`.
- [x] 101 directly-related tests pass; 1223 unrelated tests pass (108 failures are pre-existing on `main`, unrelated to this PR).
- [x] Kind validation: system playbook command routes to `noetl_worker_pool_system`, user playbook to `noetl_worker_pool_shared`.
- [x] Backward compat: 4-tuple and 5-tuple legacy callers of `_publish_commands_with_recovery` still work via defensive unpack.
- [x] Routing flag off: `route_subject` returns the bare base subject even for `system/*` paths.

## Wiki

New `pool_routing` page in the [noetl wiki](https://github.com/noetl/noetl/wiki/pool_routing) covers the contract, the catalog-path-for cache, the subject shape, the precedence rule, and validation.  Sidebar + Home table updated in lockstep (Rule 2b).

Refs noetl/ai-meta#42 (PR-1..5 routing umbrella)
Refs noetl/ai-meta#50 Phase 2.a.2
Closes noetl/ai-meta#46 Phase 2.a.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)