### PR TITLE
feat: add EHDB control-plane contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,26 +50,35 @@ execution-model boundary before any storage cutover exists.
 Environment flags:
 
 - `NOETL_EHDB_ENABLED=true` turns on contract validation.
-- `NOETL_EHDB_MODE=local_reference` selects the local reference
-  readiness mode.
-- `NOETL_EHDB_CLIENT_ROLE=worker|playbook` declares the caller role.
+- `NOETL_EHDB_MODE=control_plane|local_reference` selects either
+  control-plane embedding or local reference readiness mode.
+- `NOETL_EHDB_CLIENT_ROLE=gateway|api|server|worker|playbook|system`
+  declares the caller role.
+- `NOETL_EHDB_CAPABILITIES=control_plane` is the only capability
+  accepted for gateway/API/server control-plane embedding. Worker,
+  playbook, and system local-reference configs default to explicit
+  data-plane capabilities unless narrowed with a comma-separated list.
 - `NOETL_EHDB_LOCAL_REFERENCE_LOG=/path/to/ehdb.jsonl` provides the
   explicit local event-log path for the reference mode.
 - `NOETL_EHDB_HELPER_BIN=/path/to/helper` is required only when a
   worker/playbook asks NoETL to build a local-reference helper
   invocation plan.
 
-Gateway/server roles are rejected when EHDB is enabled. Gateway remains
-the gatekeeper; workers remain atomic compute; playbooks remain
-ephemeral blueprints; shared cache remains a state vehicle; the event
-log remains the source of truth. This contract does not connect to EHDB,
-replace PostgreSQL/NATS/object stores, add a gateway route, or start a
+Gateway/API/server roles are accepted only in explicit `control_plane`
+mode with the `control_plane` capability. They are still rejected for
+`local_reference` and any data-plane capability. Gateway remains the
+gatekeeper; workers remain atomic compute; playbooks remain ephemeral
+blueprints; shared cache remains a state vehicle; the event log remains
+the source of truth. This contract does not connect to EHDB, replace
+PostgreSQL/NATS/object stores, add a gateway route, or start a
 persistent per-tenant process.
 
 `noetl.core.ehdb_adapter.ehdb_adapter_from_env` builds the disabled-by-
 default adapter descriptor behind that contract. Disabled configuration
-returns `None`; worker/playbook `local_reference` configuration returns
-a `LocalReferenceEhdbAdapter` carrying the explicit event-log path and
+returns `None`; gateway/API/server `control_plane` configuration also
+returns `None` because it has no data-plane helper. Worker/playbook
+`local_reference` configuration returns a `LocalReferenceEhdbAdapter`
+carrying the explicit event-log path, data-plane capability set, and
 exportable runtime environment for future EHDB helper calls. The adapter
 does not open logs, connect to EHDB, or perform storage operations.
 

--- a/noetl/core/ehdb_adapter.py
+++ b/noetl/core/ehdb_adapter.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Mapping, Sequence
 
 from noetl.core.ehdb_contract import (
+    EHDB_CAPABILITIES_ENV,
     EHDB_CLIENT_ROLE_ENV,
     EHDB_ENABLED_ENV,
     EHDB_LOCAL_REFERENCE_LOG_ENV,
@@ -85,6 +86,9 @@ class LocalReferenceEhdbAdapter:
             EHDB_ENABLED_ENV: "true",
             EHDB_MODE_ENV: EhdbIntegrationMode.LOCAL_REFERENCE.value,
             EHDB_CLIENT_ROLE_ENV: self.role.value,
+            EHDB_CAPABILITIES_ENV: ",".join(
+                sorted(capability.value for capability in self.contract.capabilities)
+            ),
             EHDB_LOCAL_REFERENCE_LOG_ENV: str(self.local_reference_log),
         }
 
