### PR TITLE
feat: execute EHDB local helper summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ invocation plan is immutable and side-effect-free; it does not execute a
 subprocess, import EHDB, open logs, connect to storage, or add
 gateway/server data paths.
 
+`noetl.core.ehdb_adapter.ehdb_local_reference_summary_invocation_from_env`
+builds the first concrete helper command:
+`ehdb-local-reference summary --log <path>`. Worker/playbook contexts
+may pass that invocation to
+`noetl.core.ehdb_adapter.execute_ehdb_helper_json`, which runs the
+helper without a shell, captures stdout/stderr, enforces a timeout, and
+decodes a JSON object. Disabled configuration returns `None`, and
+gateway/API/server local-reference roles remain rejected by the
+contract. This runner is for bounded local diagnostics and integration
+tests; it does not import Rust EHDB, open storage from the gateway,
+replace platform dependencies, or create persistent per-tenant
+processes.
+
 ## Repository model (ai-meta driven)
 
 NoETL development is now coordinated through the `ai-meta` repository:

--- a/noetl/core/ehdb_adapter.py
+++ b/noetl/core/ehdb_adapter.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import os
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import Any, Mapping, Sequence
 
 from noetl.core.ehdb_contract import (
     EHDB_CAPABILITIES_ENV,
@@ -49,6 +51,17 @@ class LocalReferenceEhdbInvocation:
         env = dict(base_env or {})
         env.update(self.env)
         return env
+
+
+@dataclass(frozen=True)
+class LocalReferenceEhdbExecution:
+    """Captured JSON result from a bounded EHDB helper execution."""
+
+    invocation: LocalReferenceEhdbInvocation
+    returncode: int
+    stdout: str
+    stderr: str
+    json_payload: Mapping[str, Any]
 
 
 @dataclass(frozen=True)
@@ -144,6 +157,86 @@ def ehdb_helper_invocation_from_env(
         EHDB_HELPER_BIN_ENV,
     )
     return adapter.helper_invocation(executable=executable, args=args)
+
+
+def ehdb_local_reference_summary_invocation_from_env(
+    env: Mapping[str, str] | None = None,
+) -> LocalReferenceEhdbInvocation | None:
+    """Return the concrete local-reference summary helper invocation."""
+
+    adapter = ehdb_adapter_from_env(os.environ if env is None else env)
+    if adapter is None:
+        return None
+    return ehdb_helper_invocation_from_env(
+        env,
+        args=("summary", "--log", str(adapter.local_reference_log)),
+    )
+
+
+def execute_ehdb_helper_json(
+    invocation: LocalReferenceEhdbInvocation,
+    *,
+    timeout_seconds: float = 30.0,
+    base_env: Mapping[str, str] | None = None,
+) -> LocalReferenceEhdbExecution:
+    """Execute a bounded EHDB helper and decode a JSON object from stdout."""
+
+    if timeout_seconds <= 0:
+        raise ValueError("EHDB helper timeout must be positive")
+
+    try:
+        completed = subprocess.run(
+            invocation.argv,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=invocation.subprocess_env(base_env),
+            timeout=timeout_seconds,
+        )
+    except FileNotFoundError as exc:
+        raise ValueError(f"EHDB helper executable not found: {invocation.executable}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise TimeoutError(
+            f"EHDB helper timed out after {timeout_seconds:g}s: {invocation.executable}"
+        ) from exc
+
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"EHDB helper exited with {completed.returncode}: {completed.stderr.strip()}"
+        )
+
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError("EHDB helper stdout was not valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("EHDB helper stdout must decode to a JSON object")
+
+    return LocalReferenceEhdbExecution(
+        invocation=invocation,
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+        json_payload=payload,
+    )
+
+
+def execute_ehdb_local_reference_summary_from_env(
+    env: Mapping[str, str] | None = None,
+    *,
+    timeout_seconds: float = 30.0,
+    base_env: Mapping[str, str] | None = None,
+) -> LocalReferenceEhdbExecution | None:
+    """Execute the configured local-reference summary helper, if enabled."""
+
+    invocation = ehdb_local_reference_summary_invocation_from_env(env)
+    if invocation is None:
+        return None
+    return execute_ehdb_helper_json(
+        invocation,
+        timeout_seconds=timeout_seconds,
+        base_env=base_env,
+    )
 
 
 def _non_empty_text(value: str | None, label: str) -> str:

--- a/tests/core/test_ehdb_adapter.py
+++ b/tests/core/test_ehdb_adapter.py
@@ -1,13 +1,18 @@
+import sys
 from pathlib import Path
 
 import pytest
 
 from noetl.core.ehdb_adapter import (
     EHDB_HELPER_BIN_ENV,
+    LocalReferenceEhdbExecution,
     LocalReferenceEhdbAdapter,
     LocalReferenceEhdbInvocation,
     ehdb_adapter_from_env,
     ehdb_helper_invocation_from_env,
+    ehdb_local_reference_summary_invocation_from_env,
+    execute_ehdb_helper_json,
+    execute_ehdb_local_reference_summary_from_env,
 )
 from noetl.core.ehdb_contract import (
     EHDB_CAPABILITIES_ENV,
@@ -144,6 +149,25 @@ def test_ehdb_helper_invocation_builds_playbook_plan():
     assert invocation.local_reference_log == Path("var/noetl/ehdb/reference.jsonl")
 
 
+def test_ehdb_summary_invocation_uses_concrete_helper_command():
+    invocation = ehdb_local_reference_summary_invocation_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            EHDB_HELPER_BIN_ENV: "ehdb-local-reference",
+        }
+    )
+
+    assert invocation is not None
+    assert invocation.argv == (
+        "ehdb-local-reference",
+        "summary",
+        "--log",
+        "/tmp/noetl-ehdb.jsonl",
+    )
+
+
 def test_ehdb_helper_invocation_merges_subprocess_env():
     invocation = ehdb_helper_invocation_from_env(
         {
@@ -167,6 +191,121 @@ def test_ehdb_helper_invocation_merges_subprocess_env():
     assert merged[EHDB_CLIENT_ROLE_ENV] == "worker"
     assert EhdbCapability.STREAM_APPEND.value in merged[EHDB_CAPABILITIES_ENV].split(",")
     assert merged[EHDB_LOCAL_REFERENCE_LOG_ENV] == "/tmp/noetl-ehdb.jsonl"
+
+
+def test_execute_ehdb_local_reference_summary_decodes_json(tmp_path):
+    helper = _helper_script(
+        tmp_path,
+        """
+import json
+import os
+import sys
+
+expected_log = os.environ["NOETL_EHDB_LOCAL_REFERENCE_LOG"]
+if sys.argv[1:] != ["summary", "--log", expected_log]:
+    print("unexpected argv", file=sys.stderr)
+    sys.exit(4)
+print(json.dumps({"transaction_count": 2, "stream_count": 1}))
+""",
+    )
+
+    execution = execute_ehdb_local_reference_summary_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: str(tmp_path / "ehdb.jsonl"),
+            EHDB_HELPER_BIN_ENV: str(helper),
+        },
+        base_env={"PATH": "/usr/bin"},
+    )
+
+    assert isinstance(execution, LocalReferenceEhdbExecution)
+    assert execution.returncode == 0
+    assert execution.json_payload == {"transaction_count": 2, "stream_count": 1}
+    assert execution.invocation.argv == (
+        str(helper),
+        "summary",
+        "--log",
+        str(tmp_path / "ehdb.jsonl"),
+    )
+
+
+def test_execute_ehdb_helper_json_returns_none_when_disabled():
+    assert execute_ehdb_local_reference_summary_from_env({}) is None
+
+
+def test_execute_ehdb_helper_json_rejects_gateway_role():
+    with pytest.raises(ValueError, match="gateway remains a gatekeeper"):
+        execute_ehdb_local_reference_summary_from_env(
+            {
+                EHDB_ENABLED_ENV: "true",
+                EHDB_CLIENT_ROLE_ENV: "gateway",
+                EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+                EHDB_HELPER_BIN_ENV: "ehdb-local-reference",
+            }
+        )
+
+
+def test_execute_ehdb_helper_json_raises_on_nonzero_exit(tmp_path):
+    helper = _helper_script(
+        tmp_path,
+        """
+import sys
+
+print("helper failed", file=sys.stderr)
+sys.exit(7)
+""",
+    )
+    invocation = LocalReferenceEhdbInvocation(
+        executable=str(helper),
+        args=("summary", "--log", str(tmp_path / "ehdb.jsonl")),
+        env_items=(),
+        role=EhdbClientRole.WORKER,
+        local_reference_log=tmp_path / "ehdb.jsonl",
+    )
+
+    with pytest.raises(RuntimeError, match="exited with 7"):
+        execute_ehdb_helper_json(invocation)
+
+
+def test_execute_ehdb_helper_json_raises_on_timeout(tmp_path):
+    helper = _helper_script(
+        tmp_path,
+        """
+import time
+
+time.sleep(2)
+""",
+    )
+    invocation = LocalReferenceEhdbInvocation(
+        executable=str(helper),
+        args=("summary", "--log", str(tmp_path / "ehdb.jsonl")),
+        env_items=(),
+        role=EhdbClientRole.WORKER,
+        local_reference_log=tmp_path / "ehdb.jsonl",
+    )
+
+    with pytest.raises(TimeoutError, match="timed out"):
+        execute_ehdb_helper_json(invocation, timeout_seconds=0.01)
+
+
+def test_execute_ehdb_helper_json_rejects_non_object_json(tmp_path):
+    helper = _helper_script(
+        tmp_path,
+        """
+print("[1, 2, 3]")
+""",
+    )
+    invocation = LocalReferenceEhdbInvocation(
+        executable=str(helper),
+        args=("summary", "--log", str(tmp_path / "ehdb.jsonl")),
+        env_items=(),
+        role=EhdbClientRole.WORKER,
+        local_reference_log=tmp_path / "ehdb.jsonl",
+    )
+
+    with pytest.raises(ValueError, match="JSON object"):
+        execute_ehdb_helper_json(invocation)
 
 
 def test_ehdb_helper_invocation_requires_explicit_helper_executable():
