### PR TITLE
feat: add EHDB integration contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,28 @@ Reference docs for the event-sourced, projection-backed runtime
   durable NATS pull consumer, shard-stable, Prometheus metrics,
   replay-state folding shared with the in-process replay API.
 
+### EHDB Integration Contract
+
+EHDB integration is disabled by default in this repository. The first
+NoETL-side surface is a feature-flagged contract only; it validates the
+execution-model boundary before any storage cutover exists.
+
+Environment flags:
+
+- `NOETL_EHDB_ENABLED=true` turns on contract validation.
+- `NOETL_EHDB_MODE=local_reference` selects the local reference
+  readiness mode.
+- `NOETL_EHDB_CLIENT_ROLE=worker|playbook` declares the caller role.
+- `NOETL_EHDB_LOCAL_REFERENCE_LOG=/path/to/ehdb.jsonl` provides the
+  explicit local event-log path for the reference mode.
+
+Gateway/server roles are rejected when EHDB is enabled. Gateway remains
+the gatekeeper; workers remain atomic compute; playbooks remain
+ephemeral blueprints; shared cache remains a state vehicle; the event
+log remains the source of truth. This contract does not connect to EHDB,
+replace PostgreSQL/NATS/object stores, add a gateway route, or start a
+persistent per-tenant process.
+
 ## Repository model (ai-meta driven)
 
 NoETL development is now coordinated through the `ai-meta` repository:

