### PR TITLE
feat(ehdb): Phase C — bounded worker/playbook data-plane append/read step (#234)

### DIFF
--- a/docker/noetl/README.md
+++ b/docker/noetl/README.md
@@ -70,6 +70,6 @@ runtime image:
 
 ```bash
 docker build \
-  --build-arg EHDB_REF=0dc2016f4b692d3d868ccbc3918900962a880ca1 \
+  --build-arg EHDB_REF=3ae895016154f9e5537a61930aeba2788b814ed3 \
   --file docker/noetl/dev/Dockerfile .
 ```

--- a/docker/noetl/dev/Dockerfile
+++ b/docker/noetl/dev/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.82-slim AS ehdb-helper
 
-ARG EHDB_REF=0dc2016f4b692d3d868ccbc3918900962a880ca1
+ARG EHDB_REF=3ae895016154f9e5537a61930aeba2788b814ed3
 
 RUN apt-get update && apt-get --no-install-recommends install -y \
     ca-certificates \

--- a/docker/noetl/pip/Dockerfile
+++ b/docker/noetl/pip/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.82-slim AS ehdb-helper
 
-ARG EHDB_REF=0dc2016f4b692d3d868ccbc3918900962a880ca1
+ARG EHDB_REF=3ae895016154f9e5537a61930aeba2788b814ed3
 
 RUN apt-get update && apt-get --no-install-recommends install -y \
     ca-certificates \

--- a/noetl/core/ehdb_adapter.py
+++ b/noetl/core/ehdb_adapter.py
@@ -358,10 +358,264 @@ def read_ehdb_local_reference_summary_from_env(
     )
 
 
+EHDB_LOCAL_REFERENCE_APPEND_FIELDS = (
+    "action",
+    "log_path",
+    "tenant",
+    "namespace",
+    "stream",
+    "subject",
+    "sequence",
+    "byte_len",
+    "created_stream",
+    "stream_record_count",
+    "transaction_count",
+)
+EHDB_LOCAL_REFERENCE_READ_FIELDS = (
+    "action",
+    "log_path",
+    "tenant",
+    "namespace",
+    "stream",
+    "exists",
+    "record_count",
+    "returned",
+    "records",
+)
+
+
+@dataclass(frozen=True)
+class LocalReferenceAppendResult:
+    """Validated result of a bounded ``append`` domain-record helper call."""
+
+    log_path: Path
+    tenant: str
+    namespace: str
+    stream: str
+    subject: str
+    sequence: int
+    byte_len: int
+    created_stream: bool
+    stream_record_count: int
+    transaction_count: int
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "LocalReferenceAppendResult":
+        missing = [
+            field for field in EHDB_LOCAL_REFERENCE_APPEND_FIELDS if field not in payload
+        ]
+        if missing:
+            raise ValueError(
+                f"EHDB append result missing required fields: {', '.join(missing)}"
+            )
+        if payload["action"] != "append":
+            raise ValueError("EHDB append result action must be 'append'")
+        return cls(
+            log_path=_summary_log_path(payload["log_path"]),
+            tenant=_result_text(payload["tenant"], "tenant"),
+            namespace=_result_text(payload["namespace"], "namespace"),
+            stream=_result_text(payload["stream"], "stream"),
+            subject=_result_text(payload["subject"], "subject"),
+            sequence=_summary_count(payload["sequence"], "sequence"),
+            byte_len=_summary_count(payload["byte_len"], "byte_len"),
+            created_stream=_result_bool(payload["created_stream"], "created_stream"),
+            stream_record_count=_summary_count(
+                payload["stream_record_count"], "stream_record_count"
+            ),
+            transaction_count=_summary_count(
+                payload["transaction_count"], "transaction_count"
+            ),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "action": "append",
+            "log_path": str(self.log_path),
+            "tenant": self.tenant,
+            "namespace": self.namespace,
+            "stream": self.stream,
+            "subject": self.subject,
+            "sequence": self.sequence,
+            "byte_len": self.byte_len,
+            "created_stream": self.created_stream,
+            "stream_record_count": self.stream_record_count,
+            "transaction_count": self.transaction_count,
+        }
+
+
+@dataclass(frozen=True)
+class LocalReferenceReadResult:
+    """Validated result of a bounded ``read`` domain-record helper call."""
+
+    log_path: Path
+    tenant: str
+    namespace: str
+    stream: str
+    exists: bool
+    record_count: int
+    returned: int
+    records: tuple[Mapping[str, Any], ...]
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "LocalReferenceReadResult":
+        missing = [
+            field for field in EHDB_LOCAL_REFERENCE_READ_FIELDS if field not in payload
+        ]
+        if missing:
+            raise ValueError(
+                f"EHDB read result missing required fields: {', '.join(missing)}"
+            )
+        if payload["action"] != "read":
+            raise ValueError("EHDB read result action must be 'read'")
+        records = payload["records"]
+        if not isinstance(records, list) or not all(
+            isinstance(record, Mapping) for record in records
+        ):
+            raise ValueError("EHDB read result records must be a list of objects")
+        return cls(
+            log_path=_summary_log_path(payload["log_path"]),
+            tenant=_result_text(payload["tenant"], "tenant"),
+            namespace=_result_text(payload["namespace"], "namespace"),
+            stream=_result_text(payload["stream"], "stream"),
+            exists=_result_bool(payload["exists"], "exists"),
+            record_count=_summary_count(payload["record_count"], "record_count"),
+            returned=_summary_count(payload["returned"], "returned"),
+            records=tuple(dict(record) for record in records),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "action": "read",
+            "log_path": str(self.log_path),
+            "tenant": self.tenant,
+            "namespace": self.namespace,
+            "stream": self.stream,
+            "exists": self.exists,
+            "record_count": self.record_count,
+            "returned": self.returned,
+            "records": [dict(record) for record in self.records],
+        }
+
+
+def _domain_record_invocation(
+    adapter: LocalReferenceEhdbAdapter,
+    executable: str,
+    args: Sequence[str],
+) -> LocalReferenceEhdbInvocation:
+    """Build an invocation preserving argument values verbatim.
+
+    Unlike :meth:`LocalReferenceEhdbAdapter.helper_invocation`, this does not
+    strip arguments — a domain-record payload must reach the helper byte-for-
+    byte so the appended record matches what the caller supplied.
+    """
+
+    runtime_env = adapter.runtime_env()
+    return LocalReferenceEhdbInvocation(
+        executable=_non_empty_text(executable, "EHDB helper executable"),
+        args=tuple(args),
+        env_items=tuple(runtime_env.items()),
+        role=adapter.role,
+        local_reference_log=adapter.local_reference_log,
+    )
+
+
+def ehdb_local_reference_append_invocation_from_env(
+    env: Mapping[str, str] | None = None,
+    *,
+    stream: str,
+    subject: str,
+    transaction_id: str,
+    payload: str,
+    tenant: str | None = None,
+    namespace: str | None = None,
+) -> LocalReferenceEhdbInvocation | None:
+    """Return the concrete ``append`` domain-record helper invocation."""
+
+    source_env = os.environ if env is None else env
+    adapter = ehdb_adapter_from_env(source_env)
+    if adapter is None:
+        return None
+    executable = discover_ehdb_helper_executable(source_env)
+    if executable is None:
+        raise ValueError(
+            f"{EHDB_HELPER_BIN_ENV} is required or "
+            f"{EHDB_LOCAL_REFERENCE_HELPER_NAME} must be discoverable"
+        )
+    args = [
+        "append",
+        "--log",
+        str(adapter.local_reference_log),
+        "--stream",
+        _non_empty_text(stream, "stream"),
+        "--subject",
+        _non_empty_text(subject, "subject"),
+        "--transaction-id",
+        _non_empty_text(transaction_id, "transaction_id"),
+        "--payload",
+        payload,
+    ]
+    if tenant is not None:
+        args.extend(["--tenant", _non_empty_text(tenant, "tenant")])
+    if namespace is not None:
+        args.extend(["--namespace", _non_empty_text(namespace, "namespace")])
+    return _domain_record_invocation(adapter, executable, args)
+
+
+def ehdb_local_reference_read_invocation_from_env(
+    env: Mapping[str, str] | None = None,
+    *,
+    stream: str,
+    after: int | None = None,
+    limit: int | None = None,
+    tenant: str | None = None,
+    namespace: str | None = None,
+) -> LocalReferenceEhdbInvocation | None:
+    """Return the concrete ``read`` domain-record helper invocation."""
+
+    source_env = os.environ if env is None else env
+    adapter = ehdb_adapter_from_env(source_env)
+    if adapter is None:
+        return None
+    executable = discover_ehdb_helper_executable(source_env)
+    if executable is None:
+        raise ValueError(
+            f"{EHDB_HELPER_BIN_ENV} is required or "
+            f"{EHDB_LOCAL_REFERENCE_HELPER_NAME} must be discoverable"
+        )
+    args = [
+        "read",
+        "--log",
+        str(adapter.local_reference_log),
+        "--stream",
+        _non_empty_text(stream, "stream"),
+    ]
+    if tenant is not None:
+        args.extend(["--tenant", _non_empty_text(tenant, "tenant")])
+    if namespace is not None:
+        args.extend(["--namespace", _non_empty_text(namespace, "namespace")])
+    if limit is not None:
+        args.extend(["--limit", str(int(limit))])
+    if after is not None:
+        args.extend(["--after", str(int(after))])
+    return _domain_record_invocation(adapter, executable, args)
+
+
 def _non_empty_text(value: str | None, label: str) -> str:
     if value is None or not value.strip():
         raise ValueError(f"{label} is required")
     return value.strip()
+
+
+def _result_text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"EHDB result {field} must be a non-empty string")
+    return value
+
+
+def _result_bool(value: Any, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"EHDB result {field} must be a boolean")
+    return value
 
 
 def _summary_log_path(value: Any) -> Path:

--- a/noetl/core/ehdb_dataplane.py
+++ b/noetl/core/ehdb_dataplane.py
@@ -1,0 +1,572 @@
+"""Bounded, stateless EHDB worker/playbook data-plane step for NoETL.
+
+Phase C of the EHDB↔NoETL integration.  Phase B exposed a *readiness*
+preflight (a summary read).  Phase C adds the first bounded *data-plane*
+operation: append and read a single domain record through the local-reference
+adapter (:mod:`noetl.core.ehdb_adapter`).
+
+Hard boundaries preserved (see the EHDB Architecture wiki):
+
+* **Disabled by default** — when ``NOETL_EHDB_ENABLED`` is not truthy every
+  operation is a strict no-op: it performs no append/read, writes no file,
+  records no metric, and behaves byte-identically to a build without EHDB.
+* **Control-plane roles get no data-plane handle** — gateway / api / server
+  never append or read.  A control-plane role that reaches the data-plane is
+  refused by :func:`assert_data_plane_access_allowed` (defense-in-depth beyond
+  the contract validation), and no helper is executed.
+* **Bounded** — the payload is capped (``NOETL_EHDB_DATAPLANE_MAX_PAYLOAD_BYTES``,
+  default 65536, clamped) and the read limit is capped
+  (``NOETL_EHDB_DATAPLANE_MAX_READ_LIMIT``, default 1000, clamped).  The helper
+  runs under a short time cap.  Over-bound requests are rejected before the
+  helper is invoked.
+* **Stateless** — each call opens the bounded helper, performs one operation,
+  and returns.  No long-lived connection or per-tenant state is held between
+  requests.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Mapping
+
+from noetl.core.ehdb_adapter import (
+    LocalReferenceAppendResult,
+    LocalReferenceReadResult,
+    ehdb_local_reference_append_invocation_from_env,
+    ehdb_local_reference_read_invocation_from_env,
+    execute_ehdb_helper_json,
+)
+from noetl.core.ehdb_contract import (
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    NOETL_RUN_MODE_ENV,
+    EhdbClientRole,
+)
+from noetl.core.ehdb_readiness import EhdbControlPlaneGuardError
+
+
+# A data-plane operation is a fast bounded helper call; use the same tight
+# default cap as the readiness preflight.  Operators may override within a
+# clamped range that keeps the operation bounded regardless of the value.
+DEFAULT_DATAPLANE_TIMEOUT_SECONDS = 5.0
+_MIN_DATAPLANE_TIMEOUT_SECONDS = 0.1
+_MAX_DATAPLANE_TIMEOUT_SECONDS = 30.0
+EHDB_DATAPLANE_TIMEOUT_ENV = "NOETL_EHDB_DATAPLANE_TIMEOUT_SECONDS"
+
+# Payload + read-limit bounds.  The bound is owned by NoETL (not the helper) so
+# the "bounded" property is enforced at the platform boundary.
+DEFAULT_MAX_PAYLOAD_BYTES = 65536
+_MAX_PAYLOAD_BYTES_CEILING = 1048576
+EHDB_DATAPLANE_MAX_PAYLOAD_BYTES_ENV = "NOETL_EHDB_DATAPLANE_MAX_PAYLOAD_BYTES"
+
+DEFAULT_MAX_READ_LIMIT = 1000
+_READ_LIMIT_CEILING = 10000
+EHDB_DATAPLANE_MAX_READ_LIMIT_ENV = "NOETL_EHDB_DATAPLANE_MAX_READ_LIMIT"
+
+_CONTROL_PLANE_ROLES = frozenset(
+    {EhdbClientRole.GATEWAY, EhdbClientRole.API, EhdbClientRole.SERVER}
+)
+_DATA_PLANE_ROLES = frozenset(
+    {EhdbClientRole.WORKER, EhdbClientRole.PLAYBOOK, EhdbClientRole.SYSTEM}
+)
+
+
+class EhdbDataPlaneOperation(StrEnum):
+    """The bounded data-plane operation performed."""
+
+    APPEND = "append"
+    READ = "read"
+
+
+class EhdbDataPlaneOutcome(StrEnum):
+    """Terminal classification of a single data-plane operation."""
+
+    DISABLED = "disabled"            # EHDB off — no-op, byte-identical
+    APPENDED = "appended"            # one domain record appended
+    READ = "read"                    # domain records read (possibly empty)
+    ABSENT = "absent"                # read of a stream that was never written
+    REJECTED = "rejected"            # request exceeded a NoETL bound
+    TRUNCATED = "truncated"          # bounded time cap tripped — degraded
+    UNAVAILABLE = "unavailable"      # helper missing / errored — degraded
+    GUARD_REFUSED = "guard_refused"  # control-plane role given a data-plane env
+    INVALID = "invalid"              # misconfigured EHDB env (non-guard)
+
+
+_OK_OUTCOMES = frozenset(
+    {
+        EhdbDataPlaneOutcome.DISABLED,
+        EhdbDataPlaneOutcome.APPENDED,
+        EhdbDataPlaneOutcome.READ,
+        EhdbDataPlaneOutcome.ABSENT,
+    }
+)
+_DEGRADED_OUTCOMES = frozenset(
+    {EhdbDataPlaneOutcome.TRUNCATED, EhdbDataPlaneOutcome.UNAVAILABLE}
+)
+
+
+@dataclass(frozen=True)
+class EhdbDataPlaneResult:
+    """Structured result of a bounded data-plane operation."""
+
+    operation: EhdbDataPlaneOperation
+    outcome: EhdbDataPlaneOutcome
+    role: EhdbClientRole | None = None
+    duration_seconds: float = 0.0
+    detail: str | None = None
+    append: LocalReferenceAppendResult | None = None
+    read: LocalReferenceReadResult | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.outcome in _OK_OUTCOMES
+
+    @property
+    def degraded(self) -> bool:
+        return self.outcome in _DEGRADED_OUTCOMES
+
+    @property
+    def performed_operation(self) -> bool:
+        return self.outcome in {
+            EhdbDataPlaneOutcome.APPENDED,
+            EhdbDataPlaneOutcome.READ,
+            EhdbDataPlaneOutcome.ABSENT,
+        }
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "operation": self.operation.value,
+            "outcome": self.outcome.value,
+            "ok": self.ok,
+            "degraded": self.degraded,
+            "duration_seconds": round(self.duration_seconds, 6),
+        }
+        if self.role is not None:
+            payload["role"] = self.role.value
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        if self.append is not None:
+            payload["append"] = self.append.as_dict()
+        if self.read is not None:
+            payload["read"] = self.read.as_dict()
+        return payload
+
+
+def assert_data_plane_access_allowed(
+    role: EhdbClientRole, *, operation: EhdbDataPlaneOperation
+) -> None:
+    """Guard: only worker/playbook/system roles may touch the data plane.
+
+    Defense-in-depth on top of the contract validation.  A control-plane role
+    (gateway/api/server) must never append to or read from EHDB data, so any
+    attempt is refused here before the helper is executed.
+    """
+
+    if role in _CONTROL_PLANE_ROLES:
+        raise EhdbControlPlaneGuardError(
+            f"EHDB data-plane {operation.value} refused for control-plane role "
+            f"'{role.value}'; gateway/api/server remain gatekeepers and never "
+            "touch EHDB data"
+        )
+    if role not in _DATA_PLANE_ROLES:
+        raise EhdbControlPlaneGuardError(
+            f"EHDB data-plane {operation.value} requires a worker/playbook/system "
+            f"role, got '{role.value}'"
+        )
+
+
+def append_ehdb_domain_record(
+    stream: str,
+    subject: str,
+    payload: str,
+    *,
+    transaction_id: str | None = None,
+    tenant: str | None = None,
+    namespace: str | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout_seconds: float | None = None,
+    record_metrics: bool = True,
+) -> EhdbDataPlaneResult:
+    """Append one bounded domain record via the local-reference adapter.
+
+    When EHDB is disabled the result is
+    :attr:`EhdbDataPlaneOutcome.DISABLED` and nothing is written — behaviour is
+    byte-identical to EHDB being absent.
+    """
+
+    source_env = os.environ if env is None else env
+    started = time.monotonic()
+    op = EhdbDataPlaneOperation.APPEND
+
+    def _finish(outcome, **kwargs) -> EhdbDataPlaneResult:
+        return _record(
+            EhdbDataPlaneResult(
+                operation=op,
+                outcome=outcome,
+                duration_seconds=time.monotonic() - started,
+                **kwargs,
+            ),
+            record_metrics,
+        )
+
+    if not _truthy(source_env.get(EHDB_ENABLED_ENV)):
+        return _finish(EhdbDataPlaneOutcome.DISABLED)
+
+    role, contract, guard_result = _resolve_role(source_env, op, started, record_metrics)
+    if guard_result is not None:
+        return guard_result
+
+    # Bound the payload before touching the helper.
+    max_bytes = _bounded_max_payload_bytes(source_env)
+    payload_bytes = len(payload.encode("utf-8"))
+    if payload_bytes == 0:
+        return _finish(
+            EhdbDataPlaneOutcome.REJECTED,
+            role=role,
+            detail="empty domain-record payload",
+        )
+    if payload_bytes > max_bytes:
+        return _finish(
+            EhdbDataPlaneOutcome.REJECTED,
+            role=role,
+            detail=f"payload {payload_bytes} bytes exceeds bound {max_bytes}",
+        )
+
+    txn_id = transaction_id or _new_transaction_id()
+    bounded_timeout = _bounded_timeout(source_env, timeout_seconds)
+    try:
+        invocation = ehdb_local_reference_append_invocation_from_env(
+            source_env,
+            stream=stream,
+            subject=subject,
+            transaction_id=txn_id,
+            payload=payload,
+            tenant=tenant,
+            namespace=namespace,
+        )
+    except ValueError as exc:
+        return _finish(EhdbDataPlaneOutcome.INVALID, role=role, detail=str(exc))
+    if invocation is None:
+        return _finish(EhdbDataPlaneOutcome.DISABLED, role=role)
+
+    try:
+        execution = execute_ehdb_helper_json(
+            invocation, timeout_seconds=bounded_timeout
+        )
+        result = LocalReferenceAppendResult.from_payload(execution.json_payload)
+    except TimeoutError as exc:
+        return _finish(EhdbDataPlaneOutcome.TRUNCATED, role=role, detail=str(exc))
+    except (ValueError, RuntimeError, OSError) as exc:
+        return _finish(EhdbDataPlaneOutcome.UNAVAILABLE, role=role, detail=str(exc))
+
+    return _finish(EhdbDataPlaneOutcome.APPENDED, role=role, append=result)
+
+
+def read_ehdb_domain_records(
+    stream: str,
+    *,
+    after: int | None = None,
+    limit: int | None = None,
+    tenant: str | None = None,
+    namespace: str | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout_seconds: float | None = None,
+    record_metrics: bool = True,
+) -> EhdbDataPlaneResult:
+    """Read up to ``limit`` bounded domain records via the adapter."""
+
+    source_env = os.environ if env is None else env
+    started = time.monotonic()
+    op = EhdbDataPlaneOperation.READ
+
+    def _finish(outcome, **kwargs) -> EhdbDataPlaneResult:
+        return _record(
+            EhdbDataPlaneResult(
+                operation=op,
+                outcome=outcome,
+                duration_seconds=time.monotonic() - started,
+                **kwargs,
+            ),
+            record_metrics,
+        )
+
+    if not _truthy(source_env.get(EHDB_ENABLED_ENV)):
+        return _finish(EhdbDataPlaneOutcome.DISABLED)
+
+    role, contract, guard_result = _resolve_role(source_env, op, started, record_metrics)
+    if guard_result is not None:
+        return guard_result
+
+    bounded_limit = _bounded_read_limit(source_env, limit)
+    bounded_timeout = _bounded_timeout(source_env, timeout_seconds)
+    try:
+        invocation = ehdb_local_reference_read_invocation_from_env(
+            source_env,
+            stream=stream,
+            after=after,
+            limit=bounded_limit,
+            tenant=tenant,
+            namespace=namespace,
+        )
+    except ValueError as exc:
+        return _finish(EhdbDataPlaneOutcome.INVALID, role=role, detail=str(exc))
+    if invocation is None:
+        return _finish(EhdbDataPlaneOutcome.DISABLED, role=role)
+
+    try:
+        execution = execute_ehdb_helper_json(
+            invocation, timeout_seconds=bounded_timeout
+        )
+        result = LocalReferenceReadResult.from_payload(execution.json_payload)
+    except TimeoutError as exc:
+        return _finish(EhdbDataPlaneOutcome.TRUNCATED, role=role, detail=str(exc))
+    except (ValueError, RuntimeError, OSError) as exc:
+        return _finish(EhdbDataPlaneOutcome.UNAVAILABLE, role=role, detail=str(exc))
+
+    outcome = (
+        EhdbDataPlaneOutcome.READ if result.exists else EhdbDataPlaneOutcome.ABSENT
+    )
+    return _finish(outcome, role=role, read=result)
+
+
+def _resolve_role(
+    source_env: Mapping[str, str],
+    op: EhdbDataPlaneOperation,
+    started: float,
+    record_metrics: bool,
+) -> tuple[EhdbClientRole | None, object | None, EhdbDataPlaneResult | None]:
+    """Build the contract + enforce the guard.
+
+    Returns ``(role, contract, guard_result)``.  When ``guard_result`` is not
+    ``None`` the caller must return it immediately (guard refusal / invalid
+    config); no data-plane operation is performed.
+    """
+
+    role = _safe_client_role(source_env)
+
+    def _finish(outcome, **kwargs) -> EhdbDataPlaneResult:
+        return _record(
+            EhdbDataPlaneResult(
+                operation=op,
+                outcome=outcome,
+                duration_seconds=time.monotonic() - started,
+                **kwargs,
+            ),
+            record_metrics,
+        )
+
+    try:
+        from noetl.core.ehdb_contract import ehdb_integration_contract_from_env
+
+        contract = ehdb_integration_contract_from_env(source_env)
+    except ValueError as exc:
+        if role in _CONTROL_PLANE_ROLES:
+            return role, None, _finish(
+                EhdbDataPlaneOutcome.GUARD_REFUSED, role=role, detail=str(exc)
+            )
+        return role, None, _finish(
+            EhdbDataPlaneOutcome.INVALID, role=role, detail=str(exc)
+        )
+
+    try:
+        assert_data_plane_access_allowed(contract.role, operation=op)
+    except EhdbControlPlaneGuardError as exc:
+        return contract.role, contract, _finish(
+            EhdbDataPlaneOutcome.GUARD_REFUSED, role=contract.role, detail=str(exc)
+        )
+
+    return contract.role, contract, None
+
+
+def _new_transaction_id() -> str:
+    """Application-side transaction id (snowflake), per observability rule."""
+
+    try:
+        from noetl.core.common import get_snowflake_id_str
+
+        return f"txn-{get_snowflake_id_str()}"
+    except Exception:
+        # Fallback keeps the operation usable in minimal environments; still a
+        # valid EHDB identifier ([A-Za-z0-9_-]).
+        return f"txn-{int(time.monotonic() * 1_000_000)}"
+
+
+def _bounded_timeout(env: Mapping[str, str], timeout_seconds: float | None) -> float:
+    if timeout_seconds is None:
+        raw = env.get(EHDB_DATAPLANE_TIMEOUT_ENV)
+        if raw is not None and raw.strip():
+            try:
+                timeout_seconds = float(raw.strip())
+            except ValueError:
+                timeout_seconds = DEFAULT_DATAPLANE_TIMEOUT_SECONDS
+        else:
+            timeout_seconds = DEFAULT_DATAPLANE_TIMEOUT_SECONDS
+    return max(
+        _MIN_DATAPLANE_TIMEOUT_SECONDS,
+        min(_MAX_DATAPLANE_TIMEOUT_SECONDS, timeout_seconds),
+    )
+
+
+def _bounded_max_payload_bytes(env: Mapping[str, str]) -> int:
+    raw = env.get(EHDB_DATAPLANE_MAX_PAYLOAD_BYTES_ENV)
+    value = DEFAULT_MAX_PAYLOAD_BYTES
+    if raw is not None and raw.strip():
+        try:
+            value = int(raw.strip())
+        except ValueError:
+            value = DEFAULT_MAX_PAYLOAD_BYTES
+    return max(1, min(_MAX_PAYLOAD_BYTES_CEILING, value))
+
+
+def _bounded_read_limit(env: Mapping[str, str], limit: int | None) -> int:
+    ceiling = DEFAULT_MAX_READ_LIMIT
+    raw = env.get(EHDB_DATAPLANE_MAX_READ_LIMIT_ENV)
+    if raw is not None and raw.strip():
+        try:
+            ceiling = int(raw.strip())
+        except ValueError:
+            ceiling = DEFAULT_MAX_READ_LIMIT
+    ceiling = max(1, min(_READ_LIMIT_CEILING, ceiling))
+    if limit is None:
+        return ceiling
+    return max(1, min(ceiling, int(limit)))
+
+
+def _safe_client_role(env: Mapping[str, str]) -> EhdbClientRole | None:
+    raw = env.get(EHDB_CLIENT_ROLE_ENV) or env.get(NOETL_RUN_MODE_ENV) or "worker"
+    normalized = raw.strip().lower()
+    if normalized == "server":
+        return EhdbClientRole.SERVER
+    try:
+        return EhdbClientRole(normalized)
+    except ValueError:
+        return None
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+# ---------------------------------------------------------------------------
+# Observability — process-local counters rendered into the worker /metrics
+# text.  Metrics carry only operation + outcome labels; no stream name,
+# subject, payload, log path, or error text leaks in.
+# ---------------------------------------------------------------------------
+
+
+class _DataPlaneMetrics:
+    """In-process accumulator for EHDB data-plane operations.
+
+    Disabled operations are intentionally *not* recorded so a disabled EHDB
+    build renders byte-identical `/metrics` output.
+    """
+
+    def __init__(self) -> None:
+        self._ops: dict[tuple[str, str], int] = {}
+        self._last_duration_seconds: float = 0.0
+        self._last_ok: int = 0
+        self._last_degraded: int = 0
+
+    def record(self, result: EhdbDataPlaneResult) -> None:
+        if result.outcome is EhdbDataPlaneOutcome.DISABLED:
+            return
+        key = (result.operation.value, result.outcome.value)
+        self._ops[key] = self._ops.get(key, 0) + 1
+        self._last_duration_seconds = result.duration_seconds
+        self._last_ok = 1 if result.ok else 0
+        self._last_degraded = 1 if result.degraded else 0
+
+    def reset(self) -> None:
+        self.__init__()
+
+    def has_data(self) -> bool:
+        return bool(self._ops)
+
+    def render(self, *, labels: Mapping[str, str] | None = None) -> list[str]:
+        if not self._ops:
+            return []
+        base_labels = dict(labels or {})
+        lines = [
+            "# HELP noetl_ehdb_dataplane_ops_total EHDB data-plane operations by operation and outcome",
+            "# TYPE noetl_ehdb_dataplane_ops_total counter",
+        ]
+        for operation, outcome in sorted(self._ops):
+            merged = dict(base_labels)
+            merged["operation"] = operation
+            merged["outcome"] = outcome
+            lines.append(
+                f"noetl_ehdb_dataplane_ops_total{_format_labels(merged)} "
+                f"{self._ops[(operation, outcome)]}"
+            )
+        lines.extend(
+            [
+                "# HELP noetl_ehdb_dataplane_last_ok Last EHDB data-plane op result (1=ok)",
+                "# TYPE noetl_ehdb_dataplane_last_ok gauge",
+                f"noetl_ehdb_dataplane_last_ok{_format_labels(base_labels)} {self._last_ok}",
+                "# HELP noetl_ehdb_dataplane_last_degraded Last EHDB data-plane degraded flag",
+                "# TYPE noetl_ehdb_dataplane_last_degraded gauge",
+                f"noetl_ehdb_dataplane_last_degraded{_format_labels(base_labels)} {self._last_degraded}",
+                "# HELP noetl_ehdb_dataplane_last_duration_seconds Last EHDB data-plane op duration",
+                "# TYPE noetl_ehdb_dataplane_last_duration_seconds gauge",
+                f"noetl_ehdb_dataplane_last_duration_seconds{_format_labels(base_labels)} "
+                f"{self._last_duration_seconds:.6f}",
+            ]
+        )
+        return lines
+
+
+_METRICS = _DataPlaneMetrics()
+
+
+def _record(result: EhdbDataPlaneResult, record_metrics: bool) -> EhdbDataPlaneResult:
+    if record_metrics:
+        _METRICS.record(result)
+    return result
+
+
+def render_ehdb_dataplane_metrics(
+    *, labels: Mapping[str, str] | None = None
+) -> list[str]:
+    """Return Prometheus text lines for data-plane ops (empty when none)."""
+
+    return _METRICS.render(labels=labels)
+
+
+def reset_ehdb_dataplane_metrics() -> None:
+    """Reset the process-local data-plane metrics (test helper)."""
+
+    _METRICS.reset()
+
+
+def _format_labels(labels: Mapping[str, str]) -> str:
+    if not labels:
+        return ""
+    rendered = ",".join(
+        f'{key}="{_escape_label(labels[key])}"' for key in sorted(labels)
+    )
+    return "{" + rendered + "}"
+
+
+def _escape_label(value: str) -> str:
+    return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+__all__ = [
+    "DEFAULT_DATAPLANE_TIMEOUT_SECONDS",
+    "DEFAULT_MAX_PAYLOAD_BYTES",
+    "DEFAULT_MAX_READ_LIMIT",
+    "EHDB_DATAPLANE_MAX_PAYLOAD_BYTES_ENV",
+    "EHDB_DATAPLANE_MAX_READ_LIMIT_ENV",
+    "EHDB_DATAPLANE_TIMEOUT_ENV",
+    "EhdbDataPlaneOperation",
+    "EhdbDataPlaneOutcome",
+    "EhdbDataPlaneResult",
+    "append_ehdb_domain_record",
+    "assert_data_plane_access_allowed",
+    "read_ehdb_domain_records",
+    "render_ehdb_dataplane_metrics",
+    "reset_ehdb_dataplane_metrics",
+]

--- a/noetl/worker/metrics.py
+++ b/noetl/worker/metrics.py
@@ -27,6 +27,13 @@ def render_worker_metrics(*, worker_id: str, labels: Mapping[str, str] | None = 
     from noetl.core.ehdb_readiness import render_ehdb_readiness_metrics
 
     lines.extend(render_ehdb_readiness_metrics(labels=metric_labels))
+
+    # EHDB Phase C data-plane metrics.  Renders nothing when no bounded
+    # append/read has run (disabled EHDB never records), so `/metrics` stays
+    # byte-identical for a disabled deployment.
+    from noetl.core.ehdb_dataplane import render_ehdb_dataplane_metrics
+
+    lines.extend(render_ehdb_dataplane_metrics(labels=metric_labels))
     return "\n".join(lines) + "\n"
 
 

--- a/scripts/ehdb_dataplane_step.py
+++ b/scripts/ehdb_dataplane_step.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Worker/playbook-local EHDB bounded data-plane step (Phase C).
+
+Appends or reads a single bounded domain record through the EHDB
+local-reference adapter and prints a secret-free JSON report.  Intended as a
+worker/playbook-local command or kind smoke step — deliberately *not* a server
+endpoint, so the control-plane boundary is preserved.
+
+Exit codes:
+
+* ``0`` — ok (``disabled`` / ``appended`` / ``read`` / ``absent``); also
+  ``truncated`` / ``unavailable`` unless ``--strict`` is given.
+* ``2`` — request rejected by a NoETL bound (``rejected``).
+* ``3`` — degraded (``truncated`` / ``unavailable``) with ``--strict``.
+* ``4`` — control-plane guard refused a data-plane operation.
+* ``5`` — invalid EHDB configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Sequence
+
+from noetl.core.ehdb_dataplane import (
+    EhdbDataPlaneOutcome,
+    append_ehdb_domain_record,
+    read_ehdb_domain_records,
+)
+
+
+def _exit_code(outcome: EhdbDataPlaneOutcome, *, strict: bool, degraded: bool, ok: bool) -> int:
+    if outcome is EhdbDataPlaneOutcome.GUARD_REFUSED:
+        return 4
+    if outcome is EhdbDataPlaneOutcome.INVALID:
+        return 5
+    if outcome is EhdbDataPlaneOutcome.REJECTED:
+        return 2
+    if strict and degraded:
+        return 3
+    return 0 if ok else 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run a bounded EHDB local-reference data-plane append/read.",
+    )
+    parser.add_argument("--strict", action="store_true", help="Treat degraded outcomes as failure.")
+    parser.add_argument("--timeout", type=float, default=None, help="Helper timeout seconds (clamped 0.1-30).")
+    parser.add_argument("--tenant", default=None, help="EHDB tenant (default: adapter default).")
+    parser.add_argument("--namespace", default=None, help="EHDB namespace (default: adapter default).")
+
+    sub = parser.add_subparsers(dest="operation", required=True)
+
+    append = sub.add_parser("append", help="Append one bounded domain record.")
+    append.add_argument("--stream", required=True)
+    append.add_argument("--subject", required=True)
+    append.add_argument("--payload", required=True, help="UTF-8 domain-record payload.")
+    append.add_argument("--transaction-id", default=None, help="Override the app-generated id.")
+
+    read = sub.add_parser("read", help="Read up to --limit bounded domain records.")
+    read.add_argument("--stream", required=True)
+    read.add_argument("--limit", type=int, default=None)
+    read.add_argument("--after", type=int, default=None)
+
+    args = parser.parse_args(argv)
+
+    if args.operation == "append":
+        result = append_ehdb_domain_record(
+            args.stream,
+            args.subject,
+            args.payload,
+            transaction_id=args.transaction_id,
+            tenant=args.tenant,
+            namespace=args.namespace,
+            timeout_seconds=args.timeout,
+        )
+    else:
+        result = read_ehdb_domain_records(
+            args.stream,
+            after=args.after,
+            limit=args.limit,
+            tenant=args.tenant,
+            namespace=args.namespace,
+            timeout_seconds=args.timeout,
+        )
+
+    print(json.dumps(result.as_dict(), sort_keys=True))
+    return _exit_code(
+        result.outcome,
+        strict=args.strict,
+        degraded=result.degraded,
+        ok=result.ok,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_ehdb_dataplane.py
+++ b/scripts/smoke_ehdb_dataplane.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Smoke the EHDB Phase C bounded data-plane append/read through NoETL.
+
+Appends two domain records to a fresh local-reference stream and reads them
+back, asserting the bounded append/read roundtrip works for a worker role.
+Intended as a worker/playbook-local command or kind smoke step — not a server
+endpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from noetl.core.ehdb_adapter import EHDB_HELPER_BIN_ENV
+from noetl.core.ehdb_contract import (
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    EHDB_LOCAL_REFERENCE_LOG_ENV,
+    EHDB_MODE_ENV,
+)
+from noetl.core.ehdb_dataplane import (
+    EhdbDataPlaneOutcome,
+    append_ehdb_domain_record,
+    read_ehdb_domain_records,
+)
+
+
+def run_smoke(
+    *,
+    helper_bin: str | None = None,
+    log_path: Path | None = None,
+    role: str = "worker",
+    stream: str = "noetl-smoke-domain",
+    timeout_seconds: float = 30.0,
+    env: Mapping[str, str] | None = None,
+) -> Mapping[str, object]:
+    source_env = dict(os.environ if env is None else env)
+    log_path = log_path or _temporary_log_path()
+    source_env.update(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: "local_reference",
+            EHDB_CLIENT_ROLE_ENV: role,
+            EHDB_LOCAL_REFERENCE_LOG_ENV: str(log_path),
+        }
+    )
+    if helper_bin is not None:
+        source_env[EHDB_HELPER_BIN_ENV] = helper_bin
+
+    first = append_ehdb_domain_record(
+        stream, f"{stream}.created", '{"seq":1}',
+        env=source_env, timeout_seconds=timeout_seconds,
+    )
+    if first.outcome is not EhdbDataPlaneOutcome.APPENDED:
+        raise RuntimeError(f"first append not APPENDED: {first.as_dict()}")
+
+    second = append_ehdb_domain_record(
+        stream, f"{stream}.updated", '{"seq":2}',
+        env=source_env, timeout_seconds=timeout_seconds,
+    )
+    if second.outcome is not EhdbDataPlaneOutcome.APPENDED:
+        raise RuntimeError(f"second append not APPENDED: {second.as_dict()}")
+
+    read = read_ehdb_domain_records(
+        stream, env=source_env, timeout_seconds=timeout_seconds
+    )
+    if read.outcome is not EhdbDataPlaneOutcome.READ:
+        raise RuntimeError(f"read not READ: {read.as_dict()}")
+    if read.read is None or read.read.record_count != 2:
+        raise RuntimeError(f"expected 2 records, got: {read.as_dict()}")
+
+    return {
+        "append_first": first.as_dict(),
+        "append_second": second.as_dict(),
+        "read": read.as_dict(),
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run a bounded NoETL smoke against the EHDB Phase C data plane.",
+    )
+    parser.add_argument("--helper-bin", help="Path to ehdb-local-reference. Defaults to NoETL discovery.")
+    parser.add_argument("--log", type=Path, help="EHDB JSONL log. Defaults to a temp path.")
+    parser.add_argument("--role", default="worker", help="worker|playbook|system. Default: worker.")
+    parser.add_argument("--timeout", type=float, default=30.0, help="Helper timeout seconds. Default: 30.")
+    args = parser.parse_args(argv)
+
+    try:
+        payload = run_smoke(
+            helper_bin=args.helper_bin,
+            log_path=args.log,
+            role=args.role,
+            timeout_seconds=args.timeout,
+        )
+    except Exception as exc:
+        print(f"EHDB data-plane smoke failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+def _temporary_log_path() -> Path:
+    handle = tempfile.NamedTemporaryFile(
+        prefix="noetl-ehdb-dataplane-smoke-",
+        suffix=".jsonl",
+        delete=False,
+    )
+    handle.close()
+    return Path(handle.name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_ehdb_dataplane.py
+++ b/tests/core/test_ehdb_dataplane.py
@@ -1,0 +1,362 @@
+"""Tests for the Phase C bounded EHDB data-plane step.
+
+Two layers of coverage:
+
+* Control-flow tests drive a stateful *fake* ``ehdb-local-reference`` helper
+  (a small Python script that reads/writes a JSONL log), so the NoETL
+  data-plane layer — disabled no-op, control-plane guard, payload/read bounds,
+  outcome classification, and secret-free metrics — is exercised without the
+  Rust binary.  These run in bare CI.
+* A real-binary roundtrip test runs the actual ``ehdb-local-reference`` binary
+  when it is discoverable (built locally / bundled in the kind image), and is
+  skipped otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from noetl.core.ehdb_adapter import (
+    EHDB_HELPER_BIN_ENV,
+    discover_ehdb_helper_executable,
+)
+from noetl.core.ehdb_contract import (
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    EHDB_LOCAL_REFERENCE_LOG_ENV,
+    EHDB_MODE_ENV,
+)
+from noetl.core.ehdb_dataplane import (
+    EHDB_DATAPLANE_MAX_PAYLOAD_BYTES_ENV,
+    EHDB_DATAPLANE_MAX_READ_LIMIT_ENV,
+    EhdbDataPlaneOutcome,
+    append_ehdb_domain_record,
+    read_ehdb_domain_records,
+    render_ehdb_dataplane_metrics,
+    reset_ehdb_dataplane_metrics,
+)
+
+
+# A faithful-but-minimal stateful stand-in for the Rust helper.  It stores one
+# JSON object per line keyed by (tenant, namespace, stream) and reproduces the
+# append/read contract the dataplane parses.
+_FAKE_HELPER = r'''
+import json
+import sys
+
+def parse(argv):
+    op = argv[0]
+    flags = {}
+    i = 1
+    while i < len(argv):
+        key = argv[i][2:]
+        flags[key] = argv[i + 1]
+        i += 2
+    return op, flags
+
+def load(path):
+    try:
+        with open(path) as fh:
+            return [json.loads(line) for line in fh if line.strip()]
+    except FileNotFoundError:
+        return None
+
+op, flags = parse(sys.argv[1:])
+log = flags["log"]
+tenant = flags.get("tenant", "noetl")
+namespace = flags.get("namespace", "default")
+stream = flags["stream"]
+
+if op == "append":
+    rows = load(log) or []
+    same = [r for r in rows if r["tenant"] == tenant and r["namespace"] == namespace and r["stream"] == stream]
+    created = len(same) == 0
+    seq = len(same) + 1
+    payload = flags["payload"]
+    row = {
+        "tenant": tenant, "namespace": namespace, "stream": stream,
+        "subject": flags["subject"], "transaction_id": flags["transaction-id"],
+        "payload": payload, "sequence": seq,
+    }
+    with open(log, "a") as fh:
+        fh.write(json.dumps(row) + "\n")
+    print(json.dumps({
+        "action": "append", "log_path": log, "tenant": tenant, "namespace": namespace,
+        "stream": stream, "subject": flags["subject"], "sequence": seq,
+        "byte_len": len(payload.encode("utf-8")), "created_stream": created,
+        "stream_record_count": seq, "transaction_count": len(rows) + 1,
+    }))
+elif op == "read":
+    rows = load(log) or []
+    recs = [r for r in rows if r["tenant"] == tenant and r["namespace"] == namespace and r["stream"] == stream]
+    exists = len(recs) > 0
+    after = int(flags["after"]) if "after" in flags else 0
+    limit = int(flags["limit"]) if "limit" in flags else 100
+    filtered = [r for r in recs if r["sequence"] > after]
+    projected = [{
+        "sequence": r["sequence"], "subject": r["subject"],
+        "transaction_id": r["transaction_id"], "byte_len": len(r["payload"].encode("utf-8")),
+        "payload": r["payload"],
+    } for r in filtered[:limit]]
+    print(json.dumps({
+        "action": "read", "log_path": log, "tenant": tenant, "namespace": namespace,
+        "stream": stream, "exists": exists,
+        "record_count": len(filtered), "returned": len(projected), "records": projected,
+    }))
+else:
+    print("unexpected op", file=sys.stderr)
+    sys.exit(4)
+'''
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics():
+    reset_ehdb_dataplane_metrics()
+    yield
+    reset_ehdb_dataplane_metrics()
+
+
+def _fake_helper(tmp_path: Path) -> Path:
+    helper = tmp_path / "ehdb-local-reference-fake.py"
+    helper.write_text(f"#!{sys.executable}\n{_FAKE_HELPER.lstrip()}", encoding="utf-8")
+    helper.chmod(0o755)
+    return helper
+
+
+def _enabled_env(tmp_path: Path, helper: Path, *, role: str = "worker", mode: str = "local_reference") -> dict:
+    return {
+        EHDB_ENABLED_ENV: "true",
+        EHDB_MODE_ENV: mode,
+        EHDB_CLIENT_ROLE_ENV: role,
+        EHDB_LOCAL_REFERENCE_LOG_ENV: str(tmp_path / "ehdb.jsonl"),
+        EHDB_HELPER_BIN_ENV: str(helper),
+        "PATH": "/usr/bin",
+    }
+
+
+# --------------------------------------------------------------------------
+# Disabled → strict no-op
+# --------------------------------------------------------------------------
+
+
+def test_append_disabled_is_noop(tmp_path):
+    log = tmp_path / "ehdb.jsonl"
+    result = append_ehdb_domain_record(
+        "orders", "orders.placed", "payload",
+        env={EHDB_LOCAL_REFERENCE_LOG_ENV: str(log)},
+    )
+    assert result.outcome is EhdbDataPlaneOutcome.DISABLED
+    assert result.append is None
+    assert not log.exists()
+    assert render_ehdb_dataplane_metrics() == []
+
+
+def test_read_disabled_is_noop(tmp_path):
+    result = read_ehdb_domain_records("orders", env={})
+    assert result.outcome is EhdbDataPlaneOutcome.DISABLED
+    assert render_ehdb_dataplane_metrics() == []
+
+
+# --------------------------------------------------------------------------
+# Enabled worker/playbook/system → bounded append/read
+# --------------------------------------------------------------------------
+
+
+def test_append_then_read_roundtrip(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+
+    first = append_ehdb_domain_record("itin", "itin.created", '{"a":1}', env=env)
+    assert first.outcome is EhdbDataPlaneOutcome.APPENDED
+    assert first.append is not None
+    assert first.append.sequence == 1
+    assert first.append.created_stream is True
+
+    second = append_ehdb_domain_record("itin", "itin.updated", '{"a":2}', env=env)
+    assert second.append.sequence == 2
+    assert second.append.created_stream is False
+
+    read = read_ehdb_domain_records("itin", env=env)
+    assert read.outcome is EhdbDataPlaneOutcome.READ
+    assert read.read is not None
+    assert read.read.record_count == 2
+    assert read.read.records[0]["payload"] == '{"a":1}'
+    assert read.read.records[1]["subject"] == "itin.updated"
+
+
+@pytest.mark.parametrize("role", ["worker", "playbook", "system"])
+def test_data_plane_roles_allowed(tmp_path, role):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper, role=role)
+    result = append_ehdb_domain_record("s", "s.evt", "x", env=env)
+    assert result.outcome is EhdbDataPlaneOutcome.APPENDED
+    assert result.role.value == role
+
+
+def test_read_after_and_limit_forwarded(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+    for i in range(1, 6):
+        append_ehdb_domain_record("evt", "evt.tick", f"p{i}", env=env)
+
+    limited = read_ehdb_domain_records("evt", limit=2, env=env)
+    assert limited.read.returned == 2
+    after = read_ehdb_domain_records("evt", after=3, env=env)
+    assert after.read.records[0]["sequence"] == 4
+
+
+# --------------------------------------------------------------------------
+# Control-plane guard — gateway/api/server never touch the data plane
+# --------------------------------------------------------------------------
+
+
+def test_control_plane_embedding_refused(tmp_path):
+    # Valid control-plane embedding env; a data-plane append must be refused
+    # and the helper must never run (no log file created).
+    helper = _fake_helper(tmp_path)
+    env = {
+        EHDB_ENABLED_ENV: "true",
+        EHDB_MODE_ENV: "control_plane",
+        EHDB_CLIENT_ROLE_ENV: "gateway",
+        EHDB_HELPER_BIN_ENV: str(helper),
+        "PATH": "/usr/bin",
+    }
+    result = append_ehdb_domain_record("s", "s.evt", "x", env=env)
+    assert result.outcome is EhdbDataPlaneOutcome.GUARD_REFUSED
+    assert result.append is None
+    assert not (tmp_path / "ehdb.jsonl").exists()
+
+
+@pytest.mark.parametrize("role", ["server", "api", "gateway"])
+def test_control_plane_role_with_data_plane_env_refused(tmp_path, role):
+    # A control-plane role handed a data-plane (local_reference) env is a
+    # misconfiguration; the contract rejects it and we classify it as a guard
+    # refusal (never an append).
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper, role=role)
+    result = read_ehdb_domain_records("s", env=env)
+    assert result.outcome is EhdbDataPlaneOutcome.GUARD_REFUSED
+    assert not (tmp_path / "ehdb.jsonl").exists()
+
+
+# --------------------------------------------------------------------------
+# Bounds — payload size + read limit owned by NoETL
+# --------------------------------------------------------------------------
+
+
+def test_oversize_payload_rejected(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+    env[EHDB_DATAPLANE_MAX_PAYLOAD_BYTES_ENV] = "8"
+    result = append_ehdb_domain_record("s", "s.evt", "0123456789", env=env)
+    assert result.outcome is EhdbDataPlaneOutcome.REJECTED
+    assert "exceeds bound" in (result.detail or "")
+    assert not (tmp_path / "ehdb.jsonl").exists()
+
+
+def test_empty_payload_rejected(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+    result = append_ehdb_domain_record("s", "s.evt", "", env=env)
+    assert result.outcome is EhdbDataPlaneOutcome.REJECTED
+    assert not (tmp_path / "ehdb.jsonl").exists()
+
+
+def test_read_limit_clamped_to_bound(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+    env[EHDB_DATAPLANE_MAX_READ_LIMIT_ENV] = "2"
+    for i in range(1, 6):
+        append_ehdb_domain_record("evt", "evt.tick", f"p{i}", env=env)
+    # Request 100 but the bound is 2.
+    result = read_ehdb_domain_records("evt", limit=100, env=env)
+    assert result.read.returned == 2
+
+
+# --------------------------------------------------------------------------
+# Invalid config + degraded helper
+# --------------------------------------------------------------------------
+
+
+def test_missing_log_is_invalid(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = {
+        EHDB_ENABLED_ENV: "true",
+        EHDB_MODE_ENV: "local_reference",
+        EHDB_CLIENT_ROLE_ENV: "worker",
+        EHDB_HELPER_BIN_ENV: str(helper),
+        "PATH": "/usr/bin",
+    }
+    result = append_ehdb_domain_record("s", "s.evt", "x", env=env)
+    assert result.outcome is EhdbDataPlaneOutcome.INVALID
+    assert not (tmp_path / "ehdb.jsonl").exists()
+
+
+def test_helper_error_is_unavailable(tmp_path):
+    broken = tmp_path / "broken.py"
+    broken.write_text(f"#!{sys.executable}\nimport sys\nsys.exit(2)\n", encoding="utf-8")
+    broken.chmod(0o755)
+    env = _enabled_env(tmp_path, broken)
+    result = append_ehdb_domain_record("s", "s.evt", "x", env=env)
+    assert result.outcome is EhdbDataPlaneOutcome.UNAVAILABLE
+    assert result.degraded is True
+
+
+# --------------------------------------------------------------------------
+# Observability — metrics carry no secret values
+# --------------------------------------------------------------------------
+
+
+def test_metrics_exclude_payload_and_stream_values(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+    secret_payload = "super-secret-token-ABC123"
+    append_ehdb_domain_record("private-stream", "s.evt", secret_payload, env=env)
+    read_ehdb_domain_records("private-stream", env=env)
+
+    rendered = "\n".join(render_ehdb_dataplane_metrics(labels={"worker_id": "w-1"}))
+    assert "noetl_ehdb_dataplane_ops_total" in rendered
+    assert 'operation="append"' in rendered
+    assert 'outcome="appended"' in rendered
+    assert 'operation="read"' in rendered
+    # Neither the payload nor the stream name may leak into the metric text.
+    assert secret_payload not in rendered
+    assert "private-stream" not in rendered
+
+
+def test_disabled_records_no_metric(tmp_path):
+    append_ehdb_domain_record("s", "s.evt", "x", env={})
+    assert render_ehdb_dataplane_metrics() == []
+
+
+# --------------------------------------------------------------------------
+# Real binary roundtrip (skipped when the binary is not discoverable)
+# --------------------------------------------------------------------------
+
+
+def test_real_binary_append_read_roundtrip(tmp_path):
+    binary = discover_ehdb_helper_executable({"PATH": ""})
+    if binary is None:
+        pytest.skip("ehdb-local-reference binary not built/discoverable")
+    env = {
+        EHDB_ENABLED_ENV: "true",
+        EHDB_MODE_ENV: "local_reference",
+        EHDB_CLIENT_ROLE_ENV: "worker",
+        EHDB_LOCAL_REFERENCE_LOG_ENV: str(tmp_path / "real.jsonl"),
+        EHDB_HELPER_BIN_ENV: binary,
+        "PATH": "/usr/bin",
+    }
+    appended = append_ehdb_domain_record("muno", "muno.created", '{"city":"paris"}', env=env)
+    assert appended.outcome is EhdbDataPlaneOutcome.APPENDED
+    assert appended.append.sequence == 1
+
+    read = read_ehdb_domain_records("muno", env=env)
+    assert read.outcome is EhdbDataPlaneOutcome.READ
+    assert read.read.records[0]["payload"] == '{"city":"paris"}'
+
+    absent = read_ehdb_domain_records("never", env=env)
+    assert absent.outcome is EhdbDataPlaneOutcome.ABSENT

--- a/tests/scripts/test_ehdb_dataplane_step.py
+++ b/tests/scripts/test_ehdb_dataplane_step.py
@@ -1,0 +1,78 @@
+"""Tests for the Phase C data-plane smoke + worker/playbook-local step CLI.
+
+Both exercise the real ``ehdb-local-reference`` binary when it is discoverable
+(built locally / bundled in the kind image) and skip otherwise, so the state
+roundtrip is genuine.
+"""
+
+import json
+
+import pytest
+
+from noetl.core.ehdb_adapter import discover_ehdb_helper_executable
+from scripts.ehdb_dataplane_step import main as step_main
+from scripts.smoke_ehdb_dataplane import run_smoke
+
+
+def _binary_or_skip() -> str:
+    binary = discover_ehdb_helper_executable({"PATH": ""})
+    if binary is None:
+        pytest.skip("ehdb-local-reference binary not built/discoverable")
+    return binary
+
+
+def test_run_smoke_appends_and_reads_back(tmp_path):
+    binary = _binary_or_skip()
+    payload = run_smoke(
+        helper_bin=binary,
+        log_path=tmp_path / "ehdb.jsonl",
+        env={"PATH": "/usr/bin"},
+    )
+    assert payload["append_first"]["append"]["sequence"] == 1
+    assert payload["append_second"]["append"]["sequence"] == 2
+    assert payload["read"]["read"]["record_count"] == 2
+
+
+def test_step_append_then_read(tmp_path, capsys, monkeypatch):
+    binary = _binary_or_skip()
+    log = str(tmp_path / "ehdb.jsonl")
+    monkeypatch.setenv("NOETL_EHDB_ENABLED", "true")
+    monkeypatch.setenv("NOETL_EHDB_MODE", "local_reference")
+    monkeypatch.setenv("NOETL_EHDB_CLIENT_ROLE", "worker")
+    monkeypatch.setenv("NOETL_EHDB_LOCAL_REFERENCE_LOG", log)
+    monkeypatch.setenv("NOETL_EHDB_HELPER_BIN", binary)
+
+    code = step_main(["append", "--stream", "trips", "--subject", "trips.made", "--payload", '{"x":1}'])
+    assert code == 0
+    appended = json.loads(capsys.readouterr().out)
+    assert appended["outcome"] == "appended"
+    assert appended["append"]["sequence"] == 1
+
+    code = step_main(["read", "--stream", "trips"])
+    assert code == 0
+    read = json.loads(capsys.readouterr().out)
+    assert read["outcome"] == "read"
+    assert read["read"]["records"][0]["payload"] == '{"x":1}'
+
+
+def test_step_disabled_is_noop_exit_zero(capsys, monkeypatch):
+    # No EHDB env → disabled no-op, exit 0, no binary needed.
+    for key in (
+        "NOETL_EHDB_ENABLED",
+        "NOETL_EHDB_MODE",
+        "NOETL_EHDB_CLIENT_ROLE",
+        "NOETL_EHDB_LOCAL_REFERENCE_LOG",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    code = step_main(["read", "--stream", "trips"])
+    assert code == 0
+    assert json.loads(capsys.readouterr().out)["outcome"] == "disabled"
+
+
+def test_step_control_plane_guard_exit_four(capsys, monkeypatch):
+    monkeypatch.setenv("NOETL_EHDB_ENABLED", "true")
+    monkeypatch.setenv("NOETL_EHDB_MODE", "control_plane")
+    monkeypatch.setenv("NOETL_EHDB_CLIENT_ROLE", "gateway")
+    code = step_main(["append", "--stream", "s", "--subject", "s.e", "--payload", "x"])
+    assert code == 4
+    assert json.loads(capsys.readouterr().out)["outcome"] == "guard_refused"


### PR DESCRIPTION
## Phase C — bounded worker/playbook data-plane step

Tracks [noetl/ehdb#234](https://github.com/noetl/ehdb/issues/234). Phase B
(noetl/noetl#688) exposed a readiness *summary* preflight. Phase C adds the
first bounded **data-plane** operation: append and read a single domain
record through the local-reference adapter — still disabled-by-default, still
worker/playbook/system-only, with **no gateway/API/server data access**.

### New surface

- **`noetl/core/ehdb_dataplane.py`** — `append_ehdb_domain_record` /
  `read_ehdb_domain_records`.
  - **Disabled by default** → strict no-op: no append/read, no file, no
    metric, byte-identical to a build without EHDB.
  - **Control-plane guard** — `assert_data_plane_access_allowed` refuses
    gateway/api/server *before* any helper runs (defense-in-depth on top of
    the contract). A control-plane role handed a data-plane env → `guard_refused`.
  - **Bounded** — payload byte cap (`NOETL_EHDB_DATAPLANE_MAX_PAYLOAD_BYTES`,
    default 65536, clamped) + read-limit cap
    (`NOETL_EHDB_DATAPLANE_MAX_READ_LIMIT`, default 1000, clamped) + short
    helper time cap. Over-bound requests are `rejected` before the helper runs.
  - **Stateless** — the bounded helper is opened + dropped per call.
  - App-side snowflake transaction ids (observability rule).
  - **Secret-free metrics** — `noetl_ehdb_dataplane_ops_total{operation,outcome}`
    + last-op gauges. No stream/subject/payload/log-path values leak.
- **`ehdb_adapter.py`** — append/read invocation builders + typed
  `LocalReferenceAppendResult` / `LocalReferenceReadResult`. Payload reaches
  the helper verbatim so the appended record is byte-exact.
- **`worker/metrics.py`** — render data-plane metrics on the worker `/metrics`
  surface (renders nothing when disabled → byte-identical).
- **`scripts/ehdb_dataplane_step.py`** — worker/playbook-local step CLI
  (append/read), **not** a server endpoint. **`scripts/smoke_ehdb_dataplane.py`**
  — kind smoke.
- **`docker/noetl/*/Dockerfile`** — bump `EHDB_REF` to noetl/ehdb@3ae8950
  (append/read helper).

### Validation

- `pytest tests/core/test_ehdb_dataplane.py tests/scripts/test_ehdb_dataplane_step.py`
  → 23 passed (incl. a real-binary append/read roundtrip). Existing EHDB
  tests: 84 passed (no regression).
- **Local kind** (`kind-noetl`, Phase C overlay image, real linux binary): a
  Job ran all six checks green — disabled no-op + byte-identical `/metrics`,
  worker/system/playbook append→read roundtrip, control-plane gateway guard
  refused (exit 4, no write), secret-free metrics. Nothing on GKE/prod.

### Boundary

Needs the `ehdb-local-reference` append/read subcommands
(noetl/ehdb#235, merged). Prefer command/step over server endpoint per the
data-access boundary rule.

Refs noetl/ehdb#234