@@ -232,3 +371,10 @@ def test_local_reference_adapter_requires_local_reference_contract():
     adapter = LocalReferenceEhdbAdapter.from_contract(contract)
 
     assert adapter.runtime_env()[EHDB_MODE_ENV] == "local_reference"
+
+
+def _helper_script(tmp_path: Path, body: str) -> Path:
+    helper = tmp_path / "ehdb-helper.py"
+    helper.write_text(f"#!{sys.executable}\n{body.lstrip()}", encoding="utf-8")
+    helper.chmod(0o755)
+    return helper


### PR DESCRIPTION
## Summary
- add `ehdb_local_reference_summary_invocation_from_env` for the concrete `ehdb-local-reference summary --log <path>` command
- add bounded helper execution with no shell, captured stdout/stderr, timeout, non-zero handling, and JSON-object decode
- keep disabled/control-plane modes side-effect-free and preserve gateway/API/server local-reference rejection
- document the helper execution boundary in README

## Boundary
This is worker/playbook local helper execution only. It does not import Rust EHDB, open storage directly from gateway/API/server roles, add routes, replace PostgreSQL/NATS/object stores, or start persistent per-tenant processes.

## Validation
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_ehdb_control_plane.py tests/core/test_ehdb_surface.py` — 53 tests
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_ehdb_control_plane.py tests/core/test_ehdb_surface.py tests/core/test_runtime_topology.py tests/core/runtime/test_pool_routing.py` — 102 tests
- `.venv/bin/python -m compileall -q noetl/core/ehdb_contract.py noetl/core/ehdb_adapter.py noetl/core/ehdb_control_plane.py noetl/core/ehdb_surface.py`
- `git diff --check README.md noetl/core/ehdb_adapter.py tests/core/test_ehdb_adapter.py`
- local `forbid-client-term` added-line check

Closes #680