--- a/noetl/core/ehdb_contract.py
+++ b/noetl/core/ehdb_contract.py
@@ -1,0 +1,130 @@
+"""Feature-gated EHDB integration contract for NoETL.
+
+This module is intentionally side-effect free. It only validates the
+NoETL execution-model boundary for future EHDB wiring; it does not
+connect to EHDB, open files, or replace any existing storage backend.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Mapping
+
+
+EHDB_ENABLED_ENV = "NOETL_EHDB_ENABLED"
+EHDB_MODE_ENV = "NOETL_EHDB_MODE"
+EHDB_CLIENT_ROLE_ENV = "NOETL_EHDB_CLIENT_ROLE"
+EHDB_LOCAL_REFERENCE_LOG_ENV = "NOETL_EHDB_LOCAL_REFERENCE_LOG"
+NOETL_RUN_MODE_ENV = "NOETL_RUN_MODE"
+
+
+class EhdbIntegrationMode(StrEnum):
+    DISABLED = "disabled"
+    LOCAL_REFERENCE = "local_reference"
+
+
+class EhdbClientRole(StrEnum):
+    GATEWAY = "gateway"
+    SERVER = "server"
+    WORKER = "worker"
+    PLAYBOOK = "playbook"
+
+
+@dataclass(frozen=True)
+class EhdbIntegrationContract:
+    enabled: bool
+    mode: EhdbIntegrationMode
+    role: EhdbClientRole
+    local_reference_log: Path | None = None
+
+    @property
+    def uses_local_reference_runtime(self) -> bool:
+        return self.enabled and self.mode is EhdbIntegrationMode.LOCAL_REFERENCE
+
+
+def ehdb_integration_contract_from_env(
+    env: Mapping[str, str],
+) -> EhdbIntegrationContract:
+    """Build and validate the disabled-by-default EHDB contract."""
+
+    enabled = _truthy(env.get(EHDB_ENABLED_ENV))
+    role = _client_role(env)
+    mode = _integration_mode(env, enabled=enabled)
+    local_reference_log = _path_or_none(env.get(EHDB_LOCAL_REFERENCE_LOG_ENV))
+
+    contract = EhdbIntegrationContract(
+        enabled=enabled,
+        mode=mode,
+        role=role,
+        local_reference_log=local_reference_log,
+    )
+    validate_ehdb_integration_contract(contract)
+    return contract
+
+
+def validate_ehdb_integration_contract(
+    contract: EhdbIntegrationContract,
+) -> EhdbIntegrationContract:
+    if not contract.enabled:
+        if contract.mode is not EhdbIntegrationMode.DISABLED:
+            raise ValueError("disabled EHDB integration must use disabled mode")
+        return contract
+
+    if contract.role in {EhdbClientRole.GATEWAY, EhdbClientRole.SERVER}:
+        raise ValueError(
+            "EHDB integration may not run in gateway/server roles; "
+            "gateway remains a gatekeeper and must not touch data directly"
+        )
+
+    if contract.mode is not EhdbIntegrationMode.LOCAL_REFERENCE:
+        raise ValueError(
+            "enabled EHDB integration currently supports local_reference only"
+        )
+
+    if contract.local_reference_log is None:
+        raise ValueError(
+            "NOETL_EHDB_LOCAL_REFERENCE_LOG is required for local_reference mode"
+        )
+
+    return contract
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _integration_mode(
+    env: Mapping[str, str],
+    *,
+    enabled: bool,
+) -> EhdbIntegrationMode:
+    raw = env.get(EHDB_MODE_ENV)
+    if raw is None or not raw.strip():
+        return (
+            EhdbIntegrationMode.LOCAL_REFERENCE
+            if enabled
+            else EhdbIntegrationMode.DISABLED
+        )
+    try:
+        return EhdbIntegrationMode(raw.strip().lower())
+    except ValueError as exc:
+        raise ValueError(f"unsupported EHDB integration mode: {raw}") from exc
+
+
+def _client_role(env: Mapping[str, str]) -> EhdbClientRole:
+    raw = env.get(EHDB_CLIENT_ROLE_ENV) or env.get(NOETL_RUN_MODE_ENV) or "worker"
+    normalized = raw.strip().lower()
+    if normalized == "server":
+        return EhdbClientRole.SERVER
+    try:
+        return EhdbClientRole(normalized)
+    except ValueError as exc:
+        raise ValueError(f"unsupported EHDB client role: {raw}") from exc
+
+
+def _path_or_none(value: str | None) -> Path | None:
+    if value is None or not value.strip():
+        return None
+    return Path(value.strip())

--- a/tests/core/test_ehdb_contract.py
+++ b/tests/core/test_ehdb_contract.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+
+import pytest
+
+from noetl.core.ehdb_contract import (
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    EHDB_LOCAL_REFERENCE_LOG_ENV,
+    EHDB_MODE_ENV,
+    NOETL_RUN_MODE_ENV,
+    EhdbClientRole,
+    EhdbIntegrationMode,
+    ehdb_integration_contract_from_env,
+)
+
+
+def test_ehdb_contract_is_disabled_by_default():
+    contract = ehdb_integration_contract_from_env({})
+
+    assert contract.enabled is False
+    assert contract.mode is EhdbIntegrationMode.DISABLED
+    assert contract.role is EhdbClientRole.WORKER
+    assert contract.local_reference_log is None
+    assert contract.uses_local_reference_runtime is False
+
+
+def test_ehdb_contract_accepts_worker_local_reference_mode():
+    contract = ehdb_integration_contract_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+        }
+    )
+
+    assert contract.enabled is True
+    assert contract.mode is EhdbIntegrationMode.LOCAL_REFERENCE
+    assert contract.role is EhdbClientRole.WORKER
+    assert contract.local_reference_log == Path("/tmp/noetl-ehdb.jsonl")
+    assert contract.uses_local_reference_runtime is True
+
+
+def test_ehdb_contract_accepts_playbook_local_reference_mode():
+    contract = ehdb_integration_contract_from_env(
+        {
+            EHDB_ENABLED_ENV: "1",
+            EHDB_MODE_ENV: "local_reference",
+            EHDB_CLIENT_ROLE_ENV: "playbook",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "var/noetl/ehdb/reference.jsonl",
+        }
+    )
+
+    assert contract.role is EhdbClientRole.PLAYBOOK
+    assert contract.local_reference_log == Path("var/noetl/ehdb/reference.jsonl")
+
+
+@pytest.mark.parametrize("role", ["gateway", "server"])
+def test_ehdb_contract_rejects_gateway_and_server_data_touch_roles(role):
+    with pytest.raises(ValueError, match="gateway remains a gatekeeper"):
+        ehdb_integration_contract_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_CLIENT_ROLE_ENV: role,
+                EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            }
+        )
+
+
+def test_ehdb_contract_rejects_server_run_mode_when_role_is_not_overridden():
+    with pytest.raises(ValueError, match="gateway remains a gatekeeper"):
+        ehdb_integration_contract_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                NOETL_RUN_MODE_ENV: "server",
+                EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            }
+        )
+
+
+def test_ehdb_contract_requires_explicit_local_reference_log_when_enabled():
+    with pytest.raises(ValueError, match=EHDB_LOCAL_REFERENCE_LOG_ENV):
+        ehdb_integration_contract_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_CLIENT_ROLE_ENV: "worker",
+            }
+        )
+
+
+def test_ehdb_contract_rejects_unknown_mode_and_role():
+    with pytest.raises(ValueError, match="unsupported EHDB integration mode"):
+        ehdb_integration_contract_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_MODE_ENV: "flight",
+                EHDB_CLIENT_ROLE_ENV: "worker",
+                EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            }
+        )
+
+    with pytest.raises(ValueError, match="unsupported EHDB client role"):
+        ehdb_integration_contract_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_CLIENT_ROLE_ENV: "tenant-daemon",
+                EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            }
+        )
+


### PR DESCRIPTION
## Summary
- add a side-effect-free `noetl.core.ehdb_contract` module for the first NoETL-side EHDB integration gate
- keep EHDB disabled by default and validate `local_reference` mode only for worker/playbook roles
- reject gateway/server roles when EHDB is enabled so gateway remains a gatekeeper and does not touch data directly
- document the EHDB env flags and boundary in README

## Boundary
This is a contract/readiness slice only. It does not connect to EHDB, replace PostgreSQL/NATS/object stores, add a gateway route, start a persistent per-tenant process, or perform a kind/GKE rollout.

## Validation
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py` (8 tests)
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_runtime_topology.py tests/core/runtime/test_pool_routing.py` (57 tests)
- `.venv/bin/python -m compileall -q noetl/core/ehdb_contract.py`

Closes #668.
