### PR TITLE
feat: add EHDB surface selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ role, the `control_plane` capability, and exportable runtime
 environment. The descriptor does not create an adapter, open logs,
 connect to EHDB, or perform storage operations.
 
+`noetl.core.ehdb_surface.ehdb_surface_from_env` is the common
+side-effect-free selector. It returns `None` when EHDB is disabled,
+returns the control-plane descriptor for gateway/API/server
+`control_plane` configs, and returns the local-reference adapter for
+worker/playbook/system data-plane configs. The selected surface exposes
+role, mode, capabilities, and runtime env without opening logs,
+executing helpers, or importing EHDB.
+
 `noetl.core.ehdb_adapter.ehdb_adapter_from_env` builds the disabled-by-
 default adapter descriptor behind that contract. Disabled configuration
 returns `None`; gateway/API/server `control_plane` configuration also

--- a/noetl/core/ehdb_surface.py
+++ b/noetl/core/ehdb_surface.py
@@ -1,0 +1,71 @@
+"""Unified side-effect-free EHDB surface selector for NoETL."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from noetl.core.ehdb_adapter import LocalReferenceEhdbAdapter, ehdb_adapter_from_env
+from noetl.core.ehdb_contract import (
+    EhdbCapability,
+    EhdbClientRole,
+    EhdbIntegrationMode,
+    ehdb_integration_contract_from_env,
+)
+from noetl.core.ehdb_control_plane import (
+    ControlPlaneEhdbEmbedding,
+    ehdb_control_plane_from_env,
+)
+
+
+@dataclass(frozen=True)
+class EhdbIntegrationSurface:
+    """Selected EHDB integration surface without performing data access."""
+
+    surface: ControlPlaneEhdbEmbedding | LocalReferenceEhdbAdapter
+
+    @property
+    def mode(self) -> EhdbIntegrationMode:
+        return self.surface.contract.mode
+
+    @property
+    def role(self) -> EhdbClientRole:
+        return self.surface.role
+
+    @property
+    def capabilities(self) -> frozenset[EhdbCapability]:
+        return self.surface.contract.capabilities
+
+    @property
+    def is_control_plane(self) -> bool:
+        return isinstance(self.surface, ControlPlaneEhdbEmbedding)
+
+    @property
+    def is_local_reference(self) -> bool:
+        return isinstance(self.surface, LocalReferenceEhdbAdapter)
+
+    def runtime_env(self) -> dict[str, str]:
+        return self.surface.runtime_env()
+
+
+def ehdb_surface_from_env(
+    env: Mapping[str, str] | None = None,
+) -> EhdbIntegrationSurface | None:
+    """Return the configured EHDB surface, or None when EHDB is disabled."""
+
+    source_env = os.environ if env is None else env
+    contract = ehdb_integration_contract_from_env(source_env)
+    if not contract.enabled:
+        return None
+
+    if contract.mode is EhdbIntegrationMode.CONTROL_PLANE:
+        surface = ehdb_control_plane_from_env(source_env)
+    elif contract.mode is EhdbIntegrationMode.LOCAL_REFERENCE:
+        surface = ehdb_adapter_from_env(source_env)
+    else:
+        surface = None
+
+    if surface is None:
+        return None
+    return EhdbIntegrationSurface(surface=surface)

--- a/tests/core/test_ehdb_surface.py
+++ b/tests/core/test_ehdb_surface.py
@@ -1,0 +1,88 @@
+import pytest
+
+from noetl.core.ehdb_contract import (
+    EHDB_CAPABILITIES_ENV,
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    EHDB_LOCAL_REFERENCE_LOG_ENV,
+    EHDB_MODE_ENV,
+    EhdbCapability,
+    EhdbClientRole,
+    EhdbIntegrationMode,
+)
+from noetl.core.ehdb_surface import EhdbIntegrationSurface, ehdb_surface_from_env
+
+
+def test_ehdb_surface_returns_none_when_disabled():
+    assert ehdb_surface_from_env({}) is None
+
+
+def test_ehdb_surface_selects_control_plane_descriptor():
+    surface = ehdb_surface_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: "control_plane",
+            EHDB_CLIENT_ROLE_ENV: "gateway",
+        }
+    )
+
+    assert isinstance(surface, EhdbIntegrationSurface)
+    assert surface.is_control_plane is True
+    assert surface.is_local_reference is False
+    assert surface.mode is EhdbIntegrationMode.CONTROL_PLANE
+    assert surface.role is EhdbClientRole.GATEWAY
+    assert surface.capabilities == frozenset({EhdbCapability.CONTROL_PLANE})
+    assert surface.runtime_env() == {
+        EHDB_ENABLED_ENV: "true",
+        EHDB_MODE_ENV: "control_plane",
+        EHDB_CLIENT_ROLE_ENV: "gateway",
+        EHDB_CAPABILITIES_ENV: "control_plane",
+    }
+
+
+def test_ehdb_surface_selects_local_reference_adapter():
+    surface = ehdb_surface_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+        }
+    )
+
+    assert isinstance(surface, EhdbIntegrationSurface)
+    assert surface.is_control_plane is False
+    assert surface.is_local_reference is True
+    assert surface.mode is EhdbIntegrationMode.LOCAL_REFERENCE
+    assert surface.role is EhdbClientRole.WORKER
+    assert EhdbCapability.TRANSACTION_APPEND in surface.capabilities
+    assert surface.runtime_env()[EHDB_LOCAL_REFERENCE_LOG_ENV] == "/tmp/noetl-ehdb.jsonl"
+
+
+def test_ehdb_surface_preserves_explicit_local_reference_capabilities():
+    surface = ehdb_surface_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "playbook",
+            EHDB_CAPABILITIES_ENV: "catalog_read,transaction_append",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "var/noetl/ehdb/reference.jsonl",
+        }
+    )
+
+    assert surface is not None
+    assert surface.capabilities == frozenset(
+        {EhdbCapability.CATALOG_READ, EhdbCapability.TRANSACTION_APPEND}
+    )
+    assert surface.runtime_env()[EHDB_CAPABILITIES_ENV] == (
+        "catalog_read,transaction_append"
+    )
+
+
+def test_ehdb_surface_rejects_gateway_local_reference_data_plane():
+    with pytest.raises(ValueError, match="gateway remains a gatekeeper"):
+        ehdb_surface_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_CLIENT_ROLE_ENV: "gateway",
+                EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            }
+        )


### PR DESCRIPTION
Closes #678

## Summary
- add `noetl.core.ehdb_surface` as the common side-effect-free EHDB surface selector
- return no surface when EHDB is disabled
- select the control-plane descriptor for gateway/API/server `control_plane` configs
- select the local-reference adapter for worker/playbook/system data-plane configs
- expose common role, mode, capabilities, and runtime env without opening logs or running helpers
- document the selector in the README

## Boundary
This is selection/modeling only. It does not connect to EHDB, import Rust EHDB, open local logs, execute helpers, add gateway routes, add storage behavior, or start persistent per-tenant services.

## Validation
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_ehdb_control_plane.py tests/core/test_ehdb_surface.py`
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_ehdb_control_plane.py tests/core/test_ehdb_surface.py tests/core/test_runtime_topology.py tests/core/runtime/test_pool_routing.py`
- `.venv/bin/python -m pytest tests/core/test_ehdb_surface.py`
- `.venv/bin/python -m compileall -q noetl/core/ehdb_contract.py noetl/core/ehdb_adapter.py noetl/core/ehdb_control_plane.py noetl/core/ehdb_surface.py`
- `git diff --check README.md noetl/core/ehdb_surface.py tests/core/test_ehdb_surface.py`