### PR TITLE
feat: add EHDB control-plane descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ the source of truth. This contract does not connect to EHDB, replace
 PostgreSQL/NATS/object stores, add a gateway route, or start a
 persistent per-tenant process.
 
+`noetl.core.ehdb_control_plane.ehdb_control_plane_from_env` builds the
+planning-only descriptor for gateway/API/server control-plane embedding.
+Disabled configuration returns `None`; explicit `control_plane`
+configuration returns a `ControlPlaneEhdbEmbedding` carrying the caller
+role, the `control_plane` capability, and exportable runtime
+environment. The descriptor does not create an adapter, open logs,
+connect to EHDB, or perform storage operations.
+
 `noetl.core.ehdb_adapter.ehdb_adapter_from_env` builds the disabled-by-
 default adapter descriptor behind that contract. Disabled configuration
 returns `None`; gateway/API/server `control_plane` configuration also

--- a/noetl/core/ehdb_control_plane.py
+++ b/noetl/core/ehdb_control_plane.py
@@ -1,0 +1,80 @@
+"""Side-effect-free EHDB control-plane embedding descriptor for NoETL."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from noetl.core.ehdb_contract import (
+    EHDB_CAPABILITIES_ENV,
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    EHDB_MODE_ENV,
+    EhdbCapability,
+    EhdbClientRole,
+    EhdbIntegrationContract,
+    EhdbIntegrationMode,
+    ehdb_integration_contract_from_env,
+    validate_ehdb_integration_contract,
+)
+
+
+@dataclass(frozen=True)
+class ControlPlaneEhdbEmbedding:
+    """Planning-only descriptor for EHDB embedded in gateway/API/server roles."""
+
+    contract: EhdbIntegrationContract
+
+    @classmethod
+    def from_contract(
+        cls,
+        contract: EhdbIntegrationContract,
+    ) -> "ControlPlaneEhdbEmbedding":
+        validate_ehdb_integration_contract(contract)
+        if contract.mode is not EhdbIntegrationMode.CONTROL_PLANE:
+            raise ValueError("control-plane descriptor requires control_plane mode")
+        if contract.capabilities != frozenset({EhdbCapability.CONTROL_PLANE}):
+            raise ValueError(
+                "control-plane descriptor requires control_plane capability only"
+            )
+        if contract.role not in {
+            EhdbClientRole.GATEWAY,
+            EhdbClientRole.API,
+            EhdbClientRole.SERVER,
+        }:
+            raise ValueError(
+                "control-plane descriptor requires gateway, api, or server role"
+            )
+        return cls(contract=contract)
+
+    @property
+    def role(self) -> EhdbClientRole:
+        return self.contract.role
+
+    @property
+    def capabilities(self) -> frozenset[EhdbCapability]:
+        return self.contract.capabilities
+
+    def runtime_env(self) -> dict[str, str]:
+        """Return env vars that preserve control-plane-only embedding."""
+
+        return {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: EhdbIntegrationMode.CONTROL_PLANE.value,
+            EHDB_CLIENT_ROLE_ENV: self.role.value,
+            EHDB_CAPABILITIES_ENV: EhdbCapability.CONTROL_PLANE.value,
+        }
+
+
+def ehdb_control_plane_from_env(
+    env: Mapping[str, str] | None = None,
+) -> ControlPlaneEhdbEmbedding | None:
+    """Return the configured EHDB control-plane descriptor, or None."""
+
+    contract = ehdb_integration_contract_from_env(os.environ if env is None else env)
+    if not contract.enabled:
+        return None
+    if contract.mode is not EhdbIntegrationMode.CONTROL_PLANE:
+        return None
+    return ControlPlaneEhdbEmbedding.from_contract(contract)

--- a/tests/core/test_ehdb_control_plane.py
+++ b/tests/core/test_ehdb_control_plane.py
@@ -1,0 +1,114 @@
+import pytest
+
+from noetl.core.ehdb_control_plane import (
+    ControlPlaneEhdbEmbedding,
+    ehdb_control_plane_from_env,
+)
+from noetl.core.ehdb_contract import (
+    EHDB_CAPABILITIES_ENV,
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    EHDB_LOCAL_REFERENCE_LOG_ENV,
+    EHDB_MODE_ENV,
+    NOETL_RUN_MODE_ENV,
+    EhdbCapability,
+    EhdbClientRole,
+    EhdbIntegrationMode,
+    ehdb_integration_contract_from_env,
+)
+
+
+def test_ehdb_control_plane_returns_none_when_disabled():
+    assert ehdb_control_plane_from_env({}) is None
+
+
+@pytest.mark.parametrize(
+    ("role", "expected_role"),
+    [
+        ("gateway", EhdbClientRole.GATEWAY),
+        ("api", EhdbClientRole.API),
+        ("server", EhdbClientRole.SERVER),
+    ],
+)
+def test_ehdb_control_plane_builds_gatekeeper_descriptor(role, expected_role):
+    descriptor = ehdb_control_plane_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: "control_plane",
+            EHDB_CLIENT_ROLE_ENV: role,
+        }
+    )
+
+    assert isinstance(descriptor, ControlPlaneEhdbEmbedding)
+    assert descriptor.role is expected_role
+    assert descriptor.capabilities == frozenset({EhdbCapability.CONTROL_PLANE})
+
+
+def test_ehdb_control_plane_accepts_server_run_mode():
+    descriptor = ehdb_control_plane_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: "control_plane",
+            NOETL_RUN_MODE_ENV: "server",
+        }
+    )
+
+    assert descriptor is not None
+    assert descriptor.role is EhdbClientRole.SERVER
+
+
+def test_ehdb_control_plane_exports_runtime_env():
+    descriptor = ehdb_control_plane_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: "control_plane",
+            EHDB_CLIENT_ROLE_ENV: "gateway",
+        }
+    )
+
+    assert descriptor is not None
+    assert descriptor.runtime_env() == {
+        EHDB_ENABLED_ENV: "true",
+        EHDB_MODE_ENV: EhdbIntegrationMode.CONTROL_PLANE.value,
+        EHDB_CLIENT_ROLE_ENV: EhdbClientRole.GATEWAY.value,
+        EHDB_CAPABILITIES_ENV: EhdbCapability.CONTROL_PLANE.value,
+    }
+
+
+def test_ehdb_control_plane_returns_none_for_local_reference():
+    assert (
+        ehdb_control_plane_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_CLIENT_ROLE_ENV: "worker",
+                EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            }
+        )
+        is None
+    )
+
+
+def test_ehdb_control_plane_rejects_data_plane_capabilities():
+    with pytest.raises(ValueError, match="only allows control_plane capability"):
+        ehdb_control_plane_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_MODE_ENV: "control_plane",
+                EHDB_CLIENT_ROLE_ENV: "gateway",
+                EHDB_CAPABILITIES_ENV: "control_plane,catalog_read",
+            }
+        )
+
+
+def test_control_plane_descriptor_requires_control_plane_contract():
+    contract = ehdb_integration_contract_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: "control_plane",
+            EHDB_CLIENT_ROLE_ENV: "api",
+        }
+    )
+
+    descriptor = ControlPlaneEhdbEmbedding.from_contract(contract)
+
+    assert descriptor.runtime_env()[EHDB_CLIENT_ROLE_ENV] == "api"


### PR DESCRIPTION
Closes #676

## Summary
- add `noetl.core.ehdb_control_plane` with a side-effect-free control-plane embedding descriptor
- return no descriptor when EHDB is disabled or configured for local-reference data-plane mode
- build descriptors for gateway/API/server `control_plane` contracts carrying role, control-plane capability, and exportable runtime env
- keep data-plane/local-reference rejection delegated to the existing contract
- document the planning-only descriptor in the README

## Boundary
This is descriptor/modeling only. It does not connect to EHDB, import Rust EHDB, open local logs, execute helpers, add gateway routes, add storage behavior, or start persistent per-tenant services.

## Validation
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_ehdb_control_plane.py`
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_ehdb_control_plane.py tests/core/test_runtime_topology.py tests/core/runtime/test_pool_routing.py`
- `.venv/bin/python -m compileall -q noetl/core/ehdb_contract.py noetl/core/ehdb_adapter.py noetl/core/ehdb_control_plane.py`
- `git diff --check README.md noetl/core/ehdb_control_plane.py tests/core/test_ehdb_control_plane.py`