### PR TITLE
feat(ehdb): Phase D bounded worker/playbook event-stream drain

### DIFF
--- a/docker/noetl/README.md
+++ b/docker/noetl/README.md
@@ -70,6 +70,6 @@ runtime image:
 
 ```bash
 docker build \
-  --build-arg EHDB_REF=3ae895016154f9e5537a61930aeba2788b814ed3 \
+  --build-arg EHDB_REF=3cefba916e661d976924ad0a8d8f070fcc3c4d62 \
   --file docker/noetl/dev/Dockerfile .
 ```

--- a/docker/noetl/dev/Dockerfile
+++ b/docker/noetl/dev/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.82-slim AS ehdb-helper
 
-ARG EHDB_REF=3ae895016154f9e5537a61930aeba2788b814ed3
+ARG EHDB_REF=3cefba916e661d976924ad0a8d8f070fcc3c4d62
 
 RUN apt-get update && apt-get --no-install-recommends install -y \
     ca-certificates \

--- a/docker/noetl/pip/Dockerfile
+++ b/docker/noetl/pip/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.82-slim AS ehdb-helper
 
-ARG EHDB_REF=3ae895016154f9e5537a61930aeba2788b814ed3
+ARG EHDB_REF=3cefba916e661d976924ad0a8d8f070fcc3c4d62
 
 RUN apt-get update && apt-get --no-install-recommends install -y \
     ca-certificates \

--- a/noetl/core/ehdb_adapter.py
+++ b/noetl/core/ehdb_adapter.py
@@ -497,6 +497,155 @@ class LocalReferenceReadResult:
         }
 
 
+EHDB_LOCAL_REFERENCE_CONSUME_FIELDS = (
+    "action",
+    "log_path",
+    "tenant",
+    "namespace",
+    "stream",
+    "consumer",
+    "exists",
+    "created_consumer",
+    "acked_sequence",
+    "pending_count",
+    "returned",
+    "records",
+    "transaction_count",
+)
+EHDB_LOCAL_REFERENCE_ACK_FIELDS = (
+    "action",
+    "log_path",
+    "tenant",
+    "namespace",
+    "stream",
+    "consumer",
+    "acked_sequence",
+    "transaction_count",
+)
+
+
+@dataclass(frozen=True)
+class LocalReferenceConsumeResult:
+    """Validated result of a bounded durable-consumer ``consume`` helper call."""
+
+    log_path: Path
+    tenant: str
+    namespace: str
+    stream: str
+    consumer: str
+    exists: bool
+    created_consumer: bool
+    acked_sequence: int | None
+    pending_count: int
+    returned: int
+    records: tuple[Mapping[str, Any], ...]
+    transaction_count: int
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "LocalReferenceConsumeResult":
+        missing = [
+            field
+            for field in EHDB_LOCAL_REFERENCE_CONSUME_FIELDS
+            if field not in payload
+        ]
+        if missing:
+            raise ValueError(
+                f"EHDB consume result missing required fields: {', '.join(missing)}"
+            )
+        if payload["action"] != "consume":
+            raise ValueError("EHDB consume result action must be 'consume'")
+        records = payload["records"]
+        if not isinstance(records, list) or not all(
+            isinstance(record, Mapping) for record in records
+        ):
+            raise ValueError("EHDB consume result records must be a list of objects")
+        return cls(
+            log_path=_summary_log_path(payload["log_path"]),
+            tenant=_result_text(payload["tenant"], "tenant"),
+            namespace=_result_text(payload["namespace"], "namespace"),
+            stream=_result_text(payload["stream"], "stream"),
+            consumer=_result_text(payload["consumer"], "consumer"),
+            exists=_result_bool(payload["exists"], "exists"),
+            created_consumer=_result_bool(
+                payload["created_consumer"], "created_consumer"
+            ),
+            acked_sequence=_result_optional_count(
+                payload["acked_sequence"], "acked_sequence"
+            ),
+            pending_count=_summary_count(payload["pending_count"], "pending_count"),
+            returned=_summary_count(payload["returned"], "returned"),
+            records=tuple(dict(record) for record in records),
+            transaction_count=_summary_count(
+                payload["transaction_count"], "transaction_count"
+            ),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "action": "consume",
+            "log_path": str(self.log_path),
+            "tenant": self.tenant,
+            "namespace": self.namespace,
+            "stream": self.stream,
+            "consumer": self.consumer,
+            "exists": self.exists,
+            "created_consumer": self.created_consumer,
+            "acked_sequence": self.acked_sequence,
+            "pending_count": self.pending_count,
+            "returned": self.returned,
+            "records": [dict(record) for record in self.records],
+            "transaction_count": self.transaction_count,
+        }
+
+
+@dataclass(frozen=True)
+class LocalReferenceAckResult:
+    """Validated result of a bounded durable-consumer ``ack`` helper call."""
+
+    log_path: Path
+    tenant: str
+    namespace: str
+    stream: str
+    consumer: str
+    acked_sequence: int
+    transaction_count: int
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "LocalReferenceAckResult":
+        missing = [
+            field for field in EHDB_LOCAL_REFERENCE_ACK_FIELDS if field not in payload
+        ]
+        if missing:
+            raise ValueError(
+                f"EHDB ack result missing required fields: {', '.join(missing)}"
+            )
+        if payload["action"] != "ack":
+            raise ValueError("EHDB ack result action must be 'ack'")
+        return cls(
+            log_path=_summary_log_path(payload["log_path"]),
+            tenant=_result_text(payload["tenant"], "tenant"),
+            namespace=_result_text(payload["namespace"], "namespace"),
+            stream=_result_text(payload["stream"], "stream"),
+            consumer=_result_text(payload["consumer"], "consumer"),
+            acked_sequence=_summary_count(payload["acked_sequence"], "acked_sequence"),
+            transaction_count=_summary_count(
+                payload["transaction_count"], "transaction_count"
+            ),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "action": "ack",
+            "log_path": str(self.log_path),
+            "tenant": self.tenant,
+            "namespace": self.namespace,
+            "stream": self.stream,
+            "consumer": self.consumer,
+            "acked_sequence": self.acked_sequence,
+            "transaction_count": self.transaction_count,
+        }
+
+
 def _domain_record_invocation(
     adapter: LocalReferenceEhdbAdapter,
     executable: str,
@@ -600,6 +749,90 @@ def ehdb_local_reference_read_invocation_from_env(
     return _domain_record_invocation(adapter, executable, args)
 
 
+def ehdb_local_reference_consume_invocation_from_env(
+    env: Mapping[str, str] | None = None,
+    *,
+    stream: str,
+    consumer: str,
+    transaction_id: str,
+    limit: int | None = None,
+    tenant: str | None = None,
+    namespace: str | None = None,
+) -> LocalReferenceEhdbInvocation | None:
+    """Return the concrete durable-consumer ``consume`` helper invocation."""
+
+    source_env = os.environ if env is None else env
+    adapter = ehdb_adapter_from_env(source_env)
+    if adapter is None:
+        return None
+    executable = discover_ehdb_helper_executable(source_env)
+    if executable is None:
+        raise ValueError(
+            f"{EHDB_HELPER_BIN_ENV} is required or "
+            f"{EHDB_LOCAL_REFERENCE_HELPER_NAME} must be discoverable"
+        )
+    args = [
+        "consume",
+        "--log",
+        str(adapter.local_reference_log),
+        "--stream",
+        _non_empty_text(stream, "stream"),
+        "--consumer",
+        _non_empty_text(consumer, "consumer"),
+        "--transaction-id",
+        _non_empty_text(transaction_id, "transaction_id"),
+    ]
+    if tenant is not None:
+        args.extend(["--tenant", _non_empty_text(tenant, "tenant")])
+    if namespace is not None:
+        args.extend(["--namespace", _non_empty_text(namespace, "namespace")])
+    if limit is not None:
+        args.extend(["--limit", str(int(limit))])
+    return _domain_record_invocation(adapter, executable, args)
+
+
+def ehdb_local_reference_ack_invocation_from_env(
+    env: Mapping[str, str] | None = None,
+    *,
+    stream: str,
+    consumer: str,
+    transaction_id: str,
+    sequence: int,
+    tenant: str | None = None,
+    namespace: str | None = None,
+) -> LocalReferenceEhdbInvocation | None:
+    """Return the concrete durable-consumer ``ack`` helper invocation."""
+
+    source_env = os.environ if env is None else env
+    adapter = ehdb_adapter_from_env(source_env)
+    if adapter is None:
+        return None
+    executable = discover_ehdb_helper_executable(source_env)
+    if executable is None:
+        raise ValueError(
+            f"{EHDB_HELPER_BIN_ENV} is required or "
+            f"{EHDB_LOCAL_REFERENCE_HELPER_NAME} must be discoverable"
+        )
+    args = [
+        "ack",
+        "--log",
+        str(adapter.local_reference_log),
+        "--stream",
+        _non_empty_text(stream, "stream"),
+        "--consumer",
+        _non_empty_text(consumer, "consumer"),
+        "--transaction-id",
+        _non_empty_text(transaction_id, "transaction_id"),
+        "--sequence",
+        str(int(sequence)),
+    ]
+    if tenant is not None:
+        args.extend(["--tenant", _non_empty_text(tenant, "tenant")])
+    if namespace is not None:
+        args.extend(["--namespace", _non_empty_text(namespace, "namespace")])
+    return _domain_record_invocation(adapter, executable, args)
+
+
 def _non_empty_text(value: str | None, label: str) -> str:
     if value is None or not value.strip():
         raise ValueError(f"{label} is required")
@@ -616,6 +849,14 @@ def _result_bool(value: Any, field: str) -> bool:
     if not isinstance(value, bool):
         raise ValueError(f"EHDB result {field} must be a boolean")
     return value
+
+
+def _result_optional_count(value: Any, field: str) -> int | None:
+    """Validate an optional non-negative integer (JSON ``null`` -> ``None``)."""
+
+    if value is None:
+        return None
+    return _summary_count(value, field)
 
 
 def _summary_log_path(value: Any) -> Path:

--- a/noetl/core/ehdb_eventstream.py
+++ b/noetl/core/ehdb_eventstream.py
@@ -1,0 +1,673 @@
+"""Bounded, stateless EHDB worker/playbook event-stream step for NoETL.
+
+Phase D of the EHDB↔NoETL integration (the event-stream integration path).
+Phase C added a bounded domain-record append/read; Phase D adds the
+durable-consumer *drain* that lets a NoETL worker/playbook mirror
+already-emitted NoETL events into a derived EHDB stream and consume them with
+explicit ack-after-materialize semantics:
+
+* ``project`` — append one already-emitted NoETL event into the derived EHDB
+  local-reference stream (the Phase C ``append`` primitive is the project leg).
+* ``consume`` — pull up to ``limit`` records for a durable consumer after its
+  ack cursor, creating the consumer on first pull, *without* moving the cursor.
+* ``ack`` — advance the durable consumer's cursor after the batch is
+  materialized (ack-after-materialize).
+
+**Event-log-authoritative invariant.**  The NoETL event log
+(``noetl.event`` in Postgres / NATS JetStream) is the authoritative,
+append-only source of truth.  EHDB is a *derived, auxiliary* consumer of
+already-emitted NoETL events — this module never writes to the NoETL event
+log.  It only ever runs the bounded ``ehdb-local-reference`` helper against the
+separate EHDB JSONL fabric named by ``NOETL_EHDB_LOCAL_REFERENCE_LOG``.  There
+is deliberately no import of any NoETL event-writer here; "project" mirrors an
+event that was already committed to the authoritative log, it does not emit
+one.
+
+Hard boundaries preserved (see the EHDB Architecture wiki):
+
+* **Disabled by default** — when ``NOETL_EHDB_ENABLED`` is not truthy every
+  operation is a strict no-op: it performs no project/consume/ack, writes no
+  file, records no metric, and behaves byte-identically to a build without
+  EHDB.
+* **Control-plane roles get no data-plane handle** — gateway / api / server
+  never project, consume, or ack.  A control-plane role that reaches the data
+  plane is refused by :func:`assert_event_stream_access_allowed`
+  (defense-in-depth beyond the contract validation), and no helper is executed.
+* **Bounded** — the projected payload is capped
+  (``NOETL_EHDB_EVENTSTREAM_MAX_PAYLOAD_BYTES``, default 65536, clamped), the
+  consume batch is capped (``NOETL_EHDB_EVENTSTREAM_MAX_CONSUME_LIMIT``,
+  default 1000, clamped), the ack sequence must be a positive record sequence,
+  and the helper runs under a short time cap.  Over-bound requests are rejected
+  before the helper is invoked.
+* **Stateless** — each call opens the bounded helper, performs one operation,
+  and returns.  No long-lived connection, subscription, or per-tenant state is
+  held between requests.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Mapping
+
+from noetl.core.ehdb_adapter import (
+    LocalReferenceAckResult,
+    LocalReferenceAppendResult,
+    LocalReferenceConsumeResult,
+    ehdb_local_reference_ack_invocation_from_env,
+    ehdb_local_reference_append_invocation_from_env,
+    ehdb_local_reference_consume_invocation_from_env,
+    execute_ehdb_helper_json,
+)
+from noetl.core.ehdb_contract import (
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    NOETL_RUN_MODE_ENV,
+    EhdbClientRole,
+)
+from noetl.core.ehdb_readiness import EhdbControlPlaneGuardError
+
+
+DEFAULT_EVENTSTREAM_TIMEOUT_SECONDS = 5.0
+_MIN_EVENTSTREAM_TIMEOUT_SECONDS = 0.1
+_MAX_EVENTSTREAM_TIMEOUT_SECONDS = 30.0
+EHDB_EVENTSTREAM_TIMEOUT_ENV = "NOETL_EHDB_EVENTSTREAM_TIMEOUT_SECONDS"
+
+# Payload + consume-batch bounds.  Owned by NoETL (not the helper) so the
+# "bounded" property is enforced at the platform boundary.
+DEFAULT_MAX_PAYLOAD_BYTES = 65536
+_MAX_PAYLOAD_BYTES_CEILING = 1048576
+EHDB_EVENTSTREAM_MAX_PAYLOAD_BYTES_ENV = "NOETL_EHDB_EVENTSTREAM_MAX_PAYLOAD_BYTES"
+
+DEFAULT_MAX_CONSUME_LIMIT = 1000
+_CONSUME_LIMIT_CEILING = 10000
+EHDB_EVENTSTREAM_MAX_CONSUME_LIMIT_ENV = "NOETL_EHDB_EVENTSTREAM_MAX_CONSUME_LIMIT"
+
+_CONTROL_PLANE_ROLES = frozenset(
+    {EhdbClientRole.GATEWAY, EhdbClientRole.API, EhdbClientRole.SERVER}
+)
+_DATA_PLANE_ROLES = frozenset(
+    {EhdbClientRole.WORKER, EhdbClientRole.PLAYBOOK, EhdbClientRole.SYSTEM}
+)
+
+
+class EhdbEventStreamOperation(StrEnum):
+    """The bounded event-stream operation performed."""
+
+    PROJECT = "project"
+    CONSUME = "consume"
+    ACK = "ack"
+
+
+class EhdbEventStreamOutcome(StrEnum):
+    """Terminal classification of a single event-stream operation."""
+
+    DISABLED = "disabled"            # EHDB off — no-op, byte-identical
+    PROJECTED = "projected"          # one NoETL event mirrored into EHDB
+    CONSUMED = "consumed"            # durable-consumer pull (possibly empty)
+    ABSENT = "absent"               # consume of a stream never projected to
+    ACKED = "acked"                  # durable-consumer cursor advanced
+    REJECTED = "rejected"            # request exceeded a NoETL bound
+    TRUNCATED = "truncated"          # bounded time cap tripped — degraded
+    UNAVAILABLE = "unavailable"      # helper missing / errored — degraded
+    GUARD_REFUSED = "guard_refused"  # control-plane role given a data-plane env
+    INVALID = "invalid"              # misconfigured EHDB env (non-guard)
+
+
+_OK_OUTCOMES = frozenset(
+    {
+        EhdbEventStreamOutcome.DISABLED,
+        EhdbEventStreamOutcome.PROJECTED,
+        EhdbEventStreamOutcome.CONSUMED,
+        EhdbEventStreamOutcome.ABSENT,
+        EhdbEventStreamOutcome.ACKED,
+    }
+)
+_DEGRADED_OUTCOMES = frozenset(
+    {EhdbEventStreamOutcome.TRUNCATED, EhdbEventStreamOutcome.UNAVAILABLE}
+)
+
+
+@dataclass(frozen=True)
+class EhdbEventStreamResult:
+    """Structured result of a bounded event-stream operation."""
+
+    operation: EhdbEventStreamOperation
+    outcome: EhdbEventStreamOutcome
+    role: EhdbClientRole | None = None
+    duration_seconds: float = 0.0
+    detail: str | None = None
+    project: LocalReferenceAppendResult | None = None
+    consume: LocalReferenceConsumeResult | None = None
+    ack: LocalReferenceAckResult | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.outcome in _OK_OUTCOMES
+
+    @property
+    def degraded(self) -> bool:
+        return self.outcome in _DEGRADED_OUTCOMES
+
+    @property
+    def performed_operation(self) -> bool:
+        return self.outcome in {
+            EhdbEventStreamOutcome.PROJECTED,
+            EhdbEventStreamOutcome.CONSUMED,
+            EhdbEventStreamOutcome.ABSENT,
+            EhdbEventStreamOutcome.ACKED,
+        }
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "operation": self.operation.value,
+            "outcome": self.outcome.value,
+            "ok": self.ok,
+            "degraded": self.degraded,
+            "duration_seconds": round(self.duration_seconds, 6),
+        }
+        if self.role is not None:
+            payload["role"] = self.role.value
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        if self.project is not None:
+            payload["project"] = self.project.as_dict()
+        if self.consume is not None:
+            payload["consume"] = self.consume.as_dict()
+        if self.ack is not None:
+            payload["ack"] = self.ack.as_dict()
+        return payload
+
+
+def assert_event_stream_access_allowed(
+    role: EhdbClientRole, *, operation: EhdbEventStreamOperation
+) -> None:
+    """Guard: only worker/playbook/system roles may drive the event stream.
+
+    Defense-in-depth on top of the contract validation.  A control-plane role
+    (gateway/api/server) must never project into, consume from, or ack an EHDB
+    stream, so any attempt is refused here before the helper is executed.
+    """
+
+    if role in _CONTROL_PLANE_ROLES:
+        raise EhdbControlPlaneGuardError(
+            f"EHDB event-stream {operation.value} refused for control-plane role "
+            f"'{role.value}'; gateway/api/server remain gatekeepers and never "
+            "touch EHDB data"
+        )
+    if role not in _DATA_PLANE_ROLES:
+        raise EhdbControlPlaneGuardError(
+            f"EHDB event-stream {operation.value} requires a worker/playbook/system "
+            f"role, got '{role.value}'"
+        )
+
+
+def project_ehdb_event(
+    stream: str,
+    subject: str,
+    payload: str,
+    *,
+    transaction_id: str | None = None,
+    tenant: str | None = None,
+    namespace: str | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout_seconds: float | None = None,
+    record_metrics: bool = True,
+) -> EhdbEventStreamResult:
+    """Mirror one already-emitted NoETL event into the derived EHDB stream.
+
+    This is the project leg of the drain.  The event was already committed to
+    the authoritative NoETL event log; this only appends a derived copy into
+    the EHDB local-reference stream.  When EHDB is disabled the result is
+    :attr:`EhdbEventStreamOutcome.DISABLED` and nothing is written.
+    """
+
+    source_env = os.environ if env is None else env
+    started = time.monotonic()
+    op = EhdbEventStreamOperation.PROJECT
+
+    def _finish(outcome, **kwargs) -> EhdbEventStreamResult:
+        return _record(
+            EhdbEventStreamResult(
+                operation=op,
+                outcome=outcome,
+                duration_seconds=time.monotonic() - started,
+                **kwargs,
+            ),
+            record_metrics,
+        )
+
+    if not _truthy(source_env.get(EHDB_ENABLED_ENV)):
+        return _finish(EhdbEventStreamOutcome.DISABLED)
+
+    role, guard_result = _resolve_role(source_env, op, started, record_metrics)
+    if guard_result is not None:
+        return guard_result
+
+    max_bytes = _bounded_max_payload_bytes(source_env)
+    payload_bytes = len(payload.encode("utf-8"))
+    if payload_bytes == 0:
+        return _finish(
+            EhdbEventStreamOutcome.REJECTED,
+            role=role,
+            detail="empty event payload",
+        )
+    if payload_bytes > max_bytes:
+        return _finish(
+            EhdbEventStreamOutcome.REJECTED,
+            role=role,
+            detail=f"payload {payload_bytes} bytes exceeds bound {max_bytes}",
+        )
+
+    txn_id = transaction_id or _new_transaction_id()
+    bounded_timeout = _bounded_timeout(source_env, timeout_seconds)
+    try:
+        invocation = ehdb_local_reference_append_invocation_from_env(
+            source_env,
+            stream=stream,
+            subject=subject,
+            transaction_id=txn_id,
+            payload=payload,
+            tenant=tenant,
+            namespace=namespace,
+        )
+    except ValueError as exc:
+        return _finish(EhdbEventStreamOutcome.INVALID, role=role, detail=str(exc))
+    if invocation is None:
+        return _finish(EhdbEventStreamOutcome.DISABLED, role=role)
+
+    try:
+        execution = execute_ehdb_helper_json(invocation, timeout_seconds=bounded_timeout)
+        result = LocalReferenceAppendResult.from_payload(execution.json_payload)
+    except TimeoutError as exc:
+        return _finish(EhdbEventStreamOutcome.TRUNCATED, role=role, detail=str(exc))
+    except (ValueError, RuntimeError, OSError) as exc:
+        return _finish(EhdbEventStreamOutcome.UNAVAILABLE, role=role, detail=str(exc))
+
+    return _finish(EhdbEventStreamOutcome.PROJECTED, role=role, project=result)
+
+
+def consume_ehdb_events(
+    stream: str,
+    consumer: str,
+    *,
+    transaction_id: str | None = None,
+    limit: int | None = None,
+    tenant: str | None = None,
+    namespace: str | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout_seconds: float | None = None,
+    record_metrics: bool = True,
+) -> EhdbEventStreamResult:
+    """Pull up to ``limit`` records for a durable consumer (cursor unchanged)."""
+
+    source_env = os.environ if env is None else env
+    started = time.monotonic()
+    op = EhdbEventStreamOperation.CONSUME
+
+    def _finish(outcome, **kwargs) -> EhdbEventStreamResult:
+        return _record(
+            EhdbEventStreamResult(
+                operation=op,
+                outcome=outcome,
+                duration_seconds=time.monotonic() - started,
+                **kwargs,
+            ),
+            record_metrics,
+        )
+
+    if not _truthy(source_env.get(EHDB_ENABLED_ENV)):
+        return _finish(EhdbEventStreamOutcome.DISABLED)
+
+    role, guard_result = _resolve_role(source_env, op, started, record_metrics)
+    if guard_result is not None:
+        return guard_result
+
+    bounded_limit = _bounded_consume_limit(source_env, limit)
+    txn_id = transaction_id or _new_transaction_id()
+    bounded_timeout = _bounded_timeout(source_env, timeout_seconds)
+    try:
+        invocation = ehdb_local_reference_consume_invocation_from_env(
+            source_env,
+            stream=stream,
+            consumer=consumer,
+            transaction_id=txn_id,
+            limit=bounded_limit,
+            tenant=tenant,
+            namespace=namespace,
+        )
+    except ValueError as exc:
+        return _finish(EhdbEventStreamOutcome.INVALID, role=role, detail=str(exc))
+    if invocation is None:
+        return _finish(EhdbEventStreamOutcome.DISABLED, role=role)
+
+    try:
+        execution = execute_ehdb_helper_json(invocation, timeout_seconds=bounded_timeout)
+        result = LocalReferenceConsumeResult.from_payload(execution.json_payload)
+    except TimeoutError as exc:
+        return _finish(EhdbEventStreamOutcome.TRUNCATED, role=role, detail=str(exc))
+    except (ValueError, RuntimeError, OSError) as exc:
+        return _finish(EhdbEventStreamOutcome.UNAVAILABLE, role=role, detail=str(exc))
+
+    outcome = (
+        EhdbEventStreamOutcome.CONSUMED
+        if result.exists
+        else EhdbEventStreamOutcome.ABSENT
+    )
+    return _finish(outcome, role=role, consume=result)
+
+
+def ack_ehdb_event(
+    stream: str,
+    consumer: str,
+    sequence: int,
+    *,
+    transaction_id: str | None = None,
+    tenant: str | None = None,
+    namespace: str | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout_seconds: float | None = None,
+    record_metrics: bool = True,
+) -> EhdbEventStreamResult:
+    """Advance a durable consumer's ack cursor after materialize."""
+
+    source_env = os.environ if env is None else env
+    started = time.monotonic()
+    op = EhdbEventStreamOperation.ACK
+
+    def _finish(outcome, **kwargs) -> EhdbEventStreamResult:
+        return _record(
+            EhdbEventStreamResult(
+                operation=op,
+                outcome=outcome,
+                duration_seconds=time.monotonic() - started,
+                **kwargs,
+            ),
+            record_metrics,
+        )
+
+    if not _truthy(source_env.get(EHDB_ENABLED_ENV)):
+        return _finish(EhdbEventStreamOutcome.DISABLED)
+
+    role, guard_result = _resolve_role(source_env, op, started, record_metrics)
+    if guard_result is not None:
+        return guard_result
+
+    # A real ack names a published record; sequence 0/negative is rejected
+    # before the helper is touched (bounded, no wasted subprocess).
+    if int(sequence) < 1:
+        return _finish(
+            EhdbEventStreamOutcome.REJECTED,
+            role=role,
+            detail=f"ack sequence must be >= 1, got {sequence}",
+        )
+
+    txn_id = transaction_id or _new_transaction_id()
+    bounded_timeout = _bounded_timeout(source_env, timeout_seconds)
+    try:
+        invocation = ehdb_local_reference_ack_invocation_from_env(
+            source_env,
+            stream=stream,
+            consumer=consumer,
+            transaction_id=txn_id,
+            sequence=int(sequence),
+            tenant=tenant,
+            namespace=namespace,
+        )
+    except ValueError as exc:
+        return _finish(EhdbEventStreamOutcome.INVALID, role=role, detail=str(exc))
+    if invocation is None:
+        return _finish(EhdbEventStreamOutcome.DISABLED, role=role)
+
+    try:
+        execution = execute_ehdb_helper_json(invocation, timeout_seconds=bounded_timeout)
+        result = LocalReferenceAckResult.from_payload(execution.json_payload)
+    except TimeoutError as exc:
+        return _finish(EhdbEventStreamOutcome.TRUNCATED, role=role, detail=str(exc))
+    except (ValueError, RuntimeError, OSError) as exc:
+        # A backwards / unknown-sequence ack surfaces as a non-zero helper exit
+        # (degraded), not a silent success — the drain contract stays explicit.
+        return _finish(EhdbEventStreamOutcome.UNAVAILABLE, role=role, detail=str(exc))
+
+    return _finish(EhdbEventStreamOutcome.ACKED, role=role, ack=result)
+
+
+def _resolve_role(
+    source_env: Mapping[str, str],
+    op: EhdbEventStreamOperation,
+    started: float,
+    record_metrics: bool,
+) -> tuple[EhdbClientRole | None, EhdbEventStreamResult | None]:
+    """Build the contract + enforce the guard.
+
+    Returns ``(role, guard_result)``.  When ``guard_result`` is not ``None`` the
+    caller must return it immediately (guard refusal / invalid config); no
+    event-stream operation is performed.
+    """
+
+    role = _safe_client_role(source_env)
+
+    def _finish(outcome, **kwargs) -> EhdbEventStreamResult:
+        return _record(
+            EhdbEventStreamResult(
+                operation=op,
+                outcome=outcome,
+                duration_seconds=time.monotonic() - started,
+                **kwargs,
+            ),
+            record_metrics,
+        )
+
+    try:
+        from noetl.core.ehdb_contract import ehdb_integration_contract_from_env
+
+        contract = ehdb_integration_contract_from_env(source_env)
+    except ValueError as exc:
+        if role in _CONTROL_PLANE_ROLES:
+            return role, _finish(
+                EhdbEventStreamOutcome.GUARD_REFUSED, role=role, detail=str(exc)
+            )
+        return role, _finish(
+            EhdbEventStreamOutcome.INVALID, role=role, detail=str(exc)
+        )
+
+    try:
+        assert_event_stream_access_allowed(contract.role, operation=op)
+    except EhdbControlPlaneGuardError as exc:
+        return contract.role, _finish(
+            EhdbEventStreamOutcome.GUARD_REFUSED, role=contract.role, detail=str(exc)
+        )
+
+    return contract.role, None
+
+
+def _new_transaction_id() -> str:
+    """Application-side transaction id (snowflake), per observability rule."""
+
+    try:
+        from noetl.core.common import get_snowflake_id_str
+
+        return f"txn-{get_snowflake_id_str()}"
+    except Exception:
+        return f"txn-{int(time.monotonic() * 1_000_000)}"
+
+
+def _bounded_timeout(env: Mapping[str, str], timeout_seconds: float | None) -> float:
+    if timeout_seconds is None:
+        raw = env.get(EHDB_EVENTSTREAM_TIMEOUT_ENV)
+        if raw is not None and raw.strip():
+            try:
+                timeout_seconds = float(raw.strip())
+            except ValueError:
+                timeout_seconds = DEFAULT_EVENTSTREAM_TIMEOUT_SECONDS
+        else:
+            timeout_seconds = DEFAULT_EVENTSTREAM_TIMEOUT_SECONDS
+    return max(
+        _MIN_EVENTSTREAM_TIMEOUT_SECONDS,
+        min(_MAX_EVENTSTREAM_TIMEOUT_SECONDS, timeout_seconds),
+    )
+
+
+def _bounded_max_payload_bytes(env: Mapping[str, str]) -> int:
+    raw = env.get(EHDB_EVENTSTREAM_MAX_PAYLOAD_BYTES_ENV)
+    value = DEFAULT_MAX_PAYLOAD_BYTES
+    if raw is not None and raw.strip():
+        try:
+            value = int(raw.strip())
+        except ValueError:
+            value = DEFAULT_MAX_PAYLOAD_BYTES
+    return max(1, min(_MAX_PAYLOAD_BYTES_CEILING, value))
+
+
+def _bounded_consume_limit(env: Mapping[str, str], limit: int | None) -> int:
+    ceiling = DEFAULT_MAX_CONSUME_LIMIT
+    raw = env.get(EHDB_EVENTSTREAM_MAX_CONSUME_LIMIT_ENV)
+    if raw is not None and raw.strip():
+        try:
+            ceiling = int(raw.strip())
+        except ValueError:
+            ceiling = DEFAULT_MAX_CONSUME_LIMIT
+    ceiling = max(1, min(_CONSUME_LIMIT_CEILING, ceiling))
+    if limit is None:
+        return ceiling
+    return max(1, min(ceiling, int(limit)))
+
+
+def _safe_client_role(env: Mapping[str, str]) -> EhdbClientRole | None:
+    raw = env.get(EHDB_CLIENT_ROLE_ENV) or env.get(NOETL_RUN_MODE_ENV) or "worker"
+    normalized = raw.strip().lower()
+    if normalized == "server":
+        return EhdbClientRole.SERVER
+    try:
+        return EhdbClientRole(normalized)
+    except ValueError:
+        return None
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+# ---------------------------------------------------------------------------
+# Observability — process-local counters rendered into the worker /metrics
+# text.  Metrics carry only operation + outcome labels; no stream name,
+# subject, consumer, payload, log path, or error text leaks in.
+# ---------------------------------------------------------------------------
+
+
+class _EventStreamMetrics:
+    """In-process accumulator for EHDB event-stream operations.
+
+    Disabled operations are intentionally *not* recorded so a disabled EHDB
+    build renders byte-identical `/metrics` output.
+    """
+
+    def __init__(self) -> None:
+        self._ops: dict[tuple[str, str], int] = {}
+        self._last_duration_seconds: float = 0.0
+        self._last_ok: int = 0
+        self._last_degraded: int = 0
+
+    def record(self, result: EhdbEventStreamResult) -> None:
+        if result.outcome is EhdbEventStreamOutcome.DISABLED:
+            return
+        key = (result.operation.value, result.outcome.value)
+        self._ops[key] = self._ops.get(key, 0) + 1
+        self._last_duration_seconds = result.duration_seconds
+        self._last_ok = 1 if result.ok else 0
+        self._last_degraded = 1 if result.degraded else 0
+
+    def reset(self) -> None:
+        self.__init__()
+
+    def has_data(self) -> bool:
+        return bool(self._ops)
+
+    def render(self, *, labels: Mapping[str, str] | None = None) -> list[str]:
+        if not self._ops:
+            return []
+        base_labels = dict(labels or {})
+        lines = [
+            "# HELP noetl_ehdb_eventstream_ops_total EHDB event-stream operations by operation and outcome",
+            "# TYPE noetl_ehdb_eventstream_ops_total counter",
+        ]
+        for operation, outcome in sorted(self._ops):
+            merged = dict(base_labels)
+            merged["operation"] = operation
+            merged["outcome"] = outcome
+            lines.append(
+                f"noetl_ehdb_eventstream_ops_total{_format_labels(merged)} "
+                f"{self._ops[(operation, outcome)]}"
+            )
+        lines.extend(
+            [
+                "# HELP noetl_ehdb_eventstream_last_ok Last EHDB event-stream op result (1=ok)",
+                "# TYPE noetl_ehdb_eventstream_last_ok gauge",
+                f"noetl_ehdb_eventstream_last_ok{_format_labels(base_labels)} {self._last_ok}",
+                "# HELP noetl_ehdb_eventstream_last_degraded Last EHDB event-stream degraded flag",
+                "# TYPE noetl_ehdb_eventstream_last_degraded gauge",
+                f"noetl_ehdb_eventstream_last_degraded{_format_labels(base_labels)} {self._last_degraded}",
+                "# HELP noetl_ehdb_eventstream_last_duration_seconds Last EHDB event-stream op duration",
+                "# TYPE noetl_ehdb_eventstream_last_duration_seconds gauge",
+                f"noetl_ehdb_eventstream_last_duration_seconds{_format_labels(base_labels)} "
+                f"{self._last_duration_seconds:.6f}",
+            ]
+        )
+        return lines
+
+
+_METRICS = _EventStreamMetrics()
+
+
+def _record(result: EhdbEventStreamResult, record_metrics: bool) -> EhdbEventStreamResult:
+    if record_metrics:
+        _METRICS.record(result)
+    return result
+
+
+def render_ehdb_eventstream_metrics(
+    *, labels: Mapping[str, str] | None = None
+) -> list[str]:
+    """Return Prometheus text lines for event-stream ops (empty when none)."""
+
+    return _METRICS.render(labels=labels)
+
+
+def reset_ehdb_eventstream_metrics() -> None:
+    """Reset the process-local event-stream metrics (test helper)."""
+
+    _METRICS.reset()
+
+
+def _format_labels(labels: Mapping[str, str]) -> str:
+    if not labels:
+        return ""
+    rendered = ",".join(
+        f'{key}="{_escape_label(labels[key])}"' for key in sorted(labels)
+    )
+    return "{" + rendered + "}"
+
+
+def _escape_label(value: str) -> str:
+    return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+__all__ = [
+    "DEFAULT_EVENTSTREAM_TIMEOUT_SECONDS",
+    "DEFAULT_MAX_CONSUME_LIMIT",
+    "DEFAULT_MAX_PAYLOAD_BYTES",
+    "EHDB_EVENTSTREAM_MAX_CONSUME_LIMIT_ENV",
+    "EHDB_EVENTSTREAM_MAX_PAYLOAD_BYTES_ENV",
+    "EHDB_EVENTSTREAM_TIMEOUT_ENV",
+    "EhdbEventStreamOperation",
+    "EhdbEventStreamOutcome",
+    "EhdbEventStreamResult",
+    "ack_ehdb_event",
+    "assert_event_stream_access_allowed",
+    "consume_ehdb_events",
+    "project_ehdb_event",
+    "render_ehdb_eventstream_metrics",
+    "reset_ehdb_eventstream_metrics",
+]

--- a/noetl/worker/metrics.py
+++ b/noetl/worker/metrics.py
@@ -34,6 +34,13 @@ def render_worker_metrics(*, worker_id: str, labels: Mapping[str, str] | None = 
     from noetl.core.ehdb_dataplane import render_ehdb_dataplane_metrics
 
     lines.extend(render_ehdb_dataplane_metrics(labels=metric_labels))
+
+    # EHDB Phase D event-stream metrics.  Renders nothing when no bounded
+    # project/consume/ack has run (disabled EHDB never records), so `/metrics`
+    # stays byte-identical for a disabled deployment.
+    from noetl.core.ehdb_eventstream import render_ehdb_eventstream_metrics
+
+    lines.extend(render_ehdb_eventstream_metrics(labels=metric_labels))
     return "\n".join(lines) + "\n"
 
 

--- a/scripts/ehdb_eventstream_step.py
+++ b/scripts/ehdb_eventstream_step.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Worker/playbook-local EHDB bounded event-stream step (Phase D).
+
+Projects an already-emitted NoETL event into the derived EHDB stream, or drains
+a durable consumer (consume / ack), printing a secret-free JSON report.
+Intended as a worker/playbook-local command or kind smoke step — deliberately
+*not* a server endpoint, so the control-plane boundary is preserved.  The NoETL
+event log stays the authoritative, append-only source of truth; this step only
+touches the derived EHDB local-reference stream.
+
+Exit codes:
+
+* ``0`` — ok (``disabled`` / ``projected`` / ``consumed`` / ``absent`` /
+  ``acked``); also ``truncated`` / ``unavailable`` unless ``--strict`` is given.
+* ``2`` — request rejected by a NoETL bound (``rejected``).
+* ``3`` — degraded (``truncated`` / ``unavailable``) with ``--strict``.
+* ``4`` — control-plane guard refused an event-stream operation.
+* ``5`` — invalid EHDB configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Sequence
+
+from noetl.core.ehdb_eventstream import (
+    EhdbEventStreamOutcome,
+    ack_ehdb_event,
+    consume_ehdb_events,
+    project_ehdb_event,
+)
+
+
+def _exit_code(
+    outcome: EhdbEventStreamOutcome, *, strict: bool, degraded: bool, ok: bool
+) -> int:
+    if outcome is EhdbEventStreamOutcome.GUARD_REFUSED:
+        return 4
+    if outcome is EhdbEventStreamOutcome.INVALID:
+        return 5
+    if outcome is EhdbEventStreamOutcome.REJECTED:
+        return 2
+    if strict and degraded:
+        return 3
+    return 0 if ok else 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run a bounded EHDB local-reference event-stream project/consume/ack.",
+    )
+    parser.add_argument("--strict", action="store_true", help="Treat degraded outcomes as failure.")
+    parser.add_argument("--timeout", type=float, default=None, help="Helper timeout seconds (clamped 0.1-30).")
+    parser.add_argument("--tenant", default=None, help="EHDB tenant (default: adapter default).")
+    parser.add_argument("--namespace", default=None, help="EHDB namespace (default: adapter default).")
+
+    sub = parser.add_subparsers(dest="operation", required=True)
+
+    project = sub.add_parser("project", help="Mirror one NoETL event into the derived EHDB stream.")
+    project.add_argument("--stream", required=True)
+    project.add_argument("--subject", required=True)
+    project.add_argument("--payload", required=True, help="UTF-8 event payload (already emitted to noetl.event).")
+    project.add_argument("--transaction-id", default=None, help="Override the app-generated id.")
+
+    consume = sub.add_parser("consume", help="Pull pending records for a durable consumer.")
+    consume.add_argument("--stream", required=True)
+    consume.add_argument("--consumer", required=True)
+    consume.add_argument("--limit", type=int, default=None)
+    consume.add_argument("--transaction-id", default=None, help="Override the app-generated id.")
+
+    ack = sub.add_parser("ack", help="Advance a durable consumer cursor after materialize.")
+    ack.add_argument("--stream", required=True)
+    ack.add_argument("--consumer", required=True)
+    ack.add_argument("--sequence", type=int, required=True)
+    ack.add_argument("--transaction-id", default=None, help="Override the app-generated id.")
+
+    args = parser.parse_args(argv)
+
+    if args.operation == "project":
+        result = project_ehdb_event(
+            args.stream,
+            args.subject,
+            args.payload,
+            transaction_id=args.transaction_id,
+            tenant=args.tenant,
+            namespace=args.namespace,
+            timeout_seconds=args.timeout,
+        )
+    elif args.operation == "consume":
+        result = consume_ehdb_events(
+            args.stream,
+            args.consumer,
+            transaction_id=args.transaction_id,
+            limit=args.limit,
+            tenant=args.tenant,
+            namespace=args.namespace,
+            timeout_seconds=args.timeout,
+        )
+    else:
+        result = ack_ehdb_event(
+            args.stream,
+            args.consumer,
+            args.sequence,
+            transaction_id=args.transaction_id,
+            tenant=args.tenant,
+            namespace=args.namespace,
+            timeout_seconds=args.timeout,
+        )
+
+    print(json.dumps(result.as_dict(), sort_keys=True))
+    return _exit_code(
+        result.outcome,
+        strict=args.strict,
+        degraded=result.degraded,
+        ok=result.ok,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_ehdb_eventstream.py
+++ b/scripts/smoke_ehdb_eventstream.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Smoke the EHDB Phase D bounded event-stream drain through NoETL.
+
+Projects two already-emitted NoETL events into a fresh derived EHDB stream,
+drains them through a durable consumer, acks the first, and re-consumes to
+prove the durable cursor restarted (only the unacked record is pending).
+Intended as a worker/playbook-local command or kind smoke step — not a server
+endpoint.  The NoETL event log stays authoritative; this only touches the
+derived EHDB local-reference stream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from noetl.core.ehdb_adapter import EHDB_HELPER_BIN_ENV
+from noetl.core.ehdb_contract import (
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    EHDB_LOCAL_REFERENCE_LOG_ENV,
+    EHDB_MODE_ENV,
+)
+from noetl.core.ehdb_eventstream import (
+    EhdbEventStreamOutcome,
+    ack_ehdb_event,
+    consume_ehdb_events,
+    project_ehdb_event,
+)
+
+
+def run_smoke(
+    *,
+    helper_bin: str | None = None,
+    log_path: Path | None = None,
+    role: str = "worker",
+    stream: str = "noetl-smoke-events",
+    consumer: str = "noetl-smoke-consumer",
+    timeout_seconds: float = 30.0,
+    env: Mapping[str, str] | None = None,
+) -> Mapping[str, object]:
+    source_env = dict(os.environ if env is None else env)
+    log_path = log_path or _temporary_log_path()
+    source_env.update(
+        {
+            EHDB_ENABLED_ENV: "true",
+            EHDB_MODE_ENV: "local_reference",
+            EHDB_CLIENT_ROLE_ENV: role,
+            EHDB_LOCAL_REFERENCE_LOG_ENV: str(log_path),
+        }
+    )
+    if helper_bin is not None:
+        source_env[EHDB_HELPER_BIN_ENV] = helper_bin
+
+    first = project_ehdb_event(
+        stream, "noetl.execution.completed", '{"seq":1}',
+        env=source_env, timeout_seconds=timeout_seconds,
+    )
+    if first.outcome is not EhdbEventStreamOutcome.PROJECTED:
+        raise RuntimeError(f"first project not PROJECTED: {first.as_dict()}")
+
+    second = project_ehdb_event(
+        stream, "noetl.execution.completed", '{"seq":2}',
+        env=source_env, timeout_seconds=timeout_seconds,
+    )
+    if second.outcome is not EhdbEventStreamOutcome.PROJECTED:
+        raise RuntimeError(f"second project not PROJECTED: {second.as_dict()}")
+
+    consumed = consume_ehdb_events(
+        stream, consumer, env=source_env, timeout_seconds=timeout_seconds
+    )
+    if consumed.outcome is not EhdbEventStreamOutcome.CONSUMED:
+        raise RuntimeError(f"consume not CONSUMED: {consumed.as_dict()}")
+    if consumed.consume is None or consumed.consume.pending_count != 2:
+        raise RuntimeError(f"expected 2 pending, got: {consumed.as_dict()}")
+    if not consumed.consume.created_consumer:
+        raise RuntimeError(f"expected consumer creation, got: {consumed.as_dict()}")
+
+    acked = ack_ehdb_event(
+        stream, consumer, 1, env=source_env, timeout_seconds=timeout_seconds
+    )
+    if acked.outcome is not EhdbEventStreamOutcome.ACKED:
+        raise RuntimeError(f"ack not ACKED: {acked.as_dict()}")
+
+    reconsumed = consume_ehdb_events(
+        stream, consumer, env=source_env, timeout_seconds=timeout_seconds
+    )
+    if reconsumed.consume is None or reconsumed.consume.pending_count != 1:
+        raise RuntimeError(f"expected 1 pending after ack, got: {reconsumed.as_dict()}")
+    if reconsumed.consume.created_consumer:
+        raise RuntimeError(f"durable consumer should not be recreated: {reconsumed.as_dict()}")
+    if reconsumed.consume.acked_sequence != 1:
+        raise RuntimeError(f"expected cursor at 1, got: {reconsumed.as_dict()}")
+
+    return {
+        "project_first": first.as_dict(),
+        "project_second": second.as_dict(),
+        "consume": consumed.as_dict(),
+        "ack": acked.as_dict(),
+        "reconsume": reconsumed.as_dict(),
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run a bounded NoETL smoke against the EHDB Phase D event stream.",
+    )
+    parser.add_argument("--helper-bin", help="Path to ehdb-local-reference. Defaults to NoETL discovery.")
+    parser.add_argument("--log", type=Path, help="EHDB JSONL log. Defaults to a temp path.")
+    parser.add_argument("--role", default="worker", help="worker|playbook|system. Default: worker.")
+    parser.add_argument("--timeout", type=float, default=30.0, help="Helper timeout seconds. Default: 30.")
+    args = parser.parse_args(argv)
+
+    try:
+        payload = run_smoke(
+            helper_bin=args.helper_bin,
+            log_path=args.log,
+            role=args.role,
+            timeout_seconds=args.timeout,
+        )
+    except Exception as exc:
+        print(f"EHDB event-stream smoke failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+def _temporary_log_path() -> Path:
+    handle = tempfile.NamedTemporaryFile(
+        prefix="noetl-ehdb-eventstream-smoke-",
+        suffix=".jsonl",
+        delete=False,
+    )
+    handle.close()
+    return Path(handle.name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_ehdb_eventstream.py
+++ b/tests/core/test_ehdb_eventstream.py
@@ -1,0 +1,488 @@
+"""Tests for the Phase D bounded EHDB event-stream drain.
+
+Two layers of coverage:
+
+* Control-flow tests drive a stateful *fake* ``ehdb-local-reference`` helper
+  (a small Python script that models records + durable-consumer cursors in a
+  JSONL log), so the NoETL event-stream layer — disabled no-op, control-plane
+  guard, payload/consume bounds, ack-sequence bound, outcome classification,
+  secret-free metrics, and the event-log-authoritative invariant — is
+  exercised without the Rust binary.  These run in bare CI.
+* A real-binary drain test runs the actual ``ehdb-local-reference`` binary when
+  it is discoverable (built locally / bundled in the kind image), and is
+  skipped otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from noetl.core.ehdb_adapter import (
+    EHDB_HELPER_BIN_ENV,
+    discover_ehdb_helper_executable,
+)
+from noetl.core.ehdb_contract import (
+    EHDB_CLIENT_ROLE_ENV,
+    EHDB_ENABLED_ENV,
+    EHDB_LOCAL_REFERENCE_LOG_ENV,
+    EHDB_MODE_ENV,
+)
+from noetl.core.ehdb_eventstream import (
+    EHDB_EVENTSTREAM_MAX_CONSUME_LIMIT_ENV,
+    EHDB_EVENTSTREAM_MAX_PAYLOAD_BYTES_ENV,
+    EhdbEventStreamOutcome,
+    ack_ehdb_event,
+    consume_ehdb_events,
+    project_ehdb_event,
+    render_ehdb_eventstream_metrics,
+    reset_ehdb_eventstream_metrics,
+)
+
+
+# A faithful-but-minimal stateful stand-in for the Rust helper.  It stores one
+# JSON object per line — records (kind="record") and durable-consumer cursor
+# updates (kind="consumer") — and reproduces the append/consume/ack contract
+# the event-stream layer parses.
+_FAKE_HELPER = r'''
+import json
+import sys
+
+def parse(argv):
+    op = argv[0]
+    flags = {}
+    i = 1
+    while i < len(argv):
+        key = argv[i][2:]
+        flags[key] = argv[i + 1]
+        i += 2
+    return op, flags
+
+def load(path):
+    try:
+        with open(path) as fh:
+            return [json.loads(line) for line in fh if line.strip()]
+    except FileNotFoundError:
+        return []
+
+def records_for(rows, tenant, namespace, stream):
+    return sorted(
+        (r for r in rows if r.get("kind") == "record"
+         and r["tenant"] == tenant and r["namespace"] == namespace
+         and r["stream"] == stream),
+        key=lambda r: r["sequence"],
+    )
+
+def cursor_for(rows, tenant, namespace, stream, consumer):
+    seen = False
+    acked = None
+    for r in rows:
+        if (r.get("kind") == "consumer" and r["tenant"] == tenant
+                and r["namespace"] == namespace and r["stream"] == stream
+                and r["consumer"] == consumer):
+            seen = True
+            acked = r["acked"]
+    return seen, acked
+
+op, flags = parse(sys.argv[1:])
+log = flags["log"]
+tenant = flags.get("tenant", "noetl")
+namespace = flags.get("namespace", "default")
+stream = flags["stream"]
+rows = load(log)
+
+if op == "append":
+    same = records_for(rows, tenant, namespace, stream)
+    created = len(same) == 0
+    seq = len(same) + 1
+    payload = flags["payload"]
+    row = {
+        "kind": "record", "tenant": tenant, "namespace": namespace, "stream": stream,
+        "subject": flags["subject"], "transaction_id": flags["transaction-id"],
+        "payload": payload, "sequence": seq,
+    }
+    with open(log, "a") as fh:
+        fh.write(json.dumps(row) + "\n")
+    print(json.dumps({
+        "action": "append", "log_path": log, "tenant": tenant, "namespace": namespace,
+        "stream": stream, "subject": flags["subject"], "sequence": seq,
+        "byte_len": len(payload.encode("utf-8")), "created_stream": created,
+        "stream_record_count": seq, "transaction_count": len(rows) + 1,
+    }))
+elif op == "consume":
+    consumer = flags["consumer"]
+    limit = int(flags["limit"]) if "limit" in flags else 100
+    recs = records_for(rows, tenant, namespace, stream)
+    if not recs:
+        print(json.dumps({
+            "action": "consume", "log_path": log, "tenant": tenant, "namespace": namespace,
+            "stream": stream, "consumer": consumer, "exists": False,
+            "created_consumer": False, "acked_sequence": None, "pending_count": 0,
+            "returned": 0, "records": [], "transaction_count": len(rows),
+        }))
+        sys.exit(0)
+    seen, acked = cursor_for(rows, tenant, namespace, stream, consumer)
+    created = not seen
+    if created:
+        with open(log, "a") as fh:
+            fh.write(json.dumps({
+                "kind": "consumer", "tenant": tenant, "namespace": namespace,
+                "stream": stream, "consumer": consumer, "acked": None,
+            }) + "\n")
+    floor = acked or 0
+    pending = [r for r in recs if r["sequence"] > floor]
+    projected = [{
+        "sequence": r["sequence"], "subject": r["subject"],
+        "transaction_id": r["transaction_id"],
+        "byte_len": len(r["payload"].encode("utf-8")), "payload": r["payload"],
+    } for r in pending[:limit]]
+    print(json.dumps({
+        "action": "consume", "log_path": log, "tenant": tenant, "namespace": namespace,
+        "stream": stream, "consumer": consumer, "exists": True,
+        "created_consumer": created, "acked_sequence": acked,
+        "pending_count": len(pending), "returned": len(projected),
+        "records": projected, "transaction_count": len(rows) + (1 if created else 0),
+    }))
+elif op == "ack":
+    consumer = flags["consumer"]
+    sequence = int(flags["sequence"])
+    recs = records_for(rows, tenant, namespace, stream)
+    seqs = {r["sequence"] for r in recs}
+    seen, acked = cursor_for(rows, tenant, namespace, stream, consumer)
+    if sequence not in seqs:
+        print("not found: stream sequence %d" % sequence, file=sys.stderr)
+        sys.exit(2)
+    if not seen:
+        print("not found: consumer %s" % consumer, file=sys.stderr)
+        sys.exit(2)
+    if acked is not None and sequence < acked:
+        print("invalid state: cannot move cursor backwards", file=sys.stderr)
+        sys.exit(2)
+    with open(log, "a") as fh:
+        fh.write(json.dumps({
+            "kind": "consumer", "tenant": tenant, "namespace": namespace,
+            "stream": stream, "consumer": consumer, "acked": sequence,
+        }) + "\n")
+    print(json.dumps({
+        "action": "ack", "log_path": log, "tenant": tenant, "namespace": namespace,
+        "stream": stream, "consumer": consumer, "acked_sequence": sequence,
+        "transaction_count": len(rows) + 1,
+    }))
+else:
+    print("unexpected op", file=sys.stderr)
+    sys.exit(4)
+'''
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics():
+    reset_ehdb_eventstream_metrics()
+    yield
+    reset_ehdb_eventstream_metrics()
+
+
+def _fake_helper(tmp_path: Path) -> Path:
+    helper = tmp_path / "ehdb-local-reference-fake.py"
+    helper.write_text(f"#!{sys.executable}\n{_FAKE_HELPER.lstrip()}", encoding="utf-8")
+    helper.chmod(0o755)
+    return helper
+
+
+def _enabled_env(tmp_path: Path, helper: Path, *, role: str = "worker", mode: str = "local_reference") -> dict:
+    return {
+        EHDB_ENABLED_ENV: "true",
+        EHDB_MODE_ENV: mode,
+        EHDB_CLIENT_ROLE_ENV: role,
+        EHDB_LOCAL_REFERENCE_LOG_ENV: str(tmp_path / "ehdb.jsonl"),
+        EHDB_HELPER_BIN_ENV: str(helper),
+        "PATH": "/usr/bin",
+    }
+
+
+# --------------------------------------------------------------------------
+# Disabled → strict no-op
+# --------------------------------------------------------------------------
+
+
+def test_project_disabled_is_noop(tmp_path):
+    log = tmp_path / "ehdb.jsonl"
+    result = project_ehdb_event(
+        "events", "noetl.execution.completed", "payload",
+        env={EHDB_LOCAL_REFERENCE_LOG_ENV: str(log)},
+    )
+    assert result.outcome is EhdbEventStreamOutcome.DISABLED
+    assert result.project is None
+    assert not log.exists()
+    assert render_ehdb_eventstream_metrics() == []
+
+
+def test_consume_and_ack_disabled_are_noop(tmp_path):
+    assert consume_ehdb_events("events", "c", env={}).outcome is EhdbEventStreamOutcome.DISABLED
+    assert ack_ehdb_event("events", "c", 1, env={}).outcome is EhdbEventStreamOutcome.DISABLED
+    assert render_ehdb_eventstream_metrics() == []
+
+
+# --------------------------------------------------------------------------
+# Enabled worker/playbook/system → project → consume → ack → cursor restart
+# --------------------------------------------------------------------------
+
+
+def test_project_consume_ack_drain(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+
+    first = project_ehdb_event("events", "noetl.execution.completed", '{"n":1}', env=env)
+    assert first.outcome is EhdbEventStreamOutcome.PROJECTED
+    assert first.project.sequence == 1
+    second = project_ehdb_event("events", "noetl.execution.completed", '{"n":2}', env=env)
+    assert second.project.sequence == 2
+
+    consumed = consume_ehdb_events("events", "materializer", env=env)
+    assert consumed.outcome is EhdbEventStreamOutcome.CONSUMED
+    assert consumed.consume.created_consumer is True
+    assert consumed.consume.acked_sequence is None
+    assert consumed.consume.pending_count == 2
+    assert consumed.consume.returned == 2
+    assert consumed.consume.records[0]["sequence"] == 1
+
+    acked = ack_ehdb_event("events", "materializer", 1, env=env)
+    assert acked.outcome is EhdbEventStreamOutcome.ACKED
+    assert acked.ack.acked_sequence == 1
+
+    # Cursor restart: only the unacked record is pending, consumer not recreated.
+    again = consume_ehdb_events("events", "materializer", env=env)
+    assert again.consume.created_consumer is False
+    assert again.consume.acked_sequence == 1
+    assert again.consume.pending_count == 1
+    assert again.consume.records[0]["sequence"] == 2
+
+
+@pytest.mark.parametrize("role", ["worker", "playbook", "system"])
+def test_data_plane_roles_allowed(tmp_path, role):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper, role=role)
+    result = project_ehdb_event("s", "s.evt", "x", env=env)
+    assert result.outcome is EhdbEventStreamOutcome.PROJECTED
+    assert result.role.value == role
+
+
+def test_consume_absent_stream(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+    result = consume_ehdb_events("never", "c", env=env)
+    assert result.outcome is EhdbEventStreamOutcome.ABSENT
+    assert result.consume.exists is False
+    assert result.consume.created_consumer is False
+
+
+# --------------------------------------------------------------------------
+# Control-plane guard — gateway/api/server never touch the event stream
+# --------------------------------------------------------------------------
+
+
+def test_control_plane_embedding_refused(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = {
+        EHDB_ENABLED_ENV: "true",
+        EHDB_MODE_ENV: "control_plane",
+        EHDB_CLIENT_ROLE_ENV: "gateway",
+        EHDB_HELPER_BIN_ENV: str(helper),
+        "PATH": "/usr/bin",
+    }
+    result = project_ehdb_event("s", "s.evt", "x", env=env)
+    assert result.outcome is EhdbEventStreamOutcome.GUARD_REFUSED
+    assert result.project is None
+    assert not (tmp_path / "ehdb.jsonl").exists()
+
+
+@pytest.mark.parametrize("role", ["server", "api", "gateway"])
+def test_control_plane_role_with_data_plane_env_refused(tmp_path, role):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper, role=role)
+    result = consume_ehdb_events("s", "c", env=env)
+    assert result.outcome is EhdbEventStreamOutcome.GUARD_REFUSED
+    assert not (tmp_path / "ehdb.jsonl").exists()
+
+
+# --------------------------------------------------------------------------
+# Bounds — payload size, consume limit, ack sequence owned by NoETL
+# --------------------------------------------------------------------------
+
+
+def test_oversize_payload_rejected(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+    env[EHDB_EVENTSTREAM_MAX_PAYLOAD_BYTES_ENV] = "8"
+    result = project_ehdb_event("s", "s.evt", "0123456789", env=env)
+    assert result.outcome is EhdbEventStreamOutcome.REJECTED
+    assert "exceeds bound" in (result.detail or "")
+    assert not (tmp_path / "ehdb.jsonl").exists()
+
+
+def test_empty_payload_rejected(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+    result = project_ehdb_event("s", "s.evt", "", env=env)
+    assert result.outcome is EhdbEventStreamOutcome.REJECTED
+    assert not (tmp_path / "ehdb.jsonl").exists()
+
+
+def test_consume_limit_clamped_to_bound(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+    env[EHDB_EVENTSTREAM_MAX_CONSUME_LIMIT_ENV] = "2"
+    for i in range(1, 6):
+        project_ehdb_event("evt", "evt.tick", f"p{i}", env=env)
+    result = consume_ehdb_events("evt", "c", limit=100, env=env)
+    # Bound is 2; all five are pending but only two are returned.
+    assert result.consume.pending_count == 5
+    assert result.consume.returned == 2
+
+
+def test_ack_zero_sequence_rejected(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+    result = ack_ehdb_event("s", "c", 0, env=env)
+    assert result.outcome is EhdbEventStreamOutcome.REJECTED
+    assert not (tmp_path / "ehdb.jsonl").exists()
+
+
+def test_ack_backwards_is_unavailable(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+    for i in range(1, 3):
+        project_ehdb_event("s", "s.evt", f"p{i}", env=env)
+    consume_ehdb_events("s", "c", env=env)
+    assert ack_ehdb_event("s", "c", 2, env=env).outcome is EhdbEventStreamOutcome.ACKED
+    # Moving the cursor backwards surfaces as a non-zero helper exit (degraded),
+    # not a silent success.
+    backwards = ack_ehdb_event("s", "c", 1, env=env)
+    assert backwards.outcome is EhdbEventStreamOutcome.UNAVAILABLE
+    assert backwards.degraded is True
+
+
+# --------------------------------------------------------------------------
+# Invalid config + degraded helper
+# --------------------------------------------------------------------------
+
+
+def test_missing_log_is_invalid(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = {
+        EHDB_ENABLED_ENV: "true",
+        EHDB_MODE_ENV: "local_reference",
+        EHDB_CLIENT_ROLE_ENV: "worker",
+        EHDB_HELPER_BIN_ENV: str(helper),
+        "PATH": "/usr/bin",
+    }
+    result = project_ehdb_event("s", "s.evt", "x", env=env)
+    assert result.outcome is EhdbEventStreamOutcome.INVALID
+    assert not (tmp_path / "ehdb.jsonl").exists()
+
+
+def test_helper_error_is_unavailable(tmp_path):
+    broken = tmp_path / "broken.py"
+    broken.write_text(f"#!{sys.executable}\nimport sys\nsys.exit(2)\n", encoding="utf-8")
+    broken.chmod(0o755)
+    env = _enabled_env(tmp_path, broken)
+    result = project_ehdb_event("s", "s.evt", "x", env=env)
+    assert result.outcome is EhdbEventStreamOutcome.UNAVAILABLE
+    assert result.degraded is True
+
+
+# --------------------------------------------------------------------------
+# Event-log-authoritative invariant — EHDB never writes the NoETL event log
+# --------------------------------------------------------------------------
+
+
+def test_project_never_touches_authoritative_event_log(tmp_path):
+    # A sentinel standing in for the authoritative NoETL event log.  The drain
+    # must only ever write the derived EHDB local-reference log, never this.
+    authoritative = tmp_path / "noetl-event-log.sentinel"
+    authoritative.write_bytes(b"authoritative-source-of-truth")
+    before = authoritative.read_bytes()
+
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+    project_ehdb_event("events", "noetl.execution.completed", '{"n":1}', env=env)
+    consume_ehdb_events("events", "c", env=env)
+    ack_ehdb_event("events", "c", 1, env=env)
+
+    # The authoritative log is untouched; only the derived EHDB log grew.
+    assert authoritative.read_bytes() == before
+    assert (tmp_path / "ehdb.jsonl").exists()
+
+
+def test_module_does_not_import_noetl_event_writer():
+    # Structural guard on the invariant: the event-stream module must not reach
+    # for any NoETL event/command writer — it is a derived consumer only.
+    source = Path("noetl/core/ehdb_eventstream.py").read_text(encoding="utf-8")
+    for forbidden in ("event_log", "noetl.server.event", "outbox", "psycopg", "sqlalchemy"):
+        assert forbidden not in source, f"unexpected event-writer reference: {forbidden}"
+
+
+# --------------------------------------------------------------------------
+# Observability — metrics carry no secret values
+# --------------------------------------------------------------------------
+
+
+def test_metrics_exclude_payload_and_stream_values(tmp_path):
+    helper = _fake_helper(tmp_path)
+    env = _enabled_env(tmp_path, helper)
+    secret_payload = "super-secret-token-ABC123"
+    project_ehdb_event("private-stream", "s.evt", secret_payload, env=env)
+    consume_ehdb_events("private-stream", "secret-consumer", env=env)
+
+    rendered = "\n".join(render_ehdb_eventstream_metrics(labels={"worker_id": "w-1"}))
+    assert "noetl_ehdb_eventstream_ops_total" in rendered
+    assert 'operation="project"' in rendered
+    assert 'outcome="projected"' in rendered
+    assert 'operation="consume"' in rendered
+    assert secret_payload not in rendered
+    assert "private-stream" not in rendered
+    assert "secret-consumer" not in rendered
+
+
+def test_disabled_records_no_metric(tmp_path):
+    project_ehdb_event("s", "s.evt", "x", env={})
+    assert render_ehdb_eventstream_metrics() == []
+
+
+# --------------------------------------------------------------------------
+# Real binary drain (skipped when the binary is not discoverable)
+# --------------------------------------------------------------------------
+
+
+def test_real_binary_drain_roundtrip(tmp_path):
+    binary = discover_ehdb_helper_executable({"PATH": ""})
+    if binary is None:
+        pytest.skip("ehdb-local-reference binary not built/discoverable")
+    env = {
+        EHDB_ENABLED_ENV: "true",
+        EHDB_MODE_ENV: "local_reference",
+        EHDB_CLIENT_ROLE_ENV: "worker",
+        EHDB_LOCAL_REFERENCE_LOG_ENV: str(tmp_path / "real.jsonl"),
+        EHDB_HELPER_BIN_ENV: binary,
+        "PATH": "/usr/bin",
+    }
+    assert project_ehdb_event("muno", "muno.created", '{"n":1}', env=env).outcome is EhdbEventStreamOutcome.PROJECTED
+    assert project_ehdb_event("muno", "muno.created", '{"n":2}', env=env).outcome is EhdbEventStreamOutcome.PROJECTED
+
+    consumed = consume_ehdb_events("muno", "mat", env=env)
+    assert consumed.outcome is EhdbEventStreamOutcome.CONSUMED
+    assert consumed.consume.pending_count == 2
+    assert consumed.consume.created_consumer is True
+
+    assert ack_ehdb_event("muno", "mat", 1, env=env).outcome is EhdbEventStreamOutcome.ACKED
+
+    again = consume_ehdb_events("muno", "mat", env=env)
+    assert again.consume.pending_count == 1
+    assert again.consume.created_consumer is False
+    assert again.consume.acked_sequence == 1
+    assert again.consume.records[0]["sequence"] == 2
+
+    absent = consume_ehdb_events("never", "mat", env=env)
+    assert absent.outcome is EhdbEventStreamOutcome.ABSENT

--- a/tests/scripts/test_ehdb_eventstream_step.py
+++ b/tests/scripts/test_ehdb_eventstream_step.py
@@ -1,0 +1,84 @@
+"""Tests for the Phase D event-stream smoke + worker/playbook-local step CLI.
+
+Both exercise the real ``ehdb-local-reference`` binary when it is discoverable
+(built locally / bundled in the kind image) and skip otherwise, so the durable
+drain roundtrip is genuine.
+"""
+
+import json
+
+import pytest
+
+from noetl.core.ehdb_adapter import discover_ehdb_helper_executable
+from scripts.ehdb_eventstream_step import main as step_main
+from scripts.smoke_ehdb_eventstream import run_smoke
+
+
+def _binary_or_skip() -> str:
+    binary = discover_ehdb_helper_executable({"PATH": ""})
+    if binary is None:
+        pytest.skip("ehdb-local-reference binary not built/discoverable")
+    return binary
+
+
+def test_run_smoke_drains_durable_consumer(tmp_path):
+    binary = _binary_or_skip()
+    payload = run_smoke(
+        helper_bin=binary,
+        log_path=tmp_path / "ehdb.jsonl",
+        env={"PATH": "/usr/bin"},
+    )
+    assert payload["project_first"]["project"]["sequence"] == 1
+    assert payload["project_second"]["project"]["sequence"] == 2
+    assert payload["consume"]["consume"]["pending_count"] == 2
+    assert payload["ack"]["ack"]["acked_sequence"] == 1
+    assert payload["reconsume"]["consume"]["pending_count"] == 1
+
+
+def _enable(monkeypatch, binary, log):
+    monkeypatch.setenv("NOETL_EHDB_ENABLED", "true")
+    monkeypatch.setenv("NOETL_EHDB_MODE", "local_reference")
+    monkeypatch.setenv("NOETL_EHDB_CLIENT_ROLE", "worker")
+    monkeypatch.setenv("NOETL_EHDB_LOCAL_REFERENCE_LOG", log)
+    monkeypatch.setenv("NOETL_EHDB_HELPER_BIN", binary)
+
+
+def test_step_project_consume_ack(tmp_path, capsys, monkeypatch):
+    binary = _binary_or_skip()
+    _enable(monkeypatch, binary, str(tmp_path / "ehdb.jsonl"))
+
+    code = step_main(["project", "--stream", "trips", "--subject", "trips.made", "--payload", '{"x":1}'])
+    assert code == 0
+    assert json.loads(capsys.readouterr().out)["outcome"] == "projected"
+
+    code = step_main(["consume", "--stream", "trips", "--consumer", "mat"])
+    assert code == 0
+    consumed = json.loads(capsys.readouterr().out)
+    assert consumed["outcome"] == "consumed"
+    assert consumed["consume"]["pending_count"] == 1
+
+    code = step_main(["ack", "--stream", "trips", "--consumer", "mat", "--sequence", "1"])
+    assert code == 0
+    assert json.loads(capsys.readouterr().out)["outcome"] == "acked"
+
+
+def test_step_disabled_is_noop_exit_zero(capsys, monkeypatch):
+    for key in (
+        "NOETL_EHDB_ENABLED",
+        "NOETL_EHDB_MODE",
+        "NOETL_EHDB_CLIENT_ROLE",
+        "NOETL_EHDB_LOCAL_REFERENCE_LOG",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    code = step_main(["consume", "--stream", "trips", "--consumer", "mat"])
+    assert code == 0
+    assert json.loads(capsys.readouterr().out)["outcome"] == "disabled"
+
+
+def test_step_control_plane_guard_exit_four(capsys, monkeypatch):
+    monkeypatch.setenv("NOETL_EHDB_ENABLED", "true")
+    monkeypatch.setenv("NOETL_EHDB_MODE", "control_plane")
+    monkeypatch.setenv("NOETL_EHDB_CLIENT_ROLE", "gateway")
+    code = step_main(["project", "--stream", "s", "--subject", "s.e", "--payload", "x"])
+    assert code == 4
+    assert json.loads(capsys.readouterr().out)["outcome"] == "guard_refused"


### PR DESCRIPTION
## Summary

Integration **Phase D** of the EHDB↔NoETL integration (the event-stream
integration path). A bounded, stateless, **disabled-by-default**
worker/playbook/system step that mirrors already-emitted NoETL events into a
derived EHDB stream and drains them through a durable consumer with explicit
**ack-after-materialize** semantics — building on the Phase C data-plane step.

- **`noetl/core/ehdb_eventstream.py`** — `project` / `consume` / `ack` over the
  local-reference adapter. `project` reuses the Phase C `append` verb (the
  project leg); `consume`/`ack` use the new EHDB durable-consumer verbs
  ([noetl/ehdb#237](https://github.com/noetl/ehdb/pull/237), merged `3cefba9`).
- **`noetl/core/ehdb_adapter.py`** — `LocalReferenceConsumeResult` /
  `LocalReferenceAckResult` + consume/ack invocation builders.
- **`noetl/worker/metrics.py`** — renders `noetl_ehdb_eventstream_*` on the
  worker `/metrics` surface (renders nothing when disabled).
- **`scripts/ehdb_eventstream_step.py`**, **`scripts/smoke_ehdb_eventstream.py`**
  — worker/playbook-local step + kind smoke, **not** a server endpoint.
- **`docker/noetl/{dev,pip}/Dockerfile`** — bump `EHDB_REF` to the Phase D
  helper (`3cefba9`) so the packaged binary carries the consume/ack verbs.

## Event-log-authoritative invariant

The NoETL event log (`noetl.event`) stays the authoritative, append-only
source of truth. EHDB is a **derived, auxiliary** consumer of already-emitted
events — this module never writes the NoETL event log (no event-writer import;
a unit test asserts it), it only runs the `ehdb-local-reference` helper against
the separate derived EHDB log.

## Boundaries (all enforced in code)

- **Disabled by default → strict no-op.** No project/consume/ack, no file, no
  metric → byte-identical `/metrics`.
- **Control-plane guard.** `assert_event_stream_access_allowed` refuses
  gateway/api/server (`guard_refused`) before any helper runs.
- **Bounded.** Payload byte cap + consume-limit cap + ack sequence ≥ 1 + short
  time cap; over-bound → `rejected` / degraded. **Stateless** (helper opened +
  dropped per call). **Secret-free** `noetl_ehdb_eventstream_ops_total` metrics.

## Validation

```
pytest tests/core/test_ehdb_eventstream.py tests/scripts/test_ehdb_eventstream_step.py
  -> 27 passed (incl. real-binary project->consume->ack cursor-restart drain)
full EHDB suite -> 131 passed, no regression
```

Local **kind** validation (Phase D overlay image on `kind-noetl`): disabled
no-op + byte-identical `/metrics`, enabled worker drain + cursor restart,
control-plane gateway guard refused (exit 4, no write), secret-free metrics,
Phase C append/read no-regression. Nothing on GKE/prod.

Tracks noetl/ehdb#234 (Phase D).