### PR TITLE
feat: package EHDB helper in NoETL images

### DIFF
--- a/docker/noetl/README.md
+++ b/docker/noetl/README.md
@@ -63,3 +63,13 @@ runtime image or local checkout with:
 python scripts/smoke_ehdb_local_reference_summary.py \
   --log /tmp/noetl-ehdb-smoke.jsonl
 ```
+
+The in-repo Dockerfiles build the helper from `noetl/ehdb` using the
+`EHDB_REF` build arg and copy only the compiled binary into the final
+runtime image:
+
+```bash
+docker build \
+  --build-arg EHDB_REF=0dc2016f4b692d3d868ccbc3918900962a880ca1 \
+  --file docker/noetl/dev/Dockerfile .
+```

--- a/docker/noetl/dev/Dockerfile
+++ b/docker/noetl/dev/Dockerfile
@@ -1,5 +1,21 @@
-# Rust builder stage - can be skipped if using pre-compiled binary
-# To use pre-compiled binary: docker build --build-arg USE_PREBUILT_BINARY=true
+FROM rust:1.82-slim AS ehdb-helper
+
+ARG EHDB_REF=0dc2016f4b692d3d868ccbc3918900962a880ca1
+
+RUN apt-get update && apt-get --no-install-recommends install -y \
+    ca-certificates \
+    git \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp/ehdb
+
+RUN git init . \
+    && git remote add origin https://github.com/noetl/ehdb.git \
+    && git fetch --depth 1 origin "${EHDB_REF}" \
+    && git -c advice.detachedHead=false checkout FETCH_HEAD \
+    && cargo build --release --locked -p ehdb-reference --bin ehdb-local-reference
+
 FROM python:3.12-slim AS builder
 
 # Install uv directly instead of copying from ghcr.io
@@ -66,11 +82,7 @@ RUN apt-get update && apt-get --no-install-recommends install -y \
 # RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 COPY --from=builder /opt/noetl/.venv /opt/noetl/.venv
-
-# Optional: Copy pre-compiled Rust binary if available
-# Binaries must be built separately from https://github.com/noetl/cli.
-# ARG TARGETARCH
-# COPY target/x86_64-unknown-linux-gnu/release/noetl /usr/local/bin/noetl || echo "No Rust binary"
+COPY --from=ehdb-helper /tmp/ehdb/target/release/ehdb-local-reference /usr/local/bin/ehdb-local-reference
 
 WORKDIR /opt/noetl
 
@@ -79,6 +91,8 @@ COPY --from=builder /opt/noetl/scripts ./scripts
 COPY --from=builder /opt/noetl/pyproject.toml ./
 COPY --from=builder /opt/noetl/LICENSE ./
 COPY --from=builder /opt/noetl/README.md ./
+
+RUN ehdb-local-reference --help >/dev/null
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/docker/noetl/pip/Dockerfile
+++ b/docker/noetl/pip/Dockerfile
@@ -1,3 +1,21 @@
+FROM rust:1.82-slim AS ehdb-helper
+
+ARG EHDB_REF=0dc2016f4b692d3d868ccbc3918900962a880ca1
+
+RUN apt-get update && apt-get --no-install-recommends install -y \
+    ca-certificates \
+    git \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp/ehdb
+
+RUN git init . \
+    && git remote add origin https://github.com/noetl/ehdb.git \
+    && git fetch --depth 1 origin "${EHDB_REF}" \
+    && git -c advice.detachedHead=false checkout FETCH_HEAD \
+    && cargo build --release --locked -p ehdb-reference --bin ehdb-local-reference
+
 FROM python:3.12-slim AS base
 
 LABEL maintainer="Kadyapam"
@@ -30,6 +48,10 @@ RUN if [ "$NOETL_VERSION" = "latest" ]; then \
         echo "Installing noetl version $NOETL_VERSION" && \
         pip install --no-cache-dir noetl==$NOETL_VERSION; \
     fi
+
+COPY --from=ehdb-helper /tmp/ehdb/target/release/ehdb-local-reference /usr/local/bin/ehdb-local-reference
+
+RUN ehdb-local-reference --help >/dev/null
 
 RUN mkdir -p /opt/noetl/data /opt/noetl/logs && \
     chown -R noetl:noetl /opt/noetl


### PR DESCRIPTION
## Summary
- build `ehdb-local-reference` from pinned noetl/ehdb ref `0dc2016f4b692d3d868ccbc3918900962a880ca1` in the NoETL image Dockerfiles
- copy only the compiled helper binary into the final runtime images
- document `EHDB_REF` for local image builds

Closes #684.

## Validation
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_ehdb_control_plane.py tests/core/test_ehdb_surface.py tests/scripts/test_smoke_ehdb_local_reference_summary.py`
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_ehdb_control_plane.py tests/core/test_ehdb_surface.py tests/core/test_runtime_topology.py tests/core/runtime/test_pool_routing.py tests/scripts/test_smoke_ehdb_local_reference_summary.py`
- `.venv/bin/python -m compileall -q noetl/core/ehdb_contract.py noetl/core/ehdb_adapter.py noetl/core/ehdb_control_plane.py noetl/core/ehdb_surface.py scripts/smoke_ehdb_local_reference_summary.py`
- `git diff --check docker/noetl/dev/Dockerfile docker/noetl/pip/Dockerfile docker/noetl/README.md`
- `env -u XDG_DATA_HOME podman build --platform linux/arm64 -t local/noetl:ehdb-helper-image-test -f docker/noetl/dev/Dockerfile .`
- `env -u XDG_DATA_HOME podman run --rm local/noetl:ehdb-helper-image-test ehdb-local-reference --help`
- `env -u XDG_DATA_HOME podman run --rm local/noetl:ehdb-helper-image-test python scripts/smoke_ehdb_local_reference_summary.py --log /tmp/noetl-ehdb-image-smoke.jsonl`
- loaded image archive into local `kind-noetl`; ran `ehdb-helper-smoke` Job with `imagePullPolicy: Never` and `scripts/smoke_ehdb_local_reference_summary.py`