@@ -118,6 +122,8 @@ def ehdb_adapter_from_env(
 
     contract = ehdb_integration_contract_from_env(os.environ if env is None else env)
     if not contract.enabled:
+        return None
+    if contract.mode is not EhdbIntegrationMode.LOCAL_REFERENCE:
         return None
     return LocalReferenceEhdbAdapter.from_contract(contract)
 

--- a/noetl/core/ehdb_contract.py
+++ b/noetl/core/ehdb_contract.py
@@ -16,20 +16,56 @@ from typing import Mapping
 EHDB_ENABLED_ENV = "NOETL_EHDB_ENABLED"
 EHDB_MODE_ENV = "NOETL_EHDB_MODE"
 EHDB_CLIENT_ROLE_ENV = "NOETL_EHDB_CLIENT_ROLE"
+EHDB_CAPABILITIES_ENV = "NOETL_EHDB_CAPABILITIES"
 EHDB_LOCAL_REFERENCE_LOG_ENV = "NOETL_EHDB_LOCAL_REFERENCE_LOG"
 NOETL_RUN_MODE_ENV = "NOETL_RUN_MODE"
 
 
 class EhdbIntegrationMode(StrEnum):
     DISABLED = "disabled"
+    CONTROL_PLANE = "control_plane"
     LOCAL_REFERENCE = "local_reference"
 
 
 class EhdbClientRole(StrEnum):
     GATEWAY = "gateway"
+    API = "api"
     SERVER = "server"
     WORKER = "worker"
     PLAYBOOK = "playbook"
+    SYSTEM = "system"
+
+
+class EhdbCapability(StrEnum):
+    CONTROL_PLANE = "control_plane"
+    CATALOG_READ = "catalog_read"
+    CATALOG_WRITE = "catalog_write"
+    TRANSACTION_APPEND = "transaction_append"
+    STREAM_APPEND = "stream_append"
+    STREAM_CONSUME = "stream_consume"
+    OBJECT_READ = "object_read"
+    OBJECT_WRITE = "object_write"
+    RETRIEVAL_READ = "retrieval_read"
+    RETRIEVAL_WRITE = "retrieval_write"
+    REPLICATION_PLAN = "replication_plan"
+    SYSTEM_LIBRARY_RESOLVE = "system_library_resolve"
+
+
+_CONTROL_PLANE_ROLES = {
+    EhdbClientRole.GATEWAY,
+    EhdbClientRole.API,
+    EhdbClientRole.SERVER,
+}
+_LOCAL_REFERENCE_ROLES = {
+    EhdbClientRole.WORKER,
+    EhdbClientRole.PLAYBOOK,
+    EhdbClientRole.SYSTEM,
+}
+_DATA_PLANE_CAPABILITIES = frozenset(
+    capability
+    for capability in EhdbCapability
+    if capability is not EhdbCapability.CONTROL_PLANE
+)
 
 
 @dataclass(frozen=True)
@@ -37,11 +73,19 @@ class EhdbIntegrationContract:
     enabled: bool
     mode: EhdbIntegrationMode
     role: EhdbClientRole
+    capabilities: frozenset[EhdbCapability]
     local_reference_log: Path | None = None
 
     @property
     def uses_local_reference_runtime(self) -> bool:
         return self.enabled and self.mode is EhdbIntegrationMode.LOCAL_REFERENCE
+
+    @property
+    def uses_control_plane_embedding(self) -> bool:
+        return self.enabled and self.mode is EhdbIntegrationMode.CONTROL_PLANE
+
+    def allows_capability(self, capability: EhdbCapability) -> bool:
+        return capability in self.capabilities
 
 
 def ehdb_integration_contract_from_env(
@@ -52,12 +96,14 @@ def ehdb_integration_contract_from_env(
     enabled = _truthy(env.get(EHDB_ENABLED_ENV))
     role = _client_role(env)
     mode = _integration_mode(env, enabled=enabled)
+    capabilities = _capabilities(env, enabled=enabled, mode=mode)
     local_reference_log = _path_or_none(env.get(EHDB_LOCAL_REFERENCE_LOG_ENV))
 
     contract = EhdbIntegrationContract(
         enabled=enabled,
         mode=mode,
         role=role,
+        capabilities=capabilities,
         local_reference_log=local_reference_log,
     )
     validate_ehdb_integration_contract(contract)
@@ -70,17 +116,50 @@ def validate_ehdb_integration_contract(
     if not contract.enabled:
         if contract.mode is not EhdbIntegrationMode.DISABLED:
             raise ValueError("disabled EHDB integration must use disabled mode")
+        if contract.capabilities:
+            raise ValueError("disabled EHDB integration must not declare capabilities")
         return contract
 
-    if contract.role in {EhdbClientRole.GATEWAY, EhdbClientRole.SERVER}:
+    if contract.mode is EhdbIntegrationMode.CONTROL_PLANE:
+        if contract.role not in _CONTROL_PLANE_ROLES:
+            raise ValueError(
+                "EHDB control-plane embedding is only supported for "
+                "gateway/api/server roles"
+            )
+        if contract.capabilities != frozenset({EhdbCapability.CONTROL_PLANE}):
+            raise ValueError(
+                "EHDB control-plane embedding only allows control_plane capability"
+            )
+        if contract.local_reference_log is not None:
+            raise ValueError(
+                "EHDB control-plane embedding must not define "
+                "NOETL_EHDB_LOCAL_REFERENCE_LOG"
+            )
+        return contract
+
+    if contract.role in _CONTROL_PLANE_ROLES:
         raise ValueError(
-            "EHDB integration may not run in gateway/server roles; "
-            "gateway remains a gatekeeper and must not touch data directly"
+            "EHDB data-plane integration may not run in gateway/api/server "
+            "roles; gateway remains a gatekeeper and must not touch data directly"
         )
 
     if contract.mode is not EhdbIntegrationMode.LOCAL_REFERENCE:
         raise ValueError(
-            "enabled EHDB integration currently supports local_reference only"
+            "enabled EHDB integration currently supports control_plane "
+            "or local_reference mode only"
+        )
+
+    if contract.role not in _LOCAL_REFERENCE_ROLES:
+        raise ValueError("EHDB local_reference mode requires worker/playbook/system role")
+
+    if not contract.capabilities or EhdbCapability.CONTROL_PLANE in contract.capabilities:
+        raise ValueError("EHDB local_reference mode requires data-plane capabilities")
+
+    unsupported_capabilities = contract.capabilities - _DATA_PLANE_CAPABILITIES
+    if unsupported_capabilities:
+        raise ValueError(
+            "EHDB local_reference mode received unsupported capabilities: "
+            + ", ".join(sorted(capability.value for capability in unsupported_capabilities))
         )
 
     if contract.local_reference_log is None:
@@ -111,6 +190,36 @@ def _integration_mode(
         return EhdbIntegrationMode(raw.strip().lower())
     except ValueError as exc:
         raise ValueError(f"unsupported EHDB integration mode: {raw}") from exc
+
+
+def _capabilities(
+    env: Mapping[str, str],
+    *,
+    enabled: bool,
+    mode: EhdbIntegrationMode,
+) -> frozenset[EhdbCapability]:
+    raw = env.get(EHDB_CAPABILITIES_ENV)
+    if not enabled:
+        if raw is not None and raw.strip():
+            raise ValueError("disabled EHDB integration must not declare capabilities")
+        return frozenset()
+    if raw is None or not raw.strip():
+        if mode is EhdbIntegrationMode.CONTROL_PLANE:
+            return frozenset({EhdbCapability.CONTROL_PLANE})
+        if mode is EhdbIntegrationMode.LOCAL_REFERENCE:
+            return _DATA_PLANE_CAPABILITIES
+        return frozenset()
+
+    capabilities: set[EhdbCapability] = set()
+    for token in raw.split(","):
+        normalized = token.strip().lower()
+        if not normalized:
+            raise ValueError("empty EHDB capability token")
+        try:
+            capabilities.add(EhdbCapability(normalized))
+        except ValueError as exc:
+            raise ValueError(f"unsupported EHDB capability: {token}") from exc
+    return frozenset(capabilities)
 
 
 def _client_role(env: Mapping[str, str]) -> EhdbClientRole:

--- a/tests/core/test_ehdb_adapter.py
+++ b/tests/core/test_ehdb_adapter.py
@@ -10,10 +10,12 @@ from noetl.core.ehdb_adapter import (
     ehdb_helper_invocation_from_env,
 )
 from noetl.core.ehdb_contract import (
+    EHDB_CAPABILITIES_ENV,
     EHDB_CLIENT_ROLE_ENV,
     EHDB_ENABLED_ENV,
     EHDB_LOCAL_REFERENCE_LOG_ENV,
     EHDB_MODE_ENV,
+    EhdbCapability,
     EhdbClientRole,
     EhdbIntegrationMode,
     ehdb_integration_contract_from_env,
@@ -22,6 +24,17 @@ from noetl.core.ehdb_contract import (
 
 def test_ehdb_adapter_returns_none_when_disabled():
     assert ehdb_adapter_from_env({}) is None
+
+
+def test_ehdb_adapter_returns_none_for_control_plane_embedding():
+    env = {
+        EHDB_ENABLED_ENV: "true",
+        EHDB_MODE_ENV: "control_plane",
+        EHDB_CLIENT_ROLE_ENV: "gateway",
+    }
+
+    assert ehdb_adapter_from_env(env) is None
+    assert ehdb_helper_invocation_from_env(env) is None
 
 
 def test_ehdb_adapter_builds_worker_local_reference_adapter():
@@ -63,11 +76,19 @@ def test_ehdb_adapter_exports_worker_runtime_env():
     )
 
     assert adapter is not None
-    assert adapter.runtime_env() == {
+    runtime_env = adapter.runtime_env()
+
+    assert runtime_env == {
         EHDB_ENABLED_ENV: "true",
         EHDB_MODE_ENV: EhdbIntegrationMode.LOCAL_REFERENCE.value,
         EHDB_CLIENT_ROLE_ENV: EhdbClientRole.WORKER.value,
+        EHDB_CAPABILITIES_ENV: runtime_env[EHDB_CAPABILITIES_ENV],
         EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+    }
+    assert set(runtime_env[EHDB_CAPABILITIES_ENV].split(",")) == {
+        capability.value
+        for capability in EhdbCapability
+        if capability is not EhdbCapability.CONTROL_PLANE
     }
 
 
@@ -98,8 +119,12 @@ def test_ehdb_helper_invocation_builds_worker_argv_and_env():
         EHDB_ENABLED_ENV: "true",
         EHDB_MODE_ENV: EhdbIntegrationMode.LOCAL_REFERENCE.value,
         EHDB_CLIENT_ROLE_ENV: EhdbClientRole.WORKER.value,
+        EHDB_CAPABILITIES_ENV: invocation.env[EHDB_CAPABILITIES_ENV],
         EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
     }
+    assert EhdbCapability.TRANSACTION_APPEND.value in invocation.env[
+        EHDB_CAPABILITIES_ENV
+    ].split(",")
 
 
 def test_ehdb_helper_invocation_builds_playbook_plan():
@@ -140,6 +165,7 @@ def test_ehdb_helper_invocation_merges_subprocess_env():
     assert merged["PATH"] == "/usr/bin"
     assert merged[EHDB_ENABLED_ENV] == "true"
     assert merged[EHDB_CLIENT_ROLE_ENV] == "worker"
+    assert EhdbCapability.STREAM_APPEND.value in merged[EHDB_CAPABILITIES_ENV].split(",")
     assert merged[EHDB_LOCAL_REFERENCE_LOG_ENV] == "/tmp/noetl-ehdb.jsonl"
 
 

--- a/tests/core/test_ehdb_contract.py
+++ b/tests/core/test_ehdb_contract.py
@@ -3,11 +3,13 @@ from pathlib import Path
 import pytest
 
 from noetl.core.ehdb_contract import (
+    EHDB_CAPABILITIES_ENV,
     EHDB_CLIENT_ROLE_ENV,
     EHDB_ENABLED_ENV,
     EHDB_LOCAL_REFERENCE_LOG_ENV,
     EHDB_MODE_ENV,
     NOETL_RUN_MODE_ENV,
+    EhdbCapability,
     EhdbClientRole,
     EhdbIntegrationMode,
     ehdb_integration_contract_from_env,
@@ -20,8 +22,10 @@ def test_ehdb_contract_is_disabled_by_default():
     assert contract.enabled is False
     assert contract.mode is EhdbIntegrationMode.DISABLED
     assert contract.role is EhdbClientRole.WORKER
+    assert contract.capabilities == frozenset()
     assert contract.local_reference_log is None
     assert contract.uses_local_reference_runtime is False
+    assert contract.uses_control_plane_embedding is False
 
 
 def test_ehdb_contract_accepts_worker_local_reference_mode():
@@ -36,8 +40,11 @@ def test_ehdb_contract_accepts_worker_local_reference_mode():
     assert contract.enabled is True
     assert contract.mode is EhdbIntegrationMode.LOCAL_REFERENCE
     assert contract.role is EhdbClientRole.WORKER
+    assert EhdbCapability.TRANSACTION_APPEND in contract.capabilities
+    assert contract.allows_capability(EhdbCapability.STREAM_APPEND)
     assert contract.local_reference_log == Path("/tmp/noetl-ehdb.jsonl")
     assert contract.uses_local_reference_runtime is True
+    assert contract.uses_control_plane_embedding is False
 
 
 def test_ehdb_contract_accepts_playbook_local_reference_mode():
@@ -54,7 +61,39 @@ def test_ehdb_contract_accepts_playbook_local_reference_mode():
     assert contract.local_reference_log == Path("var/noetl/ehdb/reference.jsonl")
 
 
-@pytest.mark.parametrize("role", ["gateway", "server"])
+@pytest.mark.parametrize("role", ["gateway", "api", "server"])
+def test_ehdb_contract_accepts_control_plane_embedding_for_gatekeeper_roles(role):
+    contract = ehdb_integration_contract_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: "control_plane",
+            EHDB_CLIENT_ROLE_ENV: role,
+        }
+    )
+
+    assert contract.enabled is True
+    assert contract.mode is EhdbIntegrationMode.CONTROL_PLANE
+    assert contract.role.value == role
+    assert contract.capabilities == frozenset({EhdbCapability.CONTROL_PLANE})
+    assert contract.local_reference_log is None
+    assert contract.uses_control_plane_embedding is True
+    assert contract.uses_local_reference_runtime is False
+
+
+def test_ehdb_contract_accepts_server_run_mode_for_control_plane_embedding():
+    contract = ehdb_integration_contract_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: "control_plane",
+            NOETL_RUN_MODE_ENV: "server",
+        }
+    )
+
+    assert contract.role is EhdbClientRole.SERVER
+    assert contract.uses_control_plane_embedding is True
+
+
+@pytest.mark.parametrize("role", ["gateway", "api", "server"])
 def test_ehdb_contract_rejects_gateway_and_server_data_touch_roles(role):
     with pytest.raises(ValueError, match="gateway remains a gatekeeper"):
         ehdb_integration_contract_from_env(
@@ -72,6 +111,68 @@ def test_ehdb_contract_rejects_server_run_mode_when_role_is_not_overridden():
             {
                 EHDB_ENABLED_ENV: "true",
                 NOETL_RUN_MODE_ENV: "server",
+                EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            }
+        )
+
+
+def test_ehdb_contract_rejects_control_plane_data_capabilities():
+    with pytest.raises(ValueError, match="only allows control_plane capability"):
+        ehdb_integration_contract_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_MODE_ENV: "control_plane",
+                EHDB_CLIENT_ROLE_ENV: "gateway",
+                EHDB_CAPABILITIES_ENV: "control_plane,catalog_read",
+            }
+        )
+
+
+def test_ehdb_contract_rejects_control_plane_local_reference_log():
+    with pytest.raises(ValueError, match=EHDB_LOCAL_REFERENCE_LOG_ENV):
+        ehdb_integration_contract_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_MODE_ENV: "control_plane",
+                EHDB_CLIENT_ROLE_ENV: "api",
+                EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            }
+        )
+
+
+def test_ehdb_contract_rejects_worker_control_plane_embedding():
+    with pytest.raises(ValueError, match="gateway/api/server"):
+        ehdb_integration_contract_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_MODE_ENV: "control_plane",
+                EHDB_CLIENT_ROLE_ENV: "worker",
+            }
+        )
+
+
+def test_ehdb_contract_accepts_explicit_local_reference_capabilities():
+    contract = ehdb_integration_contract_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_CAPABILITIES_ENV: "catalog_read,transaction_append",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+        }
+    )
+
+    assert contract.capabilities == frozenset(
+        {EhdbCapability.CATALOG_READ, EhdbCapability.TRANSACTION_APPEND}
+    )
+
+
+def test_ehdb_contract_rejects_local_reference_control_plane_capability():
+    with pytest.raises(ValueError, match="requires data-plane capabilities"):
+        ehdb_integration_contract_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_CLIENT_ROLE_ENV: "worker",
+                EHDB_CAPABILITIES_ENV: "control_plane",
                 EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
             }
         )
