### PR TITLE
feat(ehdb): Phase B — bounded worker/playbook readiness hook (#234)

### DIFF
--- a/noetl/core/ehdb_adapter.py
+++ b/noetl/core/ehdb_adapter.py
@@ -136,8 +136,14 @@ class LocalReferenceEhdbAdapter:
         validate_ehdb_integration_contract(contract)
         if contract.mode is not EhdbIntegrationMode.LOCAL_REFERENCE:
             raise ValueError("local-reference adapter requires local_reference mode")
-        if contract.role not in {EhdbClientRole.WORKER, EhdbClientRole.PLAYBOOK}:
-            raise ValueError("local-reference adapter requires worker or playbook role")
+        if contract.role not in {
+            EhdbClientRole.WORKER,
+            EhdbClientRole.PLAYBOOK,
+            EhdbClientRole.SYSTEM,
+        }:
+            raise ValueError(
+                "local-reference adapter requires worker, playbook, or system role"
+            )
         return cls(contract=contract)
 
     @property

--- a/noetl/core/ehdb_readiness.py
+++ b/noetl/core/ehdb_readiness.py
@@ -1,0 +1,405 @@
+"""Bounded, stateless EHDB worker/playbook readiness hook for NoETL.
+
+Phase B of the EHDB↔NoETL integration.  This module turns the
+side-effect-free adapter surface in :mod:`noetl.core.ehdb_adapter` into a
+readiness *preflight* that a worker/playbook/system process can run at
+bootstrap (or as a standalone command / kind smoke step) to confirm the
+EHDB local-reference summary is reachable.
+
+Hard boundaries preserved (see the EHDB Architecture wiki):
+
+* **Disabled by default** — when ``NOETL_EHDB_ENABLED`` is not truthy the
+  evaluation is a strict no-op: it performs no read, records no metric, and
+  the process behaves byte-identically to a build without this module.
+* **Control-plane roles get no data-plane handle** — gateway / api / server
+  never perform the local-reference read.  A control-plane role that reaches
+  the data-plane read is refused by :func:`assert_data_plane_read_allowed`,
+  a defense-in-depth guard beyond the contract validation.
+* **Bounded + stateless** — the readiness read shells out to the bounded
+  ``ehdb-local-reference summary`` helper under a short time cap and returns a
+  fixed-shape count summary.  No long-lived connection or per-tenant state is
+  held between requests.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Mapping, Sequence
+
+from noetl.core.ehdb_adapter import (
+    LocalReferenceEhdbSummary,
+    read_ehdb_local_reference_summary_from_env,
+)
+from noetl.core.ehdb_contract import (
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    NOETL_RUN_MODE_ENV,
+    EhdbClientRole,
+)
+
+
+# Readiness is a fast preflight, so it uses a much tighter default time cap
+# than the adapter's 30s helper default.  Operators may override within a
+# clamped range; the clamp keeps the read bounded regardless of the value.
+DEFAULT_READINESS_TIMEOUT_SECONDS = 5.0
+_MIN_READINESS_TIMEOUT_SECONDS = 0.1
+_MAX_READINESS_TIMEOUT_SECONDS = 30.0
+EHDB_READINESS_TIMEOUT_ENV = "NOETL_EHDB_READINESS_TIMEOUT_SECONDS"
+
+_CONTROL_PLANE_ROLES = frozenset(
+    {EhdbClientRole.GATEWAY, EhdbClientRole.API, EhdbClientRole.SERVER}
+)
+_DATA_PLANE_ROLES = frozenset(
+    {EhdbClientRole.WORKER, EhdbClientRole.PLAYBOOK, EhdbClientRole.SYSTEM}
+)
+
+
+class EhdbControlPlaneGuardError(RuntimeError):
+    """Raised when a control-plane role attempts the data-plane read."""
+
+
+class EhdbReadinessOutcome(StrEnum):
+    """Terminal classification of a single readiness evaluation."""
+
+    DISABLED = "disabled"          # EHDB off — no-op, byte-identical
+    CONTROL_PLANE = "control_plane"  # control-plane role — no data-plane read
+    READY = "ready"                # summary read, at least one non-zero count
+    EMPTY = "empty"                # summary read, all counts zero (fresh log)
+    TRUNCATED = "truncated"        # bounded time cap tripped — degraded read
+    UNAVAILABLE = "unavailable"    # helper missing / errored — degraded
+    GUARD_REFUSED = "guard_refused"  # control-plane role given a data-plane env
+    INVALID = "invalid"            # misconfigured EHDB env (non-guard)
+
+
+# Outcomes for which the process may proceed.  Guard / invalid are hard
+# misconfigurations that a readiness gate should surface loudly.
+_READY_OUTCOMES = frozenset(
+    {
+        EhdbReadinessOutcome.DISABLED,
+        EhdbReadinessOutcome.CONTROL_PLANE,
+        EhdbReadinessOutcome.READY,
+        EhdbReadinessOutcome.EMPTY,
+        EhdbReadinessOutcome.TRUNCATED,
+        EhdbReadinessOutcome.UNAVAILABLE,
+    }
+)
+# Outcomes that still let the process run but signal something suboptimal.
+_DEGRADED_OUTCOMES = frozenset(
+    {EhdbReadinessOutcome.TRUNCATED, EhdbReadinessOutcome.UNAVAILABLE}
+)
+
+
+@dataclass(frozen=True)
+class EhdbReadinessResult:
+    """Structured, secret-free result of a readiness evaluation."""
+
+    outcome: EhdbReadinessOutcome
+    role: EhdbClientRole | None = None
+    duration_seconds: float = 0.0
+    counts: Mapping[str, int] = field(default_factory=dict)
+    log_path: str | None = None
+    detail: str | None = None
+
+    @property
+    def ready(self) -> bool:
+        return self.outcome in _READY_OUTCOMES
+
+    @property
+    def degraded(self) -> bool:
+        return self.outcome in _DEGRADED_OUTCOMES
+
+    @property
+    def performed_read(self) -> bool:
+        return self.outcome in {
+            EhdbReadinessOutcome.READY,
+            EhdbReadinessOutcome.EMPTY,
+        }
+
+    def as_dict(self) -> dict[str, object]:
+        """Secret-free serialisation for health payloads / smoke output."""
+
+        payload: dict[str, object] = {
+            "outcome": self.outcome.value,
+            "ready": self.ready,
+            "degraded": self.degraded,
+            "duration_seconds": round(self.duration_seconds, 6),
+        }
+        if self.role is not None:
+            payload["role"] = self.role.value
+        if self.log_path is not None:
+            payload["log_path"] = self.log_path
+        if self.counts:
+            payload["counts"] = dict(self.counts)
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        return payload
+
+
+def assert_data_plane_read_allowed(role: EhdbClientRole) -> None:
+    """Guard: only worker/playbook/system roles may run the data-plane read.
+
+    This is defense-in-depth on top of the contract validation in
+    :mod:`noetl.core.ehdb_contract`.  A control-plane role must never obtain a
+    local-reference data-plane handle, so any attempt to read one is refused
+    here before the helper is executed.
+    """
+
+    if role in _CONTROL_PLANE_ROLES:
+        raise EhdbControlPlaneGuardError(
+            f"EHDB data-plane read refused for control-plane role '{role.value}'; "
+            "gateway/api/server remain gatekeepers and never touch EHDB data"
+        )
+    if role not in _DATA_PLANE_ROLES:
+        raise EhdbControlPlaneGuardError(
+            f"EHDB data-plane read requires a worker/playbook/system role, got '{role.value}'"
+        )
+
+
+def evaluate_ehdb_readiness(
+    env: Mapping[str, str] | None = None,
+    *,
+    timeout_seconds: float | None = None,
+    record_metrics: bool = True,
+) -> EhdbReadinessResult:
+    """Evaluate EHDB local-reference readiness for the current role.
+
+    Returns a structured, secret-free :class:`EhdbReadinessResult`.  When EHDB
+    is disabled the result is :attr:`EhdbReadinessOutcome.DISABLED` and no
+    metric is recorded — behaviour is byte-identical to EHDB being absent.
+    """
+
+    source_env = os.environ if env is None else env
+    started = time.monotonic()
+
+    def _finish(
+        outcome: EhdbReadinessOutcome,
+        *,
+        role: EhdbClientRole | None = None,
+        counts: Mapping[str, int] | None = None,
+        log_path: str | None = None,
+        detail: str | None = None,
+    ) -> EhdbReadinessResult:
+        result = EhdbReadinessResult(
+            outcome=outcome,
+            role=role,
+            duration_seconds=time.monotonic() - started,
+            counts=dict(counts or {}),
+            log_path=log_path,
+            detail=detail,
+        )
+        if record_metrics:
+            _METRICS.record(result)
+        return result
+
+    # 1. Disabled fast path — strict no-op (no read, no metric side effect).
+    if not _truthy(source_env.get(EHDB_ENABLED_ENV)):
+        return _finish(EhdbReadinessOutcome.DISABLED)
+
+    role = _safe_client_role(source_env)
+
+    # 2. Build the contract.  A raised error is a genuine misconfiguration; a
+    #    control-plane role carrying a data-plane env classifies as a guard.
+    try:
+        # Imported lazily so the disabled path never touches the contract.
+        from noetl.core.ehdb_contract import ehdb_integration_contract_from_env
+
+        contract = ehdb_integration_contract_from_env(source_env)
+    except ValueError as exc:
+        if role in _CONTROL_PLANE_ROLES:
+            return _finish(
+                EhdbReadinessOutcome.GUARD_REFUSED, role=role, detail=str(exc)
+            )
+        return _finish(EhdbReadinessOutcome.INVALID, role=role, detail=str(exc))
+
+    role = contract.role
+
+    # 3. Control-plane roles never perform a data-plane read.
+    if contract.role in _CONTROL_PLANE_ROLES:
+        return _finish(EhdbReadinessOutcome.CONTROL_PLANE, role=contract.role)
+
+    # 4. Data-plane role: enforce the guard, then run the bounded read.
+    try:
+        assert_data_plane_read_allowed(contract.role)
+    except EhdbControlPlaneGuardError as exc:
+        return _finish(
+            EhdbReadinessOutcome.GUARD_REFUSED, role=contract.role, detail=str(exc)
+        )
+
+    bounded_timeout = _bounded_timeout(source_env, timeout_seconds)
+    try:
+        summary = read_ehdb_local_reference_summary_from_env(
+            source_env, timeout_seconds=bounded_timeout
+        )
+    except TimeoutError as exc:
+        return _finish(
+            EhdbReadinessOutcome.TRUNCATED, role=contract.role, detail=str(exc)
+        )
+    except (ValueError, RuntimeError, OSError) as exc:
+        return _finish(
+            EhdbReadinessOutcome.UNAVAILABLE, role=contract.role, detail=str(exc)
+        )
+
+    if summary is None:
+        # Enabled + local_reference should always yield a summary; treat an
+        # unexpected None as disabled rather than inventing readiness.
+        return _finish(EhdbReadinessOutcome.DISABLED, role=contract.role)
+
+    return _finish(
+        _summary_outcome(summary),
+        role=contract.role,
+        counts=summary.counts,
+        log_path=str(summary.log_path),
+    )
+
+
+def _summary_outcome(summary: LocalReferenceEhdbSummary) -> EhdbReadinessOutcome:
+    total = sum(summary.counts.values())
+    return EhdbReadinessOutcome.EMPTY if total == 0 else EhdbReadinessOutcome.READY
+
+
+def _bounded_timeout(
+    env: Mapping[str, str], timeout_seconds: float | None
+) -> float:
+    if timeout_seconds is None:
+        raw = env.get(EHDB_READINESS_TIMEOUT_ENV)
+        if raw is not None and raw.strip():
+            try:
+                timeout_seconds = float(raw.strip())
+            except ValueError:
+                timeout_seconds = DEFAULT_READINESS_TIMEOUT_SECONDS
+        else:
+            timeout_seconds = DEFAULT_READINESS_TIMEOUT_SECONDS
+    return max(
+        _MIN_READINESS_TIMEOUT_SECONDS,
+        min(_MAX_READINESS_TIMEOUT_SECONDS, timeout_seconds),
+    )
+
+
+def _safe_client_role(env: Mapping[str, str]) -> EhdbClientRole | None:
+    raw = env.get(EHDB_CLIENT_ROLE_ENV) or env.get(NOETL_RUN_MODE_ENV) or "worker"
+    normalized = raw.strip().lower()
+    if normalized == "server":
+        return EhdbClientRole.SERVER
+    try:
+        return EhdbClientRole(normalized)
+    except ValueError:
+        return None
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+# ---------------------------------------------------------------------------
+# Observability — process-local counters rendered into the worker /metrics
+# text.  Metrics carry only the outcome label + aggregate counters; no log
+# path, count values, or error text (which could echo helper stderr) leak in.
+# ---------------------------------------------------------------------------
+
+
+class _ReadinessMetrics:
+    """In-process accumulator for EHDB readiness checks.
+
+    Disabled evaluations are intentionally *not* recorded so a disabled EHDB
+    build renders byte-identical `/metrics` output.
+    """
+
+    def __init__(self) -> None:
+        self._checks: dict[str, int] = {}
+        self._last_outcome: str | None = None
+        self._last_duration_seconds: float = 0.0
+        self._last_ready: int = 0
+        self._last_degraded: int = 0
+
+    def record(self, result: EhdbReadinessResult) -> None:
+        if result.outcome is EhdbReadinessOutcome.DISABLED:
+            return
+        key = result.outcome.value
+        self._checks[key] = self._checks.get(key, 0) + 1
+        self._last_outcome = key
+        self._last_duration_seconds = result.duration_seconds
+        self._last_ready = 1 if result.ready else 0
+        self._last_degraded = 1 if result.degraded else 0
+
+    def reset(self) -> None:
+        self.__init__()
+
+    def has_data(self) -> bool:
+        return bool(self._checks)
+
+    def render(self, *, labels: Mapping[str, str] | None = None) -> list[str]:
+        if not self._checks:
+            return []
+        base_labels = dict(labels or {})
+        lines = [
+            "# HELP noetl_ehdb_readiness_checks_total EHDB readiness checks by outcome",
+            "# TYPE noetl_ehdb_readiness_checks_total counter",
+        ]
+        for outcome in sorted(self._checks):
+            merged = dict(base_labels)
+            merged["outcome"] = outcome
+            lines.append(
+                f"noetl_ehdb_readiness_checks_total{_format_labels(merged)} "
+                f"{self._checks[outcome]}"
+            )
+        lines.extend(
+            [
+                "# HELP noetl_ehdb_readiness_ready Last EHDB readiness gate result (1=ready)",
+                "# TYPE noetl_ehdb_readiness_ready gauge",
+                f"noetl_ehdb_readiness_ready{_format_labels(base_labels)} {self._last_ready}",
+                "# HELP noetl_ehdb_readiness_degraded Last EHDB readiness degraded flag",
+                "# TYPE noetl_ehdb_readiness_degraded gauge",
+                f"noetl_ehdb_readiness_degraded{_format_labels(base_labels)} {self._last_degraded}",
+                "# HELP noetl_ehdb_readiness_last_duration_seconds Last EHDB readiness duration",
+                "# TYPE noetl_ehdb_readiness_last_duration_seconds gauge",
+                f"noetl_ehdb_readiness_last_duration_seconds{_format_labels(base_labels)} "
+                f"{self._last_duration_seconds:.6f}",
+            ]
+        )
+        return lines
+
+
+_METRICS = _ReadinessMetrics()
+
+
+def render_ehdb_readiness_metrics(
+    *, labels: Mapping[str, str] | None = None
+) -> list[str]:
+    """Return Prometheus text lines for readiness checks (empty when none)."""
+
+    return _METRICS.render(labels=labels)
+
+
+def reset_ehdb_readiness_metrics() -> None:
+    """Reset the process-local readiness metrics (test helper)."""
+
+    _METRICS.reset()
+
+
+def _format_labels(labels: Mapping[str, str]) -> str:
+    if not labels:
+        return ""
+    rendered = ",".join(
+        f'{key}="{_escape_label(labels[key])}"' for key in sorted(labels)
+    )
+    return "{" + rendered + "}"
+
+
+def _escape_label(value: str) -> str:
+    return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+__all__ = [
+    "DEFAULT_READINESS_TIMEOUT_SECONDS",
+    "EHDB_READINESS_TIMEOUT_ENV",
+    "EhdbControlPlaneGuardError",
+    "EhdbReadinessOutcome",
+    "EhdbReadinessResult",
+    "assert_data_plane_read_allowed",
+    "evaluate_ehdb_readiness",
+    "render_ehdb_readiness_metrics",
+    "reset_ehdb_readiness_metrics",
+]

--- a/noetl/worker/metrics.py
+++ b/noetl/worker/metrics.py
@@ -21,6 +21,12 @@ def render_worker_metrics(*, worker_id: str, labels: Mapping[str, str] | None = 
         f"noetl_worker_up{{worker_id=\"{_escape_label(worker_id)}\"}} 1",
     ]
     append_storage_ipc_metrics(lines, default_store.ipc_stats(), labels=metric_labels)
+
+    # EHDB readiness preflight metrics.  Renders nothing when EHDB is
+    # disabled (no check recorded), so `/metrics` stays byte-identical.
+    from noetl.core.ehdb_readiness import render_ehdb_readiness_metrics
+
+    lines.extend(render_ehdb_readiness_metrics(labels=metric_labels))
     return "\n".join(lines) + "\n"
 
 

--- a/noetl/worker/nats_worker.py
+++ b/noetl/worker/nats_worker.py
@@ -3828,6 +3828,41 @@ class Worker:
                     await asyncio.sleep(delay)
 
 
+def _ehdb_readiness_preflight(worker_id: str) -> None:
+    """Run the bounded EHDB readiness preflight at worker bootstrap.
+
+    No-op and silent when EHDB is disabled (the default) so worker startup is
+    byte-identical to a build without EHDB.  Never raises: EHDB is auxiliary
+    specialized storage, so a degraded/unavailable summary must not take down
+    the worker.  A control-plane guard trip is surfaced loudly instead.
+    """
+    try:
+        from noetl.core.ehdb_readiness import (
+            EhdbReadinessOutcome,
+            evaluate_ehdb_readiness,
+        )
+
+        result = evaluate_ehdb_readiness()
+        if result.outcome is EhdbReadinessOutcome.DISABLED:
+            return
+        fields = {"worker_id": worker_id, "ehdb_readiness": result.as_dict()}
+        if result.outcome in (
+            EhdbReadinessOutcome.GUARD_REFUSED,
+            EhdbReadinessOutcome.INVALID,
+        ):
+            logger.error("EHDB readiness preflight refused", extra=fields)
+        elif result.degraded:
+            logger.warning("EHDB readiness preflight degraded", extra=fields)
+        else:
+            logger.info("EHDB readiness preflight ok", extra=fields)
+    except Exception as exc:  # readiness must never be fatal to the worker
+        logger.warning(
+            "EHDB readiness preflight error (ignored): %s",
+            exc,
+            extra={"worker_id": worker_id},
+        )
+
+
 async def run_worker(
     worker_id: str,
     nats_url: str = "nats://noetl:noetl@nats.nats.svc.cluster.local:4222",
@@ -3836,11 +3871,15 @@ async def run_worker(
     """Run a Core worker instance."""
     # Set environment variable to indicate worker context (for TransientVars API routing)
     os.environ["NOETL_WORKER_MODE"] = "true"
-    
+
     # No database pool initialization - worker uses server API for all noetl schema access
     # Only tool steps (postgres, duckdb) access external databases with their own credentials
     logger.info("Worker uses server API for variables, events, and context (no direct DB access)")
-    
+
+    # EHDB Phase B: bounded, stateless readiness preflight.  No-op when EHDB is
+    # disabled (default); never fatal to worker startup.
+    _ehdb_readiness_preflight(worker_id)
+
     worker = Worker(
         worker_id=worker_id,
         nats_url=nats_url,

--- a/scripts/ehdb_readiness_preflight.py
+++ b/scripts/ehdb_readiness_preflight.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Worker/playbook-local EHDB readiness preflight command.
+
+Runs the bounded, stateless EHDB local-reference readiness evaluation for the
+current role and prints a secret-free JSON report.  Intended as a
+worker/playbook-local command or kind smoke step — deliberately *not* a server
+endpoint, so the control-plane boundary is preserved.
+
+Exit codes:
+
+* ``0`` — ready (``disabled`` / ``control_plane`` / ``ready`` / ``empty``);
+  also ``truncated`` / ``unavailable`` unless ``--strict`` is given.
+* ``3`` — degraded (``truncated`` / ``unavailable``) with ``--strict``.
+* ``4`` — control-plane guard refused a data-plane read (misconfiguration).
+* ``5`` — invalid EHDB configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Sequence
+
+from noetl.core.ehdb_readiness import (
+    EhdbReadinessOutcome,
+    evaluate_ehdb_readiness,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the bounded EHDB local-reference readiness preflight.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        help="Readiness helper timeout in seconds (clamped 0.1-30). "
+        "Defaults to NOETL_EHDB_READINESS_TIMEOUT_SECONDS or 5s.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Treat degraded (truncated/unavailable) outcomes as failure.",
+    )
+    args = parser.parse_args(argv)
+
+    result = evaluate_ehdb_readiness(timeout_seconds=args.timeout)
+    print(json.dumps(result.as_dict(), sort_keys=True))
+
+    if result.outcome is EhdbReadinessOutcome.GUARD_REFUSED:
+        return 4
+    if result.outcome is EhdbReadinessOutcome.INVALID:
+        return 5
+    if args.strict and result.degraded:
+        return 3
+    return 0 if result.ready else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_ehdb_readiness.py
+++ b/tests/core/test_ehdb_readiness.py
@@ -1,0 +1,355 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from noetl.core.ehdb_adapter import (
+    EHDB_HELPER_BIN_ENV,
+    EHDB_LOCAL_REFERENCE_SUMMARY_FIELDS,
+)
+from noetl.core.ehdb_contract import (
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    EHDB_LOCAL_REFERENCE_LOG_ENV,
+    EHDB_MODE_ENV,
+    EhdbClientRole,
+)
+from noetl.core.ehdb_readiness import (
+    EHDB_READINESS_TIMEOUT_ENV,
+    EhdbControlPlaneGuardError,
+    EhdbReadinessOutcome,
+    assert_data_plane_read_allowed,
+    evaluate_ehdb_readiness,
+    render_ehdb_readiness_metrics,
+    reset_ehdb_readiness_metrics,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_metrics():
+    reset_ehdb_readiness_metrics()
+    yield
+    reset_ehdb_readiness_metrics()
+
+
+# --------------------------------------------------------------------------
+# Disabled = strict no-op (byte-identical behaviour)
+# --------------------------------------------------------------------------
+
+
+def test_disabled_is_noop_and_records_no_metrics():
+    result = evaluate_ehdb_readiness({})
+
+    assert result.outcome is EhdbReadinessOutcome.DISABLED
+    assert result.ready is True
+    assert result.degraded is False
+    assert result.performed_read is False
+    assert result.counts == {}
+    # No metric recorded → /metrics render is empty (byte-identical).
+    assert render_ehdb_readiness_metrics() == []
+
+
+def test_disabled_ignores_role_and_log_env():
+    result = evaluate_ehdb_readiness(
+        {
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: "/tmp/should-not-be-read.jsonl",
+        }
+    )
+
+    assert result.outcome is EhdbReadinessOutcome.DISABLED
+    assert render_ehdb_readiness_metrics() == []
+
+
+# --------------------------------------------------------------------------
+# Enabled worker/playbook local-reference read
+# --------------------------------------------------------------------------
+
+
+def test_enabled_worker_reads_bounded_summary(tmp_path):
+    log_path = tmp_path / "ehdb.jsonl"
+    log_path.write_text("", encoding="utf-8")
+    helper = _summary_helper(tmp_path, transaction_count=3)
+
+    result = evaluate_ehdb_readiness(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: str(log_path),
+            EHDB_HELPER_BIN_ENV: str(helper),
+            "PATH": "/usr/bin",
+        }
+    )
+
+    assert result.outcome is EhdbReadinessOutcome.READY
+    assert result.ready is True
+    assert result.performed_read is True
+    assert result.role is EhdbClientRole.WORKER
+    assert result.counts["transaction_count"] == 3
+    assert result.log_path == str(log_path)
+
+
+def test_enabled_playbook_empty_summary_reports_empty(tmp_path):
+    log_path = tmp_path / "ehdb.jsonl"
+    log_path.write_text("", encoding="utf-8")
+    helper = _summary_helper(tmp_path, transaction_count=0)
+
+    result = evaluate_ehdb_readiness(
+        {
+            EHDB_ENABLED_ENV: "1",
+            EHDB_MODE_ENV: "local_reference",
+            EHDB_CLIENT_ROLE_ENV: "playbook",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: str(log_path),
+            EHDB_HELPER_BIN_ENV: str(helper),
+            "PATH": "/usr/bin",
+        }
+    )
+
+    assert result.outcome is EhdbReadinessOutcome.EMPTY
+    assert result.ready is True
+    assert result.role is EhdbClientRole.PLAYBOOK
+    assert all(value == 0 for value in result.counts.values())
+
+
+def test_enabled_system_role_reads_summary(tmp_path):
+    log_path = tmp_path / "ehdb.jsonl"
+    log_path.write_text("", encoding="utf-8")
+    helper = _summary_helper(tmp_path, transaction_count=2)
+
+    result = evaluate_ehdb_readiness(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "system",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: str(log_path),
+            EHDB_HELPER_BIN_ENV: str(helper),
+            "PATH": "/usr/bin",
+        }
+    )
+
+    assert result.outcome is EhdbReadinessOutcome.READY
+    assert result.role is EhdbClientRole.SYSTEM
+
+
+# --------------------------------------------------------------------------
+# Control-plane roles never perform a data-plane read
+# --------------------------------------------------------------------------
+
+
+def test_control_plane_role_performs_no_read():
+    result = evaluate_ehdb_readiness(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: "control_plane",
+            EHDB_CLIENT_ROLE_ENV: "gateway",
+        }
+    )
+
+    assert result.outcome is EhdbReadinessOutcome.CONTROL_PLANE
+    assert result.ready is True
+    assert result.performed_read is False
+    assert result.role is EhdbClientRole.GATEWAY
+    assert result.log_path is None
+
+
+@pytest.mark.parametrize("role", ["gateway", "api", "server"])
+def test_control_plane_role_given_dataplane_env_is_guarded(role, tmp_path):
+    log_path = tmp_path / "ehdb.jsonl"
+    log_path.write_text("", encoding="utf-8")
+
+    result = evaluate_ehdb_readiness(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: "local_reference",
+            EHDB_CLIENT_ROLE_ENV: role,
+            EHDB_LOCAL_REFERENCE_LOG_ENV: str(log_path),
+            EHDB_HELPER_BIN_ENV: "/should/never/run",
+        }
+    )
+
+    assert result.outcome is EhdbReadinessOutcome.GUARD_REFUSED
+    assert result.ready is False
+    assert result.performed_read is False
+
+
+def test_assert_data_plane_read_allowed_refuses_control_plane():
+    for role in (EhdbClientRole.GATEWAY, EhdbClientRole.API, EhdbClientRole.SERVER):
+        with pytest.raises(EhdbControlPlaneGuardError):
+            assert_data_plane_read_allowed(role)
+
+
+def test_assert_data_plane_read_allowed_permits_data_plane():
+    for role in (EhdbClientRole.WORKER, EhdbClientRole.PLAYBOOK, EhdbClientRole.SYSTEM):
+        assert_data_plane_read_allowed(role) is None
+
+
+# --------------------------------------------------------------------------
+# Degraded / invalid outcomes
+# --------------------------------------------------------------------------
+
+
+def test_missing_helper_is_unavailable(tmp_path):
+    log_path = tmp_path / "ehdb.jsonl"
+    log_path.write_text("", encoding="utf-8")
+
+    result = evaluate_ehdb_readiness(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: str(log_path),
+            EHDB_HELPER_BIN_ENV: str(tmp_path / "does-not-exist"),
+            "PATH": "",
+        }
+    )
+
+    assert result.outcome is EhdbReadinessOutcome.UNAVAILABLE
+    assert result.ready is True
+    assert result.degraded is True
+
+
+def test_slow_helper_trips_bounded_timeout(tmp_path):
+    log_path = tmp_path / "ehdb.jsonl"
+    log_path.write_text("", encoding="utf-8")
+    helper = _helper_script(tmp_path, "import time\ntime.sleep(2)\n")
+
+    result = evaluate_ehdb_readiness(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: str(log_path),
+            EHDB_HELPER_BIN_ENV: str(helper),
+            EHDB_READINESS_TIMEOUT_ENV: "0.1",
+            "PATH": "/usr/bin",
+        }
+    )
+
+    assert result.outcome is EhdbReadinessOutcome.TRUNCATED
+    assert result.degraded is True
+
+
+def test_invalid_mode_is_invalid_outcome():
+    result = evaluate_ehdb_readiness(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: "not-a-real-mode",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+        }
+    )
+
+    assert result.outcome is EhdbReadinessOutcome.INVALID
+    assert result.ready is False
+
+
+# --------------------------------------------------------------------------
+# Metrics + timeout clamping
+# --------------------------------------------------------------------------
+
+
+def test_metrics_render_after_enabled_check(tmp_path):
+    log_path = tmp_path / "ehdb.jsonl"
+    log_path.write_text("", encoding="utf-8")
+    helper = _summary_helper(tmp_path, transaction_count=1)
+
+    evaluate_ehdb_readiness(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: str(log_path),
+            EHDB_HELPER_BIN_ENV: str(helper),
+            "PATH": "/usr/bin",
+        }
+    )
+
+    lines = render_ehdb_readiness_metrics(labels={"worker_id": "w-1"})
+    text = "\n".join(lines)
+    assert 'noetl_ehdb_readiness_checks_total{outcome="ready",worker_id="w-1"} 1' in text
+    assert 'noetl_ehdb_readiness_ready{worker_id="w-1"} 1' in text
+    # No secret values / log path leak into metric text.
+    assert str(log_path) not in text
+
+
+def test_timeout_env_is_clamped(tmp_path):
+    # A huge configured timeout is clamped; the helper still returns quickly.
+    log_path = tmp_path / "ehdb.jsonl"
+    log_path.write_text("", encoding="utf-8")
+    helper = _summary_helper(tmp_path, transaction_count=1)
+
+    result = evaluate_ehdb_readiness(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_CLIENT_ROLE_ENV: "worker",
+            EHDB_LOCAL_REFERENCE_LOG_ENV: str(log_path),
+            EHDB_HELPER_BIN_ENV: str(helper),
+            EHDB_READINESS_TIMEOUT_ENV: "9999",
+            "PATH": "/usr/bin",
+        }
+    )
+
+    assert result.outcome is EhdbReadinessOutcome.READY
+
+
+# --------------------------------------------------------------------------
+# Preflight CLI exit codes
+# --------------------------------------------------------------------------
+
+
+def _load_preflight_module():
+    path = (
+        Path(__file__).resolve().parents[2] / "scripts" / "ehdb_readiness_preflight.py"
+    )
+    spec = importlib.util.spec_from_file_location("ehdb_readiness_preflight", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_preflight_cli_disabled_exit_zero(monkeypatch, capsys):
+    monkeypatch.delenv(EHDB_ENABLED_ENV, raising=False)
+    module = _load_preflight_module()
+
+    assert module.main([]) == 0
+    assert '"outcome": "disabled"' in capsys.readouterr().out
+
+
+def test_preflight_cli_guard_exit_four(monkeypatch, tmp_path):
+    log_path = tmp_path / "ehdb.jsonl"
+    log_path.write_text("", encoding="utf-8")
+    monkeypatch.setenv(EHDB_ENABLED_ENV, "true")
+    monkeypatch.setenv(EHDB_MODE_ENV, "local_reference")
+    monkeypatch.setenv(EHDB_CLIENT_ROLE_ENV, "gateway")
+    monkeypatch.setenv(EHDB_LOCAL_REFERENCE_LOG_ENV, str(log_path))
+    module = _load_preflight_module()
+
+    assert module.main([]) == 4
+
+
+# --------------------------------------------------------------------------
+# Helpers (mirror tests/core/test_ehdb_adapter.py)
+# --------------------------------------------------------------------------
+
+
+def _helper_script(tmp_path: Path, body: str, *, name: str = "ehdb-helper.py") -> Path:
+    helper = tmp_path / name
+    helper.write_text(f"#!{sys.executable}\n{body.lstrip()}", encoding="utf-8")
+    helper.chmod(0o755)
+    return helper
+
+
+def _summary_helper(tmp_path: Path, *, transaction_count: int) -> Path:
+    payload = {
+        field: 0
+        for field in EHDB_LOCAL_REFERENCE_SUMMARY_FIELDS
+        if field != "log_path"
+    }
+    payload["transaction_count"] = transaction_count
+    return _helper_script(
+        tmp_path,
+        f"""
+import json
+import sys
+
+payload = {payload!r}
+payload["log_path"] = sys.argv[3]
+print(json.dumps(payload))
+""",
+    )


### PR DESCRIPTION
## EHDB↔NoETL integration — Phase B

Phase A (ops env-rendering boundary, disabled-by-default) shipped in `noetl/ops#234`. Phase B adds the **bounded, stateless worker/playbook readiness hook** over `read_ehdb_local_reference_summary_from_env`, with **no gateway/API/server data-plane access**.

Tracks noetl/ai-meta#234 (EHDB umbrella). Product code stays in `noetl/noetl`.

### What lands

- **`noetl/core/ehdb_readiness.py`** (new) — `evaluate_ehdb_readiness()` returns a secret-free structured result (outcome + role + counts + duration). Outcomes: `disabled / control_plane / ready / empty / truncated / unavailable / guard_refused / invalid`. The read is **time-bounded** (default 5s, clamped 0.1–30s via `NOETL_EHDB_READINESS_TIMEOUT_SECONDS`) and **stateless** — no connection/state held between calls.
- **Control-plane guard** — `assert_data_plane_read_allowed()` refuses a data-plane read for `gateway/api/server` (defense-in-depth on top of the contract validation). Control-plane roles never perform the read (`control_plane` outcome); a control-plane role handed a data-plane env classifies as `guard_refused`.
- **Observability** — process-local `noetl_ehdb_readiness_*` metrics (checks_total by outcome, ready/degraded gauges, last-duration), surfaced through the worker `/metrics` render. No log path, count values, or helper stderr leak into metric text. **Disabled records nothing → `/metrics` byte-identical.**
- **Worker bootstrap** — `run_worker` runs the preflight once at startup: **no-op and silent when EHDB is disabled** (the default), never fatal (EHDB is auxiliary specialized storage), guard trips logged loudly.
- **Preflight CLI** — `scripts/ehdb_readiness_preflight.py`: a worker/playbook-local command / kind smoke step (**not** a server endpoint), with role-boundary-aware exit codes (`0` ready, `3` strict-degraded, `4` guard, `5` invalid).
- **Adapter alignment** — the local-reference adapter now accepts the `system` role (the contract + Phase A ops template already treat `system` as a local-reference data-plane role).

### Boundary preserved

- gateway = gatekeeper, worker = atomic compute, playbook = ephemeral blueprint — unchanged.
- Gateway/API/server EHDB embedding stays **control-plane-only**; Phase B adds **no** data-plane access for those roles and guards against it in code.
- Disabled-by-default: when EHDB is off, the hook is a no-op and behavior is byte-identical to today.

### Validation

Unit tests — `tests/core/test_ehdb_readiness.py` (disabled no-op + no metrics; worker/playbook/system bounded read; control-plane guard refused; missing-helper degraded; bounded-timeout truncation; invalid config; metrics render; preflight CLI exit codes). Full EHDB suite: **81 passed**.

Local kind (`kind-noetl`) — a Job on an overlay image (Phase A `ehdb-helper-image-test` + this code, real `ehdb-local-reference` helper) ran the preflight and **all three checks passed**:

```
== 1. disabled (no-op) ==        {"outcome":"disabled","ready":true} rc=0
== 2. worker local_reference ==  {"outcome":"empty","ready":true,"role":"worker", ...counts...} rc=0
== 3. gateway guard (rc=4) ==    {"outcome":"guard_refused","ready":false,"role":"gateway"} rc=4
ALL_READINESS_CHECKS_PASSED
```

No GKE/prod changes.

Refs noetl/ai-meta#234