### PR TITLE
feat: discover EHDB helper for summary smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ tests; it does not import Rust EHDB, open storage from the gateway,
 replace platform dependencies, or create persistent per-tenant
 processes.
 
+Helper discovery prefers explicit `NOETL_EHDB_HELPER_BIN`, then
+`ehdb-local-reference` on `PATH`, then image/runtime paths
+`/usr/local/bin/ehdb-local-reference` and
+`/opt/noetl/bin/ehdb-local-reference`, then the ai-meta sibling EHDB
+development build outputs under `../ehdb/target/{release,debug}`.
+`scripts/smoke_ehdb_local_reference_summary.py` exercises this path by
+running `summary --log <path>` and validating the returned JSON summary
+shape.
+
 ## Repository model (ai-meta driven)
 
 NoETL development is now coordinated through the `ai-meta` repository:

--- a/docker/noetl/README.md
+++ b/docker/noetl/README.md
@@ -39,3 +39,27 @@ docker build --push --platform linux/amd64 --no-cache \
 --progress plain --tag ghcr.io/noetl/noetl:v1.0.2 \
 --file docker/noetl/dev/Dockerfile .
 ```
+
+## EHDB helper binary
+
+NoETL can execute the bounded EHDB local-reference summary helper from
+worker/playbook contexts. Images that include EHDB should place the
+binary at one of these runtime paths:
+
+- `/usr/local/bin/ehdb-local-reference`
+- `/opt/noetl/bin/ehdb-local-reference`
+
+An operator can override discovery with:
+
+```bash
+NOETL_EHDB_HELPER_BIN=/custom/path/ehdb-local-reference
+```
+
+Local ai-meta workspaces can also use the sibling EHDB build outputs
+under `../ehdb/target/{release,debug}/ehdb-local-reference`. Validate a
+runtime image or local checkout with:
+
+```bash
+python scripts/smoke_ehdb_local_reference_summary.py \
+  --log /tmp/noetl-ehdb-smoke.jsonl
+```

--- a/noetl/core/ehdb_adapter.py
+++ b/noetl/core/ehdb_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -24,6 +25,7 @@ from noetl.core.ehdb_contract import (
 
 
 EHDB_HELPER_BIN_ENV = "NOETL_EHDB_HELPER_BIN"
+EHDB_LOCAL_REFERENCE_HELPER_NAME = "ehdb-local-reference"
 
 
 @dataclass(frozen=True)
@@ -159,16 +161,50 @@ def ehdb_helper_invocation_from_env(
     return adapter.helper_invocation(executable=executable, args=args)
 
 
+def discover_ehdb_helper_executable(
+    env: Mapping[str, str] | None = None,
+    *,
+    helper_name: str = EHDB_LOCAL_REFERENCE_HELPER_NAME,
+    candidates: Sequence[Path | str] = (),
+    include_default_candidates: bool = True,
+) -> str | None:
+    """Discover the EHDB helper binary without executing it."""
+
+    source_env = os.environ if env is None else env
+    explicit = source_env.get(EHDB_HELPER_BIN_ENV)
+    if explicit is not None:
+        return _non_empty_text(explicit, EHDB_HELPER_BIN_ENV)
+
+    found = shutil.which(helper_name, path=source_env.get("PATH"))
+    if found:
+        return found
+
+    helper_candidates = [Path(candidate) for candidate in candidates]
+    if include_default_candidates:
+        helper_candidates.extend(_default_ehdb_helper_candidates(helper_name))
+    for candidate in helper_candidates:
+        if _is_executable_file(candidate):
+            return str(candidate)
+    return None
+
+
 def ehdb_local_reference_summary_invocation_from_env(
     env: Mapping[str, str] | None = None,
 ) -> LocalReferenceEhdbInvocation | None:
     """Return the concrete local-reference summary helper invocation."""
 
-    adapter = ehdb_adapter_from_env(os.environ if env is None else env)
+    source_env = os.environ if env is None else env
+    adapter = ehdb_adapter_from_env(source_env)
     if adapter is None:
         return None
-    return ehdb_helper_invocation_from_env(
-        env,
+    executable = discover_ehdb_helper_executable(source_env)
+    if executable is None:
+        raise ValueError(
+            f"{EHDB_HELPER_BIN_ENV} is required or "
+            f"{EHDB_LOCAL_REFERENCE_HELPER_NAME} must be discoverable"
+        )
+    return adapter.helper_invocation(
+        executable=executable,
         args=("summary", "--log", str(adapter.local_reference_log)),
     )
 
@@ -243,3 +279,18 @@ def _non_empty_text(value: str | None, label: str) -> str:
     if value is None or not value.strip():
         raise ValueError(f"{label} is required")
     return value.strip()
+
+
+def _default_ehdb_helper_candidates(helper_name: str) -> tuple[Path, ...]:
+    repo_root = Path(__file__).resolve().parents[2]
+    repos_root = repo_root.parent
+    return (
+        Path("/usr/local/bin") / helper_name,
+        Path("/opt/noetl/bin") / helper_name,
+        repos_root / "ehdb" / "target" / "release" / helper_name,
+        repos_root / "ehdb" / "target" / "debug" / helper_name,
+    )
+
+
+def _is_executable_file(path: Path) -> bool:
+    return path.is_file() and os.access(path, os.X_OK)

--- a/scripts/smoke_ehdb_local_reference_summary.py
+++ b/scripts/smoke_ehdb_local_reference_summary.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Smoke the EHDB local-reference summary helper through NoETL."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from noetl.core.ehdb_adapter import (
+    EHDB_HELPER_BIN_ENV,
+    execute_ehdb_local_reference_summary_from_env,
+)
+from noetl.core.ehdb_contract import (
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    EHDB_LOCAL_REFERENCE_LOG_ENV,
+    EHDB_MODE_ENV,
+)
+
+
+REQUIRED_SUMMARY_FIELDS = (
+    "log_path",
+    "transaction_count",
+    "table_count",
+    "snapshot_count",
+    "scan_grant_count",
+    "stream_count",
+    "stream_record_count",
+    "stream_consumer_count",
+    "retrieval_document_count",
+    "retrieval_chunk_count",
+    "retrieval_embedding_count",
+    "system_library_count",
+    "system_binding_count",
+    "storage_object_count",
+    "storage_replica_count",
+)
+
+
+def run_smoke(
+    *,
+    helper_bin: str | None = None,
+    log_path: Path | None = None,
+    timeout_seconds: float = 30.0,
+    env: Mapping[str, str] | None = None,
+) -> Mapping[str, object]:
+    source_env = dict(os.environ if env is None else env)
+    log_path = log_path or _temporary_log_path()
+    source_env.update(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: "local_reference",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: str(log_path),
+        }
+    )
+    if helper_bin is not None:
+        source_env[EHDB_HELPER_BIN_ENV] = helper_bin
+
+    execution = execute_ehdb_local_reference_summary_from_env(
+        source_env,
+        timeout_seconds=timeout_seconds,
+    )
+    if execution is None:
+        raise RuntimeError("EHDB local-reference summary smoke was unexpectedly disabled")
+
+    missing = [field for field in REQUIRED_SUMMARY_FIELDS if field not in execution.json_payload]
+    if missing:
+        raise ValueError(f"EHDB summary missing required fields: {', '.join(missing)}")
+    if execution.json_payload["log_path"] != str(log_path):
+        raise ValueError("EHDB summary log_path does not match requested log")
+    return execution.json_payload
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run a bounded NoETL smoke against ehdb-local-reference summary.",
+    )
+    parser.add_argument(
+        "--helper-bin",
+        help="Path to ehdb-local-reference. Defaults to NoETL discovery.",
+    )
+    parser.add_argument(
+        "--log",
+        type=Path,
+        help="EHDB JSONL log to summarize. Defaults to a temporary empty log path.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Helper timeout in seconds. Default: 30.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        payload = run_smoke(
+            helper_bin=args.helper_bin,
+            log_path=args.log,
+            timeout_seconds=args.timeout,
+        )
+    except Exception as exc:
+        print(f"EHDB local-reference summary smoke failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+def _temporary_log_path() -> Path:
+    handle = tempfile.NamedTemporaryFile(
+        prefix="noetl-ehdb-summary-smoke-",
+        suffix=".jsonl",
+        delete=False,
+    )
+    handle.close()
+    return Path(handle.name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_ehdb_adapter.py
+++ b/tests/core/test_ehdb_adapter.py
@@ -5,9 +5,11 @@ import pytest
 
 from noetl.core.ehdb_adapter import (
     EHDB_HELPER_BIN_ENV,
+    EHDB_LOCAL_REFERENCE_HELPER_NAME,
     LocalReferenceEhdbExecution,
     LocalReferenceEhdbAdapter,
     LocalReferenceEhdbInvocation,
+    discover_ehdb_helper_executable,
     ehdb_adapter_from_env,
     ehdb_helper_invocation_from_env,
     ehdb_local_reference_summary_invocation_from_env,
@@ -165,6 +167,81 @@ def test_ehdb_summary_invocation_uses_concrete_helper_command():
         "summary",
         "--log",
         "/tmp/noetl-ehdb.jsonl",
+    )
+
+
+def test_ehdb_summary_invocation_discovers_helper_from_path(tmp_path):
+    helper = _helper_script(
+        tmp_path,
+        """
+print("{}")
+""",
+        name=EHDB_LOCAL_REFERENCE_HELPER_NAME,
+    )
+    invocation = ehdb_local_reference_summary_invocation_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            "PATH": str(tmp_path),
+        }
+    )
+
+    assert invocation is not None
+    assert invocation.argv == (
+        str(helper),
+        "summary",
+        "--log",
+        "/tmp/noetl-ehdb.jsonl",
+    )
+
+
+def test_ehdb_summary_invocation_prefers_explicit_helper_over_path(tmp_path):
+    _helper_script(
+        tmp_path,
+        """
+print("{}")
+""",
+        name=EHDB_LOCAL_REFERENCE_HELPER_NAME,
+    )
+    invocation = ehdb_local_reference_summary_invocation_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/noetl-ehdb.jsonl",
+            EHDB_HELPER_BIN_ENV: "/custom/ehdb-local-reference",
+            "PATH": str(tmp_path),
+        }
+    )
+
+    assert invocation is not None
+    assert invocation.executable == "/custom/ehdb-local-reference"
+
+
+def test_ehdb_helper_discovery_uses_candidate_paths(tmp_path):
+    helper = _helper_script(
+        tmp_path,
+        """
+print("{}")
+""",
+        name=EHDB_LOCAL_REFERENCE_HELPER_NAME,
+    )
+
+    assert discover_ehdb_helper_executable(
+        {"PATH": ""},
+        candidates=(tmp_path / "missing", helper),
+        include_default_candidates=False,
+    ) == str(helper)
+
+
+def test_ehdb_helper_discovery_returns_none_when_missing(tmp_path):
+    assert (
+        discover_ehdb_helper_executable(
+            {"PATH": str(tmp_path)},
+            candidates=(),
+            include_default_candidates=False,
+        )
+        is None
     )
 
 
@@ -373,8 +450,13 @@ def test_local_reference_adapter_requires_local_reference_contract():
     assert adapter.runtime_env()[EHDB_MODE_ENV] == "local_reference"
 
 
-def _helper_script(tmp_path: Path, body: str) -> Path:
-    helper = tmp_path / "ehdb-helper.py"
+def _helper_script(
+    tmp_path: Path,
+    body: str,
+    *,
+    name: str = "ehdb-helper.py",
+) -> Path:
+    helper = tmp_path / name
     helper.write_text(f"#!{sys.executable}\n{body.lstrip()}", encoding="utf-8")
     helper.chmod(0o755)
     return helper

--- a/tests/scripts/test_smoke_ehdb_local_reference_summary.py
+++ b/tests/scripts/test_smoke_ehdb_local_reference_summary.py
@@ -1,0 +1,70 @@
+import json
+import sys
+from pathlib import Path
+
+from scripts.smoke_ehdb_local_reference_summary import REQUIRED_SUMMARY_FIELDS, main, run_smoke
+
+
+def test_run_smoke_validates_summary_shape(tmp_path):
+    log_path = tmp_path / "ehdb.jsonl"
+    helper = _summary_helper(tmp_path)
+
+    payload = run_smoke(
+        helper_bin=str(helper),
+        log_path=log_path,
+        env={"PATH": "/usr/bin"},
+    )
+
+    assert payload["log_path"] == str(log_path)
+    assert payload["transaction_count"] == 0
+    assert set(REQUIRED_SUMMARY_FIELDS).issubset(payload)
+
+
+def test_main_prints_summary_json(tmp_path, capsys):
+    log_path = tmp_path / "ehdb.jsonl"
+    helper = _summary_helper(tmp_path)
+
+    result = main(["--helper-bin", str(helper), "--log", str(log_path)])
+
+    assert result == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["log_path"] == str(log_path)
+    assert output["storage_replica_count"] == 0
+
+
+def test_main_reports_missing_fields(tmp_path, capsys):
+    helper = _helper_script(
+        tmp_path,
+        """
+import json
+
+print(json.dumps({"log_path": "missing-counts"}))
+""",
+    )
+
+    result = main(["--helper-bin", str(helper), "--log", str(tmp_path / "ehdb.jsonl")])
+
+    assert result == 1
+    assert "missing required fields" in capsys.readouterr().err
+
+
+def _summary_helper(tmp_path: Path) -> Path:
+    fields = {field: 0 for field in REQUIRED_SUMMARY_FIELDS}
+    return _helper_script(
+        tmp_path,
+        f"""
+import json
+import sys
+
+payload = {fields!r}
+payload["log_path"] = sys.argv[3]
+print(json.dumps(payload))
+""",
+    )
+
+
+def _helper_script(tmp_path: Path, body: str) -> Path:
+    helper = tmp_path / "ehdb-local-reference"
+    helper.write_text(f"#!{sys.executable}\n{body.lstrip()}", encoding="utf-8")
+    helper.chmod(0o755)
+    return helper


### PR DESCRIPTION
## Summary
- discover `ehdb-local-reference` from explicit env, PATH, container paths, and ai-meta sibling EHDB build outputs
- keep explicit `NOETL_EHDB_HELPER_BIN` as the highest-priority override
- add `scripts/smoke_ehdb_local_reference_summary.py` to execute `summary --log <path>` and validate the EHDB JSON summary shape
- document expected image/runtime helper locations in README and `docker/noetl/README.md`

## Boundary
This is helper discovery and local smoke only. It does not import Rust EHDB, add gateway routes, open storage from gateway/API/server roles, replace PostgreSQL/NATS/object stores, or start persistent per-tenant processes.

## Validation
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_ehdb_control_plane.py tests/core/test_ehdb_surface.py tests/scripts/test_smoke_ehdb_local_reference_summary.py` — 60 tests
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_ehdb_control_plane.py tests/core/test_ehdb_surface.py tests/core/test_runtime_topology.py tests/core/runtime/test_pool_routing.py tests/scripts/test_smoke_ehdb_local_reference_summary.py` — 109 tests
- `.venv/bin/python -m compileall -q noetl/core/ehdb_contract.py noetl/core/ehdb_adapter.py noetl/core/ehdb_control_plane.py noetl/core/ehdb_surface.py scripts/smoke_ehdb_local_reference_summary.py`
- `git diff --check README.md docker/noetl/README.md noetl/core/ehdb_adapter.py scripts/smoke_ehdb_local_reference_summary.py tests/core/test_ehdb_adapter.py tests/scripts/test_smoke_ehdb_local_reference_summary.py`
- local `forbid-client-term` added-line check
- `cargo build -p ehdb-reference --bin ehdb-local-reference` in sibling `repos/ehdb`
- `.venv/bin/python scripts/smoke_ehdb_local_reference_summary.py --helper-bin ../ehdb/target/debug/ehdb-local-reference --log <tmp-jsonl>`
- `.venv/bin/python scripts/smoke_ehdb_local_reference_summary.py --log <tmp-jsonl>` discovered sibling helper automatically

Closes #682
