### PR TITLE
feat: add EHDB local reference adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ log remains the source of truth. This contract does not connect to EHDB,
 replace PostgreSQL/NATS/object stores, add a gateway route, or start a
 persistent per-tenant process.
 
+`noetl.core.ehdb_adapter.ehdb_adapter_from_env` builds the disabled-by-
+default adapter descriptor behind that contract. Disabled configuration
+returns `None`; worker/playbook `local_reference` configuration returns
+a `LocalReferenceEhdbAdapter` carrying the explicit event-log path and
+exportable runtime environment for future EHDB helper calls. The adapter
+does not open logs, connect to EHDB, or perform storage operations.
+
 ## Repository model (ai-meta driven)
 
 NoETL development is now coordinated through the `ai-meta` repository:

--- a/noetl/core/ehdb_adapter.py
+++ b/noetl/core/ehdb_adapter.py
@@ -1,0 +1,71 @@
+"""Side-effect-free EHDB adapter factory for NoETL workers/playbooks."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+from noetl.core.ehdb_contract import (
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    EHDB_LOCAL_REFERENCE_LOG_ENV,
+    EHDB_MODE_ENV,
+    EhdbClientRole,
+    EhdbIntegrationContract,
+    EhdbIntegrationMode,
+    ehdb_integration_contract_from_env,
+    validate_ehdb_integration_contract,
+)
+
+
+@dataclass(frozen=True)
+class LocalReferenceEhdbAdapter:
+    """Adapter descriptor for EHDB local-reference worker/playbook usage."""
+
+    contract: EhdbIntegrationContract
+
+    @classmethod
+    def from_contract(
+        cls,
+        contract: EhdbIntegrationContract,
+    ) -> "LocalReferenceEhdbAdapter":
+        validate_ehdb_integration_contract(contract)
+        if contract.mode is not EhdbIntegrationMode.LOCAL_REFERENCE:
+            raise ValueError("local-reference adapter requires local_reference mode")
+        if contract.role not in {EhdbClientRole.WORKER, EhdbClientRole.PLAYBOOK}:
+            raise ValueError("local-reference adapter requires worker or playbook role")
+        return cls(contract=contract)
+
+    @property
+    def role(self) -> EhdbClientRole:
+        return self.contract.role
+
+    @property
+    def local_reference_log(self) -> Path:
+        if self.contract.local_reference_log is None:
+            raise ValueError("local-reference adapter requires an event-log path")
+        return self.contract.local_reference_log
+
+    def runtime_env(self) -> dict[str, str]:
+        """Return env vars a worker/playbook step can pass to EHDB helpers."""
+
+        return {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: EhdbIntegrationMode.LOCAL_REFERENCE.value,
+            EHDB_CLIENT_ROLE_ENV: self.role.value,
+            EHDB_LOCAL_REFERENCE_LOG_ENV: str(self.local_reference_log),
+        }
+
+
+def ehdb_adapter_from_env(
+    env: Mapping[str, str] | None = None,
+) -> LocalReferenceEhdbAdapter | None:
+    """Return the configured EHDB adapter, or None when EHDB is disabled."""
+
+    contract = ehdb_integration_contract_from_env(os.environ if env is None else env)
+    if not contract.enabled:
+        return None
+    return LocalReferenceEhdbAdapter.from_contract(contract)
+

--- a/tests/core/test_ehdb_adapter.py
+++ b/tests/core/test_ehdb_adapter.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+import pytest
+
+from noetl.core.ehdb_adapter import (
+    LocalReferenceEhdbAdapter,
+    ehdb_adapter_from_env,
+)
+from noetl.core.ehdb_contract import (
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    EHDB_LOCAL_REFERENCE_LOG_ENV,
+    EHDB_MODE_ENV,
+    EhdbClientRole,
+    EhdbIntegrationMode,
+    ehdb_integration_contract_from_env,
+)
+
+
+def test_ehdb_adapter_returns_none_when_disabled():
+    assert ehdb_adapter_from_env({}) is None
+
+
+def test_ehdb_adapter_builds_worker_local_reference_adapter():
+    adapter = ehdb_adapter_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+        }
+    )
+
+    assert isinstance(adapter, LocalReferenceEhdbAdapter)
+    assert adapter.role is EhdbClientRole.WORKER
+    assert adapter.local_reference_log == Path("/tmp/noetl-ehdb.jsonl")
+
+
+def test_ehdb_adapter_builds_playbook_local_reference_adapter():
+    adapter = ehdb_adapter_from_env(
+        {
+            EHDB_ENABLED_ENV: "1",
+            EHDB_MODE_ENV: "local_reference",
+            EHDB_CLIENT_ROLE_ENV: "playbook",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "var/noetl/ehdb/reference.jsonl",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.role is EhdbClientRole.PLAYBOOK
+    assert adapter.local_reference_log == Path("var/noetl/ehdb/reference.jsonl")
+
+
+def test_ehdb_adapter_exports_worker_runtime_env():
+    adapter = ehdb_adapter_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.runtime_env() == {
+        EHDB_ENABLED_ENV: "true",
+        EHDB_MODE_ENV: EhdbIntegrationMode.LOCAL_REFERENCE.value,
+        EHDB_CLIENT_ROLE_ENV: EhdbClientRole.WORKER.value,
+        EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+    }
+
+
+def test_ehdb_adapter_rejects_gateway_role_via_contract():
+    with pytest.raises(ValueError, match="gateway remains a gatekeeper"):
+        ehdb_adapter_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_CLIENT_ROLE_ENV: "gateway",
+                EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            }
+        )
+
+
+def test_local_reference_adapter_requires_local_reference_contract():
+    contract = ehdb_integration_contract_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+        }
+    )
+
+    adapter = LocalReferenceEhdbAdapter.from_contract(contract)
+
+    assert adapter.runtime_env()[EHDB_MODE_ENV] == "local_reference"
+


### PR DESCRIPTION
Closes #670

## Summary
- add a side-effect-free EHDB local-reference adapter descriptor behind the integration contract
- return no adapter when EHDB is disabled
- export worker/playbook runtime env without opening logs, connecting to EHDB, or adding gateway/server behavior
- document the adapter boundary in the README

## Validation
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_runtime_topology.py tests/core/runtime/test_pool_routing.py`
- `.venv/bin/python -m compileall -q noetl/core/ehdb_contract.py noetl/core/ehdb_adapter.py`
- `git diff --check README.md noetl/core/ehdb_adapter.py tests/core/test_ehdb_adapter.py`