@@ -107,3 +208,12 @@ def test_ehdb_contract_rejects_unknown_mode_and_role():
             }
         )
 
+    with pytest.raises(ValueError, match="unsupported EHDB capability"):
+        ehdb_integration_contract_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_CLIENT_ROLE_ENV: "worker",
+                EHDB_CAPABILITIES_ENV: "gateway_data_read",
+                EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            }
+        )


### PR DESCRIPTION
Closes #674

## Summary
- add explicit `control_plane` EHDB mode for gateway/API/server embedding
- add `NOETL_EHDB_CAPABILITIES` and a NoETL-side capability contract mirroring EHDB core policy
- allow gateway/API/server only in control-plane mode with `control_plane` capability
- keep local-reference data-plane behavior worker/playbook/system-only with explicit event-log path
- keep local-reference adapter/helper factories no-op for control-plane mode
- document the embedded control-plane/data-plane split in the README

## Boundary
This is contract/modeling only. It does not connect to EHDB, import Rust EHDB, open local logs, execute helpers, add gateway routes, add storage behavior, or start persistent per-tenant services.

## Validation
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py`
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_runtime_topology.py tests/core/runtime/test_pool_routing.py`
- `.venv/bin/python -m compileall -q noetl/core/ehdb_contract.py noetl/core/ehdb_adapter.py`
- `git diff --check README.md noetl/core/ehdb_contract.py noetl/core/ehdb_adapter.py tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py`