### PR TITLE
feat: validate EHDB local-reference summaries

### DIFF
--- a/noetl/core/ehdb_adapter.py
+++ b/noetl/core/ehdb_adapter.py
@@ -26,6 +26,26 @@ from noetl.core.ehdb_contract import (
 
 EHDB_HELPER_BIN_ENV = "NOETL_EHDB_HELPER_BIN"
 EHDB_LOCAL_REFERENCE_HELPER_NAME = "ehdb-local-reference"
+EHDB_LOCAL_REFERENCE_SUMMARY_FIELDS = (
+    "log_path",
+    "transaction_count",
+    "table_count",
+    "snapshot_count",
+    "scan_grant_count",
+    "stream_count",
+    "stream_record_count",
+    "stream_consumer_count",
+    "retrieval_document_count",
+    "retrieval_chunk_count",
+    "retrieval_embedding_count",
+    "system_library_count",
+    "system_binding_count",
+    "storage_object_count",
+    "storage_replica_count",
+)
+_EHDB_LOCAL_REFERENCE_COUNT_FIELDS = tuple(
+    field for field in EHDB_LOCAL_REFERENCE_SUMMARY_FIELDS if field != "log_path"
+)
 
 
 @dataclass(frozen=True)
@@ -64,6 +84,42 @@ class LocalReferenceEhdbExecution:
     stdout: str
     stderr: str
     json_payload: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class LocalReferenceEhdbSummary:
+    """Validated summary returned by `ehdb-local-reference summary`."""
+
+    log_path: Path
+    counts: Mapping[str, int]
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: Mapping[str, Any],
+        *,
+        expected_log: Path | str | None = None,
+    ) -> "LocalReferenceEhdbSummary":
+        missing = [
+            field for field in EHDB_LOCAL_REFERENCE_SUMMARY_FIELDS if field not in payload
+        ]
+        if missing:
+            raise ValueError(f"EHDB summary missing required fields: {', '.join(missing)}")
+
+        log_path = _summary_log_path(payload["log_path"])
+        if expected_log is not None and log_path != Path(expected_log):
+            raise ValueError("EHDB summary log_path does not match requested log")
+
+        counts: dict[str, int] = {}
+        for field in _EHDB_LOCAL_REFERENCE_COUNT_FIELDS:
+            counts[field] = _summary_count(payload[field], field)
+        return cls(log_path=log_path, counts=counts)
+
+    def as_dict(self) -> dict[str, int | str]:
+        return {
+            "log_path": str(self.log_path),
+            **self.counts,
+        }
 
 
 @dataclass(frozen=True)
@@ -275,10 +331,45 @@ def execute_ehdb_local_reference_summary_from_env(
     )
 
 
+def read_ehdb_local_reference_summary_from_env(
+    env: Mapping[str, str] | None = None,
+    *,
+    timeout_seconds: float = 30.0,
+    base_env: Mapping[str, str] | None = None,
+) -> LocalReferenceEhdbSummary | None:
+    """Execute the summary helper and return a validated typed summary."""
+
+    execution = execute_ehdb_local_reference_summary_from_env(
+        env,
+        timeout_seconds=timeout_seconds,
+        base_env=base_env,
+    )
+    if execution is None:
+        return None
+    return LocalReferenceEhdbSummary.from_payload(
+        execution.json_payload,
+        expected_log=execution.invocation.local_reference_log,
+    )
+
+
 def _non_empty_text(value: str | None, label: str) -> str:
     if value is None or not value.strip():
         raise ValueError(f"{label} is required")
     return value.strip()
+
+
+def _summary_log_path(value: Any) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("EHDB summary log_path must be a non-empty string")
+    return Path(value)
+
+
+def _summary_count(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"EHDB summary {field} must be an integer")
+    if value < 0:
+        raise ValueError(f"EHDB summary {field} must be non-negative")
+    return value
 
 
 def _default_ehdb_helper_candidates(helper_name: str) -> tuple[Path, ...]:

--- a/scripts/smoke_ehdb_local_reference_summary.py
+++ b/scripts/smoke_ehdb_local_reference_summary.py
@@ -13,7 +13,8 @@ from typing import Mapping, Sequence
 
 from noetl.core.ehdb_adapter import (
     EHDB_HELPER_BIN_ENV,
-    execute_ehdb_local_reference_summary_from_env,
+    EHDB_LOCAL_REFERENCE_SUMMARY_FIELDS,
+    read_ehdb_local_reference_summary_from_env,
 )
 from noetl.core.ehdb_contract import (
     EHDB_CLIENT_ROLE_ENV,
@@ -23,23 +24,7 @@ from noetl.core.ehdb_contract import (
 )
 
 
-REQUIRED_SUMMARY_FIELDS = (
-    "log_path",
-    "transaction_count",
-    "table_count",
-    "snapshot_count",
-    "scan_grant_count",
-    "stream_count",
-    "stream_record_count",
-    "stream_consumer_count",
-    "retrieval_document_count",
-    "retrieval_chunk_count",
-    "retrieval_embedding_count",
-    "system_library_count",
-    "system_binding_count",
-    "storage_object_count",
-    "storage_replica_count",
-)
+REQUIRED_SUMMARY_FIELDS = EHDB_LOCAL_REFERENCE_SUMMARY_FIELDS
 
 
 def run_smoke(
@@ -62,19 +47,14 @@ def run_smoke(
     if helper_bin is not None:
         source_env[EHDB_HELPER_BIN_ENV] = helper_bin
 
-    execution = execute_ehdb_local_reference_summary_from_env(
+    summary = read_ehdb_local_reference_summary_from_env(
         source_env,
         timeout_seconds=timeout_seconds,
     )
-    if execution is None:
+    if summary is None:
         raise RuntimeError("EHDB local-reference summary smoke was unexpectedly disabled")
 
-    missing = [field for field in REQUIRED_SUMMARY_FIELDS if field not in execution.json_payload]
-    if missing:
-        raise ValueError(f"EHDB summary missing required fields: {', '.join(missing)}")
-    if execution.json_payload["log_path"] != str(log_path):
-        raise ValueError("EHDB summary log_path does not match requested log")
-    return execution.json_payload
+    return summary.as_dict()
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/tests/core/test_ehdb_adapter.py
+++ b/tests/core/test_ehdb_adapter.py
@@ -5,16 +5,19 @@ import pytest
 
 from noetl.core.ehdb_adapter import (
     EHDB_HELPER_BIN_ENV,
+    EHDB_LOCAL_REFERENCE_SUMMARY_FIELDS,
     EHDB_LOCAL_REFERENCE_HELPER_NAME,
     LocalReferenceEhdbExecution,
     LocalReferenceEhdbAdapter,
     LocalReferenceEhdbInvocation,
+    LocalReferenceEhdbSummary,
     discover_ehdb_helper_executable,
     ehdb_adapter_from_env,
     ehdb_helper_invocation_from_env,
     ehdb_local_reference_summary_invocation_from_env,
     execute_ehdb_helper_json,
     execute_ehdb_local_reference_summary_from_env,
+    read_ehdb_local_reference_summary_from_env,
 )
 from noetl.core.ehdb_contract import (
     EHDB_CAPABILITIES_ENV,
@@ -307,6 +310,62 @@ print(json.dumps({"transaction_count": 2, "stream_count": 1}))
     )
 
 
+def test_read_ehdb_local_reference_summary_returns_typed_summary(tmp_path):
+    log_path = tmp_path / "ehdb.jsonl"
+    helper = _summary_helper(tmp_path)
+
+    summary = read_ehdb_local_reference_summary_from_env(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: str(log_path),
+            EHDB_HELPER_BIN_ENV: str(helper),
+        },
+        base_env={"PATH": "/usr/bin"},
+    )
+
+    assert isinstance(summary, LocalReferenceEhdbSummary)
+    assert summary.log_path == log_path
+    assert summary.counts["transaction_count"] == 3
+    assert summary.counts["storage_replica_count"] == 0
+    assert summary.as_dict()["log_path"] == str(log_path)
+
+
+def test_read_ehdb_local_reference_summary_returns_none_when_disabled():
+    assert read_ehdb_local_reference_summary_from_env({}) is None
+
+
+def test_local_reference_summary_rejects_missing_required_fields():
+    with pytest.raises(ValueError, match="missing required fields"):
+        LocalReferenceEhdbSummary.from_payload({"log_path": "/tmp/ehdb.jsonl"})
+
+
+def test_local_reference_summary_rejects_unexpected_log_path():
+    payload = _summary_payload("/tmp/actual-ehdb.jsonl")
+
+    with pytest.raises(ValueError, match="log_path does not match"):
+        LocalReferenceEhdbSummary.from_payload(
+            payload,
+            expected_log="/tmp/expected-ehdb.jsonl",
+        )
+
+
+def test_local_reference_summary_rejects_non_integer_count():
+    payload = _summary_payload("/tmp/ehdb.jsonl")
+    payload["transaction_count"] = "1"
+
+    with pytest.raises(ValueError, match="transaction_count must be an integer"):
+        LocalReferenceEhdbSummary.from_payload(payload)
+
+
+def test_local_reference_summary_rejects_negative_count():
+    payload = _summary_payload("/tmp/ehdb.jsonl")
+    payload["stream_count"] = -1
+
+    with pytest.raises(ValueError, match="stream_count must be non-negative"):
+        LocalReferenceEhdbSummary.from_payload(payload)
+
+
 def test_execute_ehdb_helper_json_returns_none_when_disabled():
     assert execute_ehdb_local_reference_summary_from_env({}) is None
 
@@ -460,3 +519,29 @@ def _helper_script(
     helper.write_text(f"#!{sys.executable}\n{body.lstrip()}", encoding="utf-8")
     helper.chmod(0o755)
     return helper
+
+
+def _summary_helper(tmp_path: Path) -> Path:
+    payload = _summary_payload("placeholder")
+    return _helper_script(
+        tmp_path,
+        f"""
+import json
+import sys
+
+payload = {payload!r}
+payload["log_path"] = sys.argv[3]
+print(json.dumps(payload))
+""",
+    )
+
+
+def _summary_payload(log_path: str) -> dict[str, int | str]:
+    payload = {
+        field: 0
+        for field in EHDB_LOCAL_REFERENCE_SUMMARY_FIELDS
+        if field != "log_path"
+    }
+    payload["log_path"] = log_path
+    payload["transaction_count"] = 3
+    return payload


### PR DESCRIPTION
## Summary
- add `LocalReferenceEhdbSummary` as the typed/validated result for `ehdb-local-reference summary`
- add `read_ehdb_local_reference_summary_from_env` so worker/playbook checks can execute the packaged helper and receive a validated summary
- make the smoke script reuse the same summary field contract instead of duplicating raw JSON validation

Closes #686.

## Boundary
- EHDB stays disabled by default
- gateway/API/server local-reference execution remains rejected by the existing contract
- no routes, persistent services, database replacement, or GKE rollout

## Validation
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_ehdb_control_plane.py tests/core/test_ehdb_surface.py tests/scripts/test_smoke_ehdb_local_reference_summary.py`
- `.venv/bin/python -m pytest tests/core/test_ehdb_contract.py tests/core/test_ehdb_adapter.py tests/core/test_ehdb_control_plane.py tests/core/test_ehdb_surface.py tests/core/test_runtime_topology.py tests/core/runtime/test_pool_routing.py tests/scripts/test_smoke_ehdb_local_reference_summary.py`
- `.venv/bin/python -m compileall -q noetl/core/ehdb_contract.py noetl/core/ehdb_adapter.py noetl/core/ehdb_control_plane.py noetl/core/ehdb_surface.py scripts/smoke_ehdb_local_reference_summary.py`
- `git diff --check noetl/core/ehdb_adapter.py scripts/smoke_ehdb_local_reference_summary.py tests/core/test_ehdb_adapter.py`
- `.venv/bin/python scripts/smoke_ehdb_local_reference_summary.py --helper-bin ../ehdb/target/release/ehdb-local-reference --log <tmp-log>`