### PR TITLE
docs: finish the noetl exec → noetl run sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 ```bash
 # Execute a playbook
-noetl exec <playbook_path> [--var key=value]
+noetl run <playbook_path> [--var key=value]
 
 # Check execution status
 noetl status <execution_id>

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@
 
 ```bash
 # Execute a playbook
-noetl exec <playbook_path> [--var key=value]
+noetl run <playbook_path> [--var key=value]
 
 # Check execution status
 noetl status <execution_id>

--- a/noetl/server/api/execution/endpoint.py
+++ b/noetl/server/api/execution/endpoint.py
@@ -585,7 +585,7 @@ def _default_validation_commands(path: str, version: Any) -> tuple[list[str], li
     version_suffix = f"@{version}" if version not in (None, "", "latest") else ""
     catalog_ref = f"catalog://{path}{version_suffix}" if path else "catalog://<playbook-path>"
     dry_run_commands = [
-        f"noetl exec {catalog_ref} -r distributed --dry-run",
+        f"noetl run {catalog_ref} -r distributed --dry-run",
     ]
     test_commands = [
         "pytest -q",


### PR DESCRIPTION
Tail of `noetl/ai-meta#193` — the last three uses of the deprecated run verb in this repo.

| file | what |
| :-- | :-- |
| `CLAUDE.md` | agent instruction header |
| `GEMINI.md` | agent instruction header |
| `noetl/server/api/execution/endpoint.py:588` | the dry-run hint string the API returns to the caller |

The third is the one with user impact: the server hands back a suggested command that, once run, prints a deprecation notice.

## Scope

The regex requires `exec` not be followed by a letter, so `noetl execute` (the `playbook`/`status`/`rerun` group syntax) and `noetl execution` are untouched. `noetl/ai-meta#193` calls both out explicitly. The compare view is exactly **3 files, 3 lines**.

No behavior change — both aliases still work.

## Note on how this was made — and a correction

These edits were applied through the GitHub Contents API rather than a local checkout, because a fresh `git worktree` of `origin/main` here reported **62 dirty paths**.

**That reading was wrong, and the repo is fine.** The checkout was correct all along; `git` was reporting on the wrong directory. `.git/modules/repos/noetl/config` sets

```
[core]  worktree = ../../../../repos/noetl
[extensions]  worktreeConfig = true
```

in the **shared** config. That relative path is right for the primary worktree (whose gitdir is `.git/modules/repos/noetl`) and off by two levels for any secondary worktree (gitdir `.git/modules/repos/noetl/worktrees/<name>`), where it resolves to `.git/modules/repos/noetl` itself. So `git status` was listing the git directory: `COMMIT_EDITMSG` and `FETCH_HEAD` as "untracked", tracked files as "deleted".

The one-line repair, per worktree:

```bash
git -C <worktree> config --worktree core.worktree "<absolute path to that worktree>"
```

Verified: dirty `62 → 0`, `--is-inside-work-tree` `false → true`, `--show-toplevel` correct.

Filed as `noetl/ai-meta#239` with the full diagnosis — it affects every secondary worktree of this submodule, including the 16 currently checked out under `.codex/worktrees/`, where `git add`/`git commit` would operate on git metadata rather than the source tree.

This PR is unaffected either way: it was built from `origin/main` server-side and the compare view above is the whole of it.

Refs noetl/ai-meta#193