### PR TITLE
perf(db): index noetl.command (event_id) — the command-claim seq scan (#155)

### DIFF
--- a/noetl/database/ddl/postgres/schema_ddl.sql
+++ b/noetl/database/ddl/postgres/schema_ddl.sql
@@ -1019,6 +1019,15 @@ CREATE INDEX IF NOT EXISTS idx_command_pending_loop_step_created
 -- command_id construction).
 CREATE INDEX IF NOT EXISTS idx_command_command_id
     ON noetl.command (command_id);
+-- Lookup-by-event_id.  `POST /api/commands/{event_id}/claim` resolves a command
+-- from the bus notification by `event_id` alone -- it has no `execution_id` to
+-- give, so every index above (all of which lead with the partition key) is
+-- unusable and the planner falls back to a parallel seq scan of all 16
+-- partitions.  Measured on a 428k-row table: 88,199 buffers touched per claim,
+-- ~295ms, paid TWICE per hop; with this index, 31 buffers and ~0.2ms.  End to
+-- end that was ~79% of a playbook turn (noetl/ai-meta#155).
+CREATE INDEX IF NOT EXISTS idx_command_event_id
+    ON noetl.command (event_id);
 
 ALTER TABLE noetl.command ADD COLUMN IF NOT EXISTS stage_id BIGINT;
 ALTER TABLE noetl.command ADD COLUMN IF NOT EXISTS frame_id BIGINT;

--- a/scripts/db/add_command_event_id_index.sql
+++ b/scripts/db/add_command_event_id_index.sql
@@ -1,0 +1,71 @@
+-- noetl/ai-meta#155 -- add the missing `noetl.command (event_id)` index ONLINE.
+--
+-- WHY
+--   `POST /api/commands/{event_id}/claim` resolves a command from the bus
+--   notification by `event_id` alone; it has no `execution_id` to give.
+--   `noetl.command` is HASH-partitioned on `execution_id` and every existing
+--   index leads with that column, so the predicate is unservable and the
+--   planner does a parallel seq scan of all 16 partitions.  Measured on a
+--   428,585-row table: 88,199 buffers (74,241 read) and ~295ms per claim,
+--   paid twice per playbook hop -- ~79% of a turn's wall clock.
+--
+-- WHY NOT JUST `CREATE INDEX`
+--   A plain CREATE INDEX on the parent takes ACCESS EXCLUSIVE on every
+--   partition and blocks all command writes for the duration -- i.e. it stops
+--   dispatch.  PostgreSQL does not accept CREATE INDEX CONCURRENTLY on a
+--   partitioned parent, so the online form is: build each partition's index
+--   concurrently, create an INVALID parent index with ONLY, then attach.  The
+--   parent index flips to valid automatically once all 16 are attached.
+--
+-- SAFETY
+--   Purely additive; changes no query results, only plans.  Reversible at any
+--   point with `DROP INDEX CONCURRENTLY noetl.idx_command_event_id;` (dropping
+--   the parent cascades to the attached partition indexes).  Cost afterwards
+--   is one more btree to maintain on insert into noetl.command.
+--
+-- RUN
+--   Each statement separately (CONCURRENTLY cannot run inside a transaction
+--   block).  psql -f runs them autocommit, which is what we want; do NOT wrap
+--   this file in BEGIN/COMMIT.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p00_event_id_idx ON noetl.command_p00 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p01_event_id_idx ON noetl.command_p01 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p02_event_id_idx ON noetl.command_p02 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p03_event_id_idx ON noetl.command_p03 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p04_event_id_idx ON noetl.command_p04 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p05_event_id_idx ON noetl.command_p05 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p06_event_id_idx ON noetl.command_p06 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p07_event_id_idx ON noetl.command_p07 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p08_event_id_idx ON noetl.command_p08 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p09_event_id_idx ON noetl.command_p09 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p10_event_id_idx ON noetl.command_p10 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p11_event_id_idx ON noetl.command_p11 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p12_event_id_idx ON noetl.command_p12 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p13_event_id_idx ON noetl.command_p13 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p14_event_id_idx ON noetl.command_p14 (event_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS command_p15_event_id_idx ON noetl.command_p15 (event_id);
+
+-- Parent: created INVALID (ON ONLY), flips to valid as the attaches complete.
+CREATE INDEX IF NOT EXISTS idx_command_event_id ON ONLY noetl.command (event_id);
+
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p00_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p01_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p02_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p03_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p04_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p05_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p06_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p07_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p08_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p09_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p10_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p11_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p12_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p13_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p14_event_id_idx;
+ALTER INDEX noetl.idx_command_event_id ATTACH PARTITION noetl.command_p15_event_id_idx;
+
+-- Verify: must return indisvalid = t.  An invalid parent means an attach was
+-- missed and the planner will still seq-scan.
+--   SELECT indisvalid FROM pg_index
+--    WHERE indexrelid = 'noetl.idx_command_event_id'::regclass;

--- a/tests/database/test_distributed_runtime_schema.py
+++ b/tests/database/test_distributed_runtime_schema.py
@@ -42,3 +42,35 @@ def test_distributed_runtime_schema_contract_is_present():
     assert "idx_event_stream_version" in ddl
     assert "idx_event_aggregate_event_id" in ddl
     assert "idx_outbox_ready" in ddl
+
+
+def test_command_lookup_by_event_id_has_an_index():
+    """`POST /api/commands/{event_id}/claim` resolves by `event_id` alone.
+
+    `noetl.command` is HASH-partitioned on `execution_id`, and every other
+    index on it leads with that column, so an `event_id`-only predicate cannot
+    use any of them -- the planner falls back to a parallel seq scan of all 16
+    partitions.  That cost ~295ms per claim on a 428k-row table and was paid
+    twice per playbook hop, which measured as ~79% of a turn's wall clock
+    (noetl/ai-meta#155).
+
+    Asserted as a property (an index whose leading column is `event_id`)
+    rather than by name, so renaming the index keeps the guard honest while
+    dropping it fails.
+    """
+    ddl = SCHEMA.read_text(encoding="utf-8")
+
+    statements = [
+        " ".join(stmt.split())
+        for stmt in ddl.split(";")
+        if "ON NOETL.COMMAND" in " ".join(stmt.split()).upper()
+        and "CREATE INDEX" in " ".join(stmt.split()).upper()
+    ]
+    leading_event_id = [
+        stmt for stmt in statements if "(event_id" in stmt.replace(" (", "(")
+    ]
+    assert leading_event_id, (
+        "noetl.command needs an index whose leading column is event_id; "
+        "without it every command claim seq-scans all 16 partitions. "
+        f"Indexes found on noetl.command: {statements}"
+    )


### PR DESCRIPTION
## What

Adds `idx_command_event_id` on `noetl.command (event_id)`.

## Why

`POST /api/commands/{event_id}/claim` resolves a command from the bus notification by `event_id` alone — it has no `execution_id` to give. `noetl.command` is HASH-partitioned on `execution_id`, and **every** existing index on it leads with that column, so the predicate is unservable: the planner does a parallel seq scan of all 16 partitions.

This runs **twice per playbook hop** — once for the step's command, once for the `__orchestrate__` meta-command the drive is dispatched as.

## Measured

Ten-hop probe playbook (every step a trivial python step, so wall clock is nearly pure orchestration tax), 5 runs each, idle kind cluster, **same worker image** on both sides:

| metric | before | after |
| --- | --- | --- |
| wall clock p50 | 20684ms | **4333ms** |
| wall clock spread | 12.9–21.2s | **4308–4396ms** |
| `command.issued → command.claimed` p50 | 559ms | **60ms** |
| `command.completed → step.enter` p50 | 568ms | **72ms** |
| `claim_outcome` RTT (worker-side mean) | 554–593ms | **62–70ms** |
| buffers per claim | 88,199 (74,241 read) | **31** |

`command.started → call.done` (real tool execution, ~120ms) is now the largest line item in a turn — the shape it should have had all along. Run-to-run variance collapsed from ±40% to ±1%.

Because the cost is a full scan, it grows with the table. That is why the same shape reads ~500ms/hop in kind (428k rows) and ~1.4s/hop on the much larger prod table — it unifies the "per-hop cost scales with log size" observation from noetl/ai-meta#130 / #156.

## Regression

Same probe, before vs after: 61 events per run (identical), exact lifecycle counts (50 each of issued/claimed/started/call.done/completed, 45 step.enter, 5 playbook_started/completed), **0 duplicate event_ids**, all runs COMPLETED with the correct terminal value (`hop: 10`). EHDB cross-store parity controls all `expected` / 0 `unexpected`. No EHDB tier or serve config touched.

## Safety / rollout

Purely additive — changes no query result, only plans. Cost afterwards is one more btree maintained on insert into `noetl.command`.

Existing deployments apply it **online** with `scripts/db/add_command_event_id_index.sql`: `CREATE INDEX CONCURRENTLY` per partition, then `ATTACH PARTITION`, because PostgreSQL rejects `CONCURRENTLY` on a partitioned parent and a plain `CREATE INDEX` there takes `ACCESS EXCLUSIVE` on all 16 partitions — i.e. it would stop dispatch for its duration. That script was validated by dropping and rebuilding the index in kind: parent `indisvalid = t`, 16 partition indexes attached, latency held at ~4.5s.

Rollback: `DROP INDEX CONCURRENTLY noetl.idx_command_event_id;`

## Guard

`test_command_lookup_by_event_id_has_an_index` asserts the **property** (an index whose leading column is `event_id`) rather than the index name, so a rename keeps it honest. Checked in both directions — it fails when the index is removed from the DDL.

Refs noetl/ai-meta#155

🤖 Generated with [Claude Code](https://claude.com/claude-code)