### PR TITLE
fix(worker): lazify noetl.tools.{postgres,duckdb,http} imports (#663 Cluster C)

### DIFF
--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -71,9 +71,14 @@ def _is_hot_path_initial_event_step(tool_kind: Optional[str]) -> bool:
 # Pre-import tool executors at module level to avoid 5s cold-start delay
 # These were previously imported inside _execute_tool() causing slow first execution
 from noetl.tools import http, postgres, duckdb, python
-from noetl.tools.http import execute_http_task
-from noetl.tools.postgres import execute_postgres_task, execute_postgres_task_async
-from noetl.tools.duckdb import execute_duckdb_task
+# noetl.tools.http import lazified below, same reason as postgres/duckdb.
+# Lazy imports for noetl.tools.postgres + noetl.tools.duckdb live inside the
+# dispatch branches below.  Both submodules import from noetl.worker.*
+# (auth_compatibility, keychain_resolver) at module load, so importing
+# them at the top of noetl.worker.nats_worker creates a circular dependency
+# that breaks pytest collection across iterator/, plugin/, render/,
+# api/, core/, and test_*.py — see noetl/noetl#663 Cluster C.
+# Cached in sys.modules after first call; subsequent dispatches are O(1).
 from noetl.tools.snowflake import execute_snowflake_task
 from noetl.tools.gcs import execute_gcs_task
 from noetl.tools.transfer import execute_transfer_action
@@ -2684,6 +2689,9 @@ class Worker:
 
             logger.debug(f"HTTP TOOL: config_keys={list(config.keys()) if isinstance(config, dict) else 'not dict'} | retry={retry_config is not None} | policies={len(retry_config) if isinstance(retry_config, list) else 0} | has_pagination={has_pagination_retry}")
 
+            # Lazy import — see module-top comment about the circular cycle.
+            from noetl.tools.http import execute_http_task
+
             if has_pagination_retry:
                 logger.info("HTTP tool using execute_with_retry_async for pagination support")
                 from noetl.core.runtime.retry import execute_with_retry_async
@@ -2720,6 +2728,8 @@ class Worker:
             # This lets the plugin pool reuse connections (same loop_id → same pool key).
             # The old pattern (run_in_executor + asyncio.run) created a new event loop
             # per call, causing a fresh pool each time and leaking connections.
+            # Lazy import — see module-top comment about the circular cycle.
+            from noetl.tools.postgres import execute_postgres_task_async
             task_with = {**config, **args}  # Merge config (has auth) with args
             result = await execute_postgres_task_async(task_config, context, jinja_env, task_with)
             # Check if plugin returned error status
@@ -2731,6 +2741,8 @@ class Worker:
         elif tool_kind == "duckdb":
             # Use plugin's execute_duckdb_task (sync function - run in executor)
             # Pass full tool config as task_with to ensure auth is available
+            # Lazy import — see module-top comment about the circular cycle.
+            from noetl.tools.duckdb import execute_duckdb_task
             task_with = {**config, **args}  # Merge config (has auth) with args
             loop = asyncio.get_running_loop()
             result = await loop.run_in_executor(


### PR DESCRIPTION
## Summary

Cluster C of [#663](https://github.com/noetl/noetl/issues/663) pytest debt: **production-side circular-import fix** that unblocks honest failure surfaces in `iterator/`, `plugin/`, `render/`, `api/`, `core/`, and several `test_*.py` test files.

## Root cause

`noetl/worker/nats_worker.py` did top-level imports of three tool modules:

```python
from noetl.tools.postgres import execute_postgres_task, execute_postgres_task_async
from noetl.tools.duckdb   import execute_duckdb_task
from noetl.tools.http     import execute_http_task
```

But each tool package's `__init__.py` pulls in `noetl.worker.*` modules (auth_compatibility, keychain_resolver, secrets). When Python loads `noetl.worker.__init__`, it runs `from .nats_worker import run_worker, ...`, which forces `nats_worker` to load, which hits the three top-level tool imports, which re-enter `noetl.worker.__init__` mid-init → **circular import**.

Surface error (any test that imports anything in `noetl.*` triggers it):

```
ImportError: cannot import name 'execute_postgres_task' from
partially initialized module 'noetl.tools.postgres' (most likely
due to a circular import)
```

## Fix

Move all three imports inside the dispatch branches that use them:

- `postgres` branch (~line 2724): lazy import `execute_postgres_task_async`
- `duckdb` branch (~line 2742): lazy import `execute_duckdb_task`  
- `http` branch (~line 2702): lazy import `execute_http_task`

Python caches each module in `sys.modules` after first import, so subsequent dispatches are O(1) dict lookups — no real performance cost in this hot path. Also dropped the unused sync `execute_postgres_task` symbol (only the `_async` variant is called in this file).

Added a module-top comment explaining the lazy-import convention so future contributors don't accidentally re-introduce the cycle.

## Why the suite-level pass count is unchanged

`pytest tests/`: 98 failed / 1234 passed (same as before this PR).

The previously-blocked `iterator/`, `plugin/`, `render/` tests now collect cleanly but hit a **deeper API divergence** — `iterator` is no longer a tool kind (replaced by a server-side `loop:` attribute) and the http tests need `await`. Those belong to Cluster E (`type:`→`tool:` + iterator/loop redesign) and Cluster D (async/await additions) respectively — separate PRs.

**The win is twofold:**

1. **Production correctness**: the latent cycle could fire in any environment that triggered a different module load order (e.g. a worker process started via a different entry point). It's a real bug, not just a test-time annoyance.
2. **Honest failure surfaces**: pytest now shows the underlying API divergence ("Unknown task tool 'iterator'") instead of masking it with "circular import". Makes follow-up triage in Clusters E + D actually possible.

## Verification

- `python -c "import noetl.worker.nats_worker"` → succeeds cleanly (previously raised at import time when triggered through pytest).
- Full pytest suite: 98 failed / 1234 passed (unchanged top-line; the previously circular-import-blocked tests now show their real Cluster D/E failures).

## Test plan

- [x] `import noetl.worker.nats_worker` succeeds standalone
- [x] No new regressions in pytest suite (same 98/1234)
- [x] Lazy-import call sites are inside hot-path dispatch branches; `sys.modules` cache makes overhead negligible
- [x] Module-top comment explains the convention for future contributors

Refs #663
Refs https://github.com/noetl/ai-meta/issues/54