### PR TITLE
feat(routing): route task_sequence to python pool (regression fix #47)

### DIFF
--- a/noetl/core/runtime/pool_routing.py
+++ b/noetl/core/runtime/pool_routing.py
@@ -45,6 +45,21 @@ POOL_FILTER_MAP: dict[str, str] = {
     # replicate the ``importlib.import_module`` + ``getattr`` shape;
     # routes to Python pool only.
     "agent": "python",
+    # `task_sequence` — engine-level pipeline construct, not a tool
+    # kind in the noetl-tools sense.  The Python worker ships
+    # ``TaskSequenceExecutor`` (``noetl/worker/task_sequence_executor.py``,
+    # ~1.2k LoC) with pipeline-local data threading via ``_prev``,
+    # per-task flow-control rules (continue/retry/break/jump/fail),
+    # ``_task`` / ``_attempt`` / ``output`` template bindings, and
+    # ``ctx.*`` / ``iter.*`` mutations.  Engine-side it has
+    # special-case suffix handling at ~11 sites in
+    # ``noetl/core/dsl/engine/executor/{events,commands,state,store,common}.py``
+    # for the synthetic ``<parent>:task_sequence`` step name.
+    # Routing to Python — porting to Rust is multi-week work and
+    # adds no value (every task_sequence step's inner tools already
+    # dispatch through the worker's ``_execute_tool`` callback, which
+    # is fast).  See noetl/ai-meta#47 for the call graph.
+    "task_sequence": "python",
 }
 
 # Catalog-path prefixes that route to a privileged pool regardless of

--- a/tests/core/runtime/test_pool_routing.py
+++ b/tests/core/runtime/test_pool_routing.py
@@ -43,6 +43,15 @@ def test_pool_filter_map_includes_agent():
     assert POOL_FILTER_MAP["agent"] == "python"
 
 
+def test_pool_filter_map_includes_task_sequence():
+    """task_sequence is engine-level (not a noetl-tools kind); only the
+    Python worker's ``TaskSequenceExecutor`` implements it.  Routing to
+    Python keeps the regression suite green on the Rust pool (see
+    noetl/ai-meta#47).
+    """
+    assert POOL_FILTER_MAP["task_sequence"] == "python"
+
+
 def test_default_segment_is_shared():
     """Anything not in POOL_FILTER_MAP defaults to the shared queue."""
     assert DEFAULT_POOL_SEGMENT == "shared"
@@ -72,6 +81,7 @@ def test_is_routing_enabled_parses_flag(monkeypatch, env_value, expected):
 
 def test_pool_segment_for_known_python_kind():
     assert pool_segment_for_kind("agent") == "python"
+    assert pool_segment_for_kind("task_sequence") == "python"
 
 
 def test_pool_segment_for_known_shared_kind():
@@ -103,6 +113,17 @@ def test_route_subject_segments_when_flag_on_agent(routing_on):
     assert (
         route_subject("noetl.commands", "agent", 12345)
         == "noetl.commands.python.12345"
+    )
+
+
+def test_route_subject_segments_when_flag_on_task_sequence(routing_on):
+    """task_sequence commands also route to the python branch — only
+    the Python worker's TaskSequenceExecutor implements the pipeline
+    semantics (noetl/ai-meta#47).
+    """
+    assert (
+        route_subject("noetl.commands", "task_sequence", 7777)
+        == "noetl.commands.python.7777"
     )
 
 


### PR DESCRIPTION
## Summary

- One-line addition to `POOL_FILTER_MAP` in `noetl/core/runtime/pool_routing.py`: `task_sequence` → `python`.
- Two new unit tests + parametrize extensions pin the mapping.

Closes noetl/ai-meta#47.

## Why route rather than implement?

`task_sequence` is an **engine-level pipeline construct**, not a tool kind in the noetl-tools sense.  The Python implementation in `noetl/worker/task_sequence_executor.py` (~1.2k LoC) covers:

- Pipeline-local data threading via `_prev` (Clojure-style `->`)
- Per-task flow-control rules with `do: continue | retry | break | jump | fail` matched on `when` predicates
- Template bindings for `_task`, `_prev`, `_attempt`, `output`, `results`, `ctx.*`, `iter.*`
- Tight engine integration: ~11 special-case sites in `noetl/core/dsl/engine/executor/{events,commands,state,store,common}.py` keyed off the synthetic `<parent>:task_sequence` step name

Porting to Rust would be multi-week work with **no runtime benefit** — each task's inner tool already dispatches through the worker's existing `_execute_tool` callback, so the only Rust-vs-Python difference is the pipeline glue (not the heavy work).

Pre-existing precedent: `agent` is already routed to python for the same reason (dynamic Python module import is hard to replicate in Rust).

## Effect on the Rust pool

- When the routing flag is on, commands with `tool_kind=task_sequence` publish to `noetl.commands.python.<eid>`.
- Rust worker's consumer filter is `noetl.commands.shared.>` → no match → the worker no longer attempts to dispatch.
- Python worker's catch-all consumer (`noetl_worker_pool`, filter=None) picks up everything → claims and dispatches via `TaskSequenceExecutor`.

This fixes the regression seen in v5.9.0 kind validation (`Tool not found: task_sequence`) without touching the Rust workspace.

## Kind validation (companion noetl/ops PR ships the rig)

\`\`\`
==> Sampling consumer deltas
    Python pool delta:  1
    Rust pool   delta:  0

    ✅ Python pool claimed the task_sequence command (delta=1 ≥ 1)
    ✅ Rust pool did NOT claim the task_sequence command (delta=0)

==> Probing noetl.event for command.issued events
    command.issued    pipe:task_sequence  tool=task_sequence  status=PENDING
    command.claimed   pipe:task_sequence                       status=RUNNING
    call.done         pipe:task_sequence                       status=COMPLETED
    command.completed pipe:task_sequence                       status=COMPLETED

==> Scanning Rust pool logs for 'Tool not found: task_sequence'
    ✅ Rust worker did not log 'Tool not found: task_sequence'
\`\`\`

## Test plan

- [x] `tests/core/runtime/test_pool_routing.py` — 2 new tests + extensions to `test_pool_segment_for_known_python_kind` and `test_route_subject_segments_when_flag_on_*`.  36/36 tests in the file pass.
- [x] Kind validation: fixture playbook `tests/fixtures/task_sequence_routing` with a 2-task python pipeline registers, executes, and completes via the Python pool.
- [x] Routing flag off: `task_sequence` returns the bare base subject (no behaviour change).

## Wiki

`pool_routing` page on the noetl wiki updated — `task_sequence` row added to the kind-based routing table; the Python-only-kinds prose explains the engine-level nature.  Ships in lockstep with this PR per Rule 2b.

Closes noetl/ai-meta#47
Refs noetl/ai-meta#42

🤖 Generated with [Claude Code](https://claude.com/claude-code)