### PR TITLE
feat: add EHDB helper invocation plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Environment flags:
 - `NOETL_EHDB_CLIENT_ROLE=worker|playbook` declares the caller role.
 - `NOETL_EHDB_LOCAL_REFERENCE_LOG=/path/to/ehdb.jsonl` provides the
   explicit local event-log path for the reference mode.
+- `NOETL_EHDB_HELPER_BIN=/path/to/helper` is required only when a
+  worker/playbook asks NoETL to build a local-reference helper
+  invocation plan.
 
 Gateway/server roles are rejected when EHDB is enabled. Gateway remains
 the gatekeeper; workers remain atomic compute; playbooks remain
@@ -69,6 +72,15 @@ returns `None`; worker/playbook `local_reference` configuration returns
 a `LocalReferenceEhdbAdapter` carrying the explicit event-log path and
 exportable runtime environment for future EHDB helper calls. The adapter
 does not open logs, connect to EHDB, or perform storage operations.
+
+`noetl.core.ehdb_adapter.ehdb_helper_invocation_from_env` builds the
+next planning surface for those helper calls. Disabled configuration
+returns `None`; enabled worker/playbook configuration requires an
+explicit helper executable and returns deterministic `argv` plus EHDB
+runtime env that can be merged into a subprocess environment. The
+invocation plan is immutable and side-effect-free; it does not execute a
+subprocess, import EHDB, open logs, connect to storage, or add
+gateway/server data paths.
 
 ## Repository model (ai-meta driven)
 

--- a/noetl/core/ehdb_adapter.py
+++ b/noetl/core/ehdb_adapter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Mapping
+from typing import Mapping, Sequence
 
 from noetl.core.ehdb_contract import (
     EHDB_CLIENT_ROLE_ENV,
@@ -18,6 +18,36 @@ from noetl.core.ehdb_contract import (
     ehdb_integration_contract_from_env,
     validate_ehdb_integration_contract,
 )
+
+
+EHDB_HELPER_BIN_ENV = "NOETL_EHDB_HELPER_BIN"
+
+
+@dataclass(frozen=True)
+class LocalReferenceEhdbInvocation:
+    """Immutable invocation plan for a future EHDB local-reference helper."""
+
+    executable: str
+    args: tuple[str, ...]
+    env_items: tuple[tuple[str, str], ...]
+    role: EhdbClientRole
+    local_reference_log: Path
+
+    @property
+    def argv(self) -> tuple[str, ...]:
+        return (self.executable, *self.args)
+
+    @property
+    def env(self) -> dict[str, str]:
+        return dict(self.env_items)
+
+    def subprocess_env(
+        self,
+        base_env: Mapping[str, str] | None = None,
+    ) -> dict[str, str]:
+        env = dict(base_env or {})
+        env.update(self.env)
+        return env
 
 
 @dataclass(frozen=True)
@@ -58,6 +88,28 @@ class LocalReferenceEhdbAdapter:
             EHDB_LOCAL_REFERENCE_LOG_ENV: str(self.local_reference_log),
         }
 
+    def helper_invocation(
+        self,
+        *,
+        executable: str,
+        args: Sequence[str] = (),
+    ) -> LocalReferenceEhdbInvocation:
+        """Return a subprocess invocation plan without executing it."""
+
+        helper_executable = _non_empty_text(executable, "EHDB helper executable")
+        helper_args = tuple(
+            _non_empty_text(arg, f"EHDB helper arg {index}")
+            for index, arg in enumerate(args)
+        )
+        runtime_env = self.runtime_env()
+        return LocalReferenceEhdbInvocation(
+            executable=helper_executable,
+            args=helper_args,
+            env_items=tuple(runtime_env.items()),
+            role=self.role,
+            local_reference_log=self.local_reference_log,
+        )
+
 
 def ehdb_adapter_from_env(
     env: Mapping[str, str] | None = None,
@@ -69,3 +121,26 @@ def ehdb_adapter_from_env(
         return None
     return LocalReferenceEhdbAdapter.from_contract(contract)
 
+
+def ehdb_helper_invocation_from_env(
+    env: Mapping[str, str] | None = None,
+    *,
+    args: Sequence[str] = (),
+) -> LocalReferenceEhdbInvocation | None:
+    """Return a configured EHDB helper invocation plan, or None when disabled."""
+
+    source_env = os.environ if env is None else env
+    adapter = ehdb_adapter_from_env(source_env)
+    if adapter is None:
+        return None
+    executable = _non_empty_text(
+        source_env.get(EHDB_HELPER_BIN_ENV),
+        EHDB_HELPER_BIN_ENV,
+    )
+    return adapter.helper_invocation(executable=executable, args=args)
+
+
+def _non_empty_text(value: str | None, label: str) -> str:
+    if value is None or not value.strip():
+        raise ValueError(f"{label} is required")
+    return value.strip()

--- a/tests/core/test_ehdb_adapter.py
+++ b/tests/core/test_ehdb_adapter.py
@@ -3,8 +3,11 @@ from pathlib import Path
 import pytest
 
 from noetl.core.ehdb_adapter import (
+    EHDB_HELPER_BIN_ENV,
     LocalReferenceEhdbAdapter,
+    LocalReferenceEhdbInvocation,
     ehdb_adapter_from_env,
+    ehdb_helper_invocation_from_env,
 )
 from noetl.core.ehdb_contract import (
     EHDB_CLIENT_ROLE_ENV,
@@ -68,6 +71,106 @@ def test_ehdb_adapter_exports_worker_runtime_env():
     }
 
 
+def test_ehdb_helper_invocation_returns_none_when_disabled():
+    assert ehdb_helper_invocation_from_env({}) is None
+
+
+def test_ehdb_helper_invocation_builds_worker_argv_and_env():
+    invocation = ehdb_helper_invocation_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            EHDB_HELPER_BIN_ENV: "/opt/noetl/bin/ehdb-local-reference",
+        },
+        args=("replay", "--dry-run"),
+    )
+
+    assert isinstance(invocation, LocalReferenceEhdbInvocation)
+    assert invocation.argv == (
+        "/opt/noetl/bin/ehdb-local-reference",
+        "replay",
+        "--dry-run",
+    )
+    assert invocation.role is EhdbClientRole.WORKER
+    assert invocation.local_reference_log == Path("/tmp/noetl-ehdb.jsonl")
+    assert invocation.env == {
+        EHDB_ENABLED_ENV: "true",
+        EHDB_MODE_ENV: EhdbIntegrationMode.LOCAL_REFERENCE.value,
+        EHDB_CLIENT_ROLE_ENV: EhdbClientRole.WORKER.value,
+        EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+    }
+
+
+def test_ehdb_helper_invocation_builds_playbook_plan():
+    invocation = ehdb_helper_invocation_from_env(
+        {
+            EHDB_ENABLED_ENV: "1",
+            EHDB_CLIENT_ROLE_ENV: "playbook",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "var/noetl/ehdb/reference.jsonl",
+            EHDB_HELPER_BIN_ENV: "ehdb-local-reference",
+        },
+        args=("scan",),
+    )
+
+    assert invocation is not None
+    assert invocation.argv == ("ehdb-local-reference", "scan")
+    assert invocation.role is EhdbClientRole.PLAYBOOK
+    assert invocation.local_reference_log == Path("var/noetl/ehdb/reference.jsonl")
+
+
+def test_ehdb_helper_invocation_merges_subprocess_env():
+    invocation = ehdb_helper_invocation_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            EHDB_HELPER_BIN_ENV: "ehdb-local-reference",
+        }
+    )
+
+    assert invocation is not None
+    merged = invocation.subprocess_env(
+        {
+            "PATH": "/usr/bin",
+            EHDB_ENABLED_ENV: "false",
+        }
+    )
+
+    assert merged["PATH"] == "/usr/bin"
+    assert merged[EHDB_ENABLED_ENV] == "true"
+    assert merged[EHDB_CLIENT_ROLE_ENV] == "worker"
+    assert merged[EHDB_LOCAL_REFERENCE_LOG_ENV] == "/tmp/noetl-ehdb.jsonl"
+
+
+def test_ehdb_helper_invocation_requires_explicit_helper_executable():
+    with pytest.raises(ValueError, match=EHDB_HELPER_BIN_ENV):
+        ehdb_helper_invocation_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_CLIENT_ROLE_ENV: "worker",
+                EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            }
+        )
+
+
+def test_ehdb_helper_invocation_rejects_blank_helper_args():
+    adapter = ehdb_adapter_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+        }
+    )
+
+    assert adapter is not None
+    with pytest.raises(ValueError, match="EHDB helper arg 1"):
+        adapter.helper_invocation(
+            executable="ehdb-local-reference",
+            args=("scan", " "),
+        )
+
+
 def test_ehdb_adapter_rejects_gateway_role_via_contract():
     with pytest.raises(ValueError, match="gateway remains a gatekeeper"):
         ehdb_adapter_from_env(
@@ -75,6 +178,18 @@ def test_ehdb_adapter_rejects_gateway_role_via_contract():
                 EHDB_ENABLED_ENV: "true",
                 EHDB_CLIENT_ROLE_ENV: "gateway",
                 EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            }
+        )
+
+
+def test_ehdb_helper_invocation_rejects_gateway_role_via_contract():
+    with pytest.raises(ValueError, match="gateway remains a gatekeeper"):
+        ehdb_helper_invocation_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_CLIENT_ROLE_ENV: "gateway",
+                EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+                EHDB_HELPER_BIN_ENV: "ehdb-local-reference",
             }
         )
 
@@ -91,4 +206,3 @@ def test_local_reference_adapter_requires_local_reference_contract():
     adapter = LocalReferenceEhdbAdapter.from_contract(contract)
 
     assert adapter.runtime_env()[EHDB_MODE_ENV] == "local_reference"
-


### PR DESCRIPTION
Closes #672

## Summary
- add a side-effect-free EHDB local-reference helper invocation descriptor
- require an explicit `NOETL_EHDB_HELPER_BIN` only when building an enabled invocation plan
- expose deterministic argv/env plus subprocess env merging for worker/playbook use
- keep gateway/server roles rejected by the existing EHDB contract
- document the invocation planning boundary in the README

## Boundary
This is invocation planning only. It does not execute a subprocess, import Rust EHDB, open local logs, connect to EHDB, replace dependencies, add gateway routes, add production storage behavior, or start persistent per-tenant services.

## Validation
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py`
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_runtime_topology.py tests/core/runtime/test_pool_routing.py`
- `.venv/bin/python -m compileall -q noetl/core/ehdb_contract.py noetl/core/ehdb_adapter.py`
- `git diff --check README.md noetl/core/ehdb_adapter.py tests/core/test_ehdb_adapter